### PR TITLE
feat: render tuple-element Option as nullable

### DIFF
--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -130,7 +130,8 @@ pub enum FieldDefType {
 /// `model_schema.rs` to build the full type definitions.
 ///
 /// Fields:
-/// - `is_optional`: If true, adds | undefined in TS and z.union([type, `z.undefined()`]) in Zod (v4 syntax)
+/// - `is_optional`: In struct-field position, adds `| undefined` / `z.union([type, z.undefined()])`.
+///   In tuple-element position, adds `| null` / `z.nullable(type)` — a positional `None` serializes as `null`.
 /// - name: Safe field name (uses serde rename if feature enabled)
 /// - docs: Doc comments from Rust - included in generated TS as `JSDoc`
 /// - `field_type`: The core type classification (see `FieldDefType`)
@@ -291,31 +292,24 @@ impl FieldDef {
         if self.has_ts_optional() { "?" } else { "" }
     }
 
-    /// Generates the TypeScript type name for this field.
-    ///
-    /// This method is the core of TypeScript type generation. It recursively builds
-    /// the TS type string based on `field_type`, `is_array`, and `is_optional`.
-    ///
-    /// Process:
-    /// 1. Match on `field_type` to get base type
-    /// 2. If `is_array`, wrap in Array<...>
-    /// 3. If `is_optional`, add | undefined
-    ///
-    /// Feature notes:
-    /// - "`object_id"`: Uses special `ObjectId` type
-    /// - Ignores `model_schema_prop_meta` currently (except implicitly through `field_type`)
-    /// - For `StringLiteral`, generates quoted string literal
-    /// - All Rust numbers map to 'number' in TS
-    ///
-    /// See generation/typescript.rs for how this is used in full type defs.
-    /// Examples in README.md show generated output.
-    pub fn typescript_typename(&self) -> String {
+    /// Builds the TypeScript type before the struct-field optional wrap: the type match
+    /// plus the `is_array` wrap. The `| undefined` wrap lives in `typescript_typename`.
+    /// An optional tuple element is null-flavored here (`{base} | null`): a positional
+    /// slot cannot be omitted, so serde emits `null` for a `None`.
+    fn typescript_base(&self) -> String {
         let result = match &self.field_type {
             FieldDefType::Unknown => "unknown".to_owned(),
             FieldDefType::Tuple(lst) => {
                 let elements = lst
                     .iter()
-                    .map(Self::typescript_typename)
+                    .map(|element| {
+                        let base = element.typescript_base();
+                        if element.is_optional {
+                            format!("{base} | null")
+                        } else {
+                            base
+                        }
+                    })
                     .collect::<Vec<_>>()
                     .join(", ");
                 format!("[{elements}]")
@@ -384,12 +378,34 @@ impl FieldDef {
                 }
             }
         };
-        let pre_result = if self.is_array {
+        if self.is_array {
             format!("Array<{result}>")
         } else {
             result
-        };
+        }
+    }
 
+    /// Generates the TypeScript type name for this field.
+    ///
+    /// This method is the core of TypeScript type generation. It recursively builds
+    /// the TS type string based on `field_type`, `is_array`, and `is_optional`.
+    ///
+    /// Process:
+    /// 1. Match on `field_type` to get base type
+    /// 2. If `is_array`, wrap in Array<...>
+    /// 3. If `is_optional`: struct-field position adds `| undefined`; tuple-element position adds `| null`
+    ///    (a positional `None` serializes as `null`, so a tuple slot cannot be omitted like an object key)
+    ///
+    /// Feature notes:
+    /// - "`object_id"`: Uses special `ObjectId` type
+    /// - Ignores `model_schema_prop_meta` currently (except implicitly through `field_type`)
+    /// - For `StringLiteral`, generates quoted string literal
+    /// - All Rust numbers map to 'number' in TS
+    ///
+    /// See generation/typescript.rs for how this is used in full type defs.
+    /// Examples in README.md show generated output.
+    pub fn typescript_typename(&self) -> String {
+        let pre_result = self.typescript_base();
         if self.is_optional {
             // `ts_optional` renders the key as `field?: T`, so the `| undefined` is redundant.
             if self.has_ts_optional() {
@@ -402,69 +418,26 @@ impl FieldDef {
         }
     }
 
+    /// Builds the Zod schema before the struct-field optional wrap: the type match, the
+    /// `is_array` wrap, and the preprocess wrap. The
+    /// `z.union([…, z.undefined()]).prefault(undefined)` wrap lives in `zod_type`. An
+    /// optional tuple element is null-flavored here (`z.nullable({base})`): a positional
+    /// slot cannot be omitted, so serde emits `null` for a `None`.
     #[cfg(feature = "zod")]
-    /// Generates the Zod schema string for this field (requires "zod" feature).
-    ///
-    /// Similar to `typescript_typename()` but generates Zod validation schema.
-    /// Uses z.* functions appropriate to the type.
-    ///
-    /// Additional logic:
-    /// - For String: Adds .`min(min_len)` if `model_schema_prop_meta` has `min_length`
-    /// - For literals: Uses z.literal(...)
-    /// - For `ObjectId`: Uses regex validation for hex string
-    /// - Wraps with `z.array()` if `is_array`
-    /// - Adds z.union([type, `z.undefined()`]) if `is_optional` (Zod v4 syntax)
-    ///
-    /// Requires Zod v4 in frontend - generates v4-compatible syntax.
-    /// See `notes/20250706_features.md` for Zod feature details.
-    /// Builds the Zod schema string for a numeric field, applying any min/max constraints.
-    #[cfg(feature = "zod")]
-    fn zod_number_type(&self, base: &str) -> String {
-        let mut result = base.to_owned();
-        if let Some(meta) = &self.model_schema_prop_meta {
-            if let Some(min) = meta.minimum {
-                result = format!("{result}.min({min})");
-            }
-            if let Some(max) = meta.maximum {
-                result = format!("{result}.max({max})");
-            }
-        }
-        result
-    }
-
-    /// Builds the Zod schema string for a string field, applying any length/pattern constraints.
-    #[cfg(feature = "zod")]
-    fn zod_string_type(&self) -> String {
-        let mut result = "z.string()".to_owned();
-        // Add min length validation if specified
-        if let Some(meta) = &self.model_schema_prop_meta
-            && let Some(min_len) = meta.min_length
-        {
-            result = format!("{result}.min({min_len})");
-        }
-        // Add max length validation if specified
-        if let Some(meta) = &self.model_schema_prop_meta
-            && let Some(max_len) = meta.max_length
-        {
-            result = format!("{result}.max({max_len})");
-        }
-        // Add pattern validation if specified
-        if let Some(meta) = &self.model_schema_prop_meta
-            && let Some(pattern) = &meta.pattern
-        {
-            result = format!("{result}.check(z.regex(/{pattern}/))");
-        }
-        result
-    }
-
-    #[cfg(feature = "zod")]
-    pub fn zod_type(&self) -> String {
+    fn zod_base(&self) -> String {
         let result = match &self.field_type {
             FieldDefType::Unknown => "z.unknown()".to_owned(),
             FieldDefType::Tuple(lst) => {
                 let elements = lst
                     .iter()
-                    .map(Self::zod_type)
+                    .map(|element| {
+                        let base = element.zod_base();
+                        if element.is_optional {
+                            format!("z.nullable({base})")
+                        } else {
+                            base
+                        }
+                    })
                     .collect::<Vec<_>>()
                     .join(", ");
                 format!("z.tuple([{elements}])")
@@ -528,7 +501,7 @@ impl FieldDef {
         };
 
         // Wrap with preprocess if specified
-        let pre_result = if let Some(meta) = &self.model_schema_prop_meta
+        if let Some(meta) = &self.model_schema_prop_meta
             && !meta.preprocess.is_empty()
         {
             let mut wrapped = array_result;
@@ -538,8 +511,67 @@ impl FieldDef {
             wrapped
         } else {
             array_result
-        };
+        }
+    }
 
+    /// Builds the Zod schema string for a numeric field, applying any min/max constraints.
+    #[cfg(feature = "zod")]
+    fn zod_number_type(&self, base: &str) -> String {
+        let mut result = base.to_owned();
+        if let Some(meta) = &self.model_schema_prop_meta {
+            if let Some(min) = meta.minimum {
+                result = format!("{result}.min({min})");
+            }
+            if let Some(max) = meta.maximum {
+                result = format!("{result}.max({max})");
+            }
+        }
+        result
+    }
+
+    /// Builds the Zod schema string for a string field, applying any length/pattern constraints.
+    #[cfg(feature = "zod")]
+    fn zod_string_type(&self) -> String {
+        let mut result = "z.string()".to_owned();
+        // Add min length validation if specified
+        if let Some(meta) = &self.model_schema_prop_meta
+            && let Some(min_len) = meta.min_length
+        {
+            result = format!("{result}.min({min_len})");
+        }
+        // Add max length validation if specified
+        if let Some(meta) = &self.model_schema_prop_meta
+            && let Some(max_len) = meta.max_length
+        {
+            result = format!("{result}.max({max_len})");
+        }
+        // Add pattern validation if specified
+        if let Some(meta) = &self.model_schema_prop_meta
+            && let Some(pattern) = &meta.pattern
+        {
+            result = format!("{result}.check(z.regex(/{pattern}/))");
+        }
+        result
+    }
+
+    #[cfg(feature = "zod")]
+    /// Generates the Zod schema string for this field (requires "zod" feature).
+    ///
+    /// Similar to `typescript_typename()` but generates Zod validation schema.
+    /// Uses z.* functions appropriate to the type.
+    ///
+    /// Additional logic:
+    /// - For String: Adds .`min(min_len)` if `model_schema_prop_meta` has `min_length`
+    /// - For literals: Uses z.literal(...)
+    /// - For `ObjectId`: Uses regex validation for hex string
+    /// - Wraps with `z.array()` if `is_array`
+    /// - If `is_optional`: struct-field position wraps `z.union([type, z.undefined()])`;
+    ///   tuple-element position wraps `z.nullable(type)` (a positional `None` serializes as `null`)
+    ///
+    /// Requires Zod v4 in frontend - generates v4-compatible syntax.
+    /// See `notes/20250706_features.md` for Zod feature details.
+    pub fn zod_type(&self) -> String {
+        let pre_result = self.zod_base();
         if self.is_optional {
             format!("z.union([{pre_result}, z.undefined()]).prefault(undefined)")
         } else {

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -2771,9 +2771,11 @@ fn write_tuple_multiple_variant_fields(
     let _: &_ = &&json_schema_variant_fields;
 }
 
-/// Builds JSON schema for a tuple element (used for single tuple and multi-tuple variants).
+/// Builds the base JSON schema for a tuple element, ignoring `is_optional`.
+///
+/// The nullable wrap is applied by `build_tuple_element_json_schema`.
 #[cfg(feature = "jsonschema")]
-fn build_tuple_element_json_schema(fld: &FieldDef) -> proc_macro2::TokenStream {
+fn build_tuple_element_base_json_schema(fld: &FieldDef) -> proc_macro2::TokenStream {
     let field_type = &fld.field_type;
 
     match field_type {
@@ -2872,6 +2874,23 @@ fn build_tuple_element_json_schema(fld: &FieldDef) -> proc_macro2::TokenStream {
             // For unknown/sibling types, use a generic object schema
             quote! { serde_json::json!({ "type": "object" }) }
         }
+    }
+}
+
+/// Builds JSON schema for a tuple element (used for single tuple and multi-tuple variants).
+///
+/// An `Option` element renders as `anyOf [<base>, null]`: a tuple slot is positional, so
+/// serde serializes `None` as JSON `null` (the slot cannot be omitted the way an object key
+/// can).
+#[cfg(feature = "jsonschema")]
+fn build_tuple_element_json_schema(fld: &FieldDef) -> proc_macro2::TokenStream {
+    let base = build_tuple_element_base_json_schema(fld);
+    if fld.is_optional {
+        quote! {
+            serde_json::json!({ "anyOf": [#base, { "type": "null" }] })
+        }
+    } else {
+        base
     }
 }
 

--- a/tests/tuple_field_tests/tests.rs
+++ b/tests/tuple_field_tests/tests.rs
@@ -184,3 +184,199 @@ fn test_optional_tuple_field_zod() {
         "Expected optional tuple wrapping. Got: {zod}"
     );
 }
+
+// The remargin compact-row shape is `Vec<(Option<String>, Vec<usize>, String,
+// Option<String>)>`. That exact struct field trips `clippy::type_complexity`
+// (the outer `Vec` + nested `Vec<usize>` + 4 elements together clear the
+// threshold), and factoring it into a `type` alias would make the macro treat it
+// as a sibling reference rather than a tuple — so the happy path is proven in two
+// composable halves: the exact inner tuple below (all four slots, including
+// `Vec<usize>` → `Array<number>` and both `Option` → null), and the outer
+// `Vec` → `Array<[...]>` wrap in `test_tuple_element_option_array_wrap`. The wire
+// round-trip exercises the full shape through a `type` alias, which serde reads
+// natively.
+
+/// Null-flavor happy path (TS): each `Option` element inside a tuple renders as
+/// `T | null` — a positional slot serializes `None` as JSON `null`, unlike an
+/// omittable object key. Also the scenario-5 negative guard: a required tuple
+/// field emits no `undefined` at all.
+#[test]
+fn test_tuple_element_option_null_flavor_ts() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct Row {
+        pub row: (Option<String>, Vec<usize>, String, Option<String>),
+    }
+
+    let ts = Row::ts_definition();
+    assert!(
+        ts.contains("row: [string | null, Array<number>, string, string | null]"),
+        "Expected null-flavored tuple elements in TS. Got: {ts}"
+    );
+    assert!(
+        !ts.contains("undefined"),
+        "A required tuple field must not emit `undefined`. Got: {ts}"
+    );
+}
+
+/// Null-flavor happy path (Zod): each tuple-element `Option<T>` renders as
+/// `z.nullable(T)`, and the required field emits no `z.undefined()`.
+#[cfg(feature = "zod")]
+#[test]
+fn test_tuple_element_option_null_flavor_zod() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct Row {
+        pub row: (Option<String>, Vec<usize>, String, Option<String>),
+    }
+
+    let zod = Row::zod_schema();
+    assert!(
+        zod.contains(
+            "row: z.tuple([z.nullable(z.string()), z.array(z.number().int()), z.string(), z.nullable(z.string())])"
+        ),
+        "Expected z.nullable tuple elements in Zod. Got: {zod}"
+    );
+    assert!(
+        !zod.contains("undefined"),
+        "A required tuple field must not emit `undefined`. Got: {zod}"
+    );
+}
+
+/// Null-flavor happy path (JSON Schema): each optional slot becomes
+/// `anyOf [<base>, null]`; arity (`minItems`/`maxItems`) stays 4 — nullability
+/// never changes item count.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn test_tuple_element_option_null_flavor_json_schema() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct Row {
+        pub row: (Option<String>, Vec<usize>, String, Option<String>),
+    }
+
+    let schema = Row::json_schema();
+    let tuple = &schema["properties"]["row"];
+
+    assert_eq!(tuple["type"].as_str(), Some("array"));
+    assert_eq!(tuple["items"].as_bool(), Some(false));
+    assert_eq!(tuple["minItems"].as_u64(), Some(4));
+    assert_eq!(tuple["maxItems"].as_u64(), Some(4));
+
+    let prefix = tuple["prefixItems"].as_array().unwrap();
+    assert_eq!(prefix.len(), 4, "Arity stays 4. Got: {prefix:?}");
+
+    let nullable_string =
+        serde_json::json!({ "anyOf": [{ "type": "string" }, { "type": "null" }] });
+    assert_eq!(
+        prefix[0], nullable_string,
+        "Slot 0 (Option<String>) should be anyOf null. Got: {}",
+        prefix[0]
+    );
+    assert_eq!(
+        prefix[3], nullable_string,
+        "Slot 3 (Option<String>) should be anyOf null. Got: {}",
+        prefix[3]
+    );
+    // Non-optional slots stay plain — no null wrapping.
+    assert_eq!(
+        prefix[1],
+        serde_json::json!({ "type": "array", "items": { "type": "integer" } })
+    );
+    assert_eq!(prefix[2], serde_json::json!({ "type": "string" }));
+}
+
+/// Array-wrap composition (TS): a `Vec<(Option<Vec<usize>>, String)>` field wraps
+/// the tuple in `Array<[...]>`, and the null flavor survives the wrap. The
+/// `Option<Vec<usize>>` slot proves the array wrap happens inside the base with
+/// `null` on top: `Array<number> | null`.
+#[test]
+fn test_tuple_element_option_array_wrap_ts() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct Rows {
+        pub pair: Vec<(Option<Vec<usize>>, String)>,
+    }
+
+    let ts = Rows::ts_definition();
+    assert!(
+        ts.contains("pair: Array<[Array<number> | null, string]>"),
+        "Expected outer Array wrap over null-flavored tuple in TS. Got: {ts}"
+    );
+    assert!(
+        !ts.contains("undefined"),
+        "A required tuple field must not emit `undefined`. Got: {ts}"
+    );
+}
+
+/// Array-wrap composition (Zod): `z.array(z.tuple([...]))` with the null flavor
+/// preserved under the array wrap.
+#[cfg(feature = "zod")]
+#[test]
+fn test_tuple_element_option_array_wrap_zod() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct Rows {
+        pub pair: Vec<(Option<Vec<usize>>, String)>,
+    }
+
+    let zod = Rows::zod_schema();
+    assert!(
+        zod.contains("pair: z.array(z.tuple([z.nullable(z.array(z.number().int())), z.string()]))"),
+        "Expected z.array wrap over null-flavored tuple in Zod. Got: {zod}"
+    );
+    assert!(
+        !zod.contains("undefined"),
+        "A required tuple field must not emit `undefined`. Got: {zod}"
+    );
+}
+
+/// Array-wrap composition (JSON Schema): the outer `Vec` becomes
+/// `{ type: array, items: <tuple schema> }`, and the optional slot keeps its
+/// `anyOf [<array>, null]` flavor.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn test_tuple_element_option_array_wrap_json_schema() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct Rows {
+        pub pair: Vec<(Option<Vec<usize>>, String)>,
+    }
+
+    let schema = Rows::json_schema();
+    let outer = &schema["properties"]["pair"];
+    assert_eq!(outer["type"].as_str(), Some("array"));
+
+    let tuple = &outer["items"];
+    assert_eq!(tuple["minItems"].as_u64(), Some(2));
+    assert_eq!(tuple["maxItems"].as_u64(), Some(2));
+
+    let prefix = tuple["prefixItems"].as_array().unwrap();
+    assert_eq!(
+        prefix[0],
+        serde_json::json!({
+            "anyOf": [{ "type": "array", "items": { "type": "integer" } }, { "type": "null" }]
+        }),
+        "Slot 0 (Option<Vec<usize>>) should be anyOf [array, null]. Got: {}",
+        prefix[0]
+    );
+}
+
+/// Wire round-trip: serde emits `null` for a `None` tuple slot and reads it back
+/// as `None`. This is the behavior the null-flavored schemas describe, exercised
+/// on the exact remargin row shape (a `type` alias, so serde handles it natively).
+#[test]
+fn test_tuple_element_option_serde_roundtrip() {
+    type Row = (Option<String>, Vec<usize>, String, Option<String>);
+
+    let row: Row = (None, vec![26_usize], "internal_report.md".to_owned(), None);
+    let json = serde_json::to_value(&row).unwrap();
+    assert_eq!(
+        json,
+        serde_json::json!([null, [26_i64], "internal_report.md", null]),
+        "None tuple slots must serialize as null. Got: {json}"
+    );
+
+    let back: Row = serde_json::from_value(json).unwrap();
+    assert_eq!(back, row, "null must deserialize back to None");
+}

--- a/tests/tuple_variant_tests/tests.rs
+++ b/tests/tuple_variant_tests/tests.rs
@@ -648,6 +648,49 @@ fn test_empty_tuple_variant() {
     // This is verified by ensuring the total schema structure is correct
 }
 
+/// Test 16: enum tuple variant with an `Option` element gets null flavor in the
+/// generated JSON Schema, via the same shared element builder used by struct
+/// tuple fields. A positional tuple slot serializes `None` as `null`, so the
+/// optional element renders `anyOf [<base>, null]`; arity is unchanged.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn test_optional_tuple_variant_element_json_schema_null_flavor() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub enum Row {
+        Link(Option<String>, Vec<usize>, String, Option<String>),
+    }
+
+    let schema = Row::json_schema();
+    let variant = schema["oneOf"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|member| member["properties"]["type"]["const"] == "Link")
+        .unwrap();
+
+    let value = &variant["properties"]["value"];
+    assert_eq!(value["type"].as_str(), Some("array"));
+
+    let prefix = value["prefixItems"].as_array().unwrap();
+    assert_eq!(prefix.len(), 4, "Arity stays 4. Got: {prefix:?}");
+
+    let nullable_string =
+        serde_json::json!({ "anyOf": [{ "type": "string" }, { "type": "null" }] });
+    assert_eq!(
+        prefix[0], nullable_string,
+        "Slot 0 (Option<String>) should be anyOf null. Got: {}",
+        prefix[0]
+    );
+    assert_eq!(
+        prefix[3], nullable_string,
+        "Slot 3 (Option<String>) should be anyOf null. Got: {}",
+        prefix[3]
+    );
+    // Non-optional slot stays plain — no null wrapping.
+    assert_eq!(prefix[2], serde_json::json!({ "type": "string" }));
+}
+
 /// Test 15: `JSDoc` comments in generated TypeScript.
 #[test]
 fn test_jsdoc_comments() {


### PR DESCRIPTION
## What

An `Option<T>` appearing as an element *inside* a tuple's parentheses — `(Option<String>, …)` — now renders **null-flavored**:

- **TS:** `T | null`
- **Zod:** `z.nullable(T)`
- **JSON Schema:** `{ "anyOf": [<base>, { "type": "null" }] }`

Struct-field `Option<T>` rendering is **unchanged** (still undefined-flavored: `| undefined` / `z.union([…, z.undefined()])` / omittable key).

## Why

Serialization behavior changes nowhere — this is purely a schema-description fix. A positional tuple slot cannot be omitted, so serde emits `null` for a `None` element (`(None, vec![26], "x", None)` → `[null,[26],"x",null]`), while the generated schemas previously described that same slot as `| undefined` / required — rejecting tixschema's own valid wire output. This mirrors JS itself: `JSON.stringify` drops `undefined` object properties but converts `undefined` array elements to `null`.

## How

- `src/field_type.rs`: extracted `typescript_base()` / `zod_base()` (everything before the struct-field optional wrap); the `| undefined` / `z.union(...)` wrap stays in `typescript_typename()` / `zod_type()` unchanged. The tuple arms null-flavor optional elements.
- `src/model_schema.rs`: renamed the tuple-element builder to `build_tuple_element_base_json_schema()` (body untouched) and added a thin `anyOf`-null wrapper under the original name, so all three call sites (struct tuple fields + enum single/multi tuple variants) pick it up. Enum tuple variants share this JSON Schema builder.
- Docs: `is_optional` now documents the struct-vs-tuple context rule.

## Scope note

The shared JSON Schema builder gives enum tuple variants the null flavor too. Enum-variant **TS/Zod** render through a different path (`typescript_typename`/`zod_type` per element) and stay undefined-flavored — matching the existing `test_optional_in_tuple`. `Vec<Option<T>>` (null inside a plain array) is out of scope.

## Tests

New coverage in `tests/tuple_field_tests/tests.rs` and `tests/tuple_variant_tests/tests.rs`: TS/Zod/JSON-Schema null flavor on the exact remargin row shape, nested `Option<Vec<usize>>` array-wrap composition, serde wire round-trip, a negative guard (no `undefined` inside a tuple literal), and an enum-variant JSON-Schema case. The struct-field regression anchor `test_optional_tuple_field_zod` is untouched. `just all` (powerset lint + 32-combo powerset tests) is green.