### PR TITLE
fix: reject cfg_attr-wrapped serde attributes at expansion time

### DIFF
--- a/src/features/serde.rs
+++ b/src/features/serde.rs
@@ -5,11 +5,19 @@
 
 #[cfg(test)]
 use crate::rename_rule::resolve_rename_rule;
-use syn::{Attribute, LitStr};
+use proc_macro2::{Delimiter, TokenTree};
+use syn::{Attribute, Error, LitStr, Meta};
+
+/// Message of the rejection raised for a serde attribute hidden behind `cfg_attr`.
+const CFG_ATTR_SERDE_REJECTION: &str = "cfg_attr-wrapped serde attribute is invisible to \
+     model_schema and will be silently ignored by the generator; write #[serde(...)] \
+     unconditionally (serde attrs are inert without the serde derive)";
 
 /// Metadata for serde attributes applied to a struct or enum.
 #[derive(Clone, Debug, Default)]
 pub struct SerdeTypeMeta {
+    /// The rejection raised when the walk met a `cfg_attr`-wrapped serde attribute.
+    pub cfg_attr_rejection: Option<Error>,
     pub content: Option<String>, // e.g., "value" for adjacently tagged enums
     pub rename_all: Option<String>, // e.g., "camelCase"
     pub tag: Option<String>,     // e.g., "behaviorType"
@@ -19,6 +27,8 @@ pub struct SerdeTypeMeta {
 /// Metadata for serde attributes applied to a field.
 #[derive(Clone, Debug, Default)]
 pub struct SerdeFieldMeta {
+    /// The rejection raised when the walk met a `cfg_attr`-wrapped serde attribute.
+    pub cfg_attr_rejection: Option<Error>,
     pub flatten: bool, // Whether the field is `#[serde(flatten)]`
     /// Whether a `None` is left out of the serialized output entirely. `skip_deserializing`
     /// does not qualify: it still writes `null` on the way out.
@@ -27,12 +37,42 @@ pub struct SerdeFieldMeta {
     pub skip: bool,             // Whether to skip the field
 }
 
+/// The rejection for a `cfg_attr` carrying a `serde(...)` attribute, or `None` for every other
+/// `cfg_attr` — gated derives and gated docs stay legal.
+///
+/// A `cfg_attr` on a field or a variant is expanded only after the attribute proc-macro has been
+/// handed the item, so a serde attribute written inside one arrives here unexpanded and would
+/// otherwise be walked past in silence. (An item's own attribute list is resolved by rustc first,
+/// so those arrive already expanded or already stripped and never reach this check.) Reading the
+/// payload would mean applying it in builds where the consumer's cfg predicate is false, and that
+/// predicate cannot be evaluated from a proc macro, so the attribute is rejected, not guessed at.
+fn cfg_attr_serde_rejection(attr: &Attribute) -> Option<Error> {
+    let Meta::List(list) = &attr.meta else {
+        return None;
+    };
+    // Only the top level of the payload is scanned: a `serde` naming the cfg predicate
+    // (`cfg_attr(feature = "serde", ..)`) is a string literal, and one naming a nested predicate
+    // sits inside a group, so neither can be mistaken for the `serde(...)` attribute itself.
+    let mut previous_is_serde = false;
+    for token in list.tokens.clone() {
+        if previous_is_serde
+            && matches!(&token, TokenTree::Group(group) if group.delimiter() == Delimiter::Parenthesis)
+        {
+            return Some(Error::new_spanned(attr, CFG_ATTR_SERDE_REJECTION));
+        }
+        previous_is_serde = matches!(&token, TokenTree::Ident(ident) if ident == "serde");
+    }
+    None
+}
+
 /// Parses serde attributes from a struct or enum.
 pub fn parse_serde_type_attributes(attrs: &[Attribute]) -> SerdeTypeMeta {
     let mut meta = SerdeTypeMeta::default();
 
     for attr in attrs {
-        if attr.path().is_ident("serde") {
+        if attr.path().is_ident("cfg_attr") && meta.cfg_attr_rejection.is_none() {
+            meta.cfg_attr_rejection = cfg_attr_serde_rejection(attr);
+        } else if attr.path().is_ident("serde") {
             attr.parse_nested_meta(|nested| {
                 // Handle `tag = "value"`
                 if nested.path.is_ident("tag") {
@@ -63,6 +103,8 @@ pub fn parse_serde_type_attributes(attrs: &[Attribute]) -> SerdeTypeMeta {
             .unwrap_or_else(|e| {
                 log::trace!("Failed to parse serde type attribute: {e}");
             });
+        } else {
+            // Ignore attributes that are neither serde nor a cfg_attr wrapper.
         }
     }
 
@@ -74,7 +116,9 @@ pub fn parse_serde_field_attributes(attrs: &[Attribute]) -> SerdeFieldMeta {
     let mut meta = SerdeFieldMeta::default();
 
     for attr in attrs {
-        if attr.path().is_ident("serde") {
+        if attr.path().is_ident("cfg_attr") && meta.cfg_attr_rejection.is_none() {
+            meta.cfg_attr_rejection = cfg_attr_serde_rejection(attr);
+        } else if attr.path().is_ident("serde") {
             attr.parse_nested_meta(|nested| {
                 // Handle `rename = "value"`
                 if nested.path.is_ident("rename") {
@@ -106,6 +150,8 @@ pub fn parse_serde_field_attributes(attrs: &[Attribute]) -> SerdeFieldMeta {
             .unwrap_or_else(|e| {
                 log::trace!("Failed to parse serde field attribute: {e}");
             });
+        } else {
+            // Ignore attributes that are neither serde nor a cfg_attr wrapper.
         }
     }
 

--- a/src/features/serde/tests.rs
+++ b/src/features/serde/tests.rs
@@ -28,6 +28,7 @@ fn test_rename_all_transformations() {
 #[test]
 fn test_final_field_name() {
     let type_meta = SerdeTypeMeta {
+        cfg_attr_rejection: None,
         tag: None,
         content: None,
         rename_all: Some("camelCase".to_owned()),
@@ -36,6 +37,7 @@ fn test_final_field_name() {
 
     // Test field with explicit rename
     let field_meta_with_rename = SerdeFieldMeta {
+        cfg_attr_rejection: None,
         rename: Some("customName".to_owned()),
         skip: false,
         omits_none: false,
@@ -48,6 +50,7 @@ fn test_final_field_name() {
 
     // Test field with rename_all
     let field_meta_no_rename = SerdeFieldMeta {
+        cfg_attr_rejection: None,
         rename: None,
         skip: false,
         omits_none: false,
@@ -140,6 +143,71 @@ fn test_omits_none_not_set_by_skip_deserializing() {
 fn test_omits_none_default_is_false() {
     let meta = SerdeFieldMeta::default();
     assert!(!meta.omits_none);
+}
+
+#[test]
+fn test_cfg_attr_wrapped_serde_field_attribute_is_rejected() {
+    let item: syn::ItemStruct = syn::parse_quote! {
+        struct S {
+            #[cfg_attr(feature = "serde", serde(rename = "renamed"))]
+            foo: String,
+        }
+    };
+    let meta = field_meta(&item);
+    let message = meta.cfg_attr_rejection.unwrap().to_string();
+    assert!(message.contains("cfg_attr"));
+    assert!(message.contains("#[serde(...)]"));
+    // The wrapper is precisely why the rename never reached the meta.
+    assert!(meta.rename.is_none());
+}
+
+#[test]
+fn test_cfg_attr_wrapped_serde_type_attribute_is_rejected() {
+    let item: syn::ItemEnum = syn::parse_quote! {
+        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+        enum E {
+            FirstOne,
+        }
+    };
+    let meta = parse_serde_type_attributes(&item.attrs);
+    let message = meta.cfg_attr_rejection.unwrap().to_string();
+    assert!(message.contains("cfg_attr"));
+    assert!(message.contains("#[serde(...)]"));
+    assert!(meta.rename_all.is_none());
+}
+
+#[test]
+fn test_cfg_attr_without_serde_payload_is_accepted() {
+    let item: syn::ItemStruct = syn::parse_quote! {
+        #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+        struct S {
+            #[cfg_attr(feature = "serde", doc = "only documented in serde builds")]
+            foo: String,
+        }
+    };
+    assert!(
+        parse_serde_type_attributes(&item.attrs)
+            .cfg_attr_rejection
+            .is_none()
+    );
+    assert!(field_meta(&item).cfg_attr_rejection.is_none());
+}
+
+#[test]
+fn test_plain_serde_attributes_carry_no_rejection() {
+    let item: syn::ItemStruct = syn::parse_quote! {
+        #[serde(rename_all = "camelCase")]
+        struct S {
+            #[serde(rename = "renamed")]
+            foo: String,
+        }
+    };
+    let type_meta = parse_serde_type_attributes(&item.attrs);
+    let meta = field_meta(&item);
+    assert_eq!(type_meta.rename_all.as_deref(), Some("camelCase"));
+    assert!(type_meta.cfg_attr_rejection.is_none());
+    assert_eq!(meta.rename.as_deref(), Some("renamed"));
+    assert!(meta.cfg_attr_rejection.is_none());
 }
 
 #[test]

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -31,7 +31,7 @@ use crate::utils::extract_example_from_docs;
 use crate::utils::lookup_alias_info;
 
 #[cfg(feature = "serde")]
-use crate::features::serde::SerdeFieldMeta;
+use crate::features::serde::{SerdeFieldMeta, SerdeTypeMeta};
 
 #[cfg(feature = "serde")]
 use crate::field_type::{parse_serde_field_attributes, parse_serde_type_attributes};
@@ -555,6 +555,54 @@ where
     Some(TokenStream::from(output))
 }
 
+/// Turns a `cfg_attr` rejection into `compile_error!` tokens naming the item it was found on,
+/// keeping the attribute's span so the diagnostic still points at the offending line.
+#[cfg(feature = "serde")]
+fn cfg_attr_guard_error(rejection: &syn::Error, item: &str) -> proc_macro2::TokenStream {
+    syn::Error::new(
+        rejection.span(),
+        format!("model_schema: {item}: {rejection}"),
+    )
+    .to_compile_error()
+}
+
+/// Names a field in a guard message; tuple slots have no ident to name.
+#[cfg(feature = "serde")]
+fn field_label(raw_field_ident: &str) -> String {
+    if raw_field_ident.is_empty() {
+        "tuple field".to_owned()
+    } else {
+        format!("field `{raw_field_ident}`")
+    }
+}
+
+/// The `compile_error!` tokens for every `cfg_attr`-wrapped serde attribute an enum carries: on the
+/// type (tagging, variant casing) and on each variant (`rename`).
+///
+/// Collected before the enum is dispatched to its shape, since all three shapes read those same
+/// attributes and each would otherwise render a contract the wrapper had quietly emptied.
+#[cfg(feature = "serde")]
+fn enum_cfg_attr_guard_errors(
+    item_enum: &syn::ItemEnum,
+    type_meta: &SerdeTypeMeta,
+) -> Vec<proc_macro2::TokenStream> {
+    let name = &item_enum.ident;
+    type_meta
+        .cfg_attr_rejection
+        .as_ref()
+        .map(|rejection| cfg_attr_guard_error(rejection, &format!("type `{name}`")))
+        .into_iter()
+        .chain(item_enum.variants.iter().filter_map(|variant| {
+            parse_serde_field_attributes(&variant.attrs)
+                .cfg_attr_rejection
+                .as_ref()
+                .map(|rejection| {
+                    cfg_attr_guard_error(rejection, &format!("variant `{}`", variant.ident))
+                })
+        }))
+        .collect()
+}
+
 /// Processes every field of a struct, returning the regular field defs, the `#[serde(flatten)]`
 /// field defs, the per-field serde validation functions and `validate()` body fragments, and the
 /// `compile_error!` tokens for any field-level guard violations.
@@ -659,7 +707,22 @@ fn process_struct(mut item_struct: syn::ItemStruct, args: &ModelSchemaArgs) -> T
     let name = &item_struct.ident;
 
     #[cfg(feature = "serde")]
-    let rename_all = parse_serde_type_attributes(&item_struct.attrs).rename_all;
+    let serde_type_meta = parse_serde_type_attributes(&item_struct.attrs);
+
+    // A hidden `rename_all` reshapes every field name, so the item is rejected before a single
+    // field is processed.
+    #[cfg(feature = "serde")]
+    if let Some(rejection) = serde_type_meta.cfg_attr_rejection.as_ref()
+        && let Some(output) = guard_failure_output(
+            &item_struct,
+            &[cfg_attr_guard_error(rejection, &format!("type `{name}`"))],
+        )
+    {
+        return output;
+    }
+
+    #[cfg(feature = "serde")]
+    let rename_all = serde_type_meta.rename_all;
     #[cfg(not(feature = "serde"))]
     let rename_all: Option<String> = None;
 
@@ -1485,6 +1548,14 @@ fn process_enum(item_enum: syn::ItemEnum) -> TokenStream {
 
     #[cfg(feature = "serde")]
     let serde_type_meta = parse_serde_type_attributes(&item_enum.attrs);
+
+    #[cfg(feature = "serde")]
+    if let Some(output) = guard_failure_output(
+        &item_enum,
+        &enum_cfg_attr_guard_errors(&item_enum, &serde_type_meta),
+    ) {
+        return output;
+    }
 
     let item_name = safe_type_name(&name.to_string());
 
@@ -2363,10 +2434,14 @@ fn collect_untagged_members(item_enum: &mut syn::ItemEnum) -> UntaggedMemberData
                 .unwrap_or_default();
             let mut field_def = get_field_def(&field_name, &field.ty, "");
             let serde_field_meta = parse_serde_field_attributes(&field.attrs);
-            if let Err(err) =
+            if let Some(rejection) = serde_field_meta.cfg_attr_rejection.as_ref() {
+                guard_errors.push(cfg_attr_guard_error(rejection, &field_label(&field_name)));
+            } else if let Err(err) =
                 check_optional_field_serialization(field, field_def.is_optional, &serde_field_meta)
             {
                 guard_errors.push(err.to_compile_error());
+            } else {
+                // No guard violated by this field.
             }
             field_def.resolve_self_references(&enum_type_name);
             field_defs.push(field_def);
@@ -4236,11 +4311,22 @@ fn process_field(
     // Create the field definition and apply any model_schema_prop overrides
     let mut field_def = get_field_def(&final_name, field_type, &field_docs);
 
+    // A hidden serde attribute leaves every other field diagnostic unreliable — the Option-null
+    // guard included, since the wrapper is exactly what kept its evidence out of the meta.
     #[cfg(feature = "serde")]
-    let guard_error =
-        check_optional_field_serialization(field, field_def.is_optional, &serde_field_meta)
-            .err()
-            .map(|err| err.to_compile_error());
+    let guard_error = serde_field_meta.cfg_attr_rejection.as_ref().map_or_else(
+        || {
+            check_optional_field_serialization(field, field_def.is_optional, &serde_field_meta)
+                .err()
+                .map(|err| err.to_compile_error())
+        },
+        |rejection| {
+            Some(cfg_attr_guard_error(
+                rejection,
+                &field_label(&raw_field_ident),
+            ))
+        },
+    );
     #[cfg(not(feature = "serde"))]
     let guard_error: Option<proc_macro2::TokenStream> = None;
 

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -2,8 +2,9 @@ use super::{FieldDefType, validate_as_number_flag, validate_ts_optional_flag};
 
 #[cfg(feature = "serde")]
 use super::{
-    check_optional_field_serialization, collect_untagged_members, get_field_def,
-    parse_serde_field_attributes,
+    cfg_attr_guard_error, check_optional_field_serialization, collect_untagged_members,
+    enum_cfg_attr_guard_errors, field_label, get_field_def, parse_serde_field_attributes,
+    parse_serde_type_attributes,
 };
 
 #[test]
@@ -202,4 +203,100 @@ fn untagged_tuple_variant_option_is_exempt() {
         }
     });
     assert!(errors.is_empty(), "got: {errors:?}");
+}
+
+/// Collects an enum's `cfg_attr` guard failures as rendered `compile_error!` token strings.
+#[cfg(feature = "serde")]
+fn enum_cfg_attr_errors(item: &syn::ItemEnum) -> Vec<String> {
+    let type_meta = parse_serde_type_attributes(&item.attrs);
+    enum_cfg_attr_guard_errors(item, &type_meta)
+        .iter()
+        .map(ToString::to_string)
+        .collect()
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn cfg_attr_wrapped_serde_on_a_type_is_rejected() {
+    let errors = enum_cfg_attr_errors(&syn::parse_quote! {
+        #[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
+        enum Status {
+            Active,
+        }
+    });
+    assert_eq!(errors.len(), 1, "got: {errors:?}");
+    assert!(errors[0].contains("compile_error"), "got: {}", errors[0]);
+    assert!(errors[0].contains("type `Status`"), "got: {}", errors[0]);
+    assert!(errors[0].contains("cfg_attr"), "got: {}", errors[0]);
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn cfg_attr_wrapped_serde_on_a_variant_is_rejected() {
+    let errors = enum_cfg_attr_errors(&syn::parse_quote! {
+        enum Status {
+            #[cfg_attr(feature = "serde", serde(rename = "active"))]
+            Active,
+        }
+    });
+    assert_eq!(errors.len(), 1, "got: {errors:?}");
+    assert!(errors[0].contains("compile_error"), "got: {}", errors[0]);
+    assert!(errors[0].contains("variant `Active`"), "got: {}", errors[0]);
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn cfg_attr_without_serde_leaves_an_enum_alone() {
+    let errors = enum_cfg_attr_errors(&syn::parse_quote! {
+        #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+        #[serde(rename_all = "lowercase")]
+        enum Status {
+            #[cfg_attr(feature = "serde", doc = "only documented in serde builds")]
+            Active,
+        }
+    });
+    assert!(errors.is_empty(), "got: {errors:?}");
+}
+
+/// Runs the field walk the way [`process_field`] does and renders the `cfg_attr` guard failure.
+#[cfg(feature = "serde")]
+fn field_cfg_attr_error(item: &syn::ItemStruct) -> Option<String> {
+    let field = item.fields.iter().next()?;
+    let name = field
+        .ident
+        .as_ref()
+        .map(ToString::to_string)
+        .unwrap_or_default();
+    parse_serde_field_attributes(&field.attrs)
+        .cfg_attr_rejection
+        .as_ref()
+        .map(|rejection| cfg_attr_guard_error(rejection, &field_label(&name)).to_string())
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn cfg_attr_wrapped_serde_on_a_field_is_rejected() {
+    let error = field_cfg_attr_error(&syn::parse_quote! {
+        struct Report {
+            #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+            note: Option<String>,
+        }
+    })
+    .unwrap();
+    assert!(error.contains("compile_error"), "got: {error}");
+    assert!(error.contains("field `note`"), "got: {error}");
+    assert!(error.contains("#[serde(...)]"), "got: {error}");
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn cfg_attr_without_serde_leaves_a_field_alone() {
+    let error = field_cfg_attr_error(&syn::parse_quote! {
+        struct Report {
+            #[cfg_attr(feature = "serde", doc = "only documented in serde builds")]
+            #[serde(skip_serializing_if = "Option::is_none")]
+            note: Option<String>,
+        }
+    });
+    assert!(error.is_none(), "got: {error:?}");
 }

--- a/tests/chrono_tests/tests.rs
+++ b/tests/chrono_tests/tests.rs
@@ -46,9 +46,8 @@ struct EventWithDate {
 
 // Test enum with DateTime variant (the original use case!).
 #[model_schema()]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "serde", serde(tag = "type"))]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(tag = "type")]
 pub enum FixedValue {
     Alphanumeric(String),
     Boolean(bool),
@@ -117,9 +116,8 @@ struct Sample {
 
 // Test enum with a TupleSingle DateTime variant honoring the as_number opt-out.
 #[model_schema()]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", serde(tag = "type"))]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(tag = "type")]
 pub enum DynamicValue {
     Native(DateTime<Utc>),
     Number(#[model_schema_prop(as_number)] DateTime<Utc>),

--- a/tests/enum_tests/tests.rs
+++ b/tests/enum_tests/tests.rs
@@ -1,4 +1,12 @@
-#[cfg(all(test, feature = "serde"))]
+#[cfg(all(
+    test,
+    any(
+        feature = "typescript",
+        feature = "jsonschema",
+        feature = "zod",
+        feature = "serde"
+    )
+))]
 use serde::{Deserialize, Serialize};
 #[cfg(all(test, feature = "jsonschema", feature = "serde"))]
 use serde_json::Value;
@@ -16,13 +24,12 @@ use tixschema::model_schema;
 // Test single-value enum used as a field in a discriminated union.
 #[cfg(all(test, any(feature = "typescript", feature = "zod", feature = "serde")))]
 #[model_schema()]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "serde", serde(tag = "source"))]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(tag = "source")]
 enum ActionWithLiteralEnum {
-    #[cfg_attr(feature = "serde", serde(rename = "generate"))]
+    #[serde(rename = "generate")]
     Generate { value: DocumentLiteralValue },
-    #[cfg_attr(feature = "serde", serde(rename = "upload"))]
+    #[serde(rename = "upload")]
     Upload { value: String },
 }
 
@@ -77,12 +84,8 @@ pub enum DistributionValidMimeType {
 
 #[cfg(all(test, any(feature = "typescript", feature = "zod", feature = "serde")))]
 #[model_schema()]
-#[cfg_attr(
-    feature = "serde",
-    derive(Serialize, Deserialize),
-    serde(rename_all = "lowercase")
-)]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "lowercase")]
 enum DocumentLiteralValue {
     Document,
 }
@@ -106,9 +109,8 @@ pub enum MimeType {
 ))]
 // Test discriminated union (tagged enum).
 #[model_schema()]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "serde", serde(tag = "type", rename_all = "camelCase"))]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(tag = "type", rename_all = "camelCase")]
 enum PaymentMethod {
     BankTransfer {
         account_number: String,
@@ -126,12 +128,8 @@ enum PaymentMethod {
 
 #[cfg(all(test, any(feature = "typescript", feature = "zod", feature = "serde")))]
 #[model_schema()]
-#[cfg_attr(
-    feature = "serde",
-    derive(Serialize, Deserialize),
-    serde(rename_all = "lowercase")
-)]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "lowercase")]
 enum UserStatus {
     Active,
     Inactive,

--- a/tests/model_schema_prop_tests/tests.rs
+++ b/tests/model_schema_prop_tests/tests.rs
@@ -199,7 +199,7 @@ struct TsOptionalStruct {
 ))]
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "serde", serde(tag = "type"))]
+#[serde(tag = "type")]
 enum TsOptionalVariant {
     FilterPart {
         #[model_schema_prop(ts_optional)]


### PR DESCRIPTION
rustc expands an item's own `cfg_attr` list before invoking an attribute proc-macro, but **not** the `cfg_attr` lists of its fields and variants. A serde attribute wrapped there — `#[cfg_attr(feature = "serde", serde(rename_all = ...))]` on a variant, `#[cfg_attr(..., serde(skip_serializing_if = ...))]` on a field — reaches `model_schema` unexpanded and was silently ignored: a hidden `rename_all` generated wrong enum strings, a hidden `skip_serializing_if` silently failed the Option-null guard the author believed they satisfied. (Verified with probe crates in both feature states; one real instance existed in this repo's own fixtures, whose generated discriminators were silently wrong.)

- Both parse walks now detect a `cfg_attr` whose payload carries a `serde(...)` attribute and reject it at expansion time via the existing guard mechanism, naming the item and telling the author to write `#[serde(...)]` unconditionally (serde attrs are inert without the serde derive). The macro cannot evaluate the consumer's cfg predicate, so rejecting beats guessing in either direction.
- Detection is token-precise at the payload's top level: the predicate's `"serde"` is a string literal, nested predicates sit inside groups — neither false-positives. `cfg_attr` payloads without serde (gated derives, gated docs — 14 fixtures in this repo) stay untouched.
- Coverage: struct type-level, struct/variant fields, untagged variant fields, enum type + every variant before shape dispatch. Red-first unit tests at parser and guard level.
- Fixture cleanup: three test files carried cfg_attr-wrapped serde attrs; converted to unconditional forms. One real behavior fix fell out: `ActionWithLiteralEnum`'s variant renames were genuinely dropped — its discriminators now read `generate`/`upload`.

Gates: `just check`, `just test` (all feature combinations) green. Downstream remargin has zero `cfg_attr` usage in .rs sources — no change needed there.