### PR TITLE
fix: apply serde's variant casing rules to enum rename_all

### DIFF
--- a/src/features/serde.rs
+++ b/src/features/serde.rs
@@ -3,6 +3,8 @@
 //! This module handles serde attribute parsing and field name transformation
 //! when the "serde" feature is enabled.
 
+#[cfg(test)]
+use crate::rename_rule::resolve_rename_rule;
 use syn::{Attribute, LitStr};
 
 /// Metadata for serde attributes applied to a struct or enum.
@@ -105,15 +107,7 @@ pub fn parse_serde_field_attributes(attrs: &[Attribute]) -> SerdeFieldMeta {
 /// Applies serde `rename_all` transformation to a field name.
 #[cfg(test)]
 pub fn apply_rename_all(field_name: &str, rename_all: Option<&str>) -> String {
-    match rename_all {
-        Some("camelCase") => to_camel_case(field_name),
-        Some("PascalCase") => to_pascal_case(field_name),
-        Some("SCREAMING_SNAKE_CASE" | "UPPERCASE") => field_name.to_uppercase(),
-        Some("kebab-case") => to_kebab_case(field_name),
-        Some("lowercase") => field_name.to_lowercase(),
-        // snake_case and unknown values keep the original snake_case name
-        _ => field_name.to_owned(),
-    }
+    resolve_rename_rule(rename_all).apply_to_field(field_name)
 }
 
 /// Get the final field name after applying serde transformations.
@@ -130,44 +124,6 @@ pub fn get_final_field_name(
 
     // Otherwise apply rename_all transformation
     apply_rename_all(original_name, type_meta.rename_all.as_deref())
-}
-
-/// Convert `snake_case` to camelCase.
-#[cfg(test)]
-fn to_camel_case(s: &str) -> String {
-    let mut result = String::new();
-    let mut capitalize_next = false;
-
-    for (i, c) in s.chars().enumerate() {
-        if c == '_' {
-            capitalize_next = true;
-        } else if capitalize_next && i > 0 {
-            result.push(c.to_ascii_uppercase());
-            capitalize_next = false;
-        } else {
-            result.push(c);
-            capitalize_next = false;
-        }
-    }
-
-    result
-}
-
-/// Convert `snake_case` to `PascalCase`.
-#[cfg(test)]
-fn to_pascal_case(s: &str) -> String {
-    let camel = to_camel_case(s);
-    if let Some(first_char) = camel.chars().next() {
-        format!("{}{}", first_char.to_ascii_uppercase(), &camel[1..])
-    } else {
-        camel
-    }
-}
-
-/// Convert `snake_case` to kebab-case.
-#[cfg(test)]
-fn to_kebab_case(s: &str) -> String {
-    s.replace('_', "-")
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ mod features;
 mod field_type;
 mod generation;
 mod model_schema;
+mod rename_rule;
 mod utils;
 
 use model_schema::exec_model_schema;

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -56,6 +56,8 @@ use crate::utils::register_alias_info;
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 use crate::utils::to_snake_case;
 
+use crate::rename_rule::resolve_rename_rule;
+
 /// Per-variant data collected from a discriminated enum: field defs, doc strings, and variant
 /// kinds (each keyed by serialized discriminator value), plus the collected serde validators.
 type DiscriminatedVariantData = (
@@ -1534,7 +1536,7 @@ fn collect_plain_enum_options(
         let field_rename: Option<String> = None;
 
         let final_name =
-            get_final_name(item.ident.to_string(), field_rename.as_deref(), rename_all);
+            get_final_variant_name(&item.ident.to_string(), field_rename.as_deref(), rename_all);
         enum_options.push(final_name);
 
         #[cfg(feature = "typescript")]
@@ -1746,7 +1748,7 @@ fn collect_discriminated_variants(
         let field_rename: Option<String> = None;
 
         let final_name =
-            get_final_name(item.ident.to_string(), field_rename.as_deref(), rename_all);
+            get_final_variant_name(&item.ident.to_string(), field_rename.as_deref(), rename_all);
         let variant_kind = classify_variant(item);
 
         let mut field_defs: Vec<FieldDef> = Vec::new();
@@ -4107,9 +4109,8 @@ fn process_field(
     field.attrs = new_attrs;
 
     let field_type: &syn::Type = &field.ty;
-    let name = raw_field_ident;
 
-    let final_name = get_final_name(name, field_rename.as_deref(), rename_all);
+    let final_name = get_final_field_name(&raw_field_ident, field_rename.as_deref(), rename_all);
     let field_docs = build_field_docs(field, &final_name);
 
     // Create the field definition and apply any model_schema_prop overrides
@@ -4280,44 +4281,28 @@ fn apply_constraint_docs(field_def: &mut FieldDef, final_name: &str) {
     }
 }
 
-/// Gets the final name for a field or enum variant, considering serde attributes.
-fn get_final_name(name: String, field_rename: Option<&str>, rename_all: Option<&str>) -> String {
+/// Gets the serialized name of a struct field. serde cases fields by different rules than enum
+/// variants, so the two must not share one entry point.
+fn get_final_field_name(
+    name: &str,
+    field_rename: Option<&str>,
+    rename_all: Option<&str>,
+) -> String {
     field_rename.map_or_else(
-        || {
-            if rename_all == Some("camelCase") {
-                snake_to_camel(&name)
-            } else if rename_all == Some("lowercase") {
-                name.to_lowercase()
-            } else {
-                name
-            }
-        },
+        || resolve_rename_rule(rename_all).apply_to_field(name),
         str::to_owned,
     )
 }
 
-/// Converts a `snake_case` string to camelCase.
-fn snake_to_camel(s: &str) -> String {
-    let mut result = String::new();
-    let mut capitalize_next = false;
-
-    for (i, c) in s.chars().enumerate() {
-        if c == '_' {
-            capitalize_next = true;
-        } else if i == 0 {
-            // Force the first character to lowercase
-            result.push(c.to_lowercase().next().unwrap());
-        } else if capitalize_next {
-            // Capitalize after an underscore
-            result.push(c.to_uppercase().next().unwrap());
-            capitalize_next = false;
-        } else {
-            // Keep other characters as is
-            result.push(c);
-        }
-    }
-
-    result
+fn get_final_variant_name(
+    name: &str,
+    variant_rename: Option<&str>,
+    rename_all: Option<&str>,
+) -> String {
+    variant_rename.map_or_else(
+        || resolve_rename_rule(rename_all).apply_to_variant(name),
+        str::to_owned,
+    )
 }
 
 #[cfg(feature = "jsonschema")]

--- a/src/rename_rule.rs
+++ b/src/rename_rule.rs
@@ -1,0 +1,128 @@
+//! serde's `rename_all` casing rules.
+//!
+//! Mirrors `RenameRule` from `serde_derive` 1.0.229 (`src/internals/case.rs`) so generated
+//! TypeScript and Zod schemas carry exactly the strings serde puts on the wire. serde applies
+//! different rules to struct fields (already `snake_case` in Rust source) than to enum variants
+//! (`PascalCase` in Rust source), so the two stay separate here as well.
+
+/// Every mode serde accepts, spelled as serde spells it. A mode serde accepts but this table
+/// omits is rejected at macro-expansion time rather than emitted as the raw Rust identifier.
+const RENAME_RULES: [(&str, RenameRule); 8] = [
+    ("lowercase", RenameRule::LowerCase),
+    ("UPPERCASE", RenameRule::UpperCase),
+    ("PascalCase", RenameRule::PascalCase),
+    ("camelCase", RenameRule::CamelCase),
+    ("snake_case", RenameRule::SnakeCase),
+    ("SCREAMING_SNAKE_CASE", RenameRule::ScreamingSnakeCase),
+    ("kebab-case", RenameRule::KebabCase),
+    ("SCREAMING-KEBAB-CASE", RenameRule::ScreamingKebabCase),
+];
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RenameRule {
+    CamelCase,
+    KebabCase,
+    LowerCase,
+    None,
+    PascalCase,
+    ScreamingKebabCase,
+    ScreamingSnakeCase,
+    SnakeCase,
+    UpperCase,
+}
+
+impl RenameRule {
+    pub fn apply_to_field(self, field: &str) -> String {
+        match self {
+            Self::None | Self::LowerCase | Self::SnakeCase => field.to_owned(),
+            Self::UpperCase | Self::ScreamingSnakeCase => field.to_ascii_uppercase(),
+            Self::PascalCase => field_to_pascal(field),
+            Self::CamelCase => lower_first(&field_to_pascal(field)),
+            Self::KebabCase => field.replace('_', "-"),
+            Self::ScreamingKebabCase => field.to_ascii_uppercase().replace('_', "-"),
+        }
+    }
+
+    pub fn apply_to_variant(self, variant: &str) -> String {
+        match self {
+            Self::None | Self::PascalCase => variant.to_owned(),
+            Self::LowerCase => variant.to_ascii_lowercase(),
+            Self::UpperCase => variant.to_ascii_uppercase(),
+            Self::CamelCase => lower_first(variant),
+            Self::SnakeCase => variant_to_snake(variant),
+            Self::ScreamingSnakeCase => variant_to_snake(variant).to_ascii_uppercase(),
+            Self::KebabCase => variant_to_snake(variant).replace('_', "-"),
+            Self::ScreamingKebabCase => variant_to_snake(variant)
+                .to_ascii_uppercase()
+                .replace('_', "-"),
+        }
+    }
+
+    pub fn from_mode(mode: &str) -> Option<Self> {
+        RENAME_RULES
+            .iter()
+            .find(|&&(name, _)| name == mode)
+            .map(|&(_, rule)| rule)
+    }
+}
+
+fn field_to_pascal(field: &str) -> String {
+    let mut pascal = String::new();
+    let mut capitalize = true;
+    for ch in field.chars() {
+        if ch == '_' {
+            capitalize = true;
+        } else if capitalize {
+            pascal.push(ch.to_ascii_uppercase());
+            capitalize = false;
+        } else {
+            pascal.push(ch);
+        }
+    }
+    pascal
+}
+
+/// serde lowercases only the leading character, leaving the rest untouched.
+fn lower_first(name: &str) -> String {
+    let mut chars = name.chars();
+    chars.next().map_or_else(String::new, |first| {
+        format!("{}{}", first.to_ascii_lowercase(), chars.as_str())
+    })
+}
+
+/// Resolves a `rename_all` mode string, rejecting any mode `RENAME_RULES` does not implement.
+///
+/// The failed assert surfaces as a compile error at macro-expansion time; falling through to the
+/// raw Rust identifier instead would silently disagree with what serde writes on the wire.
+pub fn resolve_rename_rule(rename_all: Option<&str>) -> RenameRule {
+    let Some(mode) = rename_all else {
+        return RenameRule::None;
+    };
+    let rule = RenameRule::from_mode(mode);
+    assert!(rule.is_some(), "{}", unsupported_mode_message(mode));
+    rule.unwrap()
+}
+
+pub fn unsupported_mode_message(mode: &str) -> String {
+    let supported = RENAME_RULES.map(|(name, _)| name).join(", ");
+    format!(
+        "unsupported serde `rename_all = \"{mode}\"` in model_schema; supported modes: {supported}"
+    )
+}
+
+/// serde inserts a separator before every uppercase character past the first, so an acronym run
+/// yields one underscore per capital (`HttpSSHProxy` -> `http_s_s_h_proxy`) and digits, not being
+/// uppercase, never introduce a word break (`Base64Payload` -> `base64_payload`).
+fn variant_to_snake(variant: &str) -> String {
+    let mut snake = String::new();
+    for (index, ch) in variant.char_indices() {
+        if index > 0 && ch.is_uppercase() {
+            snake.push('_');
+        }
+        snake.push(ch.to_ascii_lowercase());
+    }
+    snake
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/rename_rule/tests.rs
+++ b/src/rename_rule/tests.rs
@@ -1,0 +1,150 @@
+use super::{RenameRule, resolve_rename_rule, unsupported_mode_message};
+
+/// The expectation table from `serde_derive` 1.0.229 `src/internals/case.rs::rename_variants`,
+/// extended with the multi-word, acronym-run and digit cases this crate has to get right.
+#[test]
+fn variant_rules_match_serde() {
+    for &(original, lower, upper, camel, snake, screaming, kebab, screaming_kebab) in &[
+        (
+            "Outcome", "outcome", "OUTCOME", "outcome", "outcome", "OUTCOME", "outcome", "OUTCOME",
+        ),
+        (
+            "VeryTasty",
+            "verytasty",
+            "VERYTASTY",
+            "veryTasty",
+            "very_tasty",
+            "VERY_TASTY",
+            "very-tasty",
+            "VERY-TASTY",
+        ),
+        ("A", "a", "A", "a", "a", "A", "a", "A"),
+        ("Z42", "z42", "Z42", "z42", "z42", "Z42", "z42", "Z42"),
+        (
+            "AgentKeyUnderUserSsh",
+            "agentkeyunderuserssh",
+            "AGENTKEYUNDERUSERSSH",
+            "agentKeyUnderUserSsh",
+            "agent_key_under_user_ssh",
+            "AGENT_KEY_UNDER_USER_SSH",
+            "agent-key-under-user-ssh",
+            "AGENT-KEY-UNDER-USER-SSH",
+        ),
+        (
+            "HttpSSHProxy",
+            "httpsshproxy",
+            "HTTPSSHPROXY",
+            "httpSSHProxy",
+            "http_s_s_h_proxy",
+            "HTTP_S_S_H_PROXY",
+            "http-s-s-h-proxy",
+            "HTTP-S-S-H-PROXY",
+        ),
+        (
+            "Base64Payload",
+            "base64payload",
+            "BASE64PAYLOAD",
+            "base64Payload",
+            "base64_payload",
+            "BASE64_PAYLOAD",
+            "base64-payload",
+            "BASE64-PAYLOAD",
+        ),
+    ] {
+        assert_eq!(RenameRule::None.apply_to_variant(original), original);
+        assert_eq!(RenameRule::LowerCase.apply_to_variant(original), lower);
+        assert_eq!(RenameRule::UpperCase.apply_to_variant(original), upper);
+        assert_eq!(RenameRule::PascalCase.apply_to_variant(original), original);
+        assert_eq!(RenameRule::CamelCase.apply_to_variant(original), camel);
+        assert_eq!(RenameRule::SnakeCase.apply_to_variant(original), snake);
+        assert_eq!(
+            RenameRule::ScreamingSnakeCase.apply_to_variant(original),
+            screaming
+        );
+        assert_eq!(RenameRule::KebabCase.apply_to_variant(original), kebab);
+        assert_eq!(
+            RenameRule::ScreamingKebabCase.apply_to_variant(original),
+            screaming_kebab
+        );
+    }
+}
+
+/// The expectation table from `serde_derive` 1.0.229 `src/internals/case.rs::rename_fields`.
+#[test]
+fn field_rules_match_serde() {
+    for &(original, upper, pascal, camel, screaming, kebab, screaming_kebab) in &[
+        (
+            "outcome", "OUTCOME", "Outcome", "outcome", "OUTCOME", "outcome", "OUTCOME",
+        ),
+        (
+            "very_tasty",
+            "VERY_TASTY",
+            "VeryTasty",
+            "veryTasty",
+            "VERY_TASTY",
+            "very-tasty",
+            "VERY-TASTY",
+        ),
+        ("a", "A", "A", "a", "A", "a", "A"),
+        ("z42", "Z42", "Z42", "z42", "Z42", "z42", "Z42"),
+    ] {
+        assert_eq!(RenameRule::None.apply_to_field(original), original);
+        assert_eq!(RenameRule::LowerCase.apply_to_field(original), original);
+        assert_eq!(RenameRule::SnakeCase.apply_to_field(original), original);
+        assert_eq!(RenameRule::UpperCase.apply_to_field(original), upper);
+        assert_eq!(RenameRule::PascalCase.apply_to_field(original), pascal);
+        assert_eq!(RenameRule::CamelCase.apply_to_field(original), camel);
+        assert_eq!(
+            RenameRule::ScreamingSnakeCase.apply_to_field(original),
+            screaming
+        );
+        assert_eq!(RenameRule::KebabCase.apply_to_field(original), kebab);
+        assert_eq!(
+            RenameRule::ScreamingKebabCase.apply_to_field(original),
+            screaming_kebab
+        );
+    }
+}
+
+#[test]
+fn every_serde_mode_parses() {
+    for (mode, expected) in [
+        ("lowercase", RenameRule::LowerCase),
+        ("UPPERCASE", RenameRule::UpperCase),
+        ("PascalCase", RenameRule::PascalCase),
+        ("camelCase", RenameRule::CamelCase),
+        ("snake_case", RenameRule::SnakeCase),
+        ("SCREAMING_SNAKE_CASE", RenameRule::ScreamingSnakeCase),
+        ("kebab-case", RenameRule::KebabCase),
+        ("SCREAMING-KEBAB-CASE", RenameRule::ScreamingKebabCase),
+    ] {
+        assert_eq!(RenameRule::from_mode(mode), Some(expected));
+        assert_eq!(resolve_rename_rule(Some(mode)), expected);
+    }
+}
+
+#[test]
+fn absent_rename_all_applies_no_rule() {
+    assert_eq!(resolve_rename_rule(None), RenameRule::None);
+}
+
+#[test]
+fn unsupported_mode_does_not_parse() {
+    assert_eq!(RenameRule::from_mode("snakecase"), None);
+    assert_eq!(RenameRule::from_mode("SnakeCase"), None);
+    assert_eq!(RenameRule::from_mode(""), None);
+}
+
+#[test]
+fn unsupported_mode_message_names_mode_and_alternatives() {
+    let message = unsupported_mode_message("snakecase");
+    assert!(message.contains("snakecase"), "Got: {message}");
+    assert!(message.contains("snake_case"), "Got: {message}");
+    assert!(message.contains("SCREAMING-KEBAB-CASE"), "Got: {message}");
+}
+
+#[test]
+#[should_panic(expected = "unsupported serde `rename_all = \"snakecase\"`")]
+fn unsupported_mode_is_rejected_loudly() {
+    let _rule = resolve_rename_rule(Some("snakecase"));
+}

--- a/tests/rename_all_tests.rs
+++ b/tests/rename_all_tests.rs
@@ -1,0 +1,10 @@
+//! Tests that generated enum strings match serde's `rename_all` output exactly.
+//!
+//! Covers the rename modes the codebase relies on — `lowercase`, `snake_case`, per-variant
+//! `rename`, and no rule at all — and pins every generated string against what serde itself
+//! writes on the wire, so the two can never drift apart silently.
+
+#[cfg(test)]
+#[cfg(feature = "serde")]
+#[path = "rename_all_tests/tests.rs"]
+mod tests;

--- a/tests/rename_all_tests/tests.rs
+++ b/tests/rename_all_tests/tests.rs
@@ -1,0 +1,177 @@
+use serde::{Deserialize, Serialize};
+use tixschema::model_schema;
+
+#[model_schema()]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+enum AuthorKind {
+    Agent,
+    Human,
+}
+
+#[model_schema()]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum CopyKind {
+    BodyOnly,
+    Noop,
+    Verbatim,
+}
+
+#[model_schema()]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum FindingKind {
+    AgentKeyUnderUserSsh,
+    /// Digits never introduce a word break.
+    Base64Payload,
+    /// An acronym run gets one underscore per capital, not one per run.
+    HttpSSHProxy,
+}
+
+#[model_schema()]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+enum VerifyErrorKind {
+    ContentMismatch,
+    #[serde(rename = "verify_failed")]
+    VerifyFailed,
+}
+
+#[model_schema()]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum SandboxKind {
+    #[serde(rename = "AS-IS")]
+    AsIs,
+    PlainAdd,
+}
+
+/// The string serde itself writes for a unit variant.
+fn serde_wire_name<T>(variant: &T) -> String
+where
+    T: Serialize,
+{
+    serde_json::to_value(variant)
+        .unwrap()
+        .as_str()
+        .unwrap()
+        .to_owned()
+}
+
+fn serde_wire_names<T>(variants: &[T]) -> Vec<String>
+where
+    T: Serialize,
+{
+    variants.iter().map(serde_wire_name).collect()
+}
+
+#[test]
+fn lowercase_variants_match_serde_wire() {
+    assert_eq!(AuthorKind::enum_members(), ["agent", "human"]);
+    assert_eq!(
+        AuthorKind::enum_members(),
+        serde_wire_names(&[AuthorKind::Agent, AuthorKind::Human])
+    );
+}
+
+#[test]
+fn snake_case_variants_match_serde_wire() {
+    assert_eq!(CopyKind::enum_members(), ["body_only", "noop", "verbatim"]);
+    assert_eq!(
+        CopyKind::enum_members(),
+        serde_wire_names(&[CopyKind::BodyOnly, CopyKind::Noop, CopyKind::Verbatim])
+    );
+}
+
+#[test]
+fn snake_case_acronyms_and_digits_match_serde_wire() {
+    assert_eq!(
+        FindingKind::enum_members(),
+        [
+            "agent_key_under_user_ssh",
+            "base64_payload",
+            "http_s_s_h_proxy"
+        ]
+    );
+    assert_eq!(
+        FindingKind::enum_members(),
+        serde_wire_names(&[
+            FindingKind::AgentKeyUnderUserSsh,
+            FindingKind::Base64Payload,
+            FindingKind::HttpSSHProxy,
+        ])
+    );
+}
+
+#[test]
+fn per_variant_rename_matches_serde_wire() {
+    assert_eq!(
+        VerifyErrorKind::enum_members(),
+        ["ContentMismatch", "verify_failed"]
+    );
+    assert_eq!(
+        VerifyErrorKind::enum_members(),
+        serde_wire_names(&[
+            VerifyErrorKind::ContentMismatch,
+            VerifyErrorKind::VerifyFailed,
+        ])
+    );
+}
+
+#[test]
+fn per_variant_rename_overrides_rename_all() {
+    assert_eq!(SandboxKind::enum_members(), ["AS-IS", "plain_add"]);
+    assert_eq!(
+        SandboxKind::enum_members(),
+        serde_wire_names(&[SandboxKind::AsIs, SandboxKind::PlainAdd])
+    );
+}
+
+#[cfg(feature = "typescript")]
+#[test]
+fn snake_case_ts_union_matches_serde_wire() {
+    let ts = CopyKind::ts_definition();
+    assert!(ts.contains("\"body_only\""), "Got:\n{ts}");
+    assert!(ts.contains("\"noop\""), "Got:\n{ts}");
+    assert!(ts.contains("\"verbatim\""), "Got:\n{ts}");
+    assert!(!ts.contains("\"BodyOnly\""), "Got:\n{ts}");
+}
+
+#[cfg(feature = "zod")]
+#[test]
+fn snake_case_zod_enum_matches_serde_wire() {
+    let zod = CopyKind::zod_schema();
+    assert!(
+        zod.contains("z.enum([\"body_only\", \"noop\", \"verbatim\"])"),
+        "Got:\n{zod}"
+    );
+}
+
+#[cfg(feature = "typescript")]
+#[test]
+fn lowercase_ts_union_unchanged() {
+    let ts = AuthorKind::ts_definition();
+    assert!(ts.contains("\"agent\""), "Got:\n{ts}");
+    assert!(ts.contains("\"human\""), "Got:\n{ts}");
+}
+
+#[cfg(feature = "zod")]
+#[test]
+fn lowercase_zod_enum_unchanged() {
+    let zod = AuthorKind::zod_schema();
+    assert!(
+        zod.contains("z.enum([\"agent\", \"human\"])"),
+        "Got:\n{zod}"
+    );
+}
+
+#[cfg(feature = "jsonschema")]
+#[test]
+fn snake_case_json_schema_matches_serde_wire() {
+    let schema = CopyKind::json_schema();
+    let values = schema["enum"].as_array().unwrap();
+    assert_eq!(
+        values.iter().map(ToString::to_string).collect::<Vec<_>>(),
+        ["\"body_only\"", "\"noop\"", "\"verbatim\""]
+    );
+}


### PR DESCRIPTION
rename_all handling implemented only the lowercase transform and applied field casing rules to enum variants. serde cases variants (PascalCase source) differently from fields (snake_case source), so snake_case enums emitted raw identifiers ('BodyOnly') where serde writes 'body_only'.

- New `rename_rule` module mirroring serde_derive 1.0.229's `RenameRule` (`src/internals/case.rs`) with separate `apply_to_field` / `apply_to_variant` transforms.
- Both enum paths (plain + discriminated) and the struct-field path now resolve through it; the old ad-hoc per-mode transforms are deleted.
- A `rename_all` mode the table does not implement is rejected at macro-expansion time with a message naming the mode and the supported list — never silently emitted as the raw identifier.
- Wire-parity tests pin every generated string (`enum_members`, TS union, Zod enum, JSON schema) against what serde itself serializes, including acronym runs (`HttpSSHProxy` → `http_s_s_h_proxy`), digits (`Base64Payload` → `base64_payload`), and per-variant `rename` overriding `rename_all`.

Gates: `just check` and `just test` (all 32 feature combinations) green.

Downstream: remargin's generated `CpKind`/`Severity`/`FindingKind` currently reject real `--json` payloads because of this; its pin bump is waiting on this merge.