### PR TITLE
chore: Cover the whole workspace in llvm-cov recipes

### DIFF
--- a/justfile
+++ b/justfile
@@ -130,12 +130,12 @@ test-name TEST_NAME:
 # Generate code coverage report (requires cargo-llvm-cov)
 test-coverage:
     @echo "Generating code coverage report..."
-    cargo llvm-cov --all-features
+    cargo llvm-cov --workspace --all-features
 
 # Generate code coverage HTML report (requires cargo-llvm-cov)
 test-coverage-html:
     @echo "Generating code coverage HTML report..."
-    cargo llvm-cov --all-features --html
+    cargo llvm-cov --workspace --all-features --html
     @echo "Coverage report generated in target/llvm-cov/html/"
 
 # Benchmark tests


### PR DESCRIPTION
Switch the `test-coverage` / `test-coverage-html` recipes to `cargo llvm-cov --workspace --all-features` so they run every workspace member's tests (not just the root package). No-op for single-crate repos; correct for workspaces.