### PR TITLE
fix: map keys resolve their enum-ness through the alias registry

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -33,8 +33,8 @@ use crate::{
 #[cfg(feature = "zod")]
 use crate::utils::extract_example_from_docs;
 
-#[cfg(feature = "jsonschema")]
-use crate::utils::lookup_alias_info;
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+use crate::utils::{AliasKind, lookup_alias_info};
 
 #[cfg(feature = "serde")]
 use crate::features::serde::{SerdeFieldMeta, SerdeTypeMeta};
@@ -237,6 +237,24 @@ pub fn exec_model_schema(args: TokenStream, input: TokenStream) -> TokenStream {
     }
 }
 
+/// Classifies what an alias resolves to, for the registry.
+///
+/// A `SiblingType` is the only shape that can reach a plain enum, and it answers with whatever the
+/// named type registered: an alias of an alias of an enum inherits `EnumMembers` down the chain.
+/// A target registered after its alias reads as `Unknown`, which callers must treat as "cannot
+/// rule it out" rather than as a negative. An array (`Vec<Slot>`, `[Slot; 4]`) is a collection, not
+/// the enum it holds.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn alias_target_kind(alias_field_def: &FieldDef) -> AliasKind {
+    let FieldDefType::SiblingType(target_name, generic_args) = &alias_field_def.field_type else {
+        return AliasKind::NoEnumMembers;
+    };
+    if !generic_args.is_empty() || alias_field_def.is_array {
+        return AliasKind::NoEnumMembers;
+    }
+    lookup_alias_info(target_name).map_or(AliasKind::Unknown, |target| target.kind)
+}
+
 /// The alias schema module is referenced by all three schema features — `typescript` and `zod`
 /// through the alias's registered export name, `jsonschema` through a Rust path to
 /// `#module_ident::Schema::json_schema()`. So the module and its `register_alias_info` call are
@@ -255,9 +273,11 @@ fn process_type_alias(item_type: ItemType, args: &ModelSchemaArgs) -> TokenStrea
     let module_name = format!("{}_schema", to_snake_case(&export_name));
     let module_ident = Ident::new(&module_name, rust_ident.span());
 
-    register_alias_info(&rust_ident_str, &export_name, &module_name);
-
+    // Registered only once the target has been classified: the alias's own expansion is the only
+    // place that still holds the aliased type's tokens.
     let alias_field_def = get_field_def(export_name.as_str(), &alias.ty, "");
+    let kind = alias_target_kind(&alias_field_def);
+    register_alias_info(&rust_ident_str, &export_name, &module_name, kind);
 
     let ts_method = generate_alias_ts_definition_method(&alias, &export_name, &alias_field_def);
     let json_schema_method = generate_alias_json_schema_stub();
@@ -778,8 +798,23 @@ fn struct_module_idents(name: &syn::Ident) -> (String, String, Ident) {
     let item_name = safe_type_name(&name.to_string());
     let module_name = format!("{}_schema", to_snake_case(&item_name));
     let module_ident = Ident::new(&module_name, name.span());
-    register_alias_info(&name.to_string(), &item_name, &module_name);
+    register_alias_info(
+        &name.to_string(),
+        &item_name,
+        &module_name,
+        AliasKind::NoEnumMembers,
+    );
     (item_name, module_name, module_ident)
+}
+
+/// The enum counterpart of [`struct_module_idents`]. `kind` differs per enum shape: only a plain
+/// unit enum is given an `enum_members()`, so only it can back an enum-keyed map.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn enum_module_idents(name: &syn::Ident, item_name: &str, kind: AliasKind) -> (String, Ident) {
+    let module_name = format!("{}_schema", to_snake_case(item_name));
+    let module_ident = Ident::new(&module_name, name.span());
+    register_alias_info(&name.to_string(), item_name, &module_name, kind);
+    (module_name, module_ident)
 }
 
 /// Extracts a struct's doc lines and the first ` ```rust example ` block (if any) from them.
@@ -1581,7 +1616,12 @@ fn process_branded_newtype(item_struct: syn::ItemStruct, args: &ModelSchemaArgs)
     let module_name = format!("{}_schema", to_snake_case(&item_name));
     let module_ident = Ident::new(&module_name, name.span());
 
-    register_alias_info(&name.to_string(), &item_name, &module_name);
+    register_alias_info(
+        &name.to_string(),
+        &item_name,
+        &module_name,
+        AliasKind::NoEnumMembers,
+    );
 
     // Extract docs and example
     #[cfg(feature = "zod")]
@@ -1909,15 +1949,9 @@ fn process_plain_enum(
     rename_all: Option<&str>,
     item_name: &str,
 ) -> TokenStream {
-    // Compute module name for schema struct (same pattern as type aliases)
+    // Compute the schema module name and register the enum so other types can find it.
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-    let module_name = format!("{}_schema", to_snake_case(item_name));
-    #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-    let module_ident = Ident::new(&module_name, name.span());
-
-    // Register enum in alias registry so other types can find it
-    #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-    register_alias_info(&name.to_string(), item_name, &module_name);
+    let (_, module_ident) = enum_module_idents(name, item_name, AliasKind::EnumMembers);
 
     // Extract docs early for example extraction
     #[cfg(any(feature = "typescript", feature = "zod"))]
@@ -2181,15 +2215,9 @@ fn process_discriminated_enum(
     rename_all: Option<&str>,
     item_name: &str,
 ) -> TokenStream {
-    // Compute module name for schema struct (same pattern as type aliases)
+    // Compute the schema module name and register the enum so other types can find it.
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-    let module_name = format!("{}_schema", to_snake_case(item_name));
-    #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-    let module_ident = Ident::new(&module_name, name.span());
-
-    // Register enum in alias registry so other types can find it
-    #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-    register_alias_info(&name.to_string(), item_name, &module_name);
+    let (module_name, module_ident) = enum_module_idents(name, item_name, AliasKind::NoEnumMembers);
 
     // Extract docs early for example extraction
     #[cfg(any(feature = "typescript", feature = "zod"))]
@@ -2656,15 +2684,9 @@ fn process_untagged_enum(
     name: &syn::Ident,
     item_name: &str,
 ) -> TokenStream {
-    // Compute module name for schema struct (same pattern as type aliases)
+    // Compute the schema module name and register the enum so other types can find it.
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-    let module_name = format!("{}_schema", to_snake_case(item_name));
-    #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-    let module_ident = Ident::new(&module_name, name.span());
-
-    // Register enum in alias registry so other types can find it
-    #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-    register_alias_info(&name.to_string(), item_name, &module_name);
+    let (_, module_ident) = enum_module_idents(name, item_name, AliasKind::NoEnumMembers);
 
     // Extract docs early for example extraction
     #[cfg(any(feature = "typescript", feature = "zod"))]
@@ -3702,6 +3724,21 @@ fn build_map_field_schema(
     match &key.field_type {
         FieldDefType::String => build_string_key_map_value_schema(value, field_name_str),
         FieldDefType::SiblingType(key_type_name, lst) if lst.is_empty() => {
+            // The loop below writes the key as a *type path*, which resolves through any alias, so
+            // an alias of a non-enum lands on a type with no `enum_members()` and rustc blames
+            // `#[model_schema()]` for a missing method the author never wrote. Only a target the
+            // registry positively rules out is rejected here: an unregistered name (a foreign type,
+            // or one expanded after this struct) stays on the emitting path, where it behaves as it
+            // always has.
+            if let Some(key_alias) = lookup_alias_info(key_type_name)
+                && key_alias.kind == AliasKind::NoEnumMembers
+            {
+                let message = format!(
+                    "field `{field_name_str}`: a map key must be a plain `#[model_schema()]` enum, whose members become the object's keys — `{key_type_name}` resolves to a type with no `enum_members()`"
+                );
+                return quote! { compile_error!(#message); };
+            }
+
             // For enum_members(), we call the type directly (delegation works)
             let key_type_name_ident =
                 proc_macro2::Ident::new(key_type_name.as_str(), proc_macro2::Span::call_site());

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -8,7 +8,7 @@ use super::{
 };
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-use super::branded_guard_errors;
+use super::{AliasKind, branded_guard_errors, register_alias_info};
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 use syn::spanned::Spanned as _;
@@ -683,4 +683,84 @@ fn a_scalar_enum_keyed_map_value_expands_to_the_per_member_loop() {
         tokens.contains(r#"serde_json :: json ! ({ "type" : "string" })"#),
         "got: {tokens}"
     );
+}
+
+/// The kind an alias registers is its *target's* answer, because a type path resolves through the
+/// alias. `Vec<Slot>` is the collection, not the enum it holds; a target this expansion has not
+/// seen registered is `Unknown`, which is not a negative.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn an_alias_registers_the_kind_of_what_it_targets() {
+    register_alias_info("Slot", "Slot", "slot_schema", AliasKind::EnumMembers);
+    register_alias_info("Doc", "Doc", "doc_schema", AliasKind::NoEnumMembers);
+    for (target, expected) in [
+        ("Slot", AliasKind::EnumMembers),
+        ("Doc", AliasKind::NoEnumMembers),
+        ("String", AliasKind::NoEnumMembers),
+        ("u32", AliasKind::NoEnumMembers),
+        ("Vec<Slot>", AliasKind::NoEnumMembers),
+        ("HashMap<Slot, String>", AliasKind::NoEnumMembers),
+        ("Wrapper<Slot>", AliasKind::NoEnumMembers),
+        ("Ghost", AliasKind::Unknown),
+    ] {
+        let ty: syn::Type = syn::parse_str(target).unwrap();
+        let kind = super::alias_target_kind(&super::get_field_def("AliasType", &ty, ""));
+        assert_eq!(kind, expected, "for alias target {target}");
+    }
+}
+
+/// An alias of an alias of a plain enum is still a plain enum at the type path, so the chain
+/// carries `EnumMembers` through every link.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn an_alias_chain_carries_the_enum_kind_to_its_end() {
+    register_alias_info("Slot", "Slot", "slot_schema", AliasKind::EnumMembers);
+    let first_target: syn::Type = syn::parse_str("Slot").unwrap();
+    let first = super::alias_target_kind(&super::get_field_def("FirstType", &first_target, ""));
+    register_alias_info("First", "FirstType", "first_type_schema", first);
+
+    let second_target: syn::Type = syn::parse_str("First").unwrap();
+    let second = super::alias_target_kind(&super::get_field_def("SecondType", &second_target, ""));
+    assert_eq!(second, AliasKind::EnumMembers);
+}
+
+/// A key the registry positively rules out never reaches the emitting path: `enum_members()` on it
+/// resolves through the alias to a type that has no such method, and rustc blames the attribute for
+/// a method the author never wrote.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_map_key_known_to_lack_enum_members_names_the_requirement() {
+    register_alias_info(
+        "KeyAlias",
+        "KeyAliasType",
+        "key_alias_type_schema",
+        AliasKind::NoEnumMembers,
+    );
+    let tokens = map_field_schema("HashMap<KeyAlias, String>").to_string();
+    assert!(
+        !tokens.contains("KeyAlias :: enum_members"),
+        "got: {tokens}"
+    );
+    assert!(tokens.starts_with("compile_error !"), "got: {tokens}");
+    assert!(
+        tokens.contains("a map key must be a plain"),
+        "got: {tokens}"
+    );
+    assert!(tokens.contains("KeyAlias"), "got: {tokens}");
+}
+
+/// The registry extension is a filter, never a rewrite: for every key that compiled before it —
+/// a plain enum, an alias of one, or a name this expansion cannot classify — the emitted tokens
+/// are the ones an unregistered key has always produced.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_map_key_that_may_have_enum_members_expands_exactly_as_before() {
+    let unregistered = map_field_schema("HashMap<Slot, String>").to_string();
+    for kind in [AliasKind::EnumMembers, AliasKind::Unknown] {
+        register_alias_info("Slot", "Slot", "slot_schema", kind);
+        assert_eq!(
+            map_field_schema("HashMap<Slot, String>").to_string(),
+            unregistered
+        );
+    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,9 +7,27 @@ use syn::{Attribute, Expr, Field, Lit, Meta, Variant};
 #[cfg(any(feature = "typescript", feature = "zod"))]
 use syn::{ItemEnum, ItemStruct};
 
+/// Whether a registered Rust ident, *written as a type path*, resolves to something carrying an
+/// inherent `enum_members()` — the enumeration the JSON-schema map-key expansion calls. Only a
+/// plain unit enum gets that method, and a type path sees straight through an alias, so an alias
+/// answers for whatever it targets rather than for itself.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AliasKind {
+    /// A plain unit enum, or an alias chain ending in one.
+    EnumMembers,
+    /// Provably has none: a struct, a branded newtype, a non-plain enum, or an alias whose target
+    /// is a primitive, a collection, or one of those.
+    NoEnumMembers,
+    /// Undecidable at this expansion — an alias naming a type that was not registered before it.
+    Unknown,
+}
+
 #[derive(Clone)]
 pub struct AliasInfo {
     pub export_name: String,
+    #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+    pub kind: AliasKind,
     #[cfg(feature = "jsonschema")]
     pub module_name: String,
 }
@@ -19,7 +37,12 @@ thread_local! {
 }
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-pub fn register_alias_info(rust_ident: &str, export_name: &str, module_name: &str) {
+pub fn register_alias_info(
+    rust_ident: &str,
+    export_name: &str,
+    module_name: &str,
+    kind: AliasKind,
+) {
     #[cfg(not(feature = "jsonschema"))]
     let _: &_ = &module_name;
     ALIAS_INFO.with(|map| {
@@ -27,6 +50,7 @@ pub fn register_alias_info(rust_ident: &str, export_name: &str, module_name: &st
             rust_ident.to_owned(),
             AliasInfo {
                 export_name: export_name.to_owned(),
+                kind,
                 #[cfg(feature = "jsonschema")]
                 module_name: module_name.to_owned(),
             },

--- a/tests/alias_reference_tests/tests.rs
+++ b/tests/alias_reference_tests/tests.rs
@@ -33,6 +33,21 @@ pub struct UsesAliasAsMapValue {
     pub by_slot: HashMap<DocumentSlot, ReferencedDocumentId>,
 }
 
+#[model_schema()]
+pub type DocumentSlotAlias = DocumentSlot;
+
+#[model_schema()]
+pub type DocumentSlotAliasChain = DocumentSlotAlias;
+
+/// A map key written as an alias: the generated `enum_members()` call is a *type path*, so it
+/// resolves through every link of the chain back to the enum that has the method.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct UsesAliasAsMapKey {
+    pub by_chained_slot: HashMap<DocumentSlotAliasChain, ReferencedDocumentId>,
+    pub by_slot: HashMap<DocumentSlotAlias, ReferencedDocumentId>,
+}
+
 #[test]
 fn struct_referencing_an_alias_expands_in_this_feature_combination() {
     let value = UsesAliasByValue {
@@ -53,6 +68,20 @@ fn struct_referencing_an_alias_expands_in_this_feature_combination() {
     assert_eq!(
         map.by_slot.get(&DocumentSlot::Primary),
         Some(&"doc-3".to_owned())
+    );
+}
+
+#[test]
+fn struct_keying_a_map_by_an_alias_of_an_enum_expands_in_this_feature_combination() {
+    let mut by_slot = HashMap::new();
+    by_slot.insert(DocumentSlot::Secondary, "doc-4".to_owned());
+    let keyed = UsesAliasAsMapKey {
+        by_slot,
+        by_chained_slot: HashMap::new(),
+    };
+    assert_eq!(
+        keyed.by_slot.get(&DocumentSlot::Secondary),
+        Some(&"doc-4".to_owned())
     );
 }
 
@@ -79,6 +108,27 @@ fn alias_module_backs_the_map_value_reference() {
             by_slot.get("properties").unwrap().get(&slot).unwrap(),
             &alias_schema,
             "slot {slot} in: {by_slot}"
+        );
+    }
+}
+
+/// The alias key must enumerate the same members the enum itself would, at both link depths —
+/// nothing about the key going through an alias changes the object's properties.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn alias_keyed_map_enumerates_the_members_of_the_aliased_enum() {
+    let schema = UsesAliasAsMapKey::json_schema();
+    let properties = schema.get("properties").unwrap();
+    let alias_schema = referenced_document_id_type_schema::Schema::json_schema();
+    for field in ["by_slot", "by_chained_slot"] {
+        let keyed = properties.get(field).unwrap().get("properties").unwrap();
+        for slot in DocumentSlot::enum_members() {
+            assert_eq!(keyed.get(&slot).unwrap(), &alias_schema, "{field}: {keyed}");
+        }
+        assert_eq!(
+            keyed.as_object().unwrap().len(),
+            DocumentSlot::enum_members().len(),
+            "{field}: {keyed}"
         );
     }
 }


### PR DESCRIPTION
Stacked on #33 (same function); retargets when it merges.

A `model_schema` alias used as a map key unconditionally emitted `AliasIdent::enum_members()` — an alias of anything that isn't a plain enum failed with E0599 on a macro-internal call.

- `AliasInfo` gains a `kind` (`EnumMembers` / `NoEnumMembers` / `Unknown`), captured at each registration site from data the expansion already holds — no new parsing. All six registration sites (aliases, brands, three enum shapes) carry it; the three duplicated enum module-name/register triples collapsed into one helper on the way.
- A key that provably has no members now gets one clean expansion-time error naming the map-key requirement. `Unknown`/unregistered keys keep the original emission byte-for-byte (foreign types, forward declarations), locked by a token test.
- The direct-enum key case was never special-cased — the catch-all routes both it and aliases into one branch, so the kind check layers onto that single branch.
- Byte-identity vs the base commit proven by expand-diff over a deterministic probe (6 feature combos). The suite-wide diff surfaced that discriminated/untagged enum expansions are nondeterministic run-to-run on the pristine base — filed downstream, not touched here.

Gates: `just check`, `just lint-all` (68/68), `just test` (full powerset) green.