### PR TITLE
ci: accept eburgos/tixschema in the Discord notification guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,8 +109,8 @@ jobs:
         AUDIT: ${{ steps.audit.outcome }}
       run: |
         # Validate repository to prevent forks from sending notifications
-        if [[ "$REPO" != "tixena/tixschema" ]]; then
-          echo "⏭️ Skipping Discord notification (repository is $REPO, not tixena/tixschema)"
+        if [[ "$REPO" != "eburgos/tixschema" && "$REPO" != "tixena/tixschema" ]]; then
+          echo "⏭️ Skipping Discord notification (repository is $REPO, a fork)"
           exit 0
         fi
 


### PR DESCRIPTION
The fork guard hardcoded tixena/tixschema, but CI runs under eburgos/tixschema, so every run skipped the Discord webhook with a green step. Accept both known homes; real forks still skip.

Same fix already landed on eburgos/remargin (f67b3d0, delivery verified with HTTP 204), eburgos/os-shim, and eburgos/tixgraft.