### PR TITLE
fix: run both serde guards on the branded-newtype path

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -602,6 +602,93 @@ fn enum_cfg_attr_guard_errors(
         .collect()
 }
 
+/// The `compile_error!` tokens for a branded newtype whose inner type is `Option`, or `None` for
+/// every other inner type.
+///
+/// The shape is refused outright instead of being guarded, because no attribute can repair it.
+/// `#[serde(transparent)]` puts the inner value on the wire by itself, so a `None` arrives as
+/// `null`, and nothing suppresses that: `skip_serializing_if` needs a key to omit and a
+/// transparent newtype has none. Meanwhile every generated surface contradicts that wire — the
+/// TypeScript brand renders `T | undefined & $brand<"Name">`, which parses as
+/// `T | (undefined & $brand<"Name">)` and so admits an unbranded `T`; the Zod schema brands a
+/// `z.union([T, z.undefined()])` while its own annotation still claims the un-unioned inner; and
+/// the JSON schema keeps the inner's `type`, which rejects `null`. The generic arm is no better:
+/// it renders the type parameter and drops the `Option` entirely.
+///
+/// `is_optional` off the same `get_field_def` call the renderers make keeps the guard and the
+/// contract from ever disagreeing about what counts as an `Option`.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn branded_option_inner_error(
+    name: &Ident,
+    inner_field: &Field,
+) -> Option<proc_macro2::TokenStream> {
+    get_field_def("_inner", &inner_field.ty, "")
+        .is_optional
+        .then(|| {
+            syn::Error::new_spanned(
+                inner_field,
+                format!(
+                    "model_schema: branded newtype `{name}` wraps an `Option`, which has no \
+                     representable schema: #[serde(transparent)] writes a `None` to the wire as \
+                     `null` (skip_serializing_if cannot suppress it — a transparent newtype has \
+                     no key to omit), while the generated brand renders the inner type alone. \
+                     Brand the inner type and make the use site optional instead: `Option<{name}>`."
+                ),
+            )
+            .to_compile_error()
+        })
+}
+
+/// The `compile_error!` tokens for every `cfg_attr`-wrapped serde attribute a branded newtype
+/// carries: on the type and on its inner slot, which is positional and so has no name to print.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+fn branded_cfg_attr_guard_errors(
+    item_struct: &syn::ItemStruct,
+    inner_field: &Field,
+) -> Vec<proc_macro2::TokenStream> {
+    let name = &item_struct.ident;
+    parse_serde_type_attributes(&item_struct.attrs)
+        .cfg_attr_rejection
+        .as_ref()
+        .map(|rejection| cfg_attr_guard_error(rejection, &format!("type `{name}`")))
+        .into_iter()
+        .chain(
+            parse_serde_field_attributes(&inner_field.attrs)
+                .cfg_attr_rejection
+                .as_ref()
+                .map(|rejection| cfg_attr_guard_error(rejection, &field_label(""))),
+        )
+        .collect()
+}
+
+#[cfg(all(
+    not(feature = "serde"),
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+const fn branded_cfg_attr_guard_errors(
+    _item_struct: &syn::ItemStruct,
+    _inner_field: &Field,
+) -> Vec<proc_macro2::TokenStream> {
+    Vec::new()
+}
+
+/// The `compile_error!` tokens for every guard a branded newtype violates: a `cfg_attr`-wrapped
+/// serde attribute on the type or on its inner slot, and an `Option` inner type.
+///
+/// The branded path renders the inner type straight into the brand instead of walking fields, so
+/// it has to collect these itself; the ordinary struct walk never sees a transparent newtype.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn branded_guard_errors(item_struct: &syn::ItemStruct) -> Vec<proc_macro2::TokenStream> {
+    let inner_field = item_struct.fields.iter().next().unwrap();
+    branded_cfg_attr_guard_errors(item_struct, inner_field)
+        .into_iter()
+        .chain(branded_option_inner_error(&item_struct.ident, inner_field))
+        .collect()
+}
+
 /// Processes every field of a struct, returning the regular field defs, the `#[serde(flatten)]`
 /// field defs, the per-field serde validation functions and `validate()` body fragments, and the
 /// `compile_error!` tokens for any field-level guard violations.
@@ -1382,6 +1469,12 @@ fn assemble_branded_output(parts: &BrandedNewtypeOutput) -> TokenStream {
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn process_branded_newtype(item_struct: syn::ItemStruct, args: &ModelSchemaArgs) -> TokenStream {
+    // Checked before the type is registered in the alias registry: a rejected brand emits no
+    // schema, so nothing else should be able to resolve a reference to one.
+    if let Some(output) = guard_failure_output(&item_struct, &branded_guard_errors(&item_struct)) {
+        return output;
+    }
+
     let name = item_struct.ident.clone();
     let item_name = safe_type_name(&name.to_string());
     let module_name = format!("{}_schema", to_snake_case(&item_name));

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -329,7 +329,6 @@ fn build_struct_schema_example(
     let code = example_code?;
     let code_tokens: proc_macro2::TokenStream = code.parse().unwrap();
     Some(quote! {
-        #[cfg(feature = "zod")]
         pub fn schema_example() -> serde_json::Value {
             let value: #name = {
                 #code_tokens
@@ -965,7 +964,6 @@ fn build_branded_json_schema_method(
     }
 
     quote! {
-        #[cfg(feature = "jsonschema")]
         pub fn json_schema() -> serde_json::Value {
             let mut schema_obj = serde_json::Map::new();
             schema_obj.insert("type".to_string(), serde_json::Value::String(#json_inner_type.to_string()));
@@ -1250,7 +1248,6 @@ fn build_branded_schema_example(
         // For generic newtypes, the example constructs a concrete type (e.g., DocumentId<String>).
         // We use String as the concrete type since the Zod schema always uses z.string().
         quote! {
-            #[cfg(feature = "zod")]
             pub fn schema_example() -> serde_json::Value {
                 let value: #name<String> = {
                     #code_tokens
@@ -1260,7 +1257,6 @@ fn build_branded_schema_example(
         }
     } else {
         quote! {
-            #[cfg(feature = "zod")]
             pub fn schema_example() -> serde_json::Value {
                 let value: #name = {
                     #code_tokens
@@ -4660,6 +4656,30 @@ fn generate_json_docs_part() -> proc_macro2::TokenStream {
     }
 }
 
+/// Binds the `docs` local that an enum's `ts_definition()` renders, enriched with the JSON
+/// schema when this build of tixschema can produce one.
+///
+/// The enrichment reads `Self::json_schema()`, so it may only be emitted when tixschema's own
+/// features put that method in the schema module — deciding here rather than emitting a `cfg`
+/// keeps the reader and the method in agreement regardless of the consumer's feature table.
+#[cfg(feature = "typescript")]
+fn generate_enum_json_docs_part(docs: &str) -> proc_macro2::TokenStream {
+    #[cfg(all(feature = "jsonschema", feature = "zod"))]
+    {
+        quote::quote! {
+            let prettified = serde_json::to_string_pretty(&Self::json_schema()).unwrap().lines().map(|l| format!(" * {l}")).collect::<Vec<_>>().join("\n");
+            let docs = format!("/**\n{}\n * JSON Schema:\n{}\n **/\n", #docs, prettified);
+        }
+    }
+
+    #[cfg(not(all(feature = "jsonschema", feature = "zod")))]
+    {
+        quote::quote! {
+            let docs = format!("/**\n{}\n**/\n", #docs);
+        }
+    }
+}
+
 #[cfg(feature = "jsonschema")]
 /// Generates the JSON schema method for plain enums conditionally.
 fn generate_plain_enum_json_schema_method(
@@ -4690,17 +4710,7 @@ fn generate_plain_enum_ts_definition_method(
 ) -> proc_macro2::TokenStream {
     #[cfg(feature = "typescript")]
     {
-        // Conditional JSON schema docs
-        let json_docs_gen = quote::quote! {
-            #[cfg(all(feature = "jsonschema", feature = "zod"))]
-            let prettified = serde_json::to_string_pretty(&Self::json_schema()).unwrap().lines().map(|l| format!(" * {l}")).collect::<Vec<_>>().join("\n");
-
-            #[cfg(all(feature = "jsonschema", feature = "zod"))]
-            let docs = format!("/**\n{}\n * JSON Schema:\n{}\n **/\n", #docs, prettified);
-
-            #[cfg(not(all(feature = "jsonschema", feature = "zod")))]
-            let docs = format!("/**\n{}\n**/\n", #docs);
-        };
+        let json_docs_gen = generate_enum_json_docs_part(docs);
 
         // TypeScript type generation (only available when typescript feature is enabled)
         let typescript_type_gen = quote::quote! {
@@ -4788,17 +4798,7 @@ fn generate_discriminated_enum_ts_definition_method(
 ) -> proc_macro2::TokenStream {
     #[cfg(feature = "typescript")]
     {
-        // Conditional JSON schema docs
-        let json_docs_gen = quote::quote! {
-            #[cfg(all(feature = "jsonschema", feature = "zod"))]
-            let prettified = serde_json::to_string_pretty(&Self::json_schema()).unwrap().lines().map(|l| format!(" * {l}")).collect::<Vec<_>>().join("\n");
-
-            #[cfg(all(feature = "jsonschema", feature = "zod"))]
-            let docs = format!("/**\n{}\n * JSON Schema:\n{}\n **/\n", #docs, prettified);
-
-            #[cfg(not(all(feature = "jsonschema", feature = "zod")))]
-            let docs = format!("/**\n{}\n**/\n", #docs);
-        };
+        let json_docs_gen = generate_enum_json_docs_part(docs);
 
         quote::quote! {
             pub fn ts_definition() -> String {
@@ -4892,13 +4892,21 @@ fn generate_ts_alias_method(
 
 #[cfg(feature = "typescript")]
 fn generate_alias_json_schema_stub() -> proc_macro2::TokenStream {
-    quote! {
-        #[cfg(feature = "jsonschema")]
-        pub fn json_schema() -> serde_json::Value {
-            serde_json::json!({
-                "warning": "JSON schema generation for aliases is not yet supported"
-            })
+    #[cfg(feature = "jsonschema")]
+    {
+        quote! {
+            pub fn json_schema() -> serde_json::Value {
+                serde_json::json!({
+                    "warning": "JSON schema generation for aliases is not yet supported"
+                })
+            }
         }
+    }
+    #[cfg(not(feature = "jsonschema"))]
+    {
+        // Nothing in this build references an alias module's `json_schema()`; the sibling
+        // reference that would (`flatten_field_json_schema_ref`) is itself jsonschema-gated.
+        quote! {}
     }
 }
 
@@ -4912,7 +4920,6 @@ fn generate_alias_zod_method(export_name: &str, field_def: &FieldDef) -> proc_ma
         // `$Schema`, mirroring how struct/enum schemas expose their const.
         let schema_code = field_def.zod_type();
         quote! {
-            #[cfg(feature = "zod")]
             pub fn zod_schema() -> String {
                 format!(
                     "const {}$RawSchema = {};\n\nexport const {}$Schema: ZodType<{}> = {}$RawSchema;",

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -7,6 +7,9 @@ use super::{
     parse_serde_type_attributes,
 };
 
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+use super::branded_guard_errors;
+
 #[test]
 fn ts_optional_ok_on_option_field() {
     validate_ts_optional_flag(true, true).unwrap();
@@ -418,4 +421,83 @@ fn alias_zod_method_carries_no_cfg_attribute() {
     let field_def = super::get_field_def("AliasType", &ty, "");
     let tokens = super::generate_alias_zod_method("AliasType", &field_def);
     assert_no_cfg_attribute(&tokens, "generate_alias_zod_method");
+}
+
+/// Collects a branded newtype's guard failures as rendered `compile_error!` token strings.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn branded_errors(item: &syn::ItemStruct) -> Vec<String> {
+    branded_guard_errors(item)
+        .iter()
+        .map(ToString::to_string)
+        .collect()
+}
+
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn cfg_attr_wrapped_serde_on_a_branded_type_is_rejected() {
+    let errors = branded_errors(&syn::parse_quote! {
+        #[serde(transparent)]
+        #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+        struct UserId(pub String);
+    });
+    assert_eq!(errors.len(), 1, "got: {errors:?}");
+    assert!(errors[0].contains("compile_error"), "got: {}", errors[0]);
+    assert!(errors[0].contains("type `UserId`"), "got: {}", errors[0]);
+    assert!(errors[0].contains("cfg_attr"), "got: {}", errors[0]);
+}
+
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn cfg_attr_wrapped_serde_on_a_branded_inner_slot_is_rejected() {
+    let errors = branded_errors(&syn::parse_quote! {
+        #[serde(transparent)]
+        struct UserId(#[cfg_attr(feature = "serde", serde(rename = "inner"))] pub String);
+    });
+    assert_eq!(errors.len(), 1, "got: {errors:?}");
+    assert!(errors[0].contains("compile_error"), "got: {}", errors[0]);
+    assert!(errors[0].contains("tuple field"), "got: {}", errors[0]);
+    assert!(errors[0].contains("#[serde(...)]"), "got: {}", errors[0]);
+}
+
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn branded_newtype_over_option_is_rejected() {
+    let errors = branded_errors(&syn::parse_quote! {
+        #[serde(transparent)]
+        struct MaybeUserId(pub Option<String>);
+    });
+    assert_eq!(errors.len(), 1, "got: {errors:?}");
+    assert!(errors[0].contains("compile_error"), "got: {}", errors[0]);
+    assert!(errors[0].contains("Option"), "got: {}", errors[0]);
+    assert!(errors[0].contains("null"), "got: {}", errors[0]);
+}
+
+/// The generic arm renders the type parameter and drops the `Option` wrapper outright, so the
+/// shape is no more representable there than in the concrete case.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn generic_branded_newtype_over_option_is_rejected() {
+    let errors = branded_errors(&syn::parse_quote! {
+        #[serde(transparent)]
+        struct MaybeId<T>(pub Option<T>);
+    });
+    assert_eq!(errors.len(), 1, "got: {errors:?}");
+    assert!(errors[0].contains("Option"), "got: {}", errors[0]);
+}
+
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn compliant_branded_newtype_passes_every_guard() {
+    let errors = branded_errors(&syn::parse_quote! {
+        #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+        #[serde(transparent)]
+        struct UserId(#[cfg_attr(feature = "serde", doc = "documented in serde builds")] pub String);
+    });
+    assert!(errors.is_empty(), "got: {errors:?}");
 }

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -300,3 +300,122 @@ fn cfg_attr_without_serde_leaves_a_field_alone() {
     });
     assert!(error.is_none(), "got: {error:?}");
 }
+
+/// Reports whether `tokens` contains a `#[cfg(...)]` / `#![cfg(...)]` attribute at any nesting
+/// depth.
+fn contains_cfg_attribute(tokens: proc_macro2::TokenStream) -> bool {
+    let mut in_attr_prefix = false;
+    for tree in tokens {
+        match tree {
+            proc_macro2::TokenTree::Punct(punct) => {
+                let ch = punct.as_char();
+                in_attr_prefix = ch == '#' || (in_attr_prefix && ch == '!');
+            }
+            proc_macro2::TokenTree::Group(group) => {
+                let is_cfg_attr = in_attr_prefix
+                    && group.delimiter() == proc_macro2::Delimiter::Bracket
+                    && matches!(
+                        group.stream().into_iter().next(),
+                        Some(proc_macro2::TokenTree::Ident(ident)) if ident == "cfg"
+                    );
+                if is_cfg_attr || contains_cfg_attribute(group.stream()) {
+                    return true;
+                }
+                in_attr_prefix = false;
+            }
+            proc_macro2::TokenTree::Ident(_) | proc_macro2::TokenTree::Literal(_) => {
+                in_attr_prefix = false;
+            }
+        }
+    }
+    false
+}
+
+/// A `cfg` attribute in the macro's output is resolved against the *consumer's* feature table,
+/// not tixschema's, so an item emitted per tixschema's features can call a method the consumer
+/// cfg'd away. Every feature decision must be made while building the tokens, never emitted.
+fn assert_no_cfg_attribute(tokens: &proc_macro2::TokenStream, what: &str) {
+    assert!(
+        !contains_cfg_attribute(tokens.clone()),
+        "{what} emitted a cfg attribute into generated code: {tokens}"
+    );
+}
+
+#[test]
+fn the_cfg_probe_sees_an_emitted_cfg_attribute() {
+    assert!(contains_cfg_attribute(quote::quote! {
+        #[cfg(feature = "zod")]
+        pub fn zod_schema() -> String { String::new() }
+    }));
+    assert!(contains_cfg_attribute(quote::quote! {
+        pub fn wrapper() {
+            #[cfg(feature = "zod")]
+            let _ = 1;
+        }
+    }));
+    assert_no_cfg_attribute(
+        &quote::quote! {
+            pub fn zod_schema() -> String { String::new() }
+        },
+        "a cfg-free token stream",
+    );
+}
+
+#[cfg(feature = "zod")]
+#[test]
+fn struct_schema_example_carries_no_cfg_attribute() {
+    let name: syn::Ident = syn::parse_quote!(Report);
+    let tokens =
+        super::build_struct_schema_example(Some(&"Report { id: 1 }".to_owned()), &name).unwrap();
+    assert_no_cfg_attribute(&tokens, "build_struct_schema_example");
+}
+
+#[cfg(feature = "jsonschema")]
+#[test]
+fn branded_json_schema_method_carries_no_cfg_attribute() {
+    let args = super::ModelSchemaArgs::default();
+    let tokens = super::build_branded_json_schema_method(&args, "string");
+    assert_no_cfg_attribute(&tokens, "build_branded_json_schema_method");
+}
+
+#[cfg(feature = "zod")]
+#[test]
+fn branded_schema_example_carries_no_cfg_attribute() {
+    let name: syn::Ident = syn::parse_quote!(DocumentId);
+    let example = "DocumentId(\"abc\".to_string())".to_owned();
+    for is_generic in [false, true] {
+        let tokens = super::build_branded_schema_example(Some(&example), &name, is_generic);
+        assert_no_cfg_attribute(&tokens, "build_branded_schema_example");
+    }
+}
+
+#[cfg(feature = "typescript")]
+#[test]
+fn plain_enum_ts_definition_carries_no_cfg_attribute() {
+    let tokens = super::generate_plain_enum_ts_definition_method(" * Status", "Status", "  'a'");
+    assert_no_cfg_attribute(&tokens, "generate_plain_enum_ts_definition_method");
+}
+
+#[cfg(feature = "typescript")]
+#[test]
+fn discriminated_enum_ts_definition_carries_no_cfg_attribute() {
+    let tokens =
+        super::generate_discriminated_enum_ts_definition_method(" * Shape", "Shape", "  'a'");
+    assert_no_cfg_attribute(&tokens, "generate_discriminated_enum_ts_definition_method");
+}
+
+#[cfg(feature = "typescript")]
+#[test]
+fn alias_json_schema_stub_carries_no_cfg_attribute() {
+    let tokens = super::generate_alias_json_schema_stub();
+    assert_no_cfg_attribute(&tokens, "generate_alias_json_schema_stub");
+}
+
+#[cfg(feature = "typescript")]
+#[test]
+fn alias_zod_method_carries_no_cfg_attribute() {
+    let ty: syn::Type = syn::parse_quote!(String);
+    let field_def = super::get_field_def("AliasType", &ty, "");
+    let tokens = super::generate_alias_zod_method("AliasType", &field_def);
+    assert_no_cfg_attribute(&tokens, "generate_alias_zod_method");
+}


### PR DESCRIPTION
Stacked on #28 (same file); GitHub will retarget to master when that merges.

`process_branded_newtype` never called the serde parse walks, so `#[serde(transparent)]` single-field tuple structs bypassed both the cfg_attr rejection (#27) and any shape checking — verified by probe: a cfg_attr-wrapped serde attribute on a branded newtype compiled silently.

- Guard errors are now collected as the path's first act, before `register_alias_info`, so a rejected brand never becomes resolvable: cfg_attr-wrapped serde attributes on the type or the positional inner slot error at expansion time via the #27 mechanism.
- A branded `Option` inner is **refused outright** rather than guarded, because no attribute can repair the shape: transparent serialization writes `None` as `null` with no key for `skip_serializing_if` to omit, while the generated TS brand renders `T | undefined & $brand`, which by `&`/`|` precedence admits any unbranded `T` — the brand is void. Zod and JSON-schema surfaces contradict the wire the same way, and the generic arm drops the `Option` entirely. The diagnostic names the fix: brand the inner type, make the use site `Option<Brand>`. (Previously this shape failed anyway — but as an unattributable E0599 on the generated `Display` impl.)
- Red-first tests at the guard level plus a compliant fixture proving gated derives and gated docs on branded newtypes keep compiling.

Gates: `just check`, `just lint-all` (68/68), `just test` (full powerset) green.