### PR TITLE
feat: Render struct-field tuples as real tuples ([A,B] / z.tuple / prefixItems)

### DIFF
--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -291,10 +291,10 @@ impl FieldDef {
             FieldDefType::Tuple(lst) => {
                 let elements = lst
                     .iter()
-                    .map(|v| format!("{}: {}", v.name, v.typescript_typename()))
+                    .map(Self::typescript_typename)
                     .collect::<Vec<_>>()
-                    .join("; ");
-                format!("{{ {elements} }}")
+                    .join(", ");
+                format!("[{elements}]")
             }
             FieldDefType::SiblingType(name, lst) => {
                 if let Some(info) = lookup_alias_info(name) {
@@ -431,10 +431,10 @@ impl FieldDef {
             FieldDefType::Tuple(lst) => {
                 let elements = lst
                     .iter()
-                    .map(|v| format!("{}: {}", v.name, v.zod_type()))
+                    .map(Self::zod_type)
                     .collect::<Vec<_>>()
-                    .join("; ");
-                format!("{{ {elements} }}")
+                    .join(", ");
+                format!("z.tuple([{elements}])")
             }
             FieldDefType::SiblingType(name, lst) => {
                 if let Some(info) = lookup_alias_info(name) {

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -3558,6 +3558,49 @@ fn build_string_format_field_schema(
     }
 }
 
+/// Builds JSON schema for a tuple struct field.
+///
+/// A Rust tuple field `(A, B, ...)` serializes (via serde) as a fixed-length
+/// JSON array, so it is rendered as `{ "type": "array", "prefixItems": [...],
+/// "items": false, "minItems": N, "maxItems": N }`. This mirrors the tuple
+/// **variant** path (`write_tuple_multiple_variant_fields`) and reuses the same
+/// per-element schema builder (`build_tuple_element_json_schema`).
+#[cfg(feature = "jsonschema")]
+fn build_tuple_field_schema(
+    fld: &FieldDef,
+    field_name_str: &str,
+    lst: &[FieldDef],
+) -> proc_macro2::TokenStream {
+    let arity = lst.len();
+    let element_schemas: Vec<proc_macro2::TokenStream> =
+        lst.iter().map(build_tuple_element_json_schema).collect();
+
+    let tuple_schema = quote! {
+        serde_json::json!({
+            "type": "array",
+            "prefixItems": [#(#element_schemas),*],
+            "items": false,
+            "minItems": #arity,
+            "maxItems": #arity
+        })
+    };
+
+    if fld.is_array {
+        quote! {
+            properties.insert(#field_name_str.to_string(), {
+                serde_json::json!({
+                    "type": "array",
+                    "items": #tuple_schema
+                })
+            });
+        }
+    } else {
+        quote! {
+            properties.insert(#field_name_str.to_string(), #tuple_schema);
+        }
+    }
+}
+
 /// Builds JSON schema for a field.
 #[cfg(feature = "jsonschema")]
 fn build_field_schema(fld: &FieldDef) -> proc_macro2::TokenStream {
@@ -3602,6 +3645,7 @@ fn build_field_schema(fld: &FieldDef) -> proc_macro2::TokenStream {
             build_sibling_type_field_schema(fld, &field_name_str, name, lst)
         }
         FieldDefType::Map(key, value) => build_map_field_schema(key, value, &field_name_str),
+        FieldDefType::Tuple(lst) => build_tuple_field_schema(fld, &field_name_str, lst),
         fld_def => {
             log::trace!("Other => field_name: {field_name_str}, fld_def: {fld_def:?}");
             // Fallback: Use module pattern. This should not typically be reached

--- a/tests/semantic_types_tests/tests.rs
+++ b/tests/semantic_types_tests/tests.rs
@@ -220,11 +220,11 @@ fn test_double_generic_alias_typescript() {
         ts.contains("export type Pair<T, U>"),
         "Should include both generic type parameters. Got: {ts}"
     );
-    // Note: Rust tuples are rendered as objects with element_0, element_1, etc.
-    // This is consistent with how serde serializes tuples
+    // Rust tuples serialize (via serde) as JSON arrays, so they render as
+    // TypeScript tuples `[T, U]` (not objects).
     assert!(
-        ts.contains("element_0: T") && ts.contains("element_1: U"),
-        "Should generate object with element_0 and element_1 fields. Got: {ts}"
+        ts.contains("[T, U]"),
+        "Should generate a tuple type [T, U]. Got: {ts}"
     );
 }
 

--- a/tests/tuple_field_tests.rs
+++ b/tests/tuple_field_tests.rs
@@ -1,0 +1,17 @@
+//! Tests for tuple struct-field support.
+//!
+//! A Rust tuple struct field `(A, B, ...)` serializes (via serde) as a
+//! fixed-length JSON array, so it is rendered as:
+//! - TypeScript: `[A, B, ...]`
+//! - Zod: `z.tuple([A, B, ...])`
+//! - JSON Schema: `{ type: "array", prefixItems: [...], items: false,
+//!   minItems: N, maxItems: N }`
+//!
+//! This mirrors the already-correct tuple **variant** path
+//! (see `tests/tuple_variant_tests`).
+
+#[cfg(test)]
+#[cfg(feature = "typescript")]
+#[cfg(feature = "serde")]
+#[path = "tuple_field_tests/tests.rs"]
+mod tests;

--- a/tests/tuple_field_tests/tests.rs
+++ b/tests/tuple_field_tests/tests.rs
@@ -1,0 +1,186 @@
+use serde::{Deserialize, Serialize};
+use tixschema::model_schema;
+
+/// Test 1 + 2 + 3: A `(String, String)` struct field renders as a tuple in
+/// TypeScript, Zod, and JSON Schema.
+#[test]
+fn test_string_pair_tuple_field() {
+    /// One row of an alphanumeric "map-value" lookup table.
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+    #[serde(rename_all = "camelCase")]
+    pub struct AlphanumericMapInput {
+        pub output: String,
+        /// A (matchValue) pair, serialized as a 2-element array.
+        pub values: (String, String),
+    }
+
+    let ts = AlphanumericMapInput::ts_definition();
+
+    // TS: tuple, not an object literal.
+    assert!(
+        ts.contains("values: [string, string]"),
+        "Expected a tuple field. Got: {ts}"
+    );
+    assert!(
+        !ts.contains("element_0"),
+        "Should not emit element_N object keys. Got: {ts}"
+    );
+}
+
+/// Test 2: Zod renders `z.tuple([...])`.
+#[cfg(feature = "zod")]
+#[test]
+fn test_string_pair_tuple_field_zod() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct Pair {
+        pub values: (String, String),
+    }
+
+    let zod = Pair::zod_schema();
+
+    assert!(
+        zod.contains("values: z.tuple([z.string(), z.string()])"),
+        "Expected z.tuple in Zod schema. Got: {zod}"
+    );
+    // Must not emit the malformed bare-object-literal form.
+    assert!(
+        !zod.contains("element_0"),
+        "Should not emit element_N keys in Zod. Got: {zod}"
+    );
+}
+
+/// Test 3: JSON Schema renders a fixed-arity array with prefixItems.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn test_string_pair_tuple_field_json_schema() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct Pair {
+        pub values: (String, String),
+    }
+
+    let schema = Pair::json_schema();
+    let values = &schema["properties"]["values"];
+
+    assert_eq!(values["type"].as_str(), Some("array"));
+    assert_eq!(values["items"].as_bool(), Some(false));
+    assert_eq!(values["minItems"].as_u64(), Some(2));
+    assert_eq!(values["maxItems"].as_u64(), Some(2));
+
+    let prefix = values["prefixItems"].as_array().unwrap();
+    assert_eq!(prefix.len(), 2, "Two prefix items. Got: {prefix:?}");
+    for item in prefix {
+        assert_eq!(item["type"].as_str(), Some("string"));
+    }
+}
+
+/// Test 4: Mixed element types `(String, i64, bool)`.
+#[test]
+fn test_mixed_element_tuple_field() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct Mixed {
+        pub triple: (String, i64, bool),
+    }
+
+    let ts = Mixed::ts_definition();
+    assert!(
+        ts.contains("triple: [string, number, boolean]"),
+        "Expected mixed tuple in TS. Got: {ts}"
+    );
+}
+
+/// Test 4b: Mixed element types in Zod.
+#[cfg(feature = "zod")]
+#[test]
+fn test_mixed_element_tuple_field_zod() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct Mixed {
+        pub triple: (String, i64, bool),
+    }
+
+    let zod = Mixed::zod_schema();
+    assert!(
+        zod.contains("triple: z.tuple([z.string(), z.number().int(), z.boolean()])"),
+        "Expected mixed tuple in Zod. Got: {zod}"
+    );
+}
+
+/// Test 5: A sibling/custom element type renders by reference.
+#[test]
+fn test_sibling_element_tuple_field() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct DocumentId {
+        pub id: String,
+    }
+
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct WithSibling {
+        pub pair: (DocumentId, String),
+    }
+
+    let ts = WithSibling::ts_definition();
+    assert!(
+        ts.contains("pair: [DocumentId, string]"),
+        "Expected sibling element in TS tuple. Got: {ts}"
+    );
+
+    #[cfg(feature = "zod")]
+    {
+        let zod = WithSibling::zod_schema();
+        assert!(
+            zod.contains("pair: z.tuple([DocumentId$Schema, z.string()])"),
+            "Expected sibling $Schema in Zod tuple. Got: {zod}"
+        );
+    }
+}
+
+/// Test 6: serde round-trip — a tuple field serializes as a JSON array.
+#[test]
+fn test_tuple_field_serde_roundtrip() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+    pub struct S {
+        pub output: String,
+        pub values: (String, String),
+    }
+
+    let original = S {
+        output: "out".to_owned(),
+        values: ("a".to_owned(), "b".to_owned()),
+    };
+
+    let json = serde_json::to_value(&original).unwrap();
+    assert_eq!(
+        json.get("values"),
+        Some(&serde_json::json!(["a", "b"])),
+        "Tuple should serialize as a JSON array. Got: {json}"
+    );
+
+    let back: S = serde_json::from_value(json).unwrap();
+    assert_eq!(back, original);
+}
+
+/// Test: an optional tuple field gets the optional wrapping.
+#[cfg(feature = "zod")]
+#[test]
+fn test_optional_tuple_field_zod() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct OptionalPair {
+        pub values: Option<(String, String)>,
+    }
+
+    let zod = OptionalPair::zod_schema();
+    assert!(
+        zod.contains(
+            "values: z.union([z.tuple([z.string(), z.string()]), z.undefined()]).prefault(undefined)"
+        ),
+        "Expected optional tuple wrapping. Got: {zod}"
+    );
+}


### PR DESCRIPTION
## Summary

Renders Rust struct-field tuples as real tuples. A field like `values: (String, String)` previously generated a TypeScript/Zod **object** (`{ element_0: string; element_1: string }`); it now generates a **tuple** — TS `[string, string]`, Zod `z.tuple([z.string(), z.string()])`, JSON Schema `{ "type": "array", "prefixItems": [...], "items": false, "minItems": N, "maxItems": N }`.

This matches what serde actually serializes (a Rust tuple → JSON array) and brings the struct-field path in line with the already-correct enum-variant tuple path (`write_tuple_multiple_variant_fields`).

Unblocks the faithful migration of prodoctivity's `VariablePartAlphanumericTypeFilter.inputs[].values: [string, string]`.

## Changes

- `src/field_type.rs`
  - `typescript_typename` Tuple arm → `[A, B, ...]` (was `{ element_0: A; element_1: B }`).
  - `zod_type` Tuple arm → `z.tuple([A, B, ...])` (was a malformed bare object literal of schemas — not a valid standalone Zod schema).
- `src/model_schema.rs`
  - New `build_tuple_field_schema`, wired into `build_field_schema` for `FieldDefType::Tuple`. Emits the array/`prefixItems` form, honors `is_array` wrapping, and reuses `build_tuple_element_json_schema` — the same per-element builder the variant path uses (one source of truth).
- `tests/tuple_field_tests.rs` + `tests/tuple_field_tests/tests.rs` (new) — TS/Zod/JSON string + structural assertions, mixed element types `(String, i64, bool)`, sibling element `(DocumentId, String)`, serde array round-trip, optional-tuple `prefault(undefined)` wrapping.
- `tests/semantic_types_tests/tests.rs` — updated the one existing assertion that encoded the old (buggy) object form to expect `[T, U]` (its prior comment claiming the object form was "consistent with serde" was incorrect).

## Notes

- JSON Schema for sibling/branded tuple **elements** renders as a generic `{ "type": "object" }` — this mirrors the existing enum-variant tuple path exactly (TS and Zod still render those elements by reference). Making the JSON arm recurse into each element's `json_schema()` would be a follow-up affecting both paths.

## Verification

- `cargo test` — all pass, incl. 8 new tuple-field tests
- `cargo clippy --all-targets -- -D warnings` — clean, no `#[allow]`/`#[expect]` added
- `cargo fmt --check` — clean
- `just` (`cargo hack test --feature-powerset`) — all feature combinations pass

