### PR TITLE
feat(chrono): Native Date default, as_number opt-out, millis NaiveTime

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,6 +206,8 @@ pub struct BadConfig {
 - `HashMap<String, T>` → `Partial<Record<string, T>>`
 - Custom types → Reference by name (Json suffix stripped if present)
 - `ObjectId` → `ObjectId` (with $oid validation)
+- `DateTime<Tz>` → `Date` (Zod `z.coerce.date()`); with `#[model_schema_prop(as_number)]` → `number` (inline epoch-ms coercer)
+- `NaiveTime` → `string` (Zod `z.iso.time()` wrapped in an inline preprocessor that also accepts millis-since-start-of-day)
 - `#[serde(flatten)]` field → TypeScript intersection (`A & B`), Zod `.and(...)`
 - `#[serde(untagged)]` enum → TypeScript union (`A | B`), Zod `z.union([...])`, JSON Schema `anyOf`
 
@@ -275,11 +277,14 @@ All validation constraints generate checks in **Zod (frontend), JSON Schema, and
 | `literal = "val"` | `String` | `z.literal("val")` | `"const"` | — |
 | `preprocess = ["fn"]` | any | `z.preprocess(fn, ...)` | — | — (Zod-only) |
 | `ts_optional` | `Option<T>` | — | — | — (TypeScript-only) |
+| `as_number` | `DateTime<Tz>` | inline `z.preprocess(..., z.number())` | — | — (TS+Zod) |
 
 Multiple constraints on one field are combined. Multiple `preprocess` functions nest:
 `z.preprocess(fn1, z.preprocess(fn2, innerSchema))`.
 
 `ts_optional` is a bare flag (no value): it renders an `Option<T>` field as the optional TypeScript key `field?: T` instead of the default `field: T | undefined`. Zod and JSON Schema output are unchanged. It is only valid on `Option<T>` fields (non-`Option` is a compile error) and composes with `as = Type`.
+
+`as_number` is a bare flag (no value): it renders a `DateTime<Tz>` field as a `number` (epoch milliseconds) with an inline self-contained Zod coercer, instead of the default native `Date` (`z.coerce.date()`). It is only valid on `DateTime<Tz>` fields (anything else is a compile error) and is honored on a tuple-variant `DateTime<Tz>` enum payload.
 
 ```rust
 #[model_schema()]

--- a/README.md
+++ b/README.md
@@ -1035,16 +1035,19 @@ Supported types and mappings:
 | Rust Type | TypeScript | Zod Schema | JSON Schema Format |
 |-----------|------------|------------|--------------------|
 | `NaiveDate` | `string` | `z.iso.date()` | `"date"` |
-| `NaiveTime` | `string` | `z.iso.time()` | `"time"` |
+| `NaiveTime` | `string` | `z.preprocess(<millis arrow>, z.iso.time())` | `"time"` |
 | `NaiveDateTime` | `string` | `z.iso.datetime({ local: true })` | `"date-time"` |
-| `DateTime<Utc>` | `string` | `z.iso.datetime({ offset: true })` | `"date-time"` |
-| `DateTime<Local>` | `string` | `z.iso.datetime({ offset: true })` | `"date-time"` |
-| `DateTime<FixedOffset>` | `string` | `z.iso.datetime({ offset: true })` | `"date-time"` |
+| `DateTime<Tz>` (default) | `Date` | `z.coerce.date()` | `"date-time"` |
+| `DateTime<Tz>` + `#[model_schema_prop(as_number)]` | `number` | `z.preprocess(<epoch arrow>, z.number())` | `"date-time"` |
+
+`DateTime<Tz>` renders as a native TypeScript `Date` (`z.coerce.date()`) by default, which is what MongoDB needs to expire a BSON `Date` via TTL. The bare `as_number` flag opts a single `DateTime<Tz>` field into an epoch-milliseconds `number` instead, validated by a self-contained inline coercer (no imported helper). `as_number` is only valid on a `DateTime<Tz>` field — using it elsewhere is a compile error.
+
+`NaiveTime` stays a TypeScript `string`, but its Zod schema also accepts millis-since-start-of-day, converting them to an `HH:MM:SS` string before validation.
 
 Example:
 
 ```rust
-use tixschema::model_schema;
+use tixschema::{model_schema, model_schema_prop};
 use serde::{Deserialize, Serialize};
 use chrono::{NaiveDate, NaiveTime, NaiveDateTime, DateTime, Utc};
 
@@ -1056,6 +1059,8 @@ pub struct Event {
     pub time: NaiveTime,
     pub local_datetime: NaiveDateTime,
     pub created_at: DateTime<Utc>,
+    #[model_schema_prop(as_number)]
+    pub epoch_ms: DateTime<Utc>,
     pub updated_at: Option<DateTime<Utc>>,
 }
 ```
@@ -1068,8 +1073,9 @@ export type Event = {
   date: string;
   time: string;
   local_datetime: string;
-  created_at: string;
-  updated_at: string | undefined;
+  created_at: Date;
+  epoch_ms: number;
+  updated_at: Date | undefined;
 };
 ```
 
@@ -1079,14 +1085,15 @@ Generated Zod:
 export const Event$Schema: ZodType<Event> = z.strictObject({
   name: z.string(),
   date: z.iso.date(),
-  time: z.iso.time(),
+  time: z.preprocess((arg) => { if (typeof arg === "number") { const s = Math.floor(arg / 1000); const hh = String(Math.floor(s / 3600)).padStart(2, "0"); const mm = String(Math.floor((s % 3600) / 60)).padStart(2, "0"); const ss = String(s % 60).padStart(2, "0"); return `${hh}:${mm}:${ss}`; } return arg; }, z.iso.time()),
   local_datetime: z.iso.datetime({ local: true }),
-  created_at: z.iso.datetime({ offset: true }),
-  updated_at: z.union([z.iso.datetime({ offset: true }), z.undefined()]).prefault(undefined),
+  created_at: z.coerce.date(),
+  epoch_ms: z.preprocess((arg) => { if (arg instanceof Date) return arg.getTime(); if (typeof arg === "string") return Date.parse(arg); return arg; }, z.number()),
+  updated_at: z.union([z.coerce.date(), z.undefined()]).prefault(undefined),
 });
 ```
 
-Chrono types also work in collections (`Vec<NaiveDate>` generates `z.array(z.iso.date())`) and in enums as tuple variant elements.
+Chrono types also work in collections (`Vec<NaiveDate>` generates `z.array(z.iso.date())`) and in enums as tuple variant elements (`as_number` is honored on a tuple-variant `DateTime<Tz>` payload).
 
 ## Feature Flags
 

--- a/src/features/chrono.rs
+++ b/src/features/chrono.rs
@@ -24,9 +24,15 @@ pub fn get_naive_datetime_typescript_type() -> String {
     "string".to_owned()
 }
 
-/// Generates TypeScript type name for `DateTime<Tz>`.
+/// Generates TypeScript type name for `DateTime<Tz>` (native `Date` default).
 pub fn get_datetime_typescript_type() -> String {
-    "string".to_owned()
+    "Date".to_owned()
+}
+
+/// Generates TypeScript type name for a `DateTime<Tz>` rendered with the
+/// `#[model_schema_prop(as_number)]` opt-out (epoch milliseconds).
+pub fn get_datetime_number_typescript_type() -> String {
+    "number".to_owned()
 }
 
 /// Generates Zod schema for `NaiveDate` (date validation).
@@ -37,10 +43,16 @@ pub fn get_naive_date_zod_schema() -> String {
 }
 
 /// Generates Zod schema for `NaiveTime` (time validation).
-/// Uses Zod v4's `z.iso.time()` syntax (`z.string().time()` is deprecated).
+/// Stays a TS `string` (`z.iso.time()`) but the inline preprocessor also accepts
+/// millis-since-start-of-day, converting it to an `HH:MM:SS` string before validation.
+/// `z.string().time()` is deprecated.
 #[cfg(any(test, feature = "zod"))]
 pub fn get_naive_time_zod_schema() -> String {
-    "z.iso.time()".to_owned()
+    "z.preprocess((arg) => { if (typeof arg === \"number\") { const s = Math.floor(arg / 1000); \
+const hh = String(Math.floor(s / 3600)).padStart(2, \"0\"); \
+const mm = String(Math.floor((s % 3600) / 60)).padStart(2, \"0\"); \
+const ss = String(s % 60).padStart(2, \"0\"); return `${hh}:${mm}:${ss}`; } return arg; }, z.iso.time())"
+        .to_owned()
 }
 
 /// Generates Zod schema for `NaiveDateTime` (local datetime validation).
@@ -50,14 +62,25 @@ pub fn get_naive_datetime_zod_schema() -> String {
     "z.iso.datetime({ local: true })".to_owned()
 }
 
-/// Generates Zod schema for `DateTime<Tz>` (datetime with timezone validation).
-/// Uses Zod v4's `z.iso.datetime({ offset: true })` so both `Z` and numeric
-/// offsets (e.g. `-04:00`) are accepted, matching Rust's default serialized
-/// form for `DateTime<FixedOffset>` (and still accepting `DateTime<Utc>` /
-/// `DateTime<Local>`). `z.string().datetime()` is deprecated.
+/// Generates Zod schema for `DateTime<Tz>` rendered as a native TS `Date` (default).
+/// `z.coerce.date()` accepts `Date` instances, ISO strings, and epoch numbers,
+/// matching Rust's serialized forms while producing a BSON `Date` (`MongoDB` TTL).
 #[cfg(any(test, feature = "zod"))]
-pub fn get_datetime_zod_schema() -> String {
-    "z.iso.datetime({ offset: true })".to_owned()
+pub fn get_datetime_native_zod_schema() -> String {
+    "z.coerce.date()".to_owned()
+}
+
+/// Generates Zod schema for a `DateTime<Tz>` rendered with the
+/// `#[model_schema_prop(as_number)]` opt-out (epoch milliseconds).
+///
+/// A self-contained inline coercer: `Date` → `getTime()`, ISO string → `Date.parse`,
+/// otherwise passed through to `z.number()`. No imported helper, so generated
+/// modules remain self-contained.
+#[cfg(any(test, feature = "zod"))]
+pub fn get_datetime_number_zod_schema() -> String {
+    "z.preprocess((arg) => { if (arg instanceof Date) return arg.getTime(); \
+if (typeof arg === \"string\") return Date.parse(arg); return arg; }, z.number())"
+        .to_owned()
 }
 
 #[cfg(test)]

--- a/src/features/chrono/tests.rs
+++ b/src/features/chrono/tests.rs
@@ -5,19 +5,37 @@ fn test_typescript_types() {
     assert_eq!(get_naive_date_typescript_type(), "string");
     assert_eq!(get_naive_time_typescript_type(), "string");
     assert_eq!(get_naive_datetime_typescript_type(), "string");
-    assert_eq!(get_datetime_typescript_type(), "string");
+    assert_eq!(get_datetime_typescript_type(), "Date");
+    assert_eq!(get_datetime_number_typescript_type(), "number");
 }
 
 #[test]
 fn test_zod_schemas() {
     assert_eq!(get_naive_date_zod_schema(), "z.iso.date()");
-    assert_eq!(get_naive_time_zod_schema(), "z.iso.time()");
     assert_eq!(
         get_naive_datetime_zod_schema(),
         "z.iso.datetime({ local: true })"
     );
-    assert_eq!(
-        get_datetime_zod_schema(),
-        "z.iso.datetime({ offset: true })"
-    );
+    assert_eq!(get_datetime_native_zod_schema(), "z.coerce.date()");
+}
+
+#[test]
+fn test_datetime_number_zod_schema_is_self_contained_arrow() {
+    let schema = get_datetime_number_zod_schema();
+    assert!(schema.starts_with("z.preprocess((arg) =>"));
+    assert!(schema.contains("arg instanceof Date) return arg.getTime();"));
+    assert!(schema.contains("typeof arg === \"string\") return Date.parse(arg);"));
+    assert!(schema.ends_with("z.number())"));
+    // Must not reference a named helper or the ISO datetime renderer.
+    assert!(!schema.contains("z.iso.datetime"));
+}
+
+#[test]
+fn test_naive_time_zod_schema_accepts_millis() {
+    let schema = get_naive_time_zod_schema();
+    assert!(schema.starts_with("z.preprocess((arg) =>"));
+    assert!(schema.contains("typeof arg === \"number\""));
+    assert!(schema.contains("Math.floor(arg / 1000)"));
+    assert!(schema.contains("padStart(2, \"0\")"));
+    assert!(schema.ends_with("z.iso.time())"));
 }

--- a/src/features/model_schema_prop.rs
+++ b/src/features/model_schema_prop.rs
@@ -70,13 +70,14 @@ use syn::{Attribute, LitStr, Type};
 /// ```
 #[derive(Clone, Debug, Default)]
 pub struct ModelSchemaPropMeta {
-    pub as_type: Option<String>,   // e.g., "String" from as = String
-    pub literal: Option<String>,   // e.g., "Tixena" from literal = "Tixena"
+    pub as_number: bool, // DateTime<Tz>: epoch-number + codegen coercer instead of the native Date default
+    pub as_type: Option<String>, // e.g., "String" from as = String
+    pub literal: Option<String>, // e.g., "Tixena" from literal = "Tixena"
     pub max_length: Option<usize>, // e.g., 50 from maxLength = 50
-    pub maximum: Option<f64>,      // e.g., 100.0 from maximum = 100
+    pub maximum: Option<f64>, // e.g., 100.0 from maximum = 100
     pub min_length: Option<usize>, // e.g., 1 from minLength = 1
-    pub minimum: Option<f64>,      // e.g., 0.0 from minimum = 0
-    pub pattern: Option<String>,   // e.g., "^[0-9a-fA-F]{24}$" from pattern = "^[0-9a-fA-F]{24}$"
+    pub minimum: Option<f64>, // e.g., 0.0 from minimum = 0
+    pub pattern: Option<String>, // e.g., "^[0-9a-fA-F]{24}$" from pattern = "^[0-9a-fA-F]{24}$"
     pub preprocess: Vec<String>, // e.g., ["epoch_to_date", "trim"] from preprocess = ["epoch_to_date", "trim"]
     pub ts_optional: bool,
 }
@@ -175,6 +176,8 @@ pub fn parse_model_schema_prop_attributes(attrs: &[Attribute]) -> ModelSchemaPro
                     meta.preprocess = fns;
                 } else if nested.path.is_ident("ts_optional") {
                     meta.ts_optional = true;
+                } else if nested.path.is_ident("as_number") {
+                    meta.as_number = true;
                 } else {
                     // Ignore unknown model_schema_prop keys.
                 }

--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -216,6 +216,13 @@ impl FieldDef {
         }
     }
 
+    #[cfg(feature = "chrono")]
+    fn has_as_number(&self) -> bool {
+        self.model_schema_prop_meta
+            .as_ref()
+            .is_some_and(|m| m.as_number)
+    }
+
     fn has_ts_optional(&self) -> bool {
         self.is_optional
             && self
@@ -369,7 +376,13 @@ impl FieldDef {
             #[cfg(feature = "chrono")]
             FieldDefType::NaiveDateTime => chrono::get_naive_datetime_typescript_type(),
             #[cfg(feature = "chrono")]
-            FieldDefType::DateTime => chrono::get_datetime_typescript_type(),
+            FieldDefType::DateTime => {
+                if self.has_as_number() {
+                    chrono::get_datetime_number_typescript_type()
+                } else {
+                    chrono::get_datetime_typescript_type()
+                }
+            }
         };
         let pre_result = if self.is_array {
             format!("Array<{result}>")
@@ -500,7 +513,13 @@ impl FieldDef {
             #[cfg(feature = "chrono")]
             FieldDefType::NaiveDateTime => chrono::get_naive_datetime_zod_schema(),
             #[cfg(feature = "chrono")]
-            FieldDefType::DateTime => chrono::get_datetime_zod_schema(),
+            FieldDefType::DateTime => {
+                if self.has_as_number() {
+                    chrono::get_datetime_number_zod_schema()
+                } else {
+                    chrono::get_datetime_native_zod_schema()
+                }
+            }
         };
         let array_result = if self.is_array {
             format!("z.array({result})")

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -4003,6 +4003,21 @@ fn field_is_bare_string(field: &Field) -> bool {
     false
 }
 
+fn validate_as_number_flag(field_type: &FieldDefType, flag_set: bool) -> Result<(), String> {
+    #[cfg(not(feature = "chrono"))]
+    let _: &FieldDefType = field_type;
+
+    #[cfg(feature = "chrono")]
+    let is_datetime = matches!(field_type, FieldDefType::DateTime);
+    #[cfg(not(feature = "chrono"))]
+    let is_datetime = false;
+
+    if flag_set && !is_datetime {
+        return Err("#[model_schema_prop(as_number)] requires a chrono DateTime<Tz> field".into());
+    }
+    Ok(())
+}
+
 fn validate_ts_optional_flag(field_optional: bool, flag_set: bool) -> Result<(), String> {
     if flag_set && !field_optional {
         return Err("#[model_schema_prop(ts_optional)] requires an Option<T> field".into());
@@ -4091,6 +4106,7 @@ fn process_field(
         || model_schema_prop_meta.minimum.is_some()
         || model_schema_prop_meta.maximum.is_some()
         || model_schema_prop_meta.ts_optional
+        || model_schema_prop_meta.as_number
         || !model_schema_prop_meta.preprocess.is_empty())
     .then_some(model_schema_prop_meta);
 
@@ -4102,6 +4118,15 @@ fn process_field(
     assert!(
         validate_ts_optional_flag(field_def.is_optional, ts_optional_flag).is_ok(),
         "#[model_schema_prop(ts_optional)] requires an Option<T> field on field `{final_name}`"
+    );
+
+    let as_number_flag = field_def
+        .model_schema_prop_meta
+        .as_ref()
+        .is_some_and(|m| m.as_number);
+    assert!(
+        validate_as_number_flag(&field_def.field_type, as_number_flag).is_ok(),
+        "#[model_schema_prop(as_number)] requires a chrono DateTime<Tz> field on field `{final_name}`"
     );
 
     // Apply type overrides based on model_schema_prop attributes

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -1,4 +1,4 @@
-use super::validate_ts_optional_flag;
+use super::{FieldDefType, validate_as_number_flag, validate_ts_optional_flag};
 
 #[test]
 fn ts_optional_ok_on_option_field() {
@@ -16,4 +16,22 @@ fn ts_optional_err_on_non_option_field() {
     let err = validate_ts_optional_flag(false, true).unwrap_err();
     assert!(err.contains("ts_optional"));
     assert!(err.contains("Option<T>"));
+}
+
+#[cfg(feature = "chrono")]
+#[test]
+fn as_number_ok_on_datetime_field() {
+    validate_as_number_flag(&FieldDefType::DateTime, true).unwrap();
+}
+
+#[test]
+fn as_number_ok_when_flag_unset() {
+    validate_as_number_flag(&FieldDefType::String, false).unwrap();
+}
+
+#[test]
+fn as_number_err_on_non_datetime_field() {
+    let err = validate_as_number_flag(&FieldDefType::String, true).unwrap_err();
+    assert!(err.contains("as_number"));
+    assert!(err.contains("DateTime<Tz>"));
 }

--- a/tests/chrono_tests/tests.rs
+++ b/tests/chrono_tests/tests.rs
@@ -105,6 +105,27 @@ struct TimestampedRecord {
     id: String,
 }
 
+// Test struct mixing the default Date rendering with the `as_number` opt-out.
+#[model_schema()]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Sample {
+    #[model_schema_prop(as_number)]
+    created_at: DateTime<Utc>,
+    due_at: DateTime<Utc>,
+    start_time: NaiveTime,
+}
+
+// Test enum with a TupleSingle DateTime variant honoring the as_number opt-out.
+#[model_schema()]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", serde(tag = "type"))]
+pub enum DynamicValue {
+    Native(DateTime<Utc>),
+    Number(#[model_schema_prop(as_number)] DateTime<Utc>),
+}
+
 #[test]
 fn test_chrono_types_constructible() {
     let date = NaiveDate::from_ymd_opt(2020, 1, 1).unwrap();
@@ -195,8 +216,8 @@ fn test_naive_datetime_typescript() {
 fn test_datetime_utc_typescript() {
     let ts = TimestampedRecord::ts_definition();
     assert!(
-        ts.contains("created_at: string;"),
-        "DateTime<Utc> should map to string. Got: {ts}"
+        ts.contains("created_at: Date;"),
+        "DateTime<Utc> should map to Date. Got: {ts}"
     );
 }
 
@@ -205,8 +226,8 @@ fn test_datetime_utc_typescript() {
 fn test_datetime_local_typescript() {
     let ts = LocalTimestamp::ts_definition();
     assert!(
-        ts.contains("local_time: string;"),
-        "DateTime<Local> should map to string. Got: {ts}"
+        ts.contains("local_time: Date;"),
+        "DateTime<Local> should map to Date. Got: {ts}"
     );
 }
 
@@ -215,8 +236,8 @@ fn test_datetime_local_typescript() {
 fn test_optional_datetime_typescript() {
     let ts = OptionalTimestamp::ts_definition();
     assert!(
-        ts.contains("updated_at: string | undefined;"),
-        "Option<DateTime<Utc>> should map to string | undefined. Got: {ts}"
+        ts.contains("updated_at: Date | undefined;"),
+        "Option<DateTime<Utc>> should map to Date | undefined. Got: {ts}"
     );
 }
 
@@ -235,8 +256,8 @@ fn test_vec_date_typescript() {
 fn test_hashmap_datetime_typescript() {
     let ts = DateMap::ts_definition();
     assert!(
-        ts.contains("events: Partial<Record<string, string>>;"),
-        "HashMap<String, DateTime<Utc>> should map to Partial<Record<string, string>>. Got: {ts}"
+        ts.contains("events: Partial<Record<string, Date>>;"),
+        "HashMap<String, DateTime<Utc>> should map to Partial<Record<string, Date>>. Got: {ts}"
     );
 }
 
@@ -257,12 +278,12 @@ fn test_all_chrono_types_typescript() {
         "NaiveDateTime should be string. Got: {ts}"
     );
     assert!(
-        ts.contains("utc_datetime: string;"),
-        "DateTime<Utc> should be string. Got: {ts}"
+        ts.contains("utc_datetime: Date;"),
+        "DateTime<Utc> should be Date. Got: {ts}"
     );
     assert!(
-        ts.contains("local_timestamp: string;"),
-        "DateTime<Local> should be string. Got: {ts}"
+        ts.contains("local_timestamp: Date;"),
+        "DateTime<Local> should be Date. Got: {ts}"
     );
 }
 
@@ -283,8 +304,12 @@ fn test_naive_date_zod() {
 fn test_naive_time_zod() {
     let zod = Schedule::zod_schema();
     assert!(
-        zod.contains("start_time: z.iso.time(),"),
-        "NaiveTime should use z.iso.time(). Got: {zod}"
+        zod.contains("start_time: z.preprocess((arg) =>"),
+        "NaiveTime should be wrapped in a millis-accepting preprocessor. Got: {zod}"
+    );
+    assert!(
+        zod.contains("}, z.iso.time()),"),
+        "NaiveTime preprocessor should validate with z.iso.time(). Got: {zod}"
     );
 }
 
@@ -303,8 +328,8 @@ fn test_naive_datetime_zod() {
 fn test_datetime_utc_zod() {
     let zod = TimestampedRecord::zod_schema();
     assert!(
-        zod.contains("created_at: z.iso.datetime({ offset: true }),"),
-        "DateTime<Utc> should use z.iso.datetime({{ offset: true }}). Got: {zod}"
+        zod.contains("created_at: z.coerce.date(),"),
+        "DateTime<Utc> should use z.coerce.date(). Got: {zod}"
     );
 }
 
@@ -313,8 +338,8 @@ fn test_datetime_utc_zod() {
 fn test_datetime_local_zod() {
     let zod = LocalTimestamp::zod_schema();
     assert!(
-        zod.contains("local_time: z.iso.datetime({ offset: true }),"),
-        "DateTime<Local> should use z.iso.datetime({{ offset: true }}). Got: {zod}"
+        zod.contains("local_time: z.coerce.date(),"),
+        "DateTime<Local> should use z.coerce.date(). Got: {zod}"
     );
 }
 
@@ -323,10 +348,8 @@ fn test_datetime_local_zod() {
 fn test_optional_datetime_zod() {
     let zod = OptionalTimestamp::zod_schema();
     assert!(
-        zod.contains(
-            "updated_at: z.union([z.iso.datetime({ offset: true }), z.undefined()]).prefault(undefined),"
-        ),
-        "Option<DateTime<Utc>> should use z.union([...datetime({{ offset: true }}), z.undefined()]). Got: {zod}"
+        zod.contains("updated_at: z.union([z.coerce.date(), z.undefined()]).prefault(undefined),"),
+        "Option<DateTime<Utc>> should use z.union([z.coerce.date(), z.undefined()]). Got: {zod}"
     );
 }
 
@@ -345,8 +368,8 @@ fn test_vec_date_zod() {
 fn test_hashmap_datetime_zod() {
     let zod = DateMap::zod_schema();
     assert!(
-        zod.contains("events: z.record(z.string(), z.iso.datetime({ offset: true })),"),
-        "HashMap<String, DateTime<Utc>> should use z.record(z.string(), z.iso.datetime({{ offset: true }})). Got: {zod}"
+        zod.contains("events: z.record(z.string(), z.coerce.date()),"),
+        "HashMap<String, DateTime<Utc>> should use z.record(z.string(), z.coerce.date()). Got: {zod}"
     );
 }
 
@@ -456,4 +479,92 @@ fn test_chrono_compilation_smoke_test() {
     assert_eq!(event.name, "Test Event");
     assert_eq!(schedule.task, "Meeting");
     assert!(!timestamp.id.is_empty());
+}
+
+// ========== as_number opt-out + native Date default ==========
+
+#[test]
+#[cfg(feature = "typescript")]
+fn test_sample_typescript_mixes_date_and_number() {
+    let ts = Sample::ts_definition();
+    assert!(
+        ts.contains("due_at: Date;"),
+        "default DateTime<Utc> should be Date. Got: {ts}"
+    );
+    assert!(
+        ts.contains("created_at: number;"),
+        "as_number DateTime<Utc> should be number. Got: {ts}"
+    );
+    assert!(
+        ts.contains("start_time: string;"),
+        "NaiveTime should stay string. Got: {ts}"
+    );
+}
+
+#[test]
+#[cfg(feature = "zod")]
+fn test_sample_zod_mixes_coerce_date_and_inline_number() {
+    let zod = Sample::zod_schema();
+    assert!(
+        zod.contains("due_at: z.coerce.date(),"),
+        "default DateTime<Utc> should use z.coerce.date(). Got: {zod}"
+    );
+    assert!(
+        zod.contains("created_at: z.preprocess((arg) =>"),
+        "as_number DateTime<Utc> should use an inline preprocess arrow. Got: {zod}"
+    );
+    assert!(
+        zod.contains("arg instanceof Date) return arg.getTime();"),
+        "as_number coercer should map Date -> getTime(). Got: {zod}"
+    );
+    assert!(
+        zod.contains("}, z.number()),"),
+        "as_number coercer should validate with z.number(). Got: {zod}"
+    );
+    // It must not fall back to the ISO datetime renderer or a named fn.
+    assert!(
+        !zod.contains("created_at: z.iso.datetime"),
+        "as_number field must not use z.iso.datetime. Got: {zod}"
+    );
+}
+
+#[test]
+#[cfg(feature = "typescript")]
+fn test_tuple_variant_datetime_honors_as_number() {
+    let ts = DynamicValue::ts_definition();
+    assert!(
+        ts.contains("Date"),
+        "Native variant payload should render Date. Got: {ts}"
+    );
+    assert!(
+        ts.contains("number"),
+        "Number variant payload should render number via as_number. Got: {ts}"
+    );
+}
+
+#[test]
+#[cfg(feature = "zod")]
+fn test_tuple_variant_datetime_zod_honors_as_number() {
+    let zod = DynamicValue::zod_schema();
+    assert!(
+        zod.contains("z.coerce.date()"),
+        "Native variant payload should use z.coerce.date(). Got: {zod}"
+    );
+    assert!(
+        zod.contains("}, z.number())"),
+        "Number variant payload should use the inline as_number coercer. Got: {zod}"
+    );
+}
+
+#[test]
+fn test_as_number_types_constructible() {
+    let dt = DateTime::<Utc>::from_timestamp(0, 0).unwrap();
+    let sample = Sample {
+        created_at: dt,
+        due_at: dt,
+        start_time: NaiveTime::from_hms_opt(0, 0, 0).unwrap(),
+    };
+    assert_eq!(sample.created_at, dt);
+    let values = [DynamicValue::Native(dt), DynamicValue::Number(dt)];
+    assert_eq!(values.len(), 2);
 }


### PR DESCRIPTION
`DateTime<Tz>` now maps to TypeScript `Date` / Zod `z.coerce.date()` by default (was `string`). The new `#[model_schema_prop(as_number)]` flag opts back into `number` with an epoch-coercing preprocessor; it is a compile error on any non-`DateTime` field. `NaiveTime` now also accepts milliseconds-since-start-of-day via an inline preprocessor wrapping `z.iso.time()`.

`NaiveDate`/`NaiveDateTime` rendering and the `DateTime` JSON Schema (`string`/`date-time`) are unchanged.

**Breaking output change:** consumers of the previously-generated `string` datetime schema now receive `Date`.

`just all` green (lint + 68-combo lint-all + full powerset tests + doctests).
