### PR TITLE
feat: Add ts_optional flag to model_schema_prop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,7 +201,7 @@ pub struct BadConfig {
 - `String` → `string`
 - `bool` → `boolean`
 - Numeric types → `number`
-- `Option<T>` → `T | undefined` (Zod: `z.union([T, z.undefined()]).prefault(undefined)`)
+- `Option<T>` → `T | undefined` (Zod: `z.union([T, z.undefined()]).prefault(undefined)`); with `#[model_schema_prop(ts_optional)]` the TypeScript key becomes optional instead: `field?: T`
 - `Vec<T>` → `Array<T>`
 - `HashMap<String, T>` → `Partial<Record<string, T>>`
 - Custom types → Reference by name (Json suffix stripped if present)
@@ -274,9 +274,12 @@ All validation constraints generate checks in **Zod (frontend), JSON Schema, and
 | `maximum = N` | numeric | `.max(N)` | `"maximum"` | validator + deserializer |
 | `literal = "val"` | `String` | `z.literal("val")` | `"const"` | — |
 | `preprocess = ["fn"]` | any | `z.preprocess(fn, ...)` | — | — (Zod-only) |
+| `ts_optional` | `Option<T>` | — | — | — (TypeScript-only) |
 
 Multiple constraints on one field are combined. Multiple `preprocess` functions nest:
 `z.preprocess(fn1, z.preprocess(fn2, innerSchema))`.
+
+`ts_optional` is a bare flag (no value): it renders an `Option<T>` field as the optional TypeScript key `field?: T` instead of the default `field: T | undefined`. Zod and JSON Schema output are unchanged. It is only valid on `Option<T>` fields (non-`Option` is a compile error) and composes with `as = Type`.
 
 ```rust
 #[model_schema()]

--- a/README.md
+++ b/README.md
@@ -847,6 +847,33 @@ pub struct Event {
 }
 ```
 
+### Optional TypeScript Keys (`ts_optional`)
+
+By default an `Option<T>` field renders as a required key carrying `| undefined` (`field: T | undefined`). Add the bare `ts_optional` flag to render it as an optional key instead (`field?: T`).
+
+This is a TypeScript-only knob -- the Zod schema and JSON Schema are unchanged (the field is already optional in both). The flag is only valid on `Option<T>` fields; applying it to a non-`Option` field is a compile error. It composes with `as = Type`.
+
+```rust
+#[model_schema()]
+#[derive(Serialize, Deserialize)]
+pub struct Profile {
+    pub name: String,
+    #[model_schema_prop(ts_optional)]
+    pub nickname: Option<String>,
+}
+```
+
+Generated TypeScript:
+
+```typescript
+export type Profile = {
+  name: string;
+  nickname?: string;
+};
+```
+
+Without `ts_optional`, `nickname` would render as `nickname: string | undefined`.
+
 ## Compiler-Validated Examples
 
 You can provide compiler-validated example values for your types that will be embedded in the generated Zod schemas' `.meta()` field. Examples are written in doc comment code blocks and fully type-checked at compile time.

--- a/src/features/model_schema_prop.rs
+++ b/src/features/model_schema_prop.rs
@@ -42,12 +42,7 @@ use syn::{Attribute, LitStr, Type};
 ///
 /// - `as = Type` — override the TypeScript/Zod type emitted for this field.
 /// - `literal = "value"` — emit as a string literal type instead of `string`.
-/// - `ts_optional` — bare flag (no value). For an `Option<T>` field, emit the TypeScript
-///   key as `field?: T` (optional key) instead of the default `field: T | undefined`
-///   (required key carrying an explicit `| undefined`). Zod and JSON Schema output are
-///   unchanged. This is a TypeScript-only knob. **Requires the field to be `Option<T>`**;
-///   applying it to a non-`Option` field is a compile error at macro-expansion time.
-///   Composes with `as = Type` (the `?` still applies once `as` resolves the type name).
+/// - `ts_optional` — for an `Option<T>` field, emit `field?: T` instead of `field: T | undefined` (TypeScript only; a non-`Option` field is a compile error).
 ///
 /// ## Zod preprocessing
 ///
@@ -83,7 +78,7 @@ pub struct ModelSchemaPropMeta {
     pub minimum: Option<f64>,      // e.g., 0.0 from minimum = 0
     pub pattern: Option<String>,   // e.g., "^[0-9a-fA-F]{24}$" from pattern = "^[0-9a-fA-F]{24}$"
     pub preprocess: Vec<String>, // e.g., ["epoch_to_date", "trim"] from preprocess = ["epoch_to_date", "trim"]
-    pub ts_optional: bool,       // bare `ts_optional` flag: emit `field?: T` for Option<T> fields
+    pub ts_optional: bool,
 }
 
 /// Parses `model_schema_prop` attributes from a field.
@@ -178,9 +173,7 @@ pub fn parse_model_schema_prop_attributes(attrs: &[Attribute]) -> ModelSchemaPro
                         })
                         .collect();
                     meta.preprocess = fns;
-                }
-                // Handle bare `ts_optional` flag (no value)
-                else if nested.path.is_ident("ts_optional") {
+                } else if nested.path.is_ident("ts_optional") {
                     meta.ts_optional = true;
                 } else {
                     // Ignore unknown model_schema_prop keys.

--- a/src/features/model_schema_prop.rs
+++ b/src/features/model_schema_prop.rs
@@ -42,6 +42,12 @@ use syn::{Attribute, LitStr, Type};
 ///
 /// - `as = Type` — override the TypeScript/Zod type emitted for this field.
 /// - `literal = "value"` — emit as a string literal type instead of `string`.
+/// - `ts_optional` — bare flag (no value). For an `Option<T>` field, emit the TypeScript
+///   key as `field?: T` (optional key) instead of the default `field: T | undefined`
+///   (required key carrying an explicit `| undefined`). Zod and JSON Schema output are
+///   unchanged. This is a TypeScript-only knob. **Requires the field to be `Option<T>`**;
+///   applying it to a non-`Option` field is a compile error at macro-expansion time.
+///   Composes with `as = Type` (the `?` still applies once `as` resolves the type name).
 ///
 /// ## Zod preprocessing
 ///
@@ -77,6 +83,7 @@ pub struct ModelSchemaPropMeta {
     pub minimum: Option<f64>,      // e.g., 0.0 from minimum = 0
     pub pattern: Option<String>,   // e.g., "^[0-9a-fA-F]{24}$" from pattern = "^[0-9a-fA-F]{24}$"
     pub preprocess: Vec<String>, // e.g., ["epoch_to_date", "trim"] from preprocess = ["epoch_to_date", "trim"]
+    pub ts_optional: bool,       // bare `ts_optional` flag: emit `field?: T` for Option<T> fields
 }
 
 /// Parses `model_schema_prop` attributes from a field.
@@ -171,6 +178,10 @@ pub fn parse_model_schema_prop_attributes(attrs: &[Attribute]) -> ModelSchemaPro
                         })
                         .collect();
                     meta.preprocess = fns;
+                }
+                // Handle bare `ts_optional` flag (no value)
+                else if nested.path.is_ident("ts_optional") {
+                    meta.ts_optional = true;
                 } else {
                     // Ignore unknown model_schema_prop keys.
                 }

--- a/src/features/model_schema_prop/tests.rs
+++ b/src/features/model_schema_prop/tests.rs
@@ -63,6 +63,31 @@ fn test_parse_as_and_min_length() {
 }
 
 #[test]
+fn test_parse_ts_optional() {
+    let attr: Attribute = parse_quote! { #[model_schema_prop(ts_optional)] };
+    let meta = parse_model_schema_prop_attributes(&[attr]);
+    assert!(meta.ts_optional);
+    assert!(meta.as_type.is_none());
+    assert!(meta.literal.is_none());
+}
+
+#[test]
+fn test_parse_both_as_and_ts_optional() {
+    let attr: Attribute = parse_quote! { #[model_schema_prop(as = SomeBrand, ts_optional)] };
+    let meta = parse_model_schema_prop_attributes(&[attr]);
+    assert!(meta.as_type.is_some());
+    assert_eq!(meta.as_type.unwrap(), "SomeBrand");
+    assert!(meta.ts_optional);
+}
+
+#[test]
+fn test_parse_no_ts_optional_by_default() {
+    let attr: Attribute = parse_quote! { #[model_schema_prop(minLength = 1)] };
+    let meta = parse_model_schema_prop_attributes(&[attr]);
+    assert!(!meta.ts_optional);
+}
+
+#[test]
 fn test_parse_all_attributes() {
     let attr: Attribute =
         parse_quote! { #[model_schema_prop(as = String, literal = "test", minLength = 3)] };

--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -211,8 +211,6 @@ impl FieldDef {
         }
     }
 
-    /// Returns `true` when this field is `Option<T>` and has opted into the
-    /// `#[model_schema_prop(ts_optional)]` flag.
     fn has_ts_optional(&self) -> bool {
         self.is_optional
             && self
@@ -277,9 +275,6 @@ impl FieldDef {
         }
     }
 
-    /// Returns the TypeScript object-key optionality marker for this field:
-    /// `"?"` when the field is `Option<T>` and has `ts_optional` set, else `""`.
-    /// Render sites insert this between the field name and the `:`.
     pub fn ts_optional_key_marker(&self) -> &'static str {
         if self.has_ts_optional() { "?" } else { "" }
     }
@@ -380,9 +375,7 @@ impl FieldDef {
         };
 
         if self.is_optional {
-            // When the field opts into `ts_optional`, the key itself is emitted as
-            // `field?: T` by the render sites, so the `| undefined` here would be
-            // redundant — omit it.
+            // `ts_optional` renders the key as `field?: T`, so the `| undefined` is redundant.
             if self.has_ts_optional() {
                 pre_result
             } else {

--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -211,6 +211,16 @@ impl FieldDef {
         }
     }
 
+    /// Returns `true` when this field is `Option<T>` and has opted into the
+    /// `#[model_schema_prop(ts_optional)]` flag.
+    fn has_ts_optional(&self) -> bool {
+        self.is_optional
+            && self
+                .model_schema_prop_meta
+                .as_ref()
+                .is_some_and(|m| m.ts_optional)
+    }
+
     /// Rewrites any `Self` type reference to the concrete enclosing type name.
     ///
     /// A recursive type may refer to itself with the `Self` keyword
@@ -265,6 +275,13 @@ impl FieldDef {
             | FieldDefType::NaiveDateTime
             | FieldDefType::DateTime => {}
         }
+    }
+
+    /// Returns the TypeScript object-key optionality marker for this field:
+    /// `"?"` when the field is `Option<T>` and has `ts_optional` set, else `""`.
+    /// Render sites insert this between the field name and the `:`.
+    pub fn ts_optional_key_marker(&self) -> &'static str {
+        if self.has_ts_optional() { "?" } else { "" }
     }
 
     /// Generates the TypeScript type name for this field.
@@ -363,7 +380,14 @@ impl FieldDef {
         };
 
         if self.is_optional {
-            format!("{pre_result} | undefined")
+            // When the field opts into `ts_optional`, the key itself is emitted as
+            // `field?: T` by the render sites, so the `| undefined` here would be
+            // redundant — omit it.
+            if self.has_ts_optional() {
+                pre_result
+            } else {
+                format!("{pre_result} | undefined")
+            }
         } else {
             pre_result
         }

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -3941,11 +3941,6 @@ fn field_is_bare_string(field: &Field) -> bool {
     false
 }
 
-/// Validates the `#[model_schema_prop(ts_optional)]` flag against the field's optionality.
-///
-/// The flag only makes sense on `Option<T>` fields (where `field_optional == true`),
-/// because it controls the `field?: T` vs `field: T | undefined` rendering. Applying it
-/// to a non-`Option` field returns `Err` — the caller turns that into a compile error.
 fn validate_ts_optional_flag(field_optional: bool, flag_set: bool) -> Result<(), String> {
     if flag_set && !field_optional {
         return Err("#[model_schema_prop(ts_optional)] requires an Option<T> field".into());
@@ -4035,13 +4030,11 @@ fn process_field(
         || !model_schema_prop_meta.preprocess.is_empty())
     .then_some(model_schema_prop_meta);
 
-    // `ts_optional` is only valid on `Option<T>` fields. Reject otherwise at
-    // macro-expansion time (failed assert = compile error). The pure validator
-    // `validate_ts_optional_flag` encodes the same rule and is unit-tested directly.
     let ts_optional_flag = field_def
         .model_schema_prop_meta
         .as_ref()
         .is_some_and(|m| m.ts_optional);
+    // A failed assert here surfaces as a compile error at macro-expansion time.
     assert!(
         validate_ts_optional_flag(field_def.is_optional, ts_optional_flag).is_ok(),
         "#[model_schema_prop(ts_optional)] requires an Option<T> field on field `{final_name}`"

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -1981,7 +1981,14 @@ fn render_untagged_named(
     // TypeScript: `{ a: A; b: B }`
     let ts_fields = field_defs
         .iter()
-        .map(|fld| format!("{}: {}", fld.name, fld.typescript_typename()))
+        .map(|fld| {
+            format!(
+                "{}{}: {}",
+                fld.name,
+                fld.ts_optional_key_marker(),
+                fld.typescript_typename()
+            )
+        })
         .collect::<Vec<_>>()
         .join("; ");
     let ts = format!("{{ {ts_fields} }}");
@@ -2498,9 +2505,10 @@ fn write_named_variant_fields(
         // Add TypeScript type definition
         let _ = writeln!(
             variant_type_code,
-            "  /**\n{}\n**/\n  {}: {};",
+            "  /**\n{}\n**/\n  {}{}: {};",
             fld.docs,
             fld.name,
+            fld.ts_optional_key_marker(),
             fld.typescript_typename()
         );
 
@@ -3690,9 +3698,10 @@ fn write_field_type_and_schema(
     // Always write TypeScript type
     let _ = writeln!(
         type_code,
-        "  /**\n{}\n**/\n  {}: {};",
+        "  /**\n{}\n**/\n  {}{}: {};",
         fld.docs,
         fld.name,
+        fld.ts_optional_key_marker(),
         fld.typescript_typename()
     );
 
@@ -3932,6 +3941,18 @@ fn field_is_bare_string(field: &Field) -> bool {
     false
 }
 
+/// Validates the `#[model_schema_prop(ts_optional)]` flag against the field's optionality.
+///
+/// The flag only makes sense on `Option<T>` fields (where `field_optional == true`),
+/// because it controls the `field?: T` vs `field: T | undefined` rendering. Applying it
+/// to a non-`Option` field returns `Err` — the caller turns that into a compile error.
+fn validate_ts_optional_flag(field_optional: bool, flag_set: bool) -> Result<(), String> {
+    if flag_set && !field_optional {
+        return Err("#[model_schema_prop(ts_optional)] requires an Option<T> field".into());
+    }
+    Ok(())
+}
+
 /// Processes a field and returns its definition, optional module items (validators/deserializers),
 /// and optional `validate_body` (contribution to the type-level `validate()` method).
 fn process_field(
@@ -4010,8 +4031,21 @@ fn process_field(
         || model_schema_prop_meta.pattern.is_some()
         || model_schema_prop_meta.minimum.is_some()
         || model_schema_prop_meta.maximum.is_some()
+        || model_schema_prop_meta.ts_optional
         || !model_schema_prop_meta.preprocess.is_empty())
     .then_some(model_schema_prop_meta);
+
+    // `ts_optional` is only valid on `Option<T>` fields. Reject otherwise at
+    // macro-expansion time (failed assert = compile error). The pure validator
+    // `validate_ts_optional_flag` encodes the same rule and is unit-tested directly.
+    let ts_optional_flag = field_def
+        .model_schema_prop_meta
+        .as_ref()
+        .is_some_and(|m| m.ts_optional);
+    assert!(
+        validate_ts_optional_flag(field_def.is_optional, ts_optional_flag).is_ok(),
+        "#[model_schema_prop(ts_optional)] requires an Option<T> field on field `{final_name}`"
+    );
 
     // Apply type overrides based on model_schema_prop attributes
     if let Some(meta) = &field_def.model_schema_prop_meta
@@ -4574,3 +4608,6 @@ fn generate_alias_zod_stub() -> proc_macro2::TokenStream {
         }
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -7,7 +7,6 @@ fn ts_optional_ok_on_option_field() {
 
 #[test]
 fn ts_optional_ok_when_flag_unset() {
-    // Flag not set: valid regardless of optionality.
     validate_ts_optional_flag(true, false).unwrap();
     validate_ts_optional_flag(false, false).unwrap();
 }

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -1,0 +1,20 @@
+use super::validate_ts_optional_flag;
+
+#[test]
+fn ts_optional_ok_on_option_field() {
+    validate_ts_optional_flag(true, true).unwrap();
+}
+
+#[test]
+fn ts_optional_ok_when_flag_unset() {
+    // Flag not set: valid regardless of optionality.
+    validate_ts_optional_flag(true, false).unwrap();
+    validate_ts_optional_flag(false, false).unwrap();
+}
+
+#[test]
+fn ts_optional_err_on_non_option_field() {
+    let err = validate_ts_optional_flag(false, true).unwrap_err();
+    assert!(err.contains("ts_optional"));
+    assert!(err.contains("Option<T>"));
+}

--- a/tests/model_schema_prop_tests/tests.rs
+++ b/tests/model_schema_prop_tests/tests.rs
@@ -147,6 +147,63 @@ struct OptionalLiteral {
     pub optional_type: Option<String>,
 }
 
+// Inner sibling type referenced by ts_optional fields.
+#[cfg(all(
+    test,
+    any(
+        feature = "typescript",
+        feature = "jsonschema",
+        feature = "zod",
+        feature = "serde"
+    )
+))]
+#[model_schema()]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
+struct Inner {
+    pub value: String,
+}
+
+// Struct exercising ts_optional on a plain Option<T> field, plus a control
+// Option<T> field without the flag, and a coexistence field with `as`.
+#[cfg(all(
+    test,
+    any(
+        feature = "typescript",
+        feature = "jsonschema",
+        feature = "zod",
+        feature = "serde"
+    )
+))]
+#[model_schema()]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
+struct TsOptionalStruct {
+    #[model_schema_prop(ts_optional)]
+    pub f: Option<Inner>,
+    // Control: same shape, no flag.
+    pub g: Option<Inner>,
+    // Coexistence with `as` (a currently no-op override).
+    #[model_schema_prop(as = Inner, ts_optional)]
+    pub h: Option<Inner>,
+}
+
+// Discriminated-union enum exercising ts_optional on a named-variant field.
+#[cfg(all(
+    test,
+    any(feature = "typescript", feature = "jsonschema", feature = "zod")
+))]
+#[model_schema()]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", serde(tag = "type"))]
+enum TsOptionalVariant {
+    FilterPart {
+        #[model_schema_prop(ts_optional)]
+        filter: Option<Inner>,
+    },
+}
+
 #[test]
 #[cfg(feature = "typescript")]
 fn test_string_literal_typescript() {
@@ -417,4 +474,76 @@ fn test_combined_literal_minlength_json_schema() {
     assert_eq!(normal_prop["type"], "string");
     assert_eq!(normal_prop["minLength"], 1_i32);
     assert!(normal_prop.get("const").is_none());
+}
+
+#[test]
+#[cfg(feature = "typescript")]
+fn test_ts_optional_struct_typescript() {
+    let ts = TsOptionalStruct::ts_definition();
+
+    // ts_optional field uses the optional-key form, no `| undefined`.
+    assert!(ts.contains("f?: Inner;"), "expected `f?: Inner;` in:\n{ts}");
+    assert!(
+        !ts.contains("f: Inner | undefined"),
+        "did not expect required-key form for `f` in:\n{ts}"
+    );
+
+    // Control field without the flag keeps the required-key + `| undefined` form.
+    assert!(
+        ts.contains("g: Inner | undefined;"),
+        "expected control `g: Inner | undefined;` in:\n{ts}"
+    );
+
+    // Coexistence with `as`: still optional-key form, no panic.
+    assert!(ts.contains("h?: Inner;"), "expected `h?: Inner;` in:\n{ts}");
+}
+
+#[test]
+#[cfg(feature = "zod")]
+fn test_ts_optional_struct_zod_unchanged() {
+    let zod = TsOptionalStruct::zod_schema();
+
+    // Zod output for the ts_optional field is byte-identical to the default optional form.
+    assert!(
+        zod.contains("f: z.union([Inner$Schema, z.undefined()]).prefault(undefined)"),
+        "expected unchanged Zod for `f` in:\n{zod}"
+    );
+    assert!(
+        zod.contains("g: z.union([Inner$Schema, z.undefined()]).prefault(undefined)"),
+        "expected unchanged Zod for `g` in:\n{zod}"
+    );
+}
+
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_ts_optional_struct_json_schema_unchanged() {
+    let schema = TsOptionalStruct::json_schema();
+    let required_arr = schema["required"].as_array().unwrap();
+    let required: Vec<&str> = required_arr.iter().filter_map(|v| v.as_str()).collect();
+
+    // ts_optional does not change JSON Schema: optional fields are absent from `required`.
+    assert!(
+        !required.contains(&"f"),
+        "`f` should not be required: {required:?}"
+    );
+    assert!(
+        !required.contains(&"g"),
+        "`g` should not be required: {required:?}"
+    );
+}
+
+#[test]
+#[cfg(feature = "typescript")]
+fn test_ts_optional_variant_typescript() {
+    let ts = TsOptionalVariant::ts_definition();
+
+    // Covers the named-variant render path (write_named_variant_fields).
+    assert!(
+        ts.contains("filter?: Inner;"),
+        "expected `filter?: Inner;` in variant TS:\n{ts}"
+    );
+    assert!(
+        !ts.contains("filter: Inner | undefined"),
+        "did not expect required-key form for variant `filter` in:\n{ts}"
+    );
 }

--- a/tests/model_schema_prop_tests/tests.rs
+++ b/tests/model_schema_prop_tests/tests.rs
@@ -147,7 +147,6 @@ struct OptionalLiteral {
     pub optional_type: Option<String>,
 }
 
-// Inner sibling type referenced by ts_optional fields.
 #[cfg(all(
     test,
     any(
@@ -164,8 +163,6 @@ struct Inner {
     pub value: String,
 }
 
-// Struct exercising ts_optional on a plain Option<T> field, plus a control
-// Option<T> field without the flag, and a coexistence field with `as`.
 #[cfg(all(
     test,
     any(
@@ -181,14 +178,12 @@ struct Inner {
 struct TsOptionalStruct {
     #[model_schema_prop(ts_optional)]
     pub f: Option<Inner>,
-    // Control: same shape, no flag.
     pub g: Option<Inner>,
-    // Coexistence with `as` (a currently no-op override).
+    // `as` is currently a no-op override; this field guards their coexistence.
     #[model_schema_prop(as = Inner, ts_optional)]
     pub h: Option<Inner>,
 }
 
-// Discriminated-union enum exercising ts_optional on a named-variant field.
 #[cfg(all(
     test,
     any(feature = "typescript", feature = "jsonschema", feature = "zod")
@@ -481,20 +476,17 @@ fn test_combined_literal_minlength_json_schema() {
 fn test_ts_optional_struct_typescript() {
     let ts = TsOptionalStruct::ts_definition();
 
-    // ts_optional field uses the optional-key form, no `| undefined`.
     assert!(ts.contains("f?: Inner;"), "expected `f?: Inner;` in:\n{ts}");
     assert!(
         !ts.contains("f: Inner | undefined"),
         "did not expect required-key form for `f` in:\n{ts}"
     );
 
-    // Control field without the flag keeps the required-key + `| undefined` form.
     assert!(
         ts.contains("g: Inner | undefined;"),
         "expected control `g: Inner | undefined;` in:\n{ts}"
     );
 
-    // Coexistence with `as`: still optional-key form, no panic.
     assert!(ts.contains("h?: Inner;"), "expected `h?: Inner;` in:\n{ts}");
 }
 
@@ -503,7 +495,6 @@ fn test_ts_optional_struct_typescript() {
 fn test_ts_optional_struct_zod_unchanged() {
     let zod = TsOptionalStruct::zod_schema();
 
-    // Zod output for the ts_optional field is byte-identical to the default optional form.
     assert!(
         zod.contains("f: z.union([Inner$Schema, z.undefined()]).prefault(undefined)"),
         "expected unchanged Zod for `f` in:\n{zod}"
@@ -521,7 +512,6 @@ fn test_ts_optional_struct_json_schema_unchanged() {
     let required_arr = schema["required"].as_array().unwrap();
     let required: Vec<&str> = required_arr.iter().filter_map(|v| v.as_str()).collect();
 
-    // ts_optional does not change JSON Schema: optional fields are absent from `required`.
     assert!(
         !required.contains(&"f"),
         "`f` should not be required: {required:?}"


### PR DESCRIPTION
## What
Adds `#[model_schema_prop(ts_optional)]`. For an `Option<T>` field it renders the optional-key TypeScript form `field?: T` instead of the default required key `field: T | undefined`.

- **TypeScript only** — Zod and JSON Schema output are unchanged.
- Applying the flag to a **non-`Option`** field is a macro-expansion **compile error**.
- Composes with `as = Type` (e.g. `h?: Inner`).
- Works for struct fields, tagged enum variant fields, and untagged named fields.



## Why a new branch
The work was originally done on `labs/serde-flatten-intersection` (the wrong branch — that feature is already merged). Moved to this dedicated branch, rebased onto current `master`.

## Verification
- `just quick`: 371 passed
- `ts_optional` targeted tests: 10 passed
- `just lint` (clippy `-D warnings` + fmt): clean
- `just test` (all 32 feature combinations): all passed
