### PR TITLE
fix: scalar map values compile, and an unsupported one fails alone

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -3123,14 +3123,15 @@ fn write_tuple_multiple_variant_fields(
     let _: &_ = &&json_schema_variant_fields;
 }
 
-/// Builds the base JSON schema for a tuple element, ignoring `is_optional`.
+/// The JSON schema value expression for a field whose type renders inline as a scalar — arrayed
+/// when the field is a `Vec` — or `None` for the composite types (sibling references, maps,
+/// tuples, unknowns) that have no inline rendering.
 ///
-/// The nullable wrap is applied by `build_tuple_element_json_schema`.
+/// `is_optional` is not consulted: how an absent value is expressed depends on the position the
+/// value sits in, so each caller wraps this base itself.
 #[cfg(feature = "jsonschema")]
-fn build_tuple_element_base_json_schema(fld: &FieldDef) -> proc_macro2::TokenStream {
-    let field_type = &fld.field_type;
-
-    match field_type {
+fn scalar_field_json_schema_value(fld: &FieldDef) -> Option<proc_macro2::TokenStream> {
+    let schema = match &fld.field_type {
         FieldDefType::String => {
             if fld.is_array {
                 quote! { serde_json::json!({ "type": "array", "items": { "type": "string" } }) }
@@ -3222,11 +3223,21 @@ fn build_tuple_element_base_json_schema(fld: &FieldDef) -> proc_macro2::TokenStr
                 }) }
             }
         }
-        _ => {
-            // For unknown/sibling types, use a generic object schema
-            quote! { serde_json::json!({ "type": "object" }) }
-        }
-    }
+        FieldDefType::Unknown
+        | FieldDefType::SiblingType(..)
+        | FieldDefType::Map(..)
+        | FieldDefType::Tuple(..) => return None,
+    };
+    Some(schema)
+}
+
+/// Builds the base JSON schema for a tuple element, ignoring `is_optional`.
+///
+/// The nullable wrap is applied by `build_tuple_element_json_schema`.
+#[cfg(feature = "jsonschema")]
+fn build_tuple_element_base_json_schema(fld: &FieldDef) -> proc_macro2::TokenStream {
+    scalar_field_json_schema_value(fld)
+        .unwrap_or_else(|| quote! { serde_json::json!({ "type": "object" }) })
 }
 
 /// Builds JSON schema for a tuple element (used for single tuple and multi-tuple variants).
@@ -3658,6 +3669,28 @@ fn build_string_key_map_value_schema(
     }
 }
 
+/// Binds `value_schema` — the JSON schema every member of an enum-keyed map carries — or `None`
+/// when the value type has no rendering here.
+#[cfg(feature = "jsonschema")]
+fn build_enum_key_map_value_binding(value: &FieldDef) -> Option<proc_macro2::TokenStream> {
+    if let FieldDefType::SiblingType(value_type_name, value_lst) = &value.field_type
+        && value_lst.is_empty()
+    {
+        // For json_schema(), use the module pattern. An alias's module is named after
+        // its registered export name, which the raw ident does not reproduce.
+        let value_module_name = match lookup_alias_info(value_type_name) {
+            Some(alias) => alias.module_name,
+            None => format!("{}_schema", to_snake_case(&safe_type_name(value_type_name))),
+        };
+        let value_module_ident =
+            proc_macro2::Ident::new(value_module_name.as_str(), proc_macro2::Span::call_site());
+        return Some(quote! { let value_schema = #value_module_ident::Schema::json_schema(); });
+    }
+
+    let scalar_schema = scalar_field_json_schema_value(value)?;
+    Some(quote! { let value_schema = #scalar_schema; })
+}
+
 #[cfg(feature = "jsonschema")]
 fn build_map_field_schema(
     key: &FieldDef,
@@ -3673,23 +3706,11 @@ fn build_map_field_schema(
             let key_type_name_ident =
                 proc_macro2::Ident::new(key_type_name.as_str(), proc_macro2::Span::call_site());
 
-            let value_schema_code = if let FieldDefType::SiblingType(value_type_name, value_lst) =
-                &value.field_type
-                && value_lst.is_empty()
-            {
-                // For json_schema(), use the module pattern. An alias's module is named after
-                // its registered export name, which the raw ident does not reproduce.
-                let value_module_name = match lookup_alias_info(value_type_name) {
-                    Some(alias) => alias.module_name,
-                    None => format!("{}_schema", to_snake_case(&safe_type_name(value_type_name))),
-                };
-                let value_module_ident = proc_macro2::Ident::new(
-                    value_module_name.as_str(),
-                    proc_macro2::Span::call_site(),
-                );
-                quote! { let value_schema = #value_module_ident::Schema::json_schema(); }
-            } else {
-                quote! { compile_error!("Unsupported map value type"); }
+            // The compile_error! replaces the branch's output rather than joining it: left in
+            // place, the insertion loop below reads a `value_schema` the failed binding never
+            // bound, and the author gets a second E0425 naming macro-internal state.
+            let Some(value_schema_code) = build_enum_key_map_value_binding(value) else {
+                return quote! { compile_error!("Unsupported map value type"); };
             };
 
             quote! {

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -639,3 +639,48 @@ fn generic_display_impl_bounds_every_type_parameter() {
         "impl < IdType : std :: fmt :: Display > std :: fmt :: Display for DocumentId < IdType > { fn fmt (& self , f : & mut std :: fmt :: Formatter < '_ >) -> std :: fmt :: Result { self . 0 . fmt (f) } }"
     );
 }
+
+/// The JSON schema statements a map-typed field expands to, parsed from the map type's source.
+#[cfg(feature = "jsonschema")]
+fn map_field_schema(map_type: &str) -> proc_macro2::TokenStream {
+    let ty: syn::Type = syn::parse_str(map_type).unwrap();
+    let field = super::get_field_def("m", &ty, "");
+    let map_parts = if let FieldDefType::Map(key, value) = &field.field_type {
+        Some((key, value))
+    } else {
+        None
+    };
+    let (key, value) = map_parts.unwrap();
+    super::build_map_field_schema(key, value, "m")
+}
+
+/// A value type the enum-key branch cannot render must yield the `compile_error!` *instead of* the
+/// per-member insertion loop: leaving the loop in place adds an E0425 on the `value_schema` the
+/// failed arm never bound, and that second error names macro-internal state the author cannot act on.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn an_unsupported_enum_keyed_map_value_emits_only_the_compile_error() {
+    for map_type in [
+        "HashMap<Slot, HashMap<String, String>>",
+        "HashMap<Slot, Wrapper<String>>",
+        "HashMap<Slot, (String, u32)>",
+    ] {
+        assert_eq!(
+            map_field_schema(map_type).to_string(),
+            r#"compile_error ! ("Unsupported map value type") ;"#,
+            "for {map_type}"
+        );
+    }
+}
+
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_scalar_enum_keyed_map_value_expands_to_the_per_member_loop() {
+    let tokens = map_field_schema("HashMap<Slot, String>").to_string();
+    assert!(!tokens.contains("compile_error"), "got: {tokens}");
+    assert!(tokens.contains("Slot :: enum_members ()"), "got: {tokens}");
+    assert!(
+        tokens.contains(r#"serde_json :: json ! ({ "type" : "string" })"#),
+        "got: {tokens}"
+    );
+}

--- a/tests/chrono_tests/tests.rs
+++ b/tests/chrono_tests/tests.rs
@@ -35,6 +35,24 @@ struct DateMap {
     name: String,
 }
 
+// An enum-keyed map enumerates its keys, so every member carries the value schema outright
+// instead of the open `additionalProperties` the String-keyed `DateMap` above uses.
+#[model_schema()]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum ScheduleSlot {
+    Closing,
+    Opening,
+}
+
+#[model_schema()]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
+struct SlotSchedule {
+    dates: HashMap<ScheduleSlot, NaiveDate>,
+    timestamps: HashMap<ScheduleSlot, DateTime<Utc>>,
+}
+
 // Test struct with NaiveDate field.
 #[model_schema()]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -149,6 +167,12 @@ fn test_chrono_types_constructible() {
         name: String::new(),
     };
     assert!(date_map.events.is_empty());
+    let slot_schedule = SlotSchedule {
+        dates: HashMap::from([(ScheduleSlot::Opening, date), (ScheduleSlot::Closing, date)]),
+        timestamps: HashMap::new(),
+    };
+    assert_eq!(slot_schedule.dates.len(), 2);
+    assert!(slot_schedule.timestamps.is_empty());
     let values = [
         FixedValue::Alphanumeric(String::new()),
         FixedValue::Boolean(false),
@@ -421,6 +445,32 @@ fn test_vec_date_json_schema() {
     assert_eq!(dates_prop["type"], "array");
     assert_eq!(dates_prop["items"]["type"], "string");
     assert_eq!(dates_prop["items"]["format"], "date");
+}
+
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_enum_keyed_chrono_map_json_schema() {
+    let schema = SlotSchedule::json_schema();
+    let properties = schema["properties"].as_object().unwrap();
+
+    for (field_name, expected_format) in [("dates", "date"), ("timestamps", "date-time")] {
+        let field = &properties[field_name];
+        assert_eq!(field["type"], "object", "in: {field}");
+        assert_eq!(field["additionalProperties"], false, "in: {field}");
+        let members = ScheduleSlot::enum_members();
+        assert_eq!(
+            field["properties"].as_object().unwrap().len(),
+            members.len(),
+            "in: {field}"
+        );
+        for member in members {
+            assert_eq!(
+                field["properties"][&member],
+                serde_json::json!({ "type": "string", "format": expected_format }),
+                "member {member} in: {field}"
+            );
+        }
+    }
 }
 
 // ========== Enum Tests (Original Use Case) ==========

--- a/tests/collection_tests/tests.rs
+++ b/tests/collection_tests/tests.rs
@@ -30,6 +30,26 @@ struct HashMapWith64Bit {
     u64_map: HashMap<String, u64>,
 }
 
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum MetricSlot {
+    Daily,
+    Weekly,
+}
+
+// An enum-keyed map enumerates its keys, so every member carries the value schema outright
+// instead of the open `additionalProperties` a String-keyed map uses.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct EnumKeyedScalarValueMaps {
+    bool_value: HashMap<MetricSlot, bool>,
+    f64_value: HashMap<MetricSlot, f64>,
+    i64_value: HashMap<MetricSlot, i64>,
+    string_array: HashMap<MetricSlot, Vec<String>>,
+    string_value: HashMap<MetricSlot, String>,
+    u64_value: HashMap<MetricSlot, u64>,
+}
+
 // Test struct with collections
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -68,6 +88,29 @@ fn assert_hashmap_array_type(
         properties[field_name]["additionalProperties"]["items"]["type"],
         expected_item_type
     );
+}
+
+#[cfg(feature = "jsonschema")]
+fn assert_enum_keyed_map_value(
+    properties: &serde_json::Map<String, serde_json::Value>,
+    field_name: &str,
+    expected_value_schema: &serde_json::Value,
+) {
+    let field = &properties[field_name];
+    assert_eq!(field["type"], "object", "in: {field}");
+    assert_eq!(field["additionalProperties"], false, "in: {field}");
+    let members = MetricSlot::enum_members();
+    assert_eq!(
+        field["properties"].as_object().unwrap().len(),
+        members.len(),
+        "in: {field}"
+    );
+    for member in members {
+        assert_eq!(
+            &field["properties"][&member], expected_value_schema,
+            "member {member} in: {field}"
+        );
+    }
 }
 
 #[test]
@@ -197,6 +240,108 @@ fn test_comprehensive_hashmap_typescript_generation() {
     assert!(zod_schema.contains("i64_array: z.record(z.string(), z.array(z.number().int()))"));
     assert!(zod_schema.contains("f64_array: z.record(z.string(), z.array(z.number()))"));
     assert!(zod_schema.contains("bool_array: z.record(z.string(), z.array(z.boolean()))"));
+}
+
+#[test]
+fn test_enum_keyed_scalar_value_maps_constructible() {
+    let maps = EnumKeyedScalarValueMaps {
+        bool_value: HashMap::new(),
+        f64_value: HashMap::new(),
+        i64_value: HashMap::new(),
+        string_array: HashMap::new(),
+        string_value: HashMap::from([
+            (MetricSlot::Daily, "d".to_owned()),
+            (MetricSlot::Weekly, "w".to_owned()),
+        ]),
+        u64_value: HashMap::new(),
+    };
+    assert_eq!(
+        maps.string_value.get(&MetricSlot::Daily),
+        Some(&"d".to_owned())
+    );
+    assert_eq!(
+        maps.string_value.get(&MetricSlot::Weekly),
+        Some(&"w".to_owned())
+    );
+}
+
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_enum_keyed_scalar_value_maps_json_schema() {
+    let schema = EnumKeyedScalarValueMaps::json_schema();
+    let properties = schema["properties"].as_object().unwrap();
+
+    assert_enum_keyed_map_value(
+        properties,
+        "string_value",
+        &serde_json::json!({ "type": "string" }),
+    );
+    assert_enum_keyed_map_value(
+        properties,
+        "u64_value",
+        &serde_json::json!({ "type": "integer" }),
+    );
+    assert_enum_keyed_map_value(
+        properties,
+        "i64_value",
+        &serde_json::json!({ "type": "integer" }),
+    );
+    assert_enum_keyed_map_value(
+        properties,
+        "f64_value",
+        &serde_json::json!({ "type": "number" }),
+    );
+    assert_enum_keyed_map_value(
+        properties,
+        "bool_value",
+        &serde_json::json!({ "type": "boolean" }),
+    );
+    assert_enum_keyed_map_value(
+        properties,
+        "string_array",
+        &serde_json::json!({ "type": "array", "items": { "type": "string" } }),
+    );
+}
+
+#[test]
+#[cfg(all(feature = "typescript", feature = "zod"))]
+fn test_enum_keyed_scalar_value_maps_typescript_generation() {
+    let ts_definition = EnumKeyedScalarValueMaps::ts_definition();
+
+    assert!(
+        ts_definition.contains("string_value: Partial<Record<MetricSlot, string>>;"),
+        "Got: {ts_definition}"
+    );
+    assert!(
+        ts_definition.contains("u64_value: Partial<Record<MetricSlot, number>>;"),
+        "Got: {ts_definition}"
+    );
+    assert!(
+        ts_definition.contains("bool_value: Partial<Record<MetricSlot, boolean>>;"),
+        "Got: {ts_definition}"
+    );
+    assert!(
+        ts_definition.contains("string_array: Partial<Record<MetricSlot, Array<string>>>;"),
+        "Got: {ts_definition}"
+    );
+
+    let zod_schema = EnumKeyedScalarValueMaps::zod_schema();
+    assert!(
+        zod_schema.contains("string_value: z.record(MetricSlot$Schema, z.string())"),
+        "Got: {zod_schema}"
+    );
+    assert!(
+        zod_schema.contains("u64_value: z.record(MetricSlot$Schema, z.number().int())"),
+        "Got: {zod_schema}"
+    );
+    assert!(
+        zod_schema.contains("bool_value: z.record(MetricSlot$Schema, z.boolean())"),
+        "Got: {zod_schema}"
+    );
+    assert!(
+        zod_schema.contains("string_array: z.record(MetricSlot$Schema, z.array(z.string()))"),
+        "Got: {zod_schema}"
+    );
 }
 
 #[test]

--- a/tests/mongodb_real_tests/tests.rs
+++ b/tests/mongodb_real_tests/tests.rs
@@ -23,6 +23,21 @@ struct RealDocument {
     title: String,
 }
 
+// An enum-keyed map enumerates its keys, so every member carries the value schema outright
+// instead of the open `additionalProperties` the String-keyed maps above use.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum RefSlot {
+    Author,
+    Reviewer,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct SlottedRefs {
+    by_slot: HashMap<RefSlot, ObjectId>,
+}
+
 // Basic struct with real ObjectId
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -202,6 +217,45 @@ fn test_real_objectid_json_schema_structure() {
     );
     assert_eq!(meta_additional_props["required"][0], "$oid");
     assert_eq!(meta_additional_props["additionalProperties"], false);
+}
+
+#[test]
+fn test_slotted_refs_constructible() {
+    let slotted = SlottedRefs {
+        by_slot: HashMap::from([
+            (RefSlot::Author, ObjectId::new()),
+            (RefSlot::Reviewer, ObjectId::new()),
+        ]),
+    };
+    assert_eq!(slotted.by_slot.len(), 2);
+}
+
+#[test]
+#[cfg(all(feature = "object_id", feature = "jsonschema"))]
+fn test_enum_keyed_objectid_map_json_schema() {
+    let schema = SlottedRefs::json_schema();
+    let by_slot = &schema["properties"]["by_slot"];
+
+    assert_eq!(by_slot["type"], "object");
+    assert_eq!(by_slot["additionalProperties"], false);
+    let members = RefSlot::enum_members();
+    assert_eq!(
+        by_slot["properties"].as_object().unwrap().len(),
+        members.len(),
+        "in: {by_slot}"
+    );
+    for member in members {
+        let value = &by_slot["properties"][&member];
+        assert_eq!(value["type"], "object", "member {member} in: {by_slot}");
+        assert_eq!(
+            value["properties"]["$oid"]["type"], "string",
+            "member {member} in: {by_slot}"
+        );
+        assert_eq!(
+            value["required"][0], "$oid",
+            "member {member} in: {by_slot}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
`HashMap<EnumKey, String>` (or any scalar value) failed with `compile_error!("Unsupported map value type")` **plus** a spurious `E0425` on a variable the failed arm never bound — the error tokens were embedded inside the surrounding insertion loop instead of replacing it.

- The non-map field path's per-type scalar mapping is factored out (`scalar_field_json_schema_value`, verbatim — no duplicated table; tuple-path emissions byte-identical) and reused for enum-keyed map values, honoring `is_array` so `Vec<T>` values wrap for free. Fixtures cover string/u64/i64/f64/bool/`Vec<String>`, chrono, and ObjectId values across json-schema/TS/Zod.
- A genuinely unsupported value now early-returns the bare `compile_error!` (the `guard_failure_output` shape): end-to-end probe shows `due to 1 previous error`, not 2. Token-level pins assert exactly one diagnostic and nothing else for nested-map/generic-sibling/tuple values.

Gates: `just check`, `just lint-all` (68/68), `just test` (full powerset) green.