### PR TITLE
fix: Emit generated Schema handle as #[non_exhaustive]

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -225,6 +225,7 @@ fn process_type_alias(item_type: ItemType, args: &ModelSchemaArgs) -> TokenStrea
         pub mod #module_ident {
             use super::*;
 
+            #[non_exhaustive]
             pub struct Schema;
 
             impl Schema {
@@ -394,6 +395,7 @@ where
         pub mod #module_ident {
             use super::*;
 
+            #[non_exhaustive]
             pub struct Schema;
 
             impl Schema {
@@ -1235,6 +1237,7 @@ fn assemble_branded_output(parts: &BrandedNewtypeOutput) -> TokenStream {
         pub mod #module_ident {
             use super::*;
 
+            #[non_exhaustive]
             pub struct Schema;
 
             impl Schema {
@@ -1685,6 +1688,7 @@ fn process_plain_enum(
         pub mod #module_ident {
             use super::*;
 
+            #[non_exhaustive]
             pub struct Schema;
 
             impl Schema {


### PR DESCRIPTION
The macro-generated `pub struct Schema;` handle must stay public for cross-crate `Schema::ts_definition()`/`zod_schema()` calls, but downstream crates should not construct it. Marks all four emission sites (type-alias, struct, branded-newtype, enum) `#[non_exhaustive]` so consumers get a clean `clippy::exhaustive_structs` result instead of being able to build the handle.



`just check` and `just test` (full 32-combination feature powerset) green.
