### PR TITLE
fix: emit the alias schema module for every referencing feature

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -50,8 +50,11 @@ use crate::features::jsonschema::{
 #[cfg(any(feature = "typescript", feature = "zod"))]
 use crate::utils::{get_enum_docs, get_struct_docs, strip_examples_from_docs};
 
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+use crate::utils::compute_alias_export_name;
+
 #[cfg(feature = "typescript")]
-use crate::utils::{compute_alias_export_name, format_docs_for_ts, get_item_docs};
+use crate::utils::{format_docs_for_ts, get_item_docs};
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 use crate::utils::register_alias_info;
@@ -209,7 +212,12 @@ pub fn exec_model_schema(args: TokenStream, input: TokenStream) -> TokenStream {
     }
 }
 
-#[cfg(feature = "typescript")]
+/// The alias schema module is referenced by all three schema features — `typescript` and `zod`
+/// through the alias's registered export name, `jsonschema` through a Rust path to
+/// `#module_ident::Schema::json_schema()`. So the module and its `register_alias_info` call are
+/// driven by the union: gating them on `typescript` alone left the jsonschema references
+/// dangling. The module's *contents* are chosen per feature while building the tokens.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn process_type_alias(item_type: ItemType, args: &ModelSchemaArgs) -> TokenStream {
     let mut alias = item_type;
     alias
@@ -222,29 +230,11 @@ fn process_type_alias(item_type: ItemType, args: &ModelSchemaArgs) -> TokenStrea
     let module_name = format!("{}_schema", to_snake_case(&export_name));
     let module_ident = Ident::new(&module_name, rust_ident.span());
 
-    let docs_vec =
-        get_item_docs(&alias.attrs).unwrap_or_else(|| vec![export_name.clone(), String::new()]);
-    let docs_formatted = format_docs_for_ts(&docs_vec, &export_name);
-
     register_alias_info(&rust_ident_str, &export_name, &module_name);
-
-    let generics: Vec<String> = alias
-        .generics
-        .params
-        .iter()
-        .filter_map(|param| {
-            if let GenericParam::Type(tp) = param {
-                Some(crate::safe_type_name(&tp.ident.to_string()))
-            } else {
-                None
-            }
-        })
-        .collect();
 
     let alias_field_def = get_field_def(export_name.as_str(), &alias.ty, "");
 
-    let ts_method =
-        generate_ts_alias_method(&docs_formatted, &export_name, &generics, &alias_field_def);
+    let ts_method = generate_alias_ts_definition_method(&alias, &export_name, &alias_field_def);
     let json_schema_method = generate_alias_json_schema_stub();
     let zod_method = generate_alias_zod_method(&export_name, &alias_field_def);
 
@@ -268,7 +258,7 @@ fn process_type_alias(item_type: ItemType, args: &ModelSchemaArgs) -> TokenStrea
     TokenStream::from(output)
 }
 
-#[cfg(not(feature = "typescript"))]
+#[cfg(not(any(feature = "typescript", feature = "zod", feature = "jsonschema")))]
 fn process_type_alias(item_type: ItemType, _args: &ModelSchemaArgs) -> TokenStream {
     let mut alias = item_type;
     alias
@@ -4953,6 +4943,43 @@ fn generate_discriminated_enum_zod_schema_method(
     }
 }
 
+/// Builds the alias module's `ts_definition()`, or nothing when `typescript` is off. The doc
+/// block and the generic parameter list are only meaningful to TypeScript, so they are gathered
+/// inside the gate rather than by the caller.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn generate_alias_ts_definition_method(
+    alias: &ItemType,
+    export_name: &str,
+    field_def: &FieldDef,
+) -> proc_macro2::TokenStream {
+    #[cfg(feature = "typescript")]
+    {
+        let docs_vec = get_item_docs(&alias.attrs)
+            .unwrap_or_else(|| vec![export_name.to_owned(), String::new()]);
+        let docs_formatted = format_docs_for_ts(&docs_vec, export_name);
+
+        let generics: Vec<String> = alias
+            .generics
+            .params
+            .iter()
+            .filter_map(|param| {
+                if let GenericParam::Type(tp) = param {
+                    Some(crate::safe_type_name(&tp.ident.to_string()))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        generate_ts_alias_method(&docs_formatted, export_name, &generics, field_def)
+    }
+    #[cfg(not(feature = "typescript"))]
+    {
+        let _: &_ = &(alias, export_name, field_def);
+        quote! {}
+    }
+}
+
 #[cfg(feature = "typescript")]
 fn generate_ts_alias_method(
     docs: &str,
@@ -4983,7 +5010,7 @@ fn generate_ts_alias_method(
     }
 }
 
-#[cfg(feature = "typescript")]
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn generate_alias_json_schema_stub() -> proc_macro2::TokenStream {
     #[cfg(feature = "jsonschema")]
     {
@@ -5003,7 +5030,7 @@ fn generate_alias_json_schema_stub() -> proc_macro2::TokenStream {
     }
 }
 
-#[cfg(feature = "typescript")]
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn generate_alias_zod_method(export_name: &str, field_def: &FieldDef) -> proc_macro2::TokenStream {
     #[cfg(feature = "zod")]
     {

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -407,20 +407,33 @@ fn discriminated_enum_ts_definition_carries_no_cfg_attribute() {
     assert_no_cfg_attribute(&tokens, "generate_discriminated_enum_ts_definition_method");
 }
 
-#[cfg(feature = "typescript")]
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
 fn alias_json_schema_stub_carries_no_cfg_attribute() {
     let tokens = super::generate_alias_json_schema_stub();
     assert_no_cfg_attribute(&tokens, "generate_alias_json_schema_stub");
 }
 
-#[cfg(feature = "typescript")]
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
 fn alias_zod_method_carries_no_cfg_attribute() {
     let ty: syn::Type = syn::parse_quote!(String);
     let field_def = super::get_field_def("AliasType", &ty, "");
     let tokens = super::generate_alias_zod_method("AliasType", &field_def);
     assert_no_cfg_attribute(&tokens, "generate_alias_zod_method");
+}
+
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn alias_ts_definition_method_carries_no_cfg_attribute() {
+    let alias: syn::ItemType = syn::parse_quote!(
+        /// An aliased identifier.
+        pub type AliasIdent = String;
+    );
+    let ty: syn::Type = syn::parse_quote!(String);
+    let field_def = super::get_field_def("AliasType", &ty, "");
+    let tokens = super::generate_alias_ts_definition_method(&alias, "AliasType", &field_def);
+    assert_no_cfg_attribute(&tokens, "generate_alias_ts_definition_method");
 }
 
 /// Collects a branded newtype's guard failures as rendered `compile_error!` token strings.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -46,7 +46,9 @@ pub fn safe_type_name(key: &str) -> String {
     }
 }
 
-#[cfg(feature = "typescript")]
+/// The export name is what `register_alias_info` stores and what the alias schema module is
+/// named after, so every feature that references an alias needs it — not just `typescript`.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 pub fn compute_alias_export_name(rust_ident: &str, override_name: Option<String>) -> String {
     match override_name {
         Some(name) if name.trim().is_empty() => format!("{rust_ident}Type"),

--- a/tests/alias_reference_tests.rs
+++ b/tests/alias_reference_tests.rs
@@ -1,0 +1,10 @@
+//! Tests for structs whose fields reference a `#[model_schema()]` type alias.
+//!
+//! Deliberately **not** feature-gated: the alias fixtures below must be expanded in every
+//! feature combination of the powerset. Every other alias fixture in this suite sits behind
+//! `feature = "typescript"`, which is why a jsonschema-without-typescript build referencing a
+//! missing alias schema module went undetected.
+
+#[cfg(test)]
+#[path = "alias_reference_tests/tests.rs"]
+mod tests;

--- a/tests/alias_reference_tests/tests.rs
+++ b/tests/alias_reference_tests/tests.rs
@@ -1,0 +1,68 @@
+use serde::{Deserialize, Serialize};
+use tixschema::model_schema;
+
+#[model_schema()]
+pub type ReferencedDocumentId = String;
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct UsesAliasByValue {
+    pub id: ReferencedDocumentId,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct UsesAliasInCollections {
+    pub ids: Vec<ReferencedDocumentId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub maybe_id: Option<ReferencedDocumentId>,
+}
+
+#[test]
+fn struct_referencing_an_alias_expands_in_this_feature_combination() {
+    let value = UsesAliasByValue {
+        id: "doc-1".to_owned(),
+    };
+    assert_eq!(value.id, "doc-1");
+
+    let collections = UsesAliasInCollections {
+        ids: vec!["doc-2".to_owned()],
+        maybe_id: None,
+    };
+    assert_eq!(collections.ids, vec!["doc-2".to_owned()]);
+    assert!(collections.maybe_id.is_none());
+}
+
+#[cfg(feature = "jsonschema")]
+#[test]
+fn alias_module_backs_the_reference_emitted_by_the_referencing_struct() {
+    let schema = UsesAliasByValue::json_schema();
+    let properties = schema.get("properties").unwrap();
+    assert!(properties.get("id").is_some());
+    assert_eq!(
+        properties.get("id").unwrap(),
+        &referenced_document_id_type_schema::Schema::json_schema()
+    );
+}
+
+#[cfg(feature = "typescript")]
+#[test]
+fn alias_reference_uses_the_registered_export_name() {
+    let ts = UsesAliasByValue::ts_definition();
+    assert!(ts.contains("ReferencedDocumentIdType"), "got: {ts}");
+}
+
+#[cfg(feature = "zod")]
+#[test]
+fn alias_zod_schema_name_matches_the_reference_emitted_by_the_struct() {
+    let alias_zod = referenced_document_id_type_schema::Schema::zod_schema();
+    assert!(
+        alias_zod.contains("ReferencedDocumentIdType$Schema"),
+        "got: {alias_zod}"
+    );
+    let struct_zod = UsesAliasByValue::zod_schema();
+    assert!(
+        struct_zod.contains("ReferencedDocumentIdType$Schema"),
+        "got: {struct_zod}"
+    );
+}


### PR DESCRIPTION
`process_type_alias` emitted the alias schema module — and its `register_alias_info` call — only under the `typescript` feature. But the audit found five `jsonschema`-gated sites referencing the module as a **Rust path** (`<alias>_schema::Schema::json_schema()`), and `zod` output naming its **registered export**. Consequences, both reproduced:

- `jsonschema` without `typescript`: `error[E0433]: cannot find module or crate ..._schema` — 16 of 64 feature combinations broken for any consumer with a struct field typed as a `model_schema` alias.
- `zod` without `typescript`: generated Zod names a schema const that is never defined (silent — Zod output is a string). Verified via `cargo expand`: before, `v: Alias$Schema` with no module; after, `v: AliasType$Schema` with the module defining it. This also proves `register_alias_info` is load-bearing — the unregistered fallback name diverges from the module's actual name, so emitting the module without registering would not have fixed the E0433.

The module and registration are now driven by the union `any(typescript, zod, jsonschema)` — the same cfg `register_alias_info` itself already carried — with contents chosen per feature at expansion time (the no-emitted-cfg token-stream tests from #28 now run in 3× more combinations, plus one for the new wrapper).

Verification: red-first powerset-visible fixture (an aliased type referenced from a struct field — the gap that let this go undetected); typescript-on output proven byte-identical via `cargo expand` diff against pristine master across 15 fixture×feature combinations; consumer repro clean over a 128-combination `cargo hack check`.

Gates: `just check`, `just lint-all` (68/68), `just test` (full powerset) green.