### PR TITLE
fix: resolve aliased map-value schema modules through the alias registry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,9 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = ">=0.4.40", features = ["serde"] }
 regex = ">=1.10"
+# Test-only: `span-locations` makes `Span::source_text()` work outside a real macro expansion,
+# which is how the unit tests assert that generated tokens are spanned on the user's source.
+proc-macro2 = { version = "1", features = ["span-locations"] }
 
 # Transitive dep floors — pinned to fix known vulnerabilities:
 # - bytes >=1.11.1: RUSTSEC-2026-0007 (integer overflow in BytesMut::reserve)

--- a/README.md
+++ b/README.md
@@ -552,6 +552,32 @@ Notes:
 - Serde transparent serialization works normally -- the wrapper is invisible in JSON.
 - Use branded newtypes for opaque IDs and phantom types to prevent passing the wrong ID type across domain boundaries.
 
+#### The `Display` Requirement and `no_display`
+
+Every branded newtype gets a `Display` impl that delegates to its inner value, so **the inner type must implement `Display`**. An inner type that does not is reported at the inner field, naming the trait:
+
+```text
+error[E0277]: `Vec<String>` doesn't implement `std::fmt::Display`
+  --> src/lib.rs:7:21
+   |
+ 7 | pub struct Tags(pub Vec<String>);
+   |                     ^^^^^^^^^^^ the trait `std::fmt::Display` is not implemented for `Vec<String>`
+```
+
+Pass `no_display` for brands over container inner types. The brand then gets no `Display` impl and carries no such requirement; its schema and its serde transparency are unchanged. String constraints are a separate matter: `pattern`, `minLength`, and `maxLength` validate through `to_string()`, so a constrained brand needs a `Display` inner whether or not it passes `no_display`.
+
+```rust
+use tixschema::model_schema;
+use serde::{Deserialize, Serialize};
+
+#[model_schema(no_display)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Tags(pub Vec<String>);
+```
+
+A generic brand carries the requirement as a `Display` bound on each type parameter, so a non-`Display` type argument (e.g. `DocumentId<Vec<String>>`) is rejected where the brand is used rather than where it is declared.
+
 #### Branded Newtype Validation Constraints
 
 You can add `pattern`, `minLength`, and `maxLength` constraints directly on the `#[model_schema()]` attribute for branded newtypes. Constraints are enforced in three places: the generated Zod schema, serde deserialization, and a `validate()` method on the type.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,6 +173,37 @@ pub struct Document {
 /// `ObjectId` fields are serialized using `MongoDB`'s standard format: `{ "$oid": "hex_string" }`
 /// and include proper validation for 24-character hexadecimal `ObjectId` strings.
 ///
+/// ## Branded Newtypes and `no_display`
+///
+/// A `#[serde(transparent)]` single-field tuple struct becomes a branded type, and the macro gives
+/// it a `Display` impl that delegates to the inner value. **The inner type must implement
+/// `Display`.** An inner type that does not is reported at the inner field, naming the trait.
+///
+/// Pass `no_display` for brands whose inner type is a container (or anything else without
+/// `Display`): the brand then gets no `Display` impl and no such requirement, while the generated
+/// schema is unchanged. String constraints are a separate matter -- `pattern`, `minLength`, and
+/// `maxLength` validate through `to_string()`, so a constrained brand needs a `Display` inner
+/// whether or not it passes `no_display`.
+///
+/// ```rust
+/// use tixschema::model_schema;
+/// use serde::{Deserialize, Serialize};
+///
+/// #[model_schema()]
+/// #[derive(Serialize, Deserialize)]
+/// #[serde(transparent)]
+/// pub struct UserId(pub String);
+///
+/// // `Vec<String>` has no `Display`, so this brand opts out of the impl.
+/// #[model_schema(no_display)]
+/// #[derive(Serialize, Deserialize)]
+/// #[serde(transparent)]
+/// pub struct Tags(pub Vec<String>);
+/// ```
+///
+/// A generic brand carries the requirement as a `Display` bound on each type parameter, so a
+/// non-`Display` type argument is rejected where the brand is used, not where it is declared.
+///
 #[proc_macro_attribute]
 pub fn model_schema(args: TokenStream, input: TokenStream) -> TokenStream {
     exec_model_schema(args, input)

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -8,7 +8,13 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::parse::Parser as _;
 use syn::punctuated::Punctuated;
-use syn::{Field, Item, ItemType, MetaNameValue, Token, parse_macro_input};
+use syn::{Field, Item, ItemType, Meta, MetaNameValue, Token, parse_macro_input};
+
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+use quote::quote_spanned;
+
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+use syn::spanned::Spanned as _;
 
 #[cfg(feature = "typescript")]
 use syn::GenericParam;
@@ -109,7 +115,7 @@ type StructFieldData = (
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 struct BrandedNewtypeOutput<'parts> {
     delegate_impl_items: &'parts [proc_macro2::TokenStream],
-    display_impl: &'parts proc_macro2::TokenStream,
+    display_tokens: &'parts proc_macro2::TokenStream,
     generics: &'parts syn::Generics,
     generics_for_ty: &'parts syn::Generics,
     item_struct: &'parts syn::ItemStruct,
@@ -135,6 +141,9 @@ struct ModelSchemaArgs {
     max_length: Option<usize>,
     min_length: Option<usize>,
     name_override: Option<String>,
+    /// Opt-out of the branded newtype `Display` impl (and its inner-type assertion) for brands
+    /// whose inner type is a container rather than a scalar.
+    no_display: bool,
     pattern: Option<String>,
 }
 
@@ -154,38 +163,22 @@ impl ModelSchemaArgs {
     }
 }
 
-fn parse_model_schema_args(args: TokenStream) -> ModelSchemaArgs {
+fn parse_model_schema_args(args: proc_macro2::TokenStream) -> ModelSchemaArgs {
     let mut result = ModelSchemaArgs::default();
 
     if args.is_empty() {
         return result;
     }
 
-    let parser = Punctuated::<MetaNameValue, Token![,]>::parse_terminated;
-    if let Ok(parsed) = parser.parse(args) {
+    let parser = Punctuated::<Meta, Token![,]>::parse_terminated;
+    if let Ok(parsed) = parser.parse2(args) {
         for meta in parsed {
-            if meta.path.is_ident("name")
-                && let syn::Expr::Lit(expr_lit) = &meta.value
-                && let syn::Lit::Str(lit_str) = &expr_lit.lit
-            {
-                result.name_override = Some(lit_str.value());
-            } else if meta.path.is_ident("pattern")
-                && let syn::Expr::Lit(expr_lit) = &meta.value
-                && let syn::Lit::Str(lit_str) = &expr_lit.lit
-            {
-                result.pattern = Some(lit_str.value());
-            } else if meta.path.is_ident("minLength")
-                && let syn::Expr::Lit(expr_lit) = &meta.value
-                && let syn::Lit::Int(lit_int) = &expr_lit.lit
-            {
-                result.min_length = Some(lit_int.base10_parse::<usize>().unwrap());
-            } else if meta.path.is_ident("maxLength")
-                && let syn::Expr::Lit(expr_lit) = &meta.value
-                && let syn::Lit::Int(lit_int) = &expr_lit.lit
-            {
-                result.max_length = Some(lit_int.base10_parse::<usize>().unwrap());
-            } else {
-                // Ignore unknown model_schema args.
+            match &meta {
+                Meta::Path(path) if path.is_ident("no_display") => result.no_display = true,
+                Meta::NameValue(name_value) => apply_named_arg(&mut result, name_value),
+                Meta::Path(_) | Meta::List(_) => {
+                    // Ignore unknown model_schema args.
+                }
             }
         }
     }
@@ -193,11 +186,43 @@ fn parse_model_schema_args(args: TokenStream) -> ModelSchemaArgs {
     result
 }
 
+/// Applies one `key = value` argument to `result`, ignoring unknown keys and mistyped literals.
+fn apply_named_arg(result: &mut ModelSchemaArgs, meta: &MetaNameValue) {
+    if meta.path.is_ident("name")
+        && let syn::Expr::Lit(expr_lit) = &meta.value
+        && let syn::Lit::Str(lit_str) = &expr_lit.lit
+    {
+        result.name_override = Some(lit_str.value());
+    } else if meta.path.is_ident("pattern")
+        && let syn::Expr::Lit(expr_lit) = &meta.value
+        && let syn::Lit::Str(lit_str) = &expr_lit.lit
+    {
+        result.pattern = Some(lit_str.value());
+    } else if meta.path.is_ident("minLength")
+        && let syn::Expr::Lit(expr_lit) = &meta.value
+        && let syn::Lit::Int(lit_int) = &expr_lit.lit
+    {
+        result.min_length = Some(lit_int.base10_parse::<usize>().unwrap());
+    } else if meta.path.is_ident("maxLength")
+        && let syn::Expr::Lit(expr_lit) = &meta.value
+        && let syn::Lit::Int(lit_int) = &expr_lit.lit
+    {
+        result.max_length = Some(lit_int.base10_parse::<usize>().unwrap());
+    } else if meta.path.is_ident("no_display")
+        && let syn::Expr::Lit(expr_lit) = &meta.value
+        && let syn::Lit::Bool(lit_bool) = &expr_lit.lit
+    {
+        result.no_display = lit_bool.value();
+    } else {
+        // Ignore unknown model_schema args.
+    }
+}
+
 /// Executes the `model_schema` macro processing to generate TypeScript and Zod schema definitions.
 ///
 /// This function is the main entry point for the `model_schema` macro and handles both struct and enum types.
 pub fn exec_model_schema(args: TokenStream, input: TokenStream) -> TokenStream {
-    let parsed_args = parse_model_schema_args(args);
+    let parsed_args = parse_model_schema_args(args.into());
     let item = parse_macro_input!(input as Item);
     if let Item::Struct(item_struct) = item {
         process_struct(item_struct, &parsed_args)
@@ -1291,8 +1316,16 @@ fn build_branded_delegate_items(
 }
 
 /// Builds the `Display` impl for a branded newtype, delegating to the inner field's `Display`.
+///
+/// The delegating call carries the inner field's span, so the method-resolution failure it raises
+/// on a non-`Display` inner is reported at the field rather than at `#[model_schema()]`. Only the
+/// span changes; the emitted tokens are the same either way.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-fn build_branded_display_impl(generics: &syn::Generics, name: &Ident) -> proc_macro2::TokenStream {
+fn build_branded_display_impl(
+    generics: &syn::Generics,
+    name: &Ident,
+    inner_field: &Field,
+) -> proc_macro2::TokenStream {
     let (_, type_generics, _) = generics.split_for_impl();
     let mut display_generics = generics.clone();
     for param in &mut display_generics.params {
@@ -1301,13 +1334,91 @@ fn build_branded_display_impl(generics: &syn::Generics, name: &Ident) -> proc_ma
         }
     }
     let (display_impl_generics, _, display_where_clause) = display_generics.split_for_impl();
+    let delegate = quote_spanned! {inner_field.ty.span()=> self.0.fmt(f) };
     quote! {
         impl #display_impl_generics std::fmt::Display for #name #type_generics #display_where_clause {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                self.0.fmt(f)
+                #delegate
             }
         }
     }
+}
+
+/// Builds a branded newtype's `Display` impl together with the static assertion guarding it, or
+/// nothing at all when the brand opted out with `no_display`.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn build_branded_display_tokens(
+    generics: &syn::Generics,
+    name: &Ident,
+    inner_field: &Field,
+    args: &ModelSchemaArgs,
+) -> proc_macro2::TokenStream {
+    if args.no_display {
+        return quote! {};
+    }
+    let display_assertion = build_branded_display_assertion(inner_field, generics);
+    let display_impl = build_branded_display_impl(generics, name, inner_field);
+    quote! {
+        #display_assertion
+        #display_impl
+    }
+}
+
+/// Builds a static assertion that the branded newtype's inner type implements `Display`, spanned
+/// on the inner field so a violation surfaces as an `E0277` naming the trait at the field instead
+/// of the `E0599` raised by `self.0.fmt(f)` deep inside the generated impl.
+///
+/// Emits nothing when the inner type mentions one of the struct's generic parameters: a `const`
+/// item cannot name them, and the `Display` bound the impl adds to every type parameter already
+/// carries the requirement to the instantiation site.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn build_branded_display_assertion(
+    inner_field: &Field,
+    generics: &syn::Generics,
+) -> proc_macro2::TokenStream {
+    if type_mentions_generic_param(&inner_field.ty, generics) {
+        return quote! {};
+    }
+    let inner_ty = &inner_field.ty;
+    // The bound goes in a `where` clause: these tokens carry the user's span, so a consumer's
+    // lints judge them as if they were hand-written there.
+    quote_spanned! {inner_field.ty.span()=>
+        const _: () = {
+            const fn assert_display<T>()
+            where
+                T: std::fmt::Display,
+            {
+            }
+            assert_display::<#inner_ty>();
+        };
+    }
+}
+
+/// Reports whether `ty` names any of `generics`' parameters (type, lifetime, or const).
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn type_mentions_generic_param(ty: &syn::Type, generics: &syn::Generics) -> bool {
+    let param_names: Vec<String> = generics
+        .params
+        .iter()
+        .map(|param| match param {
+            syn::GenericParam::Type(type_param) => type_param.ident.to_string(),
+            syn::GenericParam::Lifetime(lifetime_param) => {
+                lifetime_param.lifetime.ident.to_string()
+            }
+            syn::GenericParam::Const(const_param) => const_param.ident.to_string(),
+        })
+        .collect();
+    !param_names.is_empty() && tokens_name_any(&quote! { #ty }, &param_names)
+}
+
+/// Reports whether `tokens` contains an identifier from `names` at any nesting depth.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn tokens_name_any(tokens: &proc_macro2::TokenStream, names: &[String]) -> bool {
+    tokens.clone().into_iter().any(|tree| match tree {
+        proc_macro2::TokenTree::Ident(ident) => names.iter().any(|name| ident == name.as_str()),
+        proc_macro2::TokenTree::Group(group) => tokens_name_any(&group.stream(), names),
+        proc_macro2::TokenTree::Punct(_) | proc_macro2::TokenTree::Literal(_) => false,
+    })
 }
 
 /// Builds the `schema_example()` method for a branded newtype from extracted example code.
@@ -1418,7 +1529,7 @@ fn assemble_branded_output(parts: &BrandedNewtypeOutput) -> TokenStream {
     let (_, type_generics, _) = parts.generics_for_ty.split_for_impl();
     let (impl_generics, _, where_clause) = parts.generics.split_for_impl();
     let item_struct = parts.item_struct;
-    let display_impl = parts.display_impl;
+    let display_tokens = parts.display_tokens;
     let module_ident = parts.module_ident;
     let schema_impl_items = parts.schema_impl_items;
     let validation_tokens = parts.validation_tokens;
@@ -1430,7 +1541,7 @@ fn assemble_branded_output(parts: &BrandedNewtypeOutput) -> TokenStream {
     let output = quote! {
         #item_struct
 
-        #display_impl
+        #display_tokens
 
         pub mod #module_ident {
             use super::*;
@@ -1471,8 +1582,6 @@ fn process_branded_newtype(item_struct: syn::ItemStruct, args: &ModelSchemaArgs)
     let module_ident = Ident::new(&module_name, name.span());
 
     register_alias_info(&name.to_string(), &item_name, &module_name);
-    #[cfg(not(any(feature = "zod", feature = "jsonschema", feature = "serde")))]
-    let _: &_ = &args;
 
     // Extract docs and example
     #[cfg(feature = "zod")]
@@ -1560,8 +1669,9 @@ fn process_branded_newtype(item_struct: syn::ItemStruct, args: &ModelSchemaArgs)
     let generics_for_ty = item_struct.generics.clone();
     let generics = branded_impl_generics(&item_struct, is_generic, args);
 
-    // --- Generate Display impl for branded newtypes ---
-    let display_impl = build_branded_display_impl(&item_struct.generics, &name);
+    // --- Generate Display impl for branded newtypes (unless the brand opted out) ---
+    let display_tokens =
+        build_branded_display_tokens(&item_struct.generics, &name, inner_field, args);
 
     // --- Inject serde(deserialize_with) on inner field and generate validate() ---
     #[cfg(feature = "serde")]
@@ -1582,7 +1692,7 @@ fn process_branded_newtype(item_struct: syn::ItemStruct, args: &ModelSchemaArgs)
 
     assemble_branded_output(&BrandedNewtypeOutput {
         delegate_impl_items: &delegate_impl_items,
-        display_impl: &display_impl,
+        display_tokens: &display_tokens,
         generics: &generics,
         generics_for_ty: &generics_for_ty,
         item_struct: &output_struct,

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -3567,9 +3567,12 @@ fn build_map_field_schema(
                 &value.field_type
                 && value_lst.is_empty()
             {
-                // For json_schema(), use the module pattern
-                let safe_value_name = safe_type_name(value_type_name);
-                let value_module_name = format!("{}_schema", to_snake_case(&safe_value_name));
+                // For json_schema(), use the module pattern. An alias's module is named after
+                // its registered export name, which the raw ident does not reproduce.
+                let value_module_name = match lookup_alias_info(value_type_name) {
+                    Some(alias) => alias.module_name,
+                    None => format!("{}_schema", to_snake_case(&safe_type_name(value_type_name))),
+                };
                 let value_module_ident = proc_macro2::Ident::new(
                     value_module_name.as_str(),
                     proc_macro2::Span::call_site(),

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -10,6 +10,9 @@ use super::{
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 use super::branded_guard_errors;
 
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+use syn::spanned::Spanned as _;
+
 #[test]
 fn ts_optional_ok_on_option_field() {
     validate_ts_optional_flag(true, true).unwrap();
@@ -513,4 +516,126 @@ fn compliant_branded_newtype_passes_every_guard() {
         struct UserId(#[cfg_attr(feature = "serde", doc = "documented in serde builds")] pub String);
     });
     assert!(errors.is_empty(), "got: {errors:?}");
+}
+
+#[test]
+fn no_display_is_accepted_as_a_bare_flag_and_as_a_named_bool() {
+    assert!(super::parse_model_schema_args(quote::quote! { no_display }).no_display);
+    assert!(super::parse_model_schema_args(quote::quote! { no_display = true }).no_display);
+    assert!(!super::parse_model_schema_args(quote::quote! { no_display = false }).no_display);
+    assert!(!super::parse_model_schema_args(proc_macro2::TokenStream::new()).no_display);
+}
+
+/// The bare flag shares the argument list with the `key = value` args, so parsing it must not
+/// cost the others: a parse failure here silently drops every argument.
+#[test]
+fn no_display_coexists_with_the_named_args() {
+    let args = super::parse_model_schema_args(quote::quote! {
+        name = "Slug", pattern = "^[a-z]+$", minLength = 1, maxLength = 8, no_display
+    });
+    assert_eq!(args.name_override.as_deref(), Some("Slug"));
+    assert_eq!(args.pattern.as_deref(), Some("^[a-z]+$"));
+    assert_eq!(args.min_length, Some(1));
+    assert_eq!(args.max_length, Some(8));
+    assert!(args.no_display);
+}
+
+/// Builds the `Display` assertion for the sole field of `source`, parsed from text so its spans
+/// carry file locations and `source_text()` can report what they point at.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn display_assertion(source: &str) -> proc_macro2::TokenStream {
+    let item: syn::ItemStruct = syn::parse_str(source).unwrap();
+    let field = item.fields.iter().next().unwrap();
+    super::build_branded_display_assertion(field, &item.generics)
+}
+
+/// Collects the source text each token in `tokens` points at, skipping the macro-synthesized
+/// tokens that carry no location.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn located_source_texts(tokens: &proc_macro2::TokenStream) -> Vec<String> {
+    let mut texts = Vec::new();
+    for tree in tokens.clone() {
+        match &tree {
+            proc_macro2::TokenTree::Group(group) => {
+                texts.extend(located_source_texts(&group.stream()));
+            }
+            proc_macro2::TokenTree::Ident(_)
+            | proc_macro2::TokenTree::Punct(_)
+            | proc_macro2::TokenTree::Literal(_) => texts.extend(tree.span().source_text()),
+        }
+    }
+    texts
+}
+
+/// Without a span carried over from the user's source there is no source text to report, which is
+/// what the assertion below would silently degrade into.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn the_span_probe_sees_an_unlocated_token_stream() {
+    let tokens = quote::quote! { const _: () = {}; };
+    assert!(tokens.span().source_text().is_none());
+    assert!(located_source_texts(&tokens).is_empty());
+}
+
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn display_assertion_names_the_trait_and_points_at_the_inner_field() {
+    let tokens = display_assertion("pub struct Tags(pub Vec<String>);");
+    let rendered = tokens.to_string();
+    assert!(
+        rendered.contains("std :: fmt :: Display"),
+        "got: {rendered}"
+    );
+    assert!(rendered.contains("Vec < String >"), "got: {rendered}");
+    assert_eq!(tokens.span().source_text().as_deref(), Some("Vec<String>"));
+}
+
+/// A `const` item cannot name the struct's generic parameters, and the `Display` bound the impl
+/// adds to each type parameter already reports the violation at the instantiation site.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn display_assertion_is_skipped_when_the_inner_names_a_generic_param() {
+    for source in [
+        "pub struct DocumentId<IdType>(pub IdType);",
+        "pub struct Wrapped<T>(pub Vec<T>);",
+        "pub struct Borrowed<'a>(pub &'a str);",
+        "pub struct Fixed<const N: usize>(pub [u8; N]);",
+    ] {
+        let tokens = display_assertion(source);
+        assert!(tokens.is_empty(), "expected no assertion for {source}");
+    }
+}
+
+/// Locks the delegating impl: the tokens are the ones branded newtypes have always carried, and
+/// every located one points at the inner field so a non-`Display` inner is blamed there.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn display_impl_delegates_from_the_inner_field_span() {
+    let item: syn::ItemStruct = syn::parse_str("pub struct UserId(pub String);").unwrap();
+    let field = item.fields.iter().next().unwrap();
+    let tokens = super::build_branded_display_impl(&item.generics, &item.ident, field);
+    assert_eq!(
+        tokens.to_string(),
+        "impl std :: fmt :: Display for UserId { fn fmt (& self , f : & mut std :: fmt :: Formatter < '_ >) -> std :: fmt :: Result { self . 0 . fmt (f) } }"
+    );
+    assert_eq!(
+        located_source_texts(&tokens).join(" "),
+        "UserId String String String String String String",
+        "the interpolated type name, then `self . 0 . fmt (f)` on the inner field"
+    );
+}
+
+/// The generic impl keeps its own `Display` bound on every type parameter; that bound, not the
+/// skipped assertion, is what carries the requirement.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn generic_display_impl_bounds_every_type_parameter() {
+    let item: syn::ItemStruct =
+        syn::parse_str("pub struct DocumentId<IdType>(pub IdType);").unwrap();
+    let field = item.fields.iter().next().unwrap();
+    let tokens = super::build_branded_display_impl(&item.generics, &item.ident, field);
+    assert_eq!(
+        tokens.to_string(),
+        "impl < IdType : std :: fmt :: Display > std :: fmt :: Display for DocumentId < IdType > { fn fmt (& self , f : & mut std :: fmt :: Formatter < '_ >) -> std :: fmt :: Result { self . 0 . fmt (f) } }"
+    );
 }

--- a/tests/alias_reference_tests/tests.rs
+++ b/tests/alias_reference_tests/tests.rs
@@ -1,8 +1,17 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 use tixschema::model_schema;
 
 #[model_schema()]
 pub type ReferencedDocumentId = String;
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DocumentSlot {
+    Primary,
+    Secondary,
+}
 
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -18,6 +27,12 @@ pub struct UsesAliasInCollections {
     pub maybe_id: Option<ReferencedDocumentId>,
 }
 
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct UsesAliasAsMapValue {
+    pub by_slot: HashMap<DocumentSlot, ReferencedDocumentId>,
+}
+
 #[test]
 fn struct_referencing_an_alias_expands_in_this_feature_combination() {
     let value = UsesAliasByValue {
@@ -31,6 +46,14 @@ fn struct_referencing_an_alias_expands_in_this_feature_combination() {
     };
     assert_eq!(collections.ids, vec!["doc-2".to_owned()]);
     assert!(collections.maybe_id.is_none());
+
+    let mut by_slot = HashMap::new();
+    by_slot.insert(DocumentSlot::Primary, "doc-3".to_owned());
+    let map = UsesAliasAsMapValue { by_slot };
+    assert_eq!(
+        map.by_slot.get(&DocumentSlot::Primary),
+        Some(&"doc-3".to_owned())
+    );
 }
 
 #[cfg(feature = "jsonschema")]
@@ -45,11 +68,46 @@ fn alias_module_backs_the_reference_emitted_by_the_referencing_struct() {
     );
 }
 
+#[cfg(feature = "jsonschema")]
+#[test]
+fn alias_module_backs_the_map_value_reference() {
+    let schema = UsesAliasAsMapValue::json_schema();
+    let by_slot = schema.get("properties").unwrap().get("by_slot").unwrap();
+    let alias_schema = referenced_document_id_type_schema::Schema::json_schema();
+    for slot in DocumentSlot::enum_members() {
+        assert_eq!(
+            by_slot.get("properties").unwrap().get(&slot).unwrap(),
+            &alias_schema,
+            "slot {slot} in: {by_slot}"
+        );
+    }
+}
+
 #[cfg(feature = "typescript")]
 #[test]
 fn alias_reference_uses_the_registered_export_name() {
     let ts = UsesAliasByValue::ts_definition();
     assert!(ts.contains("ReferencedDocumentIdType"), "got: {ts}");
+}
+
+#[cfg(feature = "typescript")]
+#[test]
+fn alias_map_value_uses_the_registered_export_name() {
+    let ts = UsesAliasAsMapValue::ts_definition();
+    assert!(
+        ts.contains("Record<DocumentSlot, ReferencedDocumentIdType>"),
+        "got: {ts}"
+    );
+}
+
+#[cfg(feature = "zod")]
+#[test]
+fn alias_map_value_zod_schema_name_matches_the_registered_export() {
+    let zod = UsesAliasAsMapValue::zod_schema();
+    assert!(
+        zod.contains("ReferencedDocumentIdType$Schema"),
+        "got: {zod}"
+    );
 }
 
 #[cfg(feature = "zod")]

--- a/tests/branded_newtype_tests/tests.rs
+++ b/tests/branded_newtype_tests/tests.rs
@@ -658,6 +658,47 @@ mod branded_display_tests {
     }
 }
 
+// A container inner type implements no Display, so `no_display` opts the brand out of the Display
+// impl and of the assertion that guards it. Compiling this module is the assertion: emitting
+// either one over a `Vec` inner is a hard error.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+mod branded_no_display_tests {
+    use super::*;
+
+    #[model_schema(no_display)]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct Tags(pub Vec<String>);
+
+    #[model_schema(no_display)]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct TagList<T>(pub Vec<T>);
+
+    #[test]
+    fn test_no_display_brand_wraps_a_container() {
+        let tags = Tags(vec!["a".to_owned(), "b".to_owned()]);
+        assert_eq!(tags.0, vec!["a".to_owned(), "b".to_owned()]);
+
+        let list = TagList(vec![1_u8, 2_u8]);
+        assert_eq!(list.0, vec![1_u8, 2_u8]);
+    }
+
+    #[cfg(feature = "typescript")]
+    #[test]
+    fn test_no_display_brand_still_generates_typescript() {
+        let ts = Tags::ts_definition();
+        assert!(ts.contains("export type Tags"), "Got: {ts}");
+    }
+
+    #[cfg(feature = "zod")]
+    #[test]
+    fn test_no_display_brand_still_generates_zod() {
+        let zod = Tags::zod_schema();
+        assert!(zod.contains("brand<\"Tags\">"), "Got: {zod}");
+    }
+}
+
 // zod=OFF, typescript=ON tests
 #[cfg(all(feature = "typescript", not(feature = "zod")))]
 mod no_zod_tests {


### PR DESCRIPTION
`build_map_field_schema` derived an aliased `HashMap` value's schema module from the raw type ident (`referenced_document_id_schema`) while the registered module is export-suffixed (`referenced_document_id_type_schema`) — `error[E0433]` under **default features** for any consumer with an aliased map value. The SiblingType-key branch now resolves through `lookup_alias_info` with the same fallback shape as its three peers.

- Red-first fixture: enum-keyed map with a `model_schema`-alias value, failing with the exact E0433 before the fix; jsonschema/TS/Zod surfaces all pinned.
- TS/Zod audit: negative — both string surfaces already consult the registry (verified empirically under `typescript,zod,serde` where the fixed branch is cfg'd out entirely).

Gates: `just check`, `just test` (68-combination powerset) green.