### PR TITLE
fix: stop emitting consumer-evaluated cfg into generated code

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -329,7 +329,6 @@ fn build_struct_schema_example(
     let code = example_code?;
     let code_tokens: proc_macro2::TokenStream = code.parse().unwrap();
     Some(quote! {
-        #[cfg(feature = "zod")]
         pub fn schema_example() -> serde_json::Value {
             let value: #name = {
                 #code_tokens
@@ -965,7 +964,6 @@ fn build_branded_json_schema_method(
     }
 
     quote! {
-        #[cfg(feature = "jsonschema")]
         pub fn json_schema() -> serde_json::Value {
             let mut schema_obj = serde_json::Map::new();
             schema_obj.insert("type".to_string(), serde_json::Value::String(#json_inner_type.to_string()));
@@ -1250,7 +1248,6 @@ fn build_branded_schema_example(
         // For generic newtypes, the example constructs a concrete type (e.g., DocumentId<String>).
         // We use String as the concrete type since the Zod schema always uses z.string().
         quote! {
-            #[cfg(feature = "zod")]
             pub fn schema_example() -> serde_json::Value {
                 let value: #name<String> = {
                     #code_tokens
@@ -1260,7 +1257,6 @@ fn build_branded_schema_example(
         }
     } else {
         quote! {
-            #[cfg(feature = "zod")]
             pub fn schema_example() -> serde_json::Value {
                 let value: #name = {
                     #code_tokens
@@ -4660,6 +4656,30 @@ fn generate_json_docs_part() -> proc_macro2::TokenStream {
     }
 }
 
+/// Binds the `docs` local that an enum's `ts_definition()` renders, enriched with the JSON
+/// schema when this build of tixschema can produce one.
+///
+/// The enrichment reads `Self::json_schema()`, so it may only be emitted when tixschema's own
+/// features put that method in the schema module — deciding here rather than emitting a `cfg`
+/// keeps the reader and the method in agreement regardless of the consumer's feature table.
+#[cfg(feature = "typescript")]
+fn generate_enum_json_docs_part(docs: &str) -> proc_macro2::TokenStream {
+    #[cfg(all(feature = "jsonschema", feature = "zod"))]
+    {
+        quote::quote! {
+            let prettified = serde_json::to_string_pretty(&Self::json_schema()).unwrap().lines().map(|l| format!(" * {l}")).collect::<Vec<_>>().join("\n");
+            let docs = format!("/**\n{}\n * JSON Schema:\n{}\n **/\n", #docs, prettified);
+        }
+    }
+
+    #[cfg(not(all(feature = "jsonschema", feature = "zod")))]
+    {
+        quote::quote! {
+            let docs = format!("/**\n{}\n**/\n", #docs);
+        }
+    }
+}
+
 #[cfg(feature = "jsonschema")]
 /// Generates the JSON schema method for plain enums conditionally.
 fn generate_plain_enum_json_schema_method(
@@ -4690,17 +4710,7 @@ fn generate_plain_enum_ts_definition_method(
 ) -> proc_macro2::TokenStream {
     #[cfg(feature = "typescript")]
     {
-        // Conditional JSON schema docs
-        let json_docs_gen = quote::quote! {
-            #[cfg(all(feature = "jsonschema", feature = "zod"))]
-            let prettified = serde_json::to_string_pretty(&Self::json_schema()).unwrap().lines().map(|l| format!(" * {l}")).collect::<Vec<_>>().join("\n");
-
-            #[cfg(all(feature = "jsonschema", feature = "zod"))]
-            let docs = format!("/**\n{}\n * JSON Schema:\n{}\n **/\n", #docs, prettified);
-
-            #[cfg(not(all(feature = "jsonschema", feature = "zod")))]
-            let docs = format!("/**\n{}\n**/\n", #docs);
-        };
+        let json_docs_gen = generate_enum_json_docs_part(docs);
 
         // TypeScript type generation (only available when typescript feature is enabled)
         let typescript_type_gen = quote::quote! {
@@ -4788,17 +4798,7 @@ fn generate_discriminated_enum_ts_definition_method(
 ) -> proc_macro2::TokenStream {
     #[cfg(feature = "typescript")]
     {
-        // Conditional JSON schema docs
-        let json_docs_gen = quote::quote! {
-            #[cfg(all(feature = "jsonschema", feature = "zod"))]
-            let prettified = serde_json::to_string_pretty(&Self::json_schema()).unwrap().lines().map(|l| format!(" * {l}")).collect::<Vec<_>>().join("\n");
-
-            #[cfg(all(feature = "jsonschema", feature = "zod"))]
-            let docs = format!("/**\n{}\n * JSON Schema:\n{}\n **/\n", #docs, prettified);
-
-            #[cfg(not(all(feature = "jsonschema", feature = "zod")))]
-            let docs = format!("/**\n{}\n**/\n", #docs);
-        };
+        let json_docs_gen = generate_enum_json_docs_part(docs);
 
         quote::quote! {
             pub fn ts_definition() -> String {
@@ -4892,13 +4892,21 @@ fn generate_ts_alias_method(
 
 #[cfg(feature = "typescript")]
 fn generate_alias_json_schema_stub() -> proc_macro2::TokenStream {
-    quote! {
-        #[cfg(feature = "jsonschema")]
-        pub fn json_schema() -> serde_json::Value {
-            serde_json::json!({
-                "warning": "JSON schema generation for aliases is not yet supported"
-            })
+    #[cfg(feature = "jsonschema")]
+    {
+        quote! {
+            pub fn json_schema() -> serde_json::Value {
+                serde_json::json!({
+                    "warning": "JSON schema generation for aliases is not yet supported"
+                })
+            }
         }
+    }
+    #[cfg(not(feature = "jsonschema"))]
+    {
+        // Nothing in this build references an alias module's `json_schema()`; the sibling
+        // reference that would (`flatten_field_json_schema_ref`) is itself jsonschema-gated.
+        quote! {}
     }
 }
 
@@ -4912,7 +4920,6 @@ fn generate_alias_zod_method(export_name: &str, field_def: &FieldDef) -> proc_ma
         // `$Schema`, mirroring how struct/enum schemas expose their const.
         let schema_code = field_def.zod_type();
         quote! {
-            #[cfg(feature = "zod")]
             pub fn zod_schema() -> String {
                 format!(
                     "const {}$RawSchema = {};\n\nexport const {}$Schema: ZodType<{}> = {}$RawSchema;",

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -300,3 +300,122 @@ fn cfg_attr_without_serde_leaves_a_field_alone() {
     });
     assert!(error.is_none(), "got: {error:?}");
 }
+
+/// Reports whether `tokens` contains a `#[cfg(...)]` / `#![cfg(...)]` attribute at any nesting
+/// depth.
+fn contains_cfg_attribute(tokens: proc_macro2::TokenStream) -> bool {
+    let mut in_attr_prefix = false;
+    for tree in tokens {
+        match tree {
+            proc_macro2::TokenTree::Punct(punct) => {
+                let ch = punct.as_char();
+                in_attr_prefix = ch == '#' || (in_attr_prefix && ch == '!');
+            }
+            proc_macro2::TokenTree::Group(group) => {
+                let is_cfg_attr = in_attr_prefix
+                    && group.delimiter() == proc_macro2::Delimiter::Bracket
+                    && matches!(
+                        group.stream().into_iter().next(),
+                        Some(proc_macro2::TokenTree::Ident(ident)) if ident == "cfg"
+                    );
+                if is_cfg_attr || contains_cfg_attribute(group.stream()) {
+                    return true;
+                }
+                in_attr_prefix = false;
+            }
+            proc_macro2::TokenTree::Ident(_) | proc_macro2::TokenTree::Literal(_) => {
+                in_attr_prefix = false;
+            }
+        }
+    }
+    false
+}
+
+/// A `cfg` attribute in the macro's output is resolved against the *consumer's* feature table,
+/// not tixschema's, so an item emitted per tixschema's features can call a method the consumer
+/// cfg'd away. Every feature decision must be made while building the tokens, never emitted.
+fn assert_no_cfg_attribute(tokens: &proc_macro2::TokenStream, what: &str) {
+    assert!(
+        !contains_cfg_attribute(tokens.clone()),
+        "{what} emitted a cfg attribute into generated code: {tokens}"
+    );
+}
+
+#[test]
+fn the_cfg_probe_sees_an_emitted_cfg_attribute() {
+    assert!(contains_cfg_attribute(quote::quote! {
+        #[cfg(feature = "zod")]
+        pub fn zod_schema() -> String { String::new() }
+    }));
+    assert!(contains_cfg_attribute(quote::quote! {
+        pub fn wrapper() {
+            #[cfg(feature = "zod")]
+            let _ = 1;
+        }
+    }));
+    assert_no_cfg_attribute(
+        &quote::quote! {
+            pub fn zod_schema() -> String { String::new() }
+        },
+        "a cfg-free token stream",
+    );
+}
+
+#[cfg(feature = "zod")]
+#[test]
+fn struct_schema_example_carries_no_cfg_attribute() {
+    let name: syn::Ident = syn::parse_quote!(Report);
+    let tokens =
+        super::build_struct_schema_example(Some(&"Report { id: 1 }".to_owned()), &name).unwrap();
+    assert_no_cfg_attribute(&tokens, "build_struct_schema_example");
+}
+
+#[cfg(feature = "jsonschema")]
+#[test]
+fn branded_json_schema_method_carries_no_cfg_attribute() {
+    let args = super::ModelSchemaArgs::default();
+    let tokens = super::build_branded_json_schema_method(&args, "string");
+    assert_no_cfg_attribute(&tokens, "build_branded_json_schema_method");
+}
+
+#[cfg(feature = "zod")]
+#[test]
+fn branded_schema_example_carries_no_cfg_attribute() {
+    let name: syn::Ident = syn::parse_quote!(DocumentId);
+    let example = "DocumentId(\"abc\".to_string())".to_owned();
+    for is_generic in [false, true] {
+        let tokens = super::build_branded_schema_example(Some(&example), &name, is_generic);
+        assert_no_cfg_attribute(&tokens, "build_branded_schema_example");
+    }
+}
+
+#[cfg(feature = "typescript")]
+#[test]
+fn plain_enum_ts_definition_carries_no_cfg_attribute() {
+    let tokens = super::generate_plain_enum_ts_definition_method(" * Status", "Status", "  'a'");
+    assert_no_cfg_attribute(&tokens, "generate_plain_enum_ts_definition_method");
+}
+
+#[cfg(feature = "typescript")]
+#[test]
+fn discriminated_enum_ts_definition_carries_no_cfg_attribute() {
+    let tokens =
+        super::generate_discriminated_enum_ts_definition_method(" * Shape", "Shape", "  'a'");
+    assert_no_cfg_attribute(&tokens, "generate_discriminated_enum_ts_definition_method");
+}
+
+#[cfg(feature = "typescript")]
+#[test]
+fn alias_json_schema_stub_carries_no_cfg_attribute() {
+    let tokens = super::generate_alias_json_schema_stub();
+    assert_no_cfg_attribute(&tokens, "generate_alias_json_schema_stub");
+}
+
+#[cfg(feature = "typescript")]
+#[test]
+fn alias_zod_method_carries_no_cfg_attribute() {
+    let ty: syn::Type = syn::parse_quote!(String);
+    let field_def = super::get_field_def("AliasType", &ty, "");
+    let tokens = super::generate_alias_zod_method("AliasType", &field_def);
+    assert_no_cfg_attribute(&tokens, "generate_alias_zod_method");
+}


### PR DESCRIPTION
Twelve `quote!` sites emitted `#[cfg(feature = ...)]` into the macro output. rustc resolves those against the **consumer** crate's feature table (it even warns: *using a cfg inside an attribute macro will use the cfgs from the destination crate*), so a consumer that doesn't define a `jsonschema` feature of its own failed to compile a branded newtype with E0599 — the emitted delegate calls a method whose cfg the consumer can never satisfy.

- Sites whose enclosing builder is already feature-gated in tixschema (struct/branded `schema_example`, branded `json_schema`, alias `zod_schema`) just drop the redundant emitted attribute.
- The genuinely conditional sites — the enum `ts_definition` JSON-docs enrichment (deduplicated into one shared builder) and the alias `json_schema` stub — now branch at **expansion time** on tixschema's own features, same predicates, so delegates and the methods they call are emitted together or not at all.
- Seven red-first token-stream tests pin the invariant: generated output contains no `#[cfg]` attribute at any nesting depth (plus a positive control for the walker).
- Verified against the original repro and a 7-shape probe crate (branded, alias, enums, examples, flatten) across all 64 feature combinations with the consumer defining only an unrelated feature: zero failures, zero warnings.

Gates: `just check`, `just lint-all` (68/68), `just test` (full powerset) green.