### PR TITLE
feat: compile error when a model_schema Option field can serialize null

### DIFF
--- a/src/features/serde.rs
+++ b/src/features/serde.rs
@@ -19,7 +19,10 @@ pub struct SerdeTypeMeta {
 /// Metadata for serde attributes applied to a field.
 #[derive(Clone, Debug, Default)]
 pub struct SerdeFieldMeta {
-    pub flatten: bool,          // Whether the field is `#[serde(flatten)]`
+    pub flatten: bool, // Whether the field is `#[serde(flatten)]`
+    /// Whether a `None` is left out of the serialized output entirely. `skip_deserializing`
+    /// does not qualify: it still writes `null` on the way out.
+    pub omits_none: bool,
     pub rename: Option<String>, // e.g., "new_name"
     pub skip: bool,             // Whether to skip the field
 }
@@ -82,9 +85,14 @@ pub fn parse_serde_field_attributes(attrs: &[Attribute]) -> SerdeFieldMeta {
                 // Handle `skip` or `skip_serializing_if`
                 else if nested.path.is_ident("skip")
                     || nested.path.is_ident("skip_serializing")
-                    || nested.path.is_ident("skip_deserializing")
                     || nested.path.is_ident("skip_serializing_if")
                 {
+                    meta.skip = true;
+                    meta.omits_none = true;
+                }
+                // `skip_deserializing` belongs to the `skip` lump but never suppresses a
+                // serialized `null`, so it must not set `omits_none`.
+                else if nested.path.is_ident("skip_deserializing") {
                     meta.skip = true;
                 }
                 // Handle `flatten`

--- a/src/features/serde/tests.rs
+++ b/src/features/serde/tests.rs
@@ -38,6 +38,7 @@ fn test_final_field_name() {
     let field_meta_with_rename = SerdeFieldMeta {
         rename: Some("customName".to_owned()),
         skip: false,
+        omits_none: false,
         flatten: false,
     };
     assert_eq!(
@@ -49,6 +50,7 @@ fn test_final_field_name() {
     let field_meta_no_rename = SerdeFieldMeta {
         rename: None,
         skip: false,
+        omits_none: false,
         flatten: false,
     };
     assert_eq!(
@@ -90,6 +92,54 @@ fn test_parse_non_flatten_field_attribute() {
 fn test_flatten_default_is_false() {
     let meta = SerdeFieldMeta::default();
     assert!(!meta.flatten);
+}
+
+fn field_meta(item: &syn::ItemStruct) -> SerdeFieldMeta {
+    parse_serde_field_attributes(&item.fields.iter().next().unwrap().attrs)
+}
+
+#[test]
+fn test_omits_none_set_by_serialization_skips() {
+    let skip: syn::ItemStruct = syn::parse_quote! {
+        struct S {
+            #[serde(skip)]
+            note: Option<String>,
+        }
+    };
+    let skip_serializing: syn::ItemStruct = syn::parse_quote! {
+        struct S {
+            #[serde(skip_serializing)]
+            note: Option<String>,
+        }
+    };
+    let skip_serializing_if: syn::ItemStruct = syn::parse_quote! {
+        struct S {
+            #[serde(skip_serializing_if = "Option::is_none")]
+            note: Option<String>,
+        }
+    };
+    assert!(field_meta(&skip).omits_none);
+    assert!(field_meta(&skip_serializing).omits_none);
+    assert!(field_meta(&skip_serializing_if).omits_none);
+}
+
+#[test]
+fn test_omits_none_not_set_by_skip_deserializing() {
+    let item: syn::ItemStruct = syn::parse_quote! {
+        struct S {
+            #[serde(skip_deserializing)]
+            note: Option<String>,
+        }
+    };
+    let meta = field_meta(&item);
+    assert!(!meta.omits_none);
+    assert!(meta.skip);
+}
+
+#[test]
+fn test_omits_none_default_is_false() {
+    let meta = SerdeFieldMeta::default();
+    assert!(!meta.omits_none);
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ use utils::safe_type_name;
 ///     pub id: String,
 ///     pub first_name: String,
 ///     pub last_name: String,
+///     #[serde(skip_serializing_if = "Option::is_none")]
 ///     pub age: Option<u32>,
 ///     pub roles: Vec<String>,
 /// }
@@ -101,6 +102,7 @@ use utils::safe_type_name;
 ///     },
 ///     UserDeleted {
 ///         user_id: String,
+///         #[serde(skip_serializing_if = "Option::is_none")]
 ///         reason: Option<String>,
 ///     }
 /// }
@@ -141,6 +143,7 @@ pub struct Document {
     pub author_id: ObjectId,
     pub tags: Vec<ObjectId>,
     pub metadata: HashMap<String, ObjectId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub parent_id: Option<ObjectId>,
 }
 

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -31,6 +31,9 @@ use crate::utils::extract_example_from_docs;
 use crate::utils::lookup_alias_info;
 
 #[cfg(feature = "serde")]
+use crate::features::serde::SerdeFieldMeta;
+
+#[cfg(feature = "serde")]
 use crate::field_type::{parse_serde_field_attributes, parse_serde_type_attributes};
 
 use crate::features::model_schema_prop::parse_model_schema_prop_attributes;
@@ -59,11 +62,13 @@ use crate::utils::to_snake_case;
 use crate::rename_rule::resolve_rename_rule;
 
 /// Per-variant data collected from a discriminated enum: field defs, doc strings, and variant
-/// kinds (each keyed by serialized discriminator value), plus the collected serde validators.
+/// kinds (each keyed by serialized discriminator value), plus the collected serde validators and
+/// the `compile_error!` tokens for any field-level guard violations.
 type DiscriminatedVariantData = (
     HashMap<String, Vec<FieldDef>>,
     HashMap<String, String>,
     HashMap<String, VariantKind>,
+    Vec<proc_macro2::TokenStream>,
     Vec<proc_macro2::TokenStream>,
 );
 
@@ -72,6 +77,28 @@ type DiscriminatedVariantData = (
 type RenderedVariants = (
     Vec<String>,
     Vec<(String, Vec<String>)>,
+    Vec<proc_macro2::TokenStream>,
+);
+
+/// Per-member data collected from an untagged enum: the TypeScript member types, the Zod member
+/// schemas, the JSON-schema value tokens, and the `compile_error!` tokens for any field-level
+/// guard violations.
+#[cfg(feature = "serde")]
+type UntaggedMemberData = (
+    Vec<String>,
+    Vec<String>,
+    Vec<proc_macro2::TokenStream>,
+    Vec<proc_macro2::TokenStream>,
+);
+
+/// Per-field data collected from a struct: the regular field defs, the `#[serde(flatten)]` field
+/// defs, the serde validation functions, the `validate()` body fragments, and the
+/// `compile_error!` tokens for any field-level guard violations.
+type StructFieldData = (
+    Vec<FieldDef>,
+    Vec<FieldDef>,
+    Vec<proc_macro2::TokenStream>,
+    Vec<proc_macro2::TokenStream>,
     Vec<proc_macro2::TokenStream>,
 );
 
@@ -504,23 +531,44 @@ fn render_struct_field_bodies(
     (type_code, schema_code, json_schema_fields, fields_empty)
 }
 
+/// Emits the original item followed by the `compile_error!` tokens of every violated field guard,
+/// or `None` when there are none.
+///
+/// The item itself is kept so downstream references still resolve and the guard message stays the
+/// primary error; the schema surface is deliberately dropped, since it would encode a contract the
+/// field has already been shown to break.
+fn guard_failure_output<ItemT>(
+    item: &ItemT,
+    guard_errors: &[proc_macro2::TokenStream],
+) -> Option<TokenStream>
+where
+    ItemT: quote::ToTokens,
+{
+    if guard_errors.is_empty() {
+        return None;
+    }
+    let output = quote! {
+        #item
+        #(#guard_errors)*
+    };
+    log::trace!("{output}");
+    Some(TokenStream::from(output))
+}
+
 /// Processes every field of a struct, returning the regular field defs, the `#[serde(flatten)]`
-/// field defs, and the per-field serde validation functions and `validate()` body fragments.
+/// field defs, the per-field serde validation functions and `validate()` body fragments, and the
+/// `compile_error!` tokens for any field-level guard violations.
 fn collect_struct_fields(
     fields: &mut syn::Fields,
     rename_all: Option<&str>,
     module_name_opt: Option<&str>,
     type_name: &str,
-) -> (
-    Vec<FieldDef>,
-    Vec<FieldDef>,
-    Vec<proc_macro2::TokenStream>,
-    Vec<proc_macro2::TokenStream>,
-) {
+) -> StructFieldData {
     let mut field_defs = Vec::new();
     let mut flattened_fields: Vec<FieldDef> = Vec::new();
     let mut validation_fns: Vec<proc_macro2::TokenStream> = Vec::new();
     let mut validate_bodies: Vec<proc_macro2::TokenStream> = Vec::new();
+    let mut guard_errors: Vec<proc_macro2::TokenStream> = Vec::new();
 
     for field in fields.iter_mut() {
         #[cfg(feature = "serde")]
@@ -528,8 +576,12 @@ fn collect_struct_fields(
         #[cfg(not(feature = "serde"))]
         let is_flatten = false;
 
-        let (f_def, validation_fn, validate_body) =
+        let (f_def, validation_fn, validate_body, guard_error) =
             process_field(rename_all, field, module_name_opt, type_name);
+
+        if let Some(err) = guard_error {
+            guard_errors.push(err);
+        }
 
         if is_flatten {
             let _: (&_, &_) = (&validation_fn, &validate_body);
@@ -551,6 +603,7 @@ fn collect_struct_fields(
         flattened_fields,
         validation_fns,
         validate_bodies,
+        guard_errors,
     )
 }
 
@@ -625,9 +678,10 @@ fn process_struct(mut item_struct: syn::ItemStruct, args: &ModelSchemaArgs) -> T
     #[cfg(not(any(feature = "typescript", feature = "zod", feature = "jsonschema")))]
     let module_name_opt: Option<&str> = None;
 
-    // `collected`: (field_defs, flattened_fields, validation_fns, validate_bodies). Bound as a
-    // whole so feature-gated field access (`.0`/`.2`/`.3`) marks it used without per-element
-    // unused warnings; `collect_struct_fields` is always called for its `item_struct` mutation.
+    // `collected`: (field_defs, flattened_fields, validation_fns, validate_bodies, guard_errors).
+    // Bound as a whole so feature-gated field access (`.0`/`.2`/`.3`) marks it used without
+    // per-element unused warnings; `collect_struct_fields` is always called for its `item_struct`
+    // mutation.
     let collected = collect_struct_fields(
         &mut item_struct.fields,
         rename_all.as_deref(),
@@ -636,6 +690,12 @@ fn process_struct(mut item_struct: syn::ItemStruct, args: &ModelSchemaArgs) -> T
     );
     #[cfg(not(any(feature = "typescript", feature = "zod", feature = "jsonschema")))]
     let _: &_ = &&collected;
+
+    // A violated field guard makes the whole contract unsound, so the schema surface is dropped
+    // and only the original item plus the errors are emitted.
+    if let Some(output) = guard_failure_output(&item_struct, &collected.4) {
+        return output;
+    }
 
     #[cfg(feature = "typescript")]
     let docs = build_item_jsdoc(docs_and_example.0.as_deref(), name);
@@ -1739,6 +1799,7 @@ fn collect_discriminated_variants(
     let mut docs_by_variant: HashMap<String, String> = HashMap::new();
     let mut kinds_by_variant: HashMap<String, VariantKind> = HashMap::new();
     let mut enum_validation_fns: Vec<proc_macro2::TokenStream> = Vec::new();
+    let mut guard_errors: Vec<proc_macro2::TokenStream> = Vec::new();
     let enum_type_name = item_enum.ident.to_string();
 
     for item in &mut item_enum.variants {
@@ -1753,10 +1814,13 @@ fn collect_discriminated_variants(
 
         let mut field_defs: Vec<FieldDef> = Vec::new();
         for field in &mut item.fields {
-            let (f_def, validation_fn, _validate_body) =
+            let (f_def, validation_fn, _validate_body, guard_error) =
                 process_field(rename_all, field, enum_module_name_opt, &enum_type_name);
             if let Some(vfn) = validation_fn {
                 enum_validation_fns.push(vfn);
+            }
+            if let Some(err) = guard_error {
+                guard_errors.push(err);
             }
             field_defs.push(f_def);
         }
@@ -1789,6 +1853,7 @@ fn collect_discriminated_variants(
         docs_by_variant,
         kinds_by_variant,
         enum_validation_fns,
+        guard_errors,
     )
 }
 
@@ -1882,8 +1947,12 @@ fn process_discriminated_enum(
     let enum_module_name_opt = None;
 
     // Bind both result tuples whole so feature-gated field access marks them used (no per-element
-    // guards): `variants` = (field_defs, docs, kinds, validation_fns); `rendered` = (ts, zod, json).
+    // guards): `variants` = (field_defs, docs, kinds, validation_fns, guard_errors);
+    // `rendered` = (ts, zod, json).
     let variants = collect_discriminated_variants(&mut item_enum, rename_all, enum_module_name_opt);
+    if let Some(output) = guard_failure_output(&item_enum, &variants.4) {
+        return output;
+    }
     let rendered = render_discriminated_variants(
         tag_name,
         content_name,
@@ -2266,16 +2335,20 @@ fn field_json_schema_value(fld: &FieldDef) -> proc_macro2::TokenStream {
 }
 
 /// Collects each untagged variant's union-member parts: the TypeScript member type, the Zod member
-/// schema, and the JSON-schema value token. All three are always returned; the caller selects which
-/// to use based on the enabled features.
+/// schema, and the JSON-schema value token, plus the `compile_error!` tokens for any field-level
+/// guard violations. The first three are always returned; the caller selects which to use based on
+/// the enabled features.
+///
+/// This path builds its field defs directly rather than through [`process_field`], so it runs
+/// [`check_optional_field_serialization`] itself — a named `Option` in a struct variant renders in
+/// the absent form here exactly as it does in a struct, and must carry the same guarantee.
 #[cfg(feature = "serde")]
-fn collect_untagged_members(
-    item_enum: &mut syn::ItemEnum,
-) -> (Vec<String>, Vec<String>, Vec<proc_macro2::TokenStream>) {
+fn collect_untagged_members(item_enum: &mut syn::ItemEnum) -> UntaggedMemberData {
     let enum_type_name = item_enum.ident.to_string();
     let mut ts_parts: Vec<String> = Vec::new();
     let mut zod_parts: Vec<String> = Vec::new();
     let mut json_parts: Vec<proc_macro2::TokenStream> = Vec::new();
+    let mut guard_errors: Vec<proc_macro2::TokenStream> = Vec::new();
 
     for variant in &mut item_enum.variants {
         let kind = classify_variant(variant);
@@ -2289,6 +2362,12 @@ fn collect_untagged_members(
                 .map(ToString::to_string)
                 .unwrap_or_default();
             let mut field_def = get_field_def(&field_name, &field.ty, "");
+            let serde_field_meta = parse_serde_field_attributes(&field.attrs);
+            if let Err(err) =
+                check_optional_field_serialization(field, field_def.is_optional, &serde_field_meta)
+            {
+                guard_errors.push(err.to_compile_error());
+            }
             field_def.resolve_self_references(&enum_type_name);
             field_defs.push(field_def);
         }
@@ -2300,7 +2379,7 @@ fn collect_untagged_members(
         json_parts.push(json_val);
     }
 
-    (ts_parts, zod_parts, json_parts)
+    (ts_parts, zod_parts, json_parts, guard_errors)
 }
 
 /// Processes an untagged enum (`#[serde(untagged)]`) and generates its definitions.
@@ -2333,7 +2412,14 @@ fn process_untagged_enum(
         .and_then(|docs| extract_example_from_docs(docs));
 
     // Render each variant into its union member (TS / Zod / JSON parts).
-    let (ts_parts, zod_parts, json_parts) = collect_untagged_members(&mut item_enum);
+    let (ts_parts, zod_parts, json_parts, guard_errors) = collect_untagged_members(&mut item_enum);
+
+    // A violated field guard makes the whole contract unsound, so the schema surface is dropped
+    // and only the original item plus the errors are emitted.
+    if let Some(output) = guard_failure_output(&item_enum, &guard_errors) {
+        return output;
+    }
+
     #[cfg(not(any(feature = "typescript", feature = "zod", feature = "jsonschema")))]
     let _: &_ = &name;
     #[cfg(not(feature = "zod"))]
@@ -4046,8 +4132,39 @@ fn validate_ts_optional_flag(field_optional: bool, flag_set: bool) -> Result<(),
     Ok(())
 }
 
+/// Rejects a named `Option` field whose serde attributes let a `None` reach the wire as `null`.
+///
+/// The generated contract renders such a field in the absent form — `T | undefined` and a
+/// `z.union([T, z.undefined()]).prefault(undefined)` inside a `z.strictObject` — which admits a
+/// missing key but never `null`. `is_optional` is the same signal that drives that rendering,
+/// which keeps the guard and the contract from ever disagreeing. Positional fields are exempt: a
+/// tuple slot cannot be omitted, so there `None` correctly renders as nullable.
+#[cfg(feature = "serde")]
+fn check_optional_field_serialization(
+    field: &Field,
+    is_optional: bool,
+    meta: &SerdeFieldMeta,
+) -> Result<(), syn::Error> {
+    let Some(ident) = field.ident.as_ref() else {
+        return Ok(());
+    };
+    if !is_optional || meta.omits_none {
+        return Ok(());
+    }
+    Err(syn::Error::new_spanned(
+        field,
+        format!(
+            "model_schema: field `{ident}` is `Option` but is serialized as `null` when `None`, \
+             while the generated schema only accepts the key being absent. Add \
+             #[serde(skip_serializing_if = \"Option::is_none\")] (plus `default` if the type \
+             derives Deserialize), or `skip` / `skip_serializing`."
+        ),
+    ))
+}
+
 /// Processes a field and returns its definition, optional module items (validators/deserializers),
-/// and optional `validate_body` (contribution to the type-level `validate()` method).
+/// optional `validate_body` (contribution to the type-level `validate()` method), and the
+/// `compile_error!` tokens for any guard the field violates.
 fn process_field(
     rename_all: Option<&str>,
     field: &mut Field,
@@ -4057,11 +4174,14 @@ fn process_field(
     FieldDef,
     Option<proc_macro2::TokenStream>,
     Option<proc_macro2::TokenStream>,
+    Option<proc_macro2::TokenStream>,
 ) {
     let mut new_attrs = Vec::new();
 
     #[cfg(feature = "serde")]
-    let field_rename = parse_serde_field_attributes(&field.attrs).rename;
+    let serde_field_meta = parse_serde_field_attributes(&field.attrs);
+    #[cfg(feature = "serde")]
+    let field_rename = serde_field_meta.rename.clone();
     #[cfg(not(feature = "serde"))]
     let field_rename: Option<String> = None;
 
@@ -4115,6 +4235,15 @@ fn process_field(
 
     // Create the field definition and apply any model_schema_prop overrides
     let mut field_def = get_field_def(&final_name, field_type, &field_docs);
+
+    #[cfg(feature = "serde")]
+    let guard_error =
+        check_optional_field_serialization(field, field_def.is_optional, &serde_field_meta)
+            .err()
+            .map(|err| err.to_compile_error());
+    #[cfg(not(feature = "serde"))]
+    let guard_error: Option<proc_macro2::TokenStream> = None;
+
     // Resolve `Self` references to the concrete type name so recursive fields
     // (e.g. `Vec<Self>`) are treated exactly like `Vec<EnclosingType>`.
     field_def.resolve_self_references(type_name);
@@ -4161,7 +4290,7 @@ fn process_field(
     // Update field docs to include length/range constraint information
     apply_constraint_docs(&mut field_def, &final_name);
 
-    (field_def, validation_fn, validate_body)
+    (field_def, validation_fn, validate_body, guard_error)
 }
 
 /// Generates per-field serde validation code (static validator + `deserialize_with`) and, when

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -1,5 +1,11 @@
 use super::{FieldDefType, validate_as_number_flag, validate_ts_optional_flag};
 
+#[cfg(feature = "serde")]
+use super::{
+    check_optional_field_serialization, collect_untagged_members, get_field_def,
+    parse_serde_field_attributes,
+};
+
 #[test]
 fn ts_optional_ok_on_option_field() {
     validate_ts_optional_flag(true, true).unwrap();
@@ -34,4 +40,166 @@ fn as_number_err_on_non_datetime_field() {
     let err = validate_as_number_flag(&FieldDefType::String, true).unwrap_err();
     assert!(err.contains("as_number"));
     assert!(err.contains("DateTime<Tz>"));
+}
+
+/// Runs the guard over the sole field of `item`, deriving `is_optional` the way the generator
+/// does rather than re-sniffing the type.
+#[cfg(feature = "serde")]
+fn guard_result(item: &syn::ItemStruct) -> Result<(), syn::Error> {
+    let field = item.fields.iter().next().unwrap();
+    let field_name = field
+        .ident
+        .as_ref()
+        .map(ToString::to_string)
+        .unwrap_or_default();
+    let field_def = get_field_def(&field_name, &field.ty, "");
+    let meta = parse_serde_field_attributes(&field.attrs);
+    check_optional_field_serialization(field, field_def.is_optional, &meta)
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn bare_option_field_is_rejected() {
+    let item: syn::ItemStruct = syn::parse_quote! {
+        struct Report {
+            note: Option<String>,
+        }
+    };
+    let message = guard_result(&item).unwrap_err().to_string();
+    assert!(message.contains("note"));
+    assert!(message.contains("skip_serializing_if = \"Option::is_none\""));
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn skip_serializing_if_satisfies_the_guard() {
+    let item: syn::ItemStruct = syn::parse_quote! {
+        struct Report {
+            #[serde(skip_serializing_if = "Option::is_none")]
+            note: Option<String>,
+        }
+    };
+    guard_result(&item).unwrap();
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn any_skip_serializing_if_predicate_satisfies_the_guard() {
+    let item: syn::ItemStruct = syn::parse_quote! {
+        struct Report {
+            #[serde(skip_serializing_if = "crate::is_boring")]
+            note: Option<String>,
+        }
+    };
+    guard_result(&item).unwrap();
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn skip_satisfies_the_guard() {
+    let item: syn::ItemStruct = syn::parse_quote! {
+        struct Report {
+            #[serde(skip)]
+            note: Option<String>,
+        }
+    };
+    guard_result(&item).unwrap();
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn skip_serializing_satisfies_the_guard() {
+    let item: syn::ItemStruct = syn::parse_quote! {
+        struct Report {
+            #[serde(skip_serializing)]
+            note: Option<String>,
+        }
+    };
+    guard_result(&item).unwrap();
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn skip_deserializing_alone_does_not_satisfy_the_guard() {
+    let item: syn::ItemStruct = syn::parse_quote! {
+        struct Report {
+            #[serde(skip_deserializing)]
+            note: Option<String>,
+        }
+    };
+    let message = guard_result(&item).unwrap_err().to_string();
+    assert!(message.contains("note"));
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn non_option_field_is_unaffected() {
+    let item: syn::ItemStruct = syn::parse_quote! {
+        struct Report {
+            name: String,
+        }
+    };
+    guard_result(&item).unwrap();
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn positional_option_field_is_exempt() {
+    let item: syn::ItemStruct = syn::parse_quote! {
+        struct Report(Option<String>);
+    };
+    guard_result(&item).unwrap();
+}
+
+/// Collects the untagged-path guard failures as rendered `compile_error!` token strings.
+#[cfg(feature = "serde")]
+fn untagged_guard_errors(mut item: syn::ItemEnum) -> Vec<String> {
+    collect_untagged_members(&mut item)
+        .3
+        .iter()
+        .map(ToString::to_string)
+        .collect()
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn untagged_named_variant_bare_option_is_rejected() {
+    let errors = untagged_guard_errors(syn::parse_quote! {
+        enum Choice {
+            Report { note: Option<String> },
+            Plain(i64),
+        }
+    });
+    assert_eq!(errors.len(), 1, "got: {errors:?}");
+    assert!(errors[0].contains("note"), "got: {}", errors[0]);
+    assert!(
+        errors[0].contains("skip_serializing_if"),
+        "got: {}",
+        errors[0]
+    );
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn untagged_named_variant_omitting_none_is_accepted() {
+    let errors = untagged_guard_errors(syn::parse_quote! {
+        enum Choice {
+            Report {
+                #[serde(skip_serializing_if = "Option::is_none")]
+                note: Option<String>,
+            },
+        }
+    });
+    assert!(errors.is_empty(), "got: {errors:?}");
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn untagged_tuple_variant_option_is_exempt() {
+    let errors = untagged_guard_errors(syn::parse_quote! {
+        enum Choice {
+            Maybe(Option<i64>),
+        }
+    });
+    assert!(errors.is_empty(), "got: {errors:?}");
 }

--- a/tests/advanced_tests/tests.rs
+++ b/tests/advanced_tests/tests.rs
@@ -31,8 +31,10 @@ struct Company {
 #[serde(rename_all = "camelCase")]
 struct CompanySettings {
     allow_remote_work: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
     health_insurance_provider: Option<String>,
     max_vacation_days: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
     retirement_plan: Option<RetirementPlan>,
 }
 
@@ -45,6 +47,7 @@ enum ComplexEvent {
         items: Vec<PurchaseItem>,
         order_id: String,
         payment_method: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
         shipping_address: Option<Address>,
         total_amount: u32,
         user_id: String,
@@ -68,7 +71,9 @@ enum ComplexEvent {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct ContactInfo {
     email: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     emergency_contact: Option<EmergencyContact>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     phone: Option<String>,
 }
 
@@ -84,6 +89,7 @@ struct DocumentedUser {
     /// Whether the user's account is active.
     is_active: bool,
     /// Optional additional metadata.
+    #[serde(skip_serializing_if = "Option::is_none")]
     metadata: Option<HashMap<String, String>>,
     /// The user's full name.
     name: String,
@@ -98,11 +104,15 @@ struct EdgeCases {
     medium_number: u32,
     nested_array: Vec<ContactInfo>,
     // Nested optional structures
+    #[serde(skip_serializing_if = "Option::is_none")]
     nested_optional: Option<ContactInfo>,
     numbers: Vec<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     optional_nested_array: Option<Vec<ContactInfo>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     optional_numbers: Option<Vec<u32>>,
     // Optional collections
+    #[serde(skip_serializing_if = "Option::is_none")]
     optional_strings: Option<Vec<String>>,
     small_number: u16,
     // Simple maps (only string keys and values supported)
@@ -126,6 +136,7 @@ struct EmergencyContact {
 struct Employee {
     contact: ContactInfo,
     id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     manager: Option<String>, // Manager ID
     name: String,
     position: String,
@@ -137,7 +148,9 @@ struct Employee {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct Project {
     assigned_employees: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     budget: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     deadline: Option<String>,
     id: String,
     name: String,
@@ -158,6 +171,7 @@ enum ProjectStatus {
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct PurchaseItem {
+    #[serde(skip_serializing_if = "Option::is_none")]
     discount_applied: Option<u32>,
     product_id: String,
     quantity: u32,

--- a/tests/basic_tests/tests.rs
+++ b/tests/basic_tests/tests.rs
@@ -1,6 +1,5 @@
 #[cfg(all(
     test,
-    feature = "serde",
     any(feature = "typescript", feature = "jsonschema", feature = "zod")
 ))]
 use serde::{Deserialize, Serialize};
@@ -43,13 +42,15 @@ struct EmptyStruct;
 ))]
 // Test struct with optional fields.
 #[model_schema()]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct UserWithOptionals {
+    #[serde(skip_serializing_if = "Option::is_none")]
     age: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     email: Option<String>,
     id: String,
     name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     nickname: Option<String>,
 }
 

--- a/tests/chrono_tests/tests.rs
+++ b/tests/chrono_tests/tests.rs
@@ -1,7 +1,6 @@
 use chrono::{DateTime, Local, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 use std::collections::HashMap;
 
-#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use tixschema::model_schema;
@@ -80,10 +79,10 @@ struct LocalTimestamp {
 
 // Test struct with optional DateTime.
 #[model_schema()]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct OptionalTimestamp {
     id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     updated_at: Option<DateTime<Utc>>,
 }
 

--- a/tests/edge_cases_tests/tests.rs
+++ b/tests/edge_cases_tests/tests.rs
@@ -1,4 +1,4 @@
-#[cfg(all(test, feature = "serde"))]
+#[cfg(all(test, any(feature = "typescript", feature = "zod", feature = "serde")))]
 use serde::{Deserialize, Serialize};
 
 #[cfg(all(
@@ -79,10 +79,10 @@ type QuadrupleNestedValue = Vec<HashMap<String, Vec<HashMap<String, u64>>>>;
 #[cfg(all(test, any(feature = "typescript", feature = "zod", feature = "serde")))]
 // Now let's try the really complex case
 #[model_schema()]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct ReallyComplexTest {
     // Another challenging case with optional nested structures
+    #[serde(skip_serializing_if = "Option::is_none")]
     optional_nested: Option<HashMap<String, OptionalNestedValue>>,
 
     // The quadruple nested case that was causing issues

--- a/tests/example_tests/tests.rs
+++ b/tests/example_tests/tests.rs
@@ -122,6 +122,7 @@ fn test_nested_types_example() {
     #[derive(Serialize, Deserialize, Debug, Clone)]
     pub struct Profile {
         pub metadata: HashMap<String, String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub optional_field: Option<String>,
         pub tags: Vec<String>,
     }

--- a/tests/jsonschema_tests/tests.rs
+++ b/tests/jsonschema_tests/tests.rs
@@ -31,6 +31,7 @@ struct AllNumericTypes {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 struct ArrayFields {
     numbers: Vec<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     optional_array: Option<Vec<String>>,
     tags: Vec<String>,
 }
@@ -48,6 +49,7 @@ struct BasicStruct {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 struct ComplexCollections {
     map_of_arrays: HashMap<String, Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     optional_map: Option<HashMap<String, i32>>,
 }
 
@@ -73,8 +75,11 @@ struct MapFields {
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 struct OptionalFields {
+    #[serde(skip_serializing_if = "Option::is_none")]
     optional_bool: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     optional_number: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     optional_string: Option<String>,
     required: String,
 }
@@ -338,6 +343,7 @@ fn test_objectid_generates_proper_schema() {
     #[model_schema()]
     #[derive(Serialize, Deserialize, Debug, Clone)]
     struct Document {
+        #[serde(skip_serializing_if = "Option::is_none")]
         author_id: Option<ObjectId>,
         id: ObjectId,
         tag_ids: Vec<ObjectId>,

--- a/tests/model_schema_prop_tests/tests.rs
+++ b/tests/model_schema_prop_tests/tests.rs
@@ -1,4 +1,12 @@
-#[cfg(all(test, feature = "serde"))]
+#[cfg(all(
+    test,
+    any(
+        feature = "typescript",
+        feature = "jsonschema",
+        feature = "zod",
+        feature = "serde"
+    )
+))]
 use serde::{Deserialize, Serialize};
 #[cfg(all(
     test,
@@ -87,8 +95,7 @@ struct CombinedTest {
     )
 ))]
 #[model_schema()]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct MinLengthTest {
     // Regular string without minLength
     pub description: String,
@@ -96,6 +103,7 @@ struct MinLengthTest {
     pub name: String,
     // Optional string with minLength
     #[model_schema_prop(as = String, minLength = 3)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub nickname: Option<String>,
     #[model_schema_prop(as = String, minLength = 10)]
     pub password: String,
@@ -139,11 +147,11 @@ struct MultipleLiterals {
     )
 ))]
 #[model_schema()]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct OptionalLiteral {
     pub id: String,
     #[model_schema_prop(literal = "optional_literal")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub optional_type: Option<String>,
 }
 
@@ -157,8 +165,7 @@ struct OptionalLiteral {
     )
 ))]
 #[model_schema()]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct Inner {
     pub value: String,
 }
@@ -173,14 +180,16 @@ struct Inner {
     )
 ))]
 #[model_schema()]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct TsOptionalStruct {
     #[model_schema_prop(ts_optional)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub f: Option<Inner>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub g: Option<Inner>,
     // `as` is currently a no-op override; this field guards their coexistence.
     #[model_schema_prop(as = Inner, ts_optional)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub h: Option<Inner>,
 }
 
@@ -189,12 +198,12 @@ struct TsOptionalStruct {
     any(feature = "typescript", feature = "jsonschema", feature = "zod")
 ))]
 #[model_schema()]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", serde(tag = "type"))]
 enum TsOptionalVariant {
     FilterPart {
         #[model_schema_prop(ts_optional)]
+        #[serde(skip_serializing_if = "Option::is_none")]
         filter: Option<Inner>,
     },
 }

--- a/tests/mongodb_real_tests/tests.rs
+++ b/tests/mongodb_real_tests/tests.rs
@@ -17,6 +17,7 @@ struct RealDocument {
     id: ObjectId,
     metadata: HashMap<String, ObjectId>,
     nested_refs: HashMap<String, Vec<ObjectId>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     parent_id: Option<ObjectId>,
     references: Vec<ObjectId>,
     title: String,
@@ -26,6 +27,7 @@ struct RealDocument {
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct RealUser {
+    #[serde(skip_serializing_if = "Option::is_none")]
     email: Option<String>,
     id: ObjectId,
     name: String,

--- a/tests/mongodb_tests/tests.rs
+++ b/tests/mongodb_tests/tests.rs
@@ -1,21 +1,18 @@
-#[cfg(feature = "serde")]
 use core::fmt;
-#[cfg(feature = "serde")]
 use serde::de::{self, MapAccess, Visitor};
-#[cfg(feature = "serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::HashMap;
 use tixschema::model_schema;
 
 // Test struct with more complex ObjectId nesting
 #[model_schema()]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct ComplexDocument {
     author_id: ObjectId,
     id: ObjectId,
     metadata: HashMap<String, ObjectId>,
     nested_refs: HashMap<String, Vec<ObjectId>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     parent_id: Option<ObjectId>,
     references: Vec<ObjectId>,
     title: String,
@@ -23,13 +20,13 @@ struct ComplexDocument {
 
 // Test struct with complex ObjectId usage
 #[model_schema()]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct Document {
     author_id: ObjectId,
     id: ObjectId,
     metadata: HashMap<String, ObjectId>,
     nested_refs: HashMap<String, Vec<ObjectId>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     parent_id: Option<ObjectId>,
     references: Vec<ObjectId>,
     title: String,
@@ -43,20 +40,20 @@ pub struct ObjectId(String);
 
 // Test struct with optional nested ObjectId
 #[model_schema()]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct Post {
     author_id: ObjectId,
     id: ObjectId,
+    #[serde(skip_serializing_if = "Option::is_none")]
     parent_id: Option<ObjectId>,
     title: String,
 }
 
 // Test struct with ObjectId field
 #[model_schema()]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct User {
+    #[serde(skip_serializing_if = "Option::is_none")]
     email: Option<String>,
     id: ObjectId,
     name: String,
@@ -94,10 +91,10 @@ struct UserWithObjectIdMap {
 
 // Test struct with optional ObjectId field
 #[model_schema()]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct UserWithOptionalId {
     email: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     id: Option<ObjectId>,
     name: String,
 }
@@ -112,7 +109,6 @@ struct UserWithOtherHashMapObjectId {
     name: String,
 }
 
-#[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for ObjectId {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -160,7 +156,6 @@ impl ObjectId {
     }
 }
 
-#[cfg(feature = "serde")]
 impl Serialize for ObjectId {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/tests/pattern_preprocess_tests/tests.rs
+++ b/tests/pattern_preprocess_tests/tests.rs
@@ -230,6 +230,7 @@ fn test_pattern_optional_field_zod() {
     #[derive(Serialize, Deserialize)]
     pub struct PatternOptional {
         #[model_schema_prop(pattern = "^[0-9]+$")]
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub code: Option<String>,
     }
 
@@ -299,6 +300,7 @@ fn test_preprocess_optional_field_zod() {
     #[derive(Serialize, Deserialize)]
     pub struct PreprocessOptional {
         #[model_schema_prop(preprocess = ["trim"])]
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub nickname: Option<String>,
     }
 

--- a/tests/primitive_types_tests/tests.rs
+++ b/tests/primitive_types_tests/tests.rs
@@ -1,6 +1,5 @@
 #[cfg(all(
     test,
-    feature = "serde",
     any(feature = "typescript", feature = "jsonschema", feature = "zod")
 ))]
 use serde::{Deserialize, Serialize};
@@ -22,15 +21,16 @@ use tixschema::model_schema;
     any(feature = "typescript", feature = "jsonschema", feature = "zod")
 ))]
 #[model_schema()]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct LargeNumbers {
     array_of_i64: Vec<i64>,
     array_of_u64: Vec<u64>,
     id: String,
     large_signed: i64,
     large_unsigned: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
     optional_large_signed: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     optional_large_unsigned: Option<u64>,
 }
 
@@ -61,8 +61,7 @@ struct MixedIntegers {
 ))]
 // Test edge cases with all primitive integer types in various contexts
 #[model_schema()]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct PrimitiveTypesShowcase {
     arch_signed: isize,
     arch_unsigned: usize,
@@ -81,11 +80,17 @@ struct PrimitiveTypesShowcase {
     map_to_u64_array: HashMap<String, Vec<u64>>,
     medium_signed: i32,
     medium_unsigned: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
     opt_array_f64: Option<Vec<f64>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     opt_array_i8: Option<Vec<i8>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     opt_array_u64: Option<Vec<u64>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     opt_f64: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     opt_i8: Option<i8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     opt_u64: Option<u64>,
     small_signed: i16,
     small_unsigned: u16,

--- a/tests/semantic_types_tests/tests.rs
+++ b/tests/semantic_types_tests/tests.rs
@@ -90,6 +90,7 @@ struct CollectionAlias {
 struct ComplexAliasStruct {
     mapped_scores: HashMap<String, Vec<Score>>,
     nested_ids: Vec<Vec<DocumentId>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     optional_id: Option<DocumentId>,
 }
 

--- a/tests/serde_tests/tests.rs
+++ b/tests/serde_tests/tests.rs
@@ -52,10 +52,27 @@ struct Lowercase {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 struct OptionalFields {
+    #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "customOptional")]
     another_optional: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     optional_field: Option<String>,
     required_field: String,
+}
+
+// ========================================================================
+// Option Fields That Satisfy the None-Serialization Guard
+// ========================================================================
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct CompliantOptionals {
+    name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    note: Option<String>,
+    #[model_schema_prop(ts_optional)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tag: Option<String>,
 }
 
 // ========================================================================
@@ -282,4 +299,54 @@ fn test_discriminated_union_with_serde_zod() {
     assert!(zod.contains("userId"));
     assert!(zod.contains("userName"));
     assert!(zod.contains("newEmail"));
+}
+
+#[test]
+#[cfg(feature = "typescript")]
+fn test_compliant_optionals_typescript() {
+    let ts = CompliantOptionals::ts_definition();
+
+    assert!(
+        ts.contains("tag?: string;"),
+        "expected `tag?: string;`:\n{ts}"
+    );
+    assert!(
+        ts.contains("note: string | undefined;"),
+        "expected `note: string | undefined;`:\n{ts}"
+    );
+}
+
+#[test]
+#[cfg(feature = "zod")]
+fn test_compliant_optionals_zod_keeps_undefined_union() {
+    let zod = CompliantOptionals::zod_schema();
+
+    assert!(zod.contains("z.strictObject"));
+    assert!(zod.contains("z.union([z.string(), z.undefined()]).prefault(undefined)"));
+    assert!(!zod.contains("z.nullable"));
+}
+
+/// The guard exists so the wire form matches the schema: `None` must leave the key out.
+#[test]
+fn test_compliant_optionals_serialize_absent_and_parse_absent() {
+    let none = CompliantOptionals {
+        name: "n".to_owned(),
+        note: None,
+        tag: None,
+    };
+    let json = serde_json::to_string(&none).unwrap();
+    assert_eq!(json, r#"{"name":"n"}"#);
+
+    let parsed: CompliantOptionals = serde_json::from_str(r#"{"name":"n"}"#).unwrap();
+    assert_eq!(parsed, none);
+
+    let some = CompliantOptionals {
+        name: "n".to_owned(),
+        note: Some("here".to_owned()),
+        tag: None,
+    };
+    assert_eq!(
+        serde_json::to_string(&some).unwrap(),
+        r#"{"name":"n","note":"here"}"#
+    );
 }

--- a/tests/tuple_field_tests/tests.rs
+++ b/tests/tuple_field_tests/tests.rs
@@ -173,6 +173,7 @@ fn test_optional_tuple_field_zod() {
     #[model_schema()]
     #[derive(Serialize, Deserialize, Debug, Clone)]
     pub struct OptionalPair {
+        #[serde(skip_serializing_if = "Option::is_none")]
         pub values: Option<(String, String)>,
     }
 

--- a/tests/untagged_tests/tests.rs
+++ b/tests/untagged_tests/tests.rs
@@ -45,6 +45,20 @@ enum NamedUnion {
     B { y: i64 },
 }
 
+// Untagged enum whose struct variant carries an `Option` that keeps `None` off the wire, matching
+// the absent form the union member renders.
+#[model_schema()]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+enum CompliantUnion {
+    Count(i64),
+    Note {
+        id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        note: Option<String>,
+    },
+}
+
 #[test]
 fn test_untagged_entry_constructible() {
     let entry = DataElementSampleValueEntry {
@@ -76,6 +90,16 @@ fn test_named_union_typescript() {
     let ts = NamedUnion::ts_definition();
     assert!(
         ts.contains("export type NamedUnion = { x: string } | { y: number };"),
+        "Got:\n{ts}"
+    );
+}
+
+#[test]
+#[cfg(feature = "typescript")]
+fn test_compliant_union_typescript() {
+    let ts = CompliantUnion::ts_definition();
+    assert!(
+        ts.contains("number | { id: string; note: string | undefined };"),
         "Got:\n{ts}"
     );
 }
@@ -143,6 +167,20 @@ fn test_named_union_zod() {
 
 #[test]
 #[cfg(feature = "zod")]
+fn test_compliant_union_zod() {
+    let zod = CompliantUnion::zod_schema();
+    assert!(
+        zod.contains(
+            "z.strictObject({ id: z.string(), \
+             note: z.union([z.string(), z.undefined()]).prefault(undefined), })"
+        ),
+        "Got:\n{zod}"
+    );
+    assert!(!zod.contains("z.nullable"), "Got:\n{zod}");
+}
+
+#[test]
+#[cfg(feature = "zod")]
 fn test_flatten_end_to_end_zod() {
     let zod = DataElementSampleValueVariant::zod_schema();
     assert!(
@@ -182,6 +220,22 @@ fn test_named_union_json_schema() {
 
 #[test]
 #[cfg(feature = "jsonschema")]
+fn test_compliant_union_json_schema() {
+    let schema = CompliantUnion::json_schema();
+    let any_of = schema["anyOf"].as_array().unwrap();
+    let required = any_of[1]["required"].as_array().unwrap();
+    assert!(
+        required.contains(&serde_json::json!("id")),
+        "Got:\n{schema}"
+    );
+    assert!(
+        !required.contains(&serde_json::json!("note")),
+        "Got:\n{schema}"
+    );
+}
+
+#[test]
+#[cfg(feature = "jsonschema")]
 fn test_flatten_end_to_end_json_schema() {
     // A single-variant flattened entry collapses to a flat object (no `oneOf`); the untagged
     // `Vec<DateValue>` still renders its `anyOf` under `sampleValues.items`.
@@ -204,6 +258,20 @@ fn test_serde_round_trip_string_member() {
     let json = serde_json::to_string(&value).unwrap();
     assert_eq!(json, "\"2026-06-26\"");
     let back: DateValue = serde_json::from_str(&json).unwrap();
+    assert_eq!(back, value);
+}
+
+/// The guard exists so the wire form matches the schema: `None` must leave the key out, and the
+/// absent form must parse back through the untagged union.
+#[test]
+fn test_serde_round_trip_compliant_union_omits_none() {
+    let value = CompliantUnion::Note {
+        id: "a".to_owned(),
+        note: None,
+    };
+    let json = serde_json::to_string(&value).unwrap();
+    assert_eq!(json, r#"{"id":"a"}"#);
+    let back: CompliantUnion = serde_json::from_str(&json).unwrap();
     assert_eq!(back, value);
 }
 

--- a/tests/zod_tests/tests.rs
+++ b/tests/zod_tests/tests.rs
@@ -30,6 +30,7 @@ struct AllNumericTypes {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 struct ArrayFields {
     numbers: Vec<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     optional_array: Option<Vec<String>>,
     tags: Vec<String>,
 }
@@ -48,6 +49,7 @@ struct BasicStruct {
 struct ComplexCollections {
     array_of_maps: Vec<HashMap<String, String>>,
     map_of_arrays: HashMap<String, Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     optional_map: Option<HashMap<String, i32>>,
 }
 
@@ -73,8 +75,11 @@ struct MapFields {
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 struct OptionalFields {
+    #[serde(skip_serializing_if = "Option::is_none")]
     optional_bool: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     optional_number: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     optional_string: Option<String>,
     required: String,
 }
@@ -375,6 +380,7 @@ fn test_objectid_generates_proper_validation() {
     #[model_schema()]
     #[derive(Serialize, Deserialize, Debug, Clone)]
     struct Document {
+        #[serde(skip_serializing_if = "Option::is_none")]
         author_id: Option<ObjectId>,
         id: ObjectId,
         tag_ids: Vec<ObjectId>,


### PR DESCRIPTION
A named `Option` field renders in the generated contract as the absent form (`field?: T`, `z.union([T, z.undefined()]).prefault(undefined)` in a `z.strictObject`), but bare serde serializes `None` as an explicit `null` — a latent contract violation for every such field. Three real instances shipped downstream in remargin before being caught one by one.

- `model_schema` now rejects, at macro-expansion time, any named field (plain struct, tagged variant, or untagged variant) whose type is `Option<...>` without `skip_serializing_if` / `skip` / `skip_serializing`. The error names the field and the exact attribute to add.
- `skip_deserializing` does not qualify — it still writes `null` on serialize — and now has its own parse arm; the pre-existing lumped `skip` flag keeps its meaning.
- Positional tuple slots stay exempt: they render `nullable`, which is correct since a slot cannot be omitted.
- Guard keys off the same `is_optional` signal that drives the optional rendering, so guard and contract cannot disagree.
- Crate test fixtures with bare `Option` fields updated to comply; new fixtures pin the error, each satisfying attribute form, the untagged path, and tuple exemption.

Known limit (filed downstream as a follow-up): rustc does not expand `cfg_attr` before attribute proc-macros, so a `cfg_attr`-wrapped serde attribute is invisible to the derive and cannot satisfy the guard; affected fixtures had their serde derives made unconditional.

Gates: `just check`, `just test` (all 32 feature combinations), and `just lint-all` green.