### PR TITLE
build: require syn 3.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["macros", "proc-macro", "typescript", "zod", "codegen", "tixschema"]
 proc-macro = true
 
 [dependencies]
-syn = { version = "2", features = ["full", "parsing", "extra-traits"] }
+syn = { version = ">=3", features = ["full", "parsing", "extra-traits"] }
 quote = "1"
 proc-macro2 = "1"
 log = "0.4"


### PR DESCRIPTION
## Dependencies
- Bump the `syn` requirement from `2` to `>=3`, moving the proc-macro parsing layer onto the syn 3.x line.
- Affects all macro-expansion code paths that parse Rust syntax: `model_schema` entry point, type analysis, serde attribute parsing, and field-level `model_schema_prop` parsing.

## Breaking change
The crate now builds against syn 3.x only. Downstream crates pinning syn 2.x in a shared dependency graph will need to upgrade, and any consumer patching or vendoring syn must move to the 3.x line.