### PR TITLE
feat: generate real Zod $Schema for #[model_schema] type aliases

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -217,7 +217,7 @@ fn process_type_alias(item_type: ItemType, args: &ModelSchemaArgs) -> TokenStrea
     let ts_method =
         generate_ts_alias_method(&docs_formatted, &export_name, &generics, &alias_field_def);
     let json_schema_method = generate_alias_json_schema_stub();
-    let zod_method = generate_alias_zod_stub();
+    let zod_method = generate_alias_zod_method(&export_name, &alias_field_def);
 
     let output = quote! {
         #alias
@@ -4703,12 +4703,30 @@ fn generate_alias_json_schema_stub() -> proc_macro2::TokenStream {
 }
 
 #[cfg(feature = "typescript")]
-fn generate_alias_zod_stub() -> proc_macro2::TokenStream {
-    quote! {
-        #[cfg(feature = "zod")]
-        pub fn zod_schema() -> String {
-            String::from("// Zod schema generation for aliases is not yet supported")
+fn generate_alias_zod_method(export_name: &str, field_def: &FieldDef) -> proc_macro2::TokenStream {
+    #[cfg(feature = "zod")]
+    {
+        // The alias's rendered Zod is its FieldDef expression (a tuple alias yields
+        // the null-flavored `z.tuple([...])`, a scalar yields `z.string()`, a sibling
+        // yields `Name$Schema`). Bind it to `$RawSchema` and re-export the annotated
+        // `$Schema`, mirroring how struct/enum schemas expose their const.
+        let schema_code = field_def.zod_type();
+        quote! {
+            #[cfg(feature = "zod")]
+            pub fn zod_schema() -> String {
+                format!(
+                    "const {}$RawSchema = {};\n\nexport const {}$Schema: ZodType<{}> = {}$RawSchema;",
+                    #export_name, #schema_code, #export_name, #export_name, #export_name
+                )
+            }
         }
+    }
+    #[cfg(not(feature = "zod"))]
+    {
+        // Without the `zod` feature, `FieldDef::zod_type` does not exist; nothing in
+        // this build has zod enabled, so the schema method would be cfg'd out anyway.
+        let _: &_ = &(export_name, field_def);
+        quote! {}
     }
 }
 

--- a/tests/semantic_types_tests/tests.rs
+++ b/tests/semantic_types_tests/tests.rs
@@ -14,6 +14,13 @@ use tixschema::model_schema;
 #[model_schema(name = "AuditId")]
 pub type AuditId = OrderId;
 
+/// Tuple type alias mirroring remargin's compact link row: two optional string
+/// slots (null-flavored inside a positional tuple), a `Vec<usize>`, and a
+/// required string.
+#[cfg(all(test, feature = "typescript"))]
+#[model_schema(name = "CompactLinkRow")]
+pub type CompactLinkRow = (Option<String>, Vec<usize>, String, Option<String>);
+
 /// Simple string-based type alias.
 #[cfg(all(test, feature = "typescript"))]
 #[model_schema(name = "DocumentId")]
@@ -84,6 +91,13 @@ struct ComplexAliasStruct {
     mapped_scores: HashMap<String, Vec<Score>>,
     nested_ids: Vec<Vec<DocumentId>>,
     optional_id: Option<DocumentId>,
+}
+
+#[cfg(all(test, feature = "zod", feature = "typescript", feature = "serde"))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct CompactRowHolder {
+    rows: Vec<CompactLinkRow>,
 }
 
 #[cfg(all(test, feature = "typescript", feature = "serde"))]
@@ -197,6 +211,21 @@ fn test_vec_alias_typescript() {
     assert!(
         ts.contains("export type Tags = Array<string>;"),
         "Should generate Array type alias. Got: {ts}"
+    );
+}
+
+#[test]
+#[cfg(feature = "typescript")]
+fn test_tuple_alias_typescript() {
+    let row: CompactLinkRow = (None, Vec::new(), String::new(), None);
+    assert!(row.0.is_none());
+    let ts = compact_link_row_schema::Schema::ts_definition();
+
+    assert!(
+        ts.contains(
+            "export type CompactLinkRow = [string | null, Array<number>, string, string | null];"
+        ),
+        "Tuple alias should render a null-flavored TS tuple. Got: {ts}"
     );
 }
 
@@ -348,14 +377,63 @@ fn test_alias_in_hashmap() {
 
 #[test]
 #[cfg(all(feature = "zod", feature = "typescript"))]
-fn test_alias_zod_schema_exists() {
-    // Zod schema generation for aliases currently returns a stub
+fn test_scalar_alias_zod_schema() {
     let zod = document_id_schema::Schema::zod_schema();
 
-    // Verify the method exists and returns something
     assert!(
-        !zod.is_empty(),
-        "Zod schema should return a non-empty string"
+        zod.contains("const DocumentId$RawSchema = z.string();"),
+        "Scalar alias should bind its Zod to $RawSchema. Got: {zod}"
+    );
+    assert!(
+        zod.contains("export const DocumentId$Schema: ZodType<DocumentId> = DocumentId$RawSchema;"),
+        "Scalar alias should re-export an annotated $Schema. Got: {zod}"
+    );
+    assert!(
+        !zod.contains("not yet supported"),
+        "Alias Zod must no longer be a stub. Got: {zod}"
+    );
+}
+
+/// Tuple alias emits a valid `$Schema` whose Zod is the null-flavored tuple —
+/// the exact shape a struct field `Vec<CompactLinkRow>` references.
+#[test]
+#[cfg(all(feature = "zod", feature = "typescript"))]
+fn test_tuple_alias_zod_schema() {
+    let zod = compact_link_row_schema::Schema::zod_schema();
+
+    assert!(
+        zod.contains(
+            "const CompactLinkRow$RawSchema = z.tuple([z.nullable(z.string()), z.array(z.number().int()), z.string(), z.nullable(z.string())]);"
+        ),
+        "Tuple alias should render the null-flavored z.tuple. Got: {zod}"
+    );
+    assert!(
+        zod.contains(
+            "export const CompactLinkRow$Schema: ZodType<CompactLinkRow> = CompactLinkRow$RawSchema;"
+        ),
+        "Tuple alias should re-export an annotated $Schema. Got: {zod}"
+    );
+    assert!(
+        !zod.contains("not yet supported"),
+        "Alias Zod must no longer be a stub. Got: {zod}"
+    );
+}
+
+/// A struct field `Vec<CompactLinkRow>` references the alias's now-defined
+/// `$Schema` via `z.array(...)` in Zod and `Array<...>` in TS.
+#[test]
+#[cfg(all(feature = "zod", feature = "typescript", feature = "serde"))]
+fn test_vec_of_alias_references_schema() {
+    let zod = CompactRowHolder::zod_schema();
+    assert!(
+        zod.contains("rows: z.array(CompactLinkRow$Schema)"),
+        "Vec<CompactLinkRow> should reference the alias $Schema. Got: {zod}"
+    );
+
+    let ts = CompactRowHolder::ts_definition();
+    assert!(
+        ts.contains("rows: Array<CompactLinkRow>;"),
+        "Vec<CompactLinkRow> should render Array<CompactLinkRow> in TS. Got: {ts}"
     );
 }
 


### PR DESCRIPTION
## What

`#[model_schema]` on a `type` alias generated a correct TypeScript `type X = …` but its **Zod** method was a stub — `generate_alias_zod_stub()` returned the literal string `// Zod schema generation for aliases is not yet supported`. So `<Alias>$Schema` was never a real const, and any struct field typed `Vec<SomeAlias>` (which references `SomeAlias$Schema` via the SiblingType Zod path in `field_type.rs`) produced a `schemas.ts` that fails `tsc` on the undefined symbol.

This replaces the stub with real generation: `process_type_alias` now emits

```
const <Name>$RawSchema = <zod expression>;
export const <Name>$Schema: ZodType<<Name>> = <Name>$RawSchema;
```

mirroring how struct/enum schemas expose their const. The Zod expression comes from the alias's own `FieldDef::zod_type()` — the same renderer struct fields use — so a **tuple alias reuses the null-in-tuple flavor** (from #20) with no reimplementation:

```
type CompactLinkRow = (Option<String>, Vec<usize>, String, Option<String>)
```
→
```
const CompactLinkRow$RawSchema = z.tuple([z.nullable(z.string()), z.array(z.number().int()), z.string(), z.nullable(z.string())]);
export const CompactLinkRow$Schema: ZodType<CompactLinkRow> = CompactLinkRow$RawSchema;
```

and a struct field `Vec<CompactLinkRow>` renders `z.array(CompactLinkRow$Schema)` / `Array<CompactLinkRow>`.

## Why

Downstream (remargin) needs a compact columnar payload whose row is a 4-element nullable tuple. The literal tuple field trips `clippy::type_complexity` (deny-level) and can't be silenced; the clippy-clean spelling is a named `type` alias — which only works once the alias emits a real Zod schema. This change enables that.

## Scope

General across alias kinds (tuple / scalar / sibling) — all flow through `FieldDef::zod_type()`. The JSON-schema alias stub is left unchanged (not consumed downstream). No suppressions; `just all` (powerset lint + 32-combo powerset tests) is green.

## Tests

`tests/semantic_types_tests/tests.rs`: scalar alias `$Schema`, the null-flavored tuple alias `$Schema`, a `Vec<alias>` field referencing it, and the TS side — all asserting the stub comment is gone. Feature-gated to match the existing alias/tuple tests so the powerset stays green.