### PR TITLE
fix: the json-schema dispatcher renders Unknown fields permissively

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -3123,14 +3123,15 @@ fn write_tuple_multiple_variant_fields(
     let _: &_ = &&json_schema_variant_fields;
 }
 
-/// Builds the base JSON schema for a tuple element, ignoring `is_optional`.
+/// The JSON schema value expression for a field whose type renders inline as a scalar — arrayed
+/// when the field is a `Vec` — or `None` for the composite types (sibling references, maps,
+/// tuples, unknowns) that have no inline rendering.
 ///
-/// The nullable wrap is applied by `build_tuple_element_json_schema`.
+/// `is_optional` is not consulted: how an absent value is expressed depends on the position the
+/// value sits in, so each caller wraps this base itself.
 #[cfg(feature = "jsonschema")]
-fn build_tuple_element_base_json_schema(fld: &FieldDef) -> proc_macro2::TokenStream {
-    let field_type = &fld.field_type;
-
-    match field_type {
+fn scalar_field_json_schema_value(fld: &FieldDef) -> Option<proc_macro2::TokenStream> {
+    let schema = match &fld.field_type {
         FieldDefType::String => {
             if fld.is_array {
                 quote! { serde_json::json!({ "type": "array", "items": { "type": "string" } }) }
@@ -3222,11 +3223,21 @@ fn build_tuple_element_base_json_schema(fld: &FieldDef) -> proc_macro2::TokenStr
                 }) }
             }
         }
-        _ => {
-            // For unknown/sibling types, use a generic object schema
-            quote! { serde_json::json!({ "type": "object" }) }
-        }
-    }
+        FieldDefType::Unknown
+        | FieldDefType::SiblingType(..)
+        | FieldDefType::Map(..)
+        | FieldDefType::Tuple(..) => return None,
+    };
+    Some(schema)
+}
+
+/// Builds the base JSON schema for a tuple element, ignoring `is_optional`.
+///
+/// The nullable wrap is applied by `build_tuple_element_json_schema`.
+#[cfg(feature = "jsonschema")]
+fn build_tuple_element_base_json_schema(fld: &FieldDef) -> proc_macro2::TokenStream {
+    scalar_field_json_schema_value(fld)
+        .unwrap_or_else(|| quote! { serde_json::json!({ "type": "object" }) })
 }
 
 /// Builds JSON schema for a tuple element (used for single tuple and multi-tuple variants).
@@ -3658,6 +3669,28 @@ fn build_string_key_map_value_schema(
     }
 }
 
+/// Binds `value_schema` — the JSON schema every member of an enum-keyed map carries — or `None`
+/// when the value type has no rendering here.
+#[cfg(feature = "jsonschema")]
+fn build_enum_key_map_value_binding(value: &FieldDef) -> Option<proc_macro2::TokenStream> {
+    if let FieldDefType::SiblingType(value_type_name, value_lst) = &value.field_type
+        && value_lst.is_empty()
+    {
+        // For json_schema(), use the module pattern. An alias's module is named after
+        // its registered export name, which the raw ident does not reproduce.
+        let value_module_name = match lookup_alias_info(value_type_name) {
+            Some(alias) => alias.module_name,
+            None => format!("{}_schema", to_snake_case(&safe_type_name(value_type_name))),
+        };
+        let value_module_ident =
+            proc_macro2::Ident::new(value_module_name.as_str(), proc_macro2::Span::call_site());
+        return Some(quote! { let value_schema = #value_module_ident::Schema::json_schema(); });
+    }
+
+    let scalar_schema = scalar_field_json_schema_value(value)?;
+    Some(quote! { let value_schema = #scalar_schema; })
+}
+
 #[cfg(feature = "jsonschema")]
 fn build_map_field_schema(
     key: &FieldDef,
@@ -3673,23 +3706,11 @@ fn build_map_field_schema(
             let key_type_name_ident =
                 proc_macro2::Ident::new(key_type_name.as_str(), proc_macro2::Span::call_site());
 
-            let value_schema_code = if let FieldDefType::SiblingType(value_type_name, value_lst) =
-                &value.field_type
-                && value_lst.is_empty()
-            {
-                // For json_schema(), use the module pattern. An alias's module is named after
-                // its registered export name, which the raw ident does not reproduce.
-                let value_module_name = match lookup_alias_info(value_type_name) {
-                    Some(alias) => alias.module_name,
-                    None => format!("{}_schema", to_snake_case(&safe_type_name(value_type_name))),
-                };
-                let value_module_ident = proc_macro2::Ident::new(
-                    value_module_name.as_str(),
-                    proc_macro2::Span::call_site(),
-                );
-                quote! { let value_schema = #value_module_ident::Schema::json_schema(); }
-            } else {
-                quote! { compile_error!("Unsupported map value type"); }
+            // The compile_error! replaces the branch's output rather than joining it: left in
+            // place, the insertion loop below reads a `value_schema` the failed binding never
+            // bound, and the author gets a second E0425 naming macro-internal state.
+            let Some(value_schema_code) = build_enum_key_map_value_binding(value) else {
+                return quote! { compile_error!("Unsupported map value type"); };
             };
 
             quote! {

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -33,8 +33,8 @@ use crate::{
 #[cfg(feature = "zod")]
 use crate::utils::extract_example_from_docs;
 
-#[cfg(feature = "jsonschema")]
-use crate::utils::lookup_alias_info;
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+use crate::utils::{AliasKind, lookup_alias_info};
 
 #[cfg(feature = "serde")]
 use crate::features::serde::{SerdeFieldMeta, SerdeTypeMeta};
@@ -237,6 +237,24 @@ pub fn exec_model_schema(args: TokenStream, input: TokenStream) -> TokenStream {
     }
 }
 
+/// Classifies what an alias resolves to, for the registry.
+///
+/// A `SiblingType` is the only shape that can reach a plain enum, and it answers with whatever the
+/// named type registered: an alias of an alias of an enum inherits `EnumMembers` down the chain.
+/// A target registered after its alias reads as `Unknown`, which callers must treat as "cannot
+/// rule it out" rather than as a negative. An array (`Vec<Slot>`, `[Slot; 4]`) is a collection, not
+/// the enum it holds.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn alias_target_kind(alias_field_def: &FieldDef) -> AliasKind {
+    let FieldDefType::SiblingType(target_name, generic_args) = &alias_field_def.field_type else {
+        return AliasKind::NoEnumMembers;
+    };
+    if !generic_args.is_empty() || alias_field_def.is_array {
+        return AliasKind::NoEnumMembers;
+    }
+    lookup_alias_info(target_name).map_or(AliasKind::Unknown, |target| target.kind)
+}
+
 /// The alias schema module is referenced by all three schema features — `typescript` and `zod`
 /// through the alias's registered export name, `jsonschema` through a Rust path to
 /// `#module_ident::Schema::json_schema()`. So the module and its `register_alias_info` call are
@@ -255,9 +273,11 @@ fn process_type_alias(item_type: ItemType, args: &ModelSchemaArgs) -> TokenStrea
     let module_name = format!("{}_schema", to_snake_case(&export_name));
     let module_ident = Ident::new(&module_name, rust_ident.span());
 
-    register_alias_info(&rust_ident_str, &export_name, &module_name);
-
+    // Registered only once the target has been classified: the alias's own expansion is the only
+    // place that still holds the aliased type's tokens.
     let alias_field_def = get_field_def(export_name.as_str(), &alias.ty, "");
+    let kind = alias_target_kind(&alias_field_def);
+    register_alias_info(&rust_ident_str, &export_name, &module_name, kind);
 
     let ts_method = generate_alias_ts_definition_method(&alias, &export_name, &alias_field_def);
     let json_schema_method = generate_alias_json_schema_stub();
@@ -778,8 +798,23 @@ fn struct_module_idents(name: &syn::Ident) -> (String, String, Ident) {
     let item_name = safe_type_name(&name.to_string());
     let module_name = format!("{}_schema", to_snake_case(&item_name));
     let module_ident = Ident::new(&module_name, name.span());
-    register_alias_info(&name.to_string(), &item_name, &module_name);
+    register_alias_info(
+        &name.to_string(),
+        &item_name,
+        &module_name,
+        AliasKind::NoEnumMembers,
+    );
     (item_name, module_name, module_ident)
+}
+
+/// The enum counterpart of [`struct_module_idents`]. `kind` differs per enum shape: only a plain
+/// unit enum is given an `enum_members()`, so only it can back an enum-keyed map.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn enum_module_idents(name: &syn::Ident, item_name: &str, kind: AliasKind) -> (String, Ident) {
+    let module_name = format!("{}_schema", to_snake_case(item_name));
+    let module_ident = Ident::new(&module_name, name.span());
+    register_alias_info(&name.to_string(), item_name, &module_name, kind);
+    (module_name, module_ident)
 }
 
 /// Extracts a struct's doc lines and the first ` ```rust example ` block (if any) from them.
@@ -1581,7 +1616,12 @@ fn process_branded_newtype(item_struct: syn::ItemStruct, args: &ModelSchemaArgs)
     let module_name = format!("{}_schema", to_snake_case(&item_name));
     let module_ident = Ident::new(&module_name, name.span());
 
-    register_alias_info(&name.to_string(), &item_name, &module_name);
+    register_alias_info(
+        &name.to_string(),
+        &item_name,
+        &module_name,
+        AliasKind::NoEnumMembers,
+    );
 
     // Extract docs and example
     #[cfg(feature = "zod")]
@@ -1909,15 +1949,9 @@ fn process_plain_enum(
     rename_all: Option<&str>,
     item_name: &str,
 ) -> TokenStream {
-    // Compute module name for schema struct (same pattern as type aliases)
+    // Compute the schema module name and register the enum so other types can find it.
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-    let module_name = format!("{}_schema", to_snake_case(item_name));
-    #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-    let module_ident = Ident::new(&module_name, name.span());
-
-    // Register enum in alias registry so other types can find it
-    #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-    register_alias_info(&name.to_string(), item_name, &module_name);
+    let (_, module_ident) = enum_module_idents(name, item_name, AliasKind::EnumMembers);
 
     // Extract docs early for example extraction
     #[cfg(any(feature = "typescript", feature = "zod"))]
@@ -2181,15 +2215,9 @@ fn process_discriminated_enum(
     rename_all: Option<&str>,
     item_name: &str,
 ) -> TokenStream {
-    // Compute module name for schema struct (same pattern as type aliases)
+    // Compute the schema module name and register the enum so other types can find it.
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-    let module_name = format!("{}_schema", to_snake_case(item_name));
-    #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-    let module_ident = Ident::new(&module_name, name.span());
-
-    // Register enum in alias registry so other types can find it
-    #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-    register_alias_info(&name.to_string(), item_name, &module_name);
+    let (module_name, module_ident) = enum_module_idents(name, item_name, AliasKind::NoEnumMembers);
 
     // Extract docs early for example extraction
     #[cfg(any(feature = "typescript", feature = "zod"))]
@@ -2656,15 +2684,9 @@ fn process_untagged_enum(
     name: &syn::Ident,
     item_name: &str,
 ) -> TokenStream {
-    // Compute module name for schema struct (same pattern as type aliases)
+    // Compute the schema module name and register the enum so other types can find it.
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-    let module_name = format!("{}_schema", to_snake_case(item_name));
-    #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-    let module_ident = Ident::new(&module_name, name.span());
-
-    // Register enum in alias registry so other types can find it
-    #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-    register_alias_info(&name.to_string(), item_name, &module_name);
+    let (_, module_ident) = enum_module_idents(name, item_name, AliasKind::NoEnumMembers);
 
     // Extract docs early for example extraction
     #[cfg(any(feature = "typescript", feature = "zod"))]
@@ -3702,6 +3724,21 @@ fn build_map_field_schema(
     match &key.field_type {
         FieldDefType::String => build_string_key_map_value_schema(value, field_name_str),
         FieldDefType::SiblingType(key_type_name, lst) if lst.is_empty() => {
+            // The loop below writes the key as a *type path*, which resolves through any alias, so
+            // an alias of a non-enum lands on a type with no `enum_members()` and rustc blames
+            // `#[model_schema()]` for a missing method the author never wrote. Only a target the
+            // registry positively rules out is rejected here: an unregistered name (a foreign type,
+            // or one expanded after this struct) stays on the emitting path, where it behaves as it
+            // always has.
+            if let Some(key_alias) = lookup_alias_info(key_type_name)
+                && key_alias.kind == AliasKind::NoEnumMembers
+            {
+                let message = format!(
+                    "field `{field_name_str}`: a map key must be a plain `#[model_schema()]` enum, whose members become the object's keys — `{key_type_name}` resolves to a type with no `enum_members()`"
+                );
+                return quote! { compile_error!(#message); };
+            }
+
             // For enum_members(), we call the type directly (delegation works)
             let key_type_name_ident =
                 proc_macro2::Ident::new(key_type_name.as_str(), proc_macro2::Span::call_site());

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -4107,6 +4107,30 @@ fn build_tuple_field_schema(
     }
 }
 
+/// Builds the JSON schema for an opaque field — a `serde_json::Value`, a function pointer, or any
+/// other type the parser could not classify. No type name is carried, so there is no schema module
+/// to reference: the field admits any value, which is the permissive empty schema. Matches the
+/// `unknown` TypeScript type and the `z.unknown()` Zod schema emitted for the same field.
+#[cfg(feature = "jsonschema")]
+fn build_unknown_field_schema(fld: &FieldDef, field_name_str: &str) -> proc_macro2::TokenStream {
+    log::trace!("Unknown => field_name: {field_name_str}, fld: {fld:?}");
+
+    if fld.is_array {
+        quote! {
+            properties.insert(#field_name_str.to_string(), {
+                serde_json::json!({
+                    "type": "array",
+                    "items": {}
+                })
+            });
+        }
+    } else {
+        quote! {
+            properties.insert(#field_name_str.to_string(), serde_json::json!({}));
+        }
+    }
+}
+
 /// Builds JSON schema for a field.
 #[cfg(feature = "jsonschema")]
 fn build_field_schema(fld: &FieldDef) -> proc_macro2::TokenStream {
@@ -4152,20 +4176,9 @@ fn build_field_schema(fld: &FieldDef) -> proc_macro2::TokenStream {
         }
         FieldDefType::Map(key, value) => build_map_field_schema(key, value, &field_name_str),
         FieldDefType::Tuple(lst) => build_tuple_field_schema(fld, &field_name_str, lst),
-        fld_def => {
-            log::trace!("Other => field_name: {field_name_str}, fld_def: {fld_def:?}");
-            // Fallback: Use module pattern. This should not typically be reached
-            // for properly annotated types, but provides a reasonable fallback.
-            let name = &fld.name;
-            let safe_name = safe_type_name(name);
-            let module_name = format!("{}_schema", to_snake_case(&safe_name));
-            let module_ident =
-                proc_macro2::Ident::new(module_name.as_str(), proc_macro2::Span::call_site());
-            let type_json_schema = quote! { #module_ident::Schema::json_schema() };
-            quote! {
-                properties.insert(#field_name_str.to_string(), #type_json_schema);
-            }
-        }
+        // Named exhaustively rather than caught by a wildcard: a new variant must be given a
+        // schema here, not silently routed to whatever the last arm happens to emit.
+        FieldDefType::Unknown => build_unknown_field_schema(fld, &field_name_str),
     };
 
     let required_code = if fld.is_optional {

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -639,3 +639,48 @@ fn generic_display_impl_bounds_every_type_parameter() {
         "impl < IdType : std :: fmt :: Display > std :: fmt :: Display for DocumentId < IdType > { fn fmt (& self , f : & mut std :: fmt :: Formatter < '_ >) -> std :: fmt :: Result { self . 0 . fmt (f) } }"
     );
 }
+
+/// The JSON schema statements a map-typed field expands to, parsed from the map type's source.
+#[cfg(feature = "jsonschema")]
+fn map_field_schema(map_type: &str) -> proc_macro2::TokenStream {
+    let ty: syn::Type = syn::parse_str(map_type).unwrap();
+    let field = super::get_field_def("m", &ty, "");
+    let map_parts = if let FieldDefType::Map(key, value) = &field.field_type {
+        Some((key, value))
+    } else {
+        None
+    };
+    let (key, value) = map_parts.unwrap();
+    super::build_map_field_schema(key, value, "m")
+}
+
+/// A value type the enum-key branch cannot render must yield the `compile_error!` *instead of* the
+/// per-member insertion loop: leaving the loop in place adds an E0425 on the `value_schema` the
+/// failed arm never bound, and that second error names macro-internal state the author cannot act on.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn an_unsupported_enum_keyed_map_value_emits_only_the_compile_error() {
+    for map_type in [
+        "HashMap<Slot, HashMap<String, String>>",
+        "HashMap<Slot, Wrapper<String>>",
+        "HashMap<Slot, (String, u32)>",
+    ] {
+        assert_eq!(
+            map_field_schema(map_type).to_string(),
+            r#"compile_error ! ("Unsupported map value type") ;"#,
+            "for {map_type}"
+        );
+    }
+}
+
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_scalar_enum_keyed_map_value_expands_to_the_per_member_loop() {
+    let tokens = map_field_schema("HashMap<Slot, String>").to_string();
+    assert!(!tokens.contains("compile_error"), "got: {tokens}");
+    assert!(tokens.contains("Slot :: enum_members ()"), "got: {tokens}");
+    assert!(
+        tokens.contains(r#"serde_json :: json ! ({ "type" : "string" })"#),
+        "got: {tokens}"
+    );
+}

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -8,7 +8,7 @@ use super::{
 };
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-use super::branded_guard_errors;
+use super::{AliasKind, branded_guard_errors, register_alias_info};
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 use syn::spanned::Spanned as _;
@@ -683,4 +683,84 @@ fn a_scalar_enum_keyed_map_value_expands_to_the_per_member_loop() {
         tokens.contains(r#"serde_json :: json ! ({ "type" : "string" })"#),
         "got: {tokens}"
     );
+}
+
+/// The kind an alias registers is its *target's* answer, because a type path resolves through the
+/// alias. `Vec<Slot>` is the collection, not the enum it holds; a target this expansion has not
+/// seen registered is `Unknown`, which is not a negative.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn an_alias_registers_the_kind_of_what_it_targets() {
+    register_alias_info("Slot", "Slot", "slot_schema", AliasKind::EnumMembers);
+    register_alias_info("Doc", "Doc", "doc_schema", AliasKind::NoEnumMembers);
+    for (target, expected) in [
+        ("Slot", AliasKind::EnumMembers),
+        ("Doc", AliasKind::NoEnumMembers),
+        ("String", AliasKind::NoEnumMembers),
+        ("u32", AliasKind::NoEnumMembers),
+        ("Vec<Slot>", AliasKind::NoEnumMembers),
+        ("HashMap<Slot, String>", AliasKind::NoEnumMembers),
+        ("Wrapper<Slot>", AliasKind::NoEnumMembers),
+        ("Ghost", AliasKind::Unknown),
+    ] {
+        let ty: syn::Type = syn::parse_str(target).unwrap();
+        let kind = super::alias_target_kind(&super::get_field_def("AliasType", &ty, ""));
+        assert_eq!(kind, expected, "for alias target {target}");
+    }
+}
+
+/// An alias of an alias of a plain enum is still a plain enum at the type path, so the chain
+/// carries `EnumMembers` through every link.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn an_alias_chain_carries_the_enum_kind_to_its_end() {
+    register_alias_info("Slot", "Slot", "slot_schema", AliasKind::EnumMembers);
+    let first_target: syn::Type = syn::parse_str("Slot").unwrap();
+    let first = super::alias_target_kind(&super::get_field_def("FirstType", &first_target, ""));
+    register_alias_info("First", "FirstType", "first_type_schema", first);
+
+    let second_target: syn::Type = syn::parse_str("First").unwrap();
+    let second = super::alias_target_kind(&super::get_field_def("SecondType", &second_target, ""));
+    assert_eq!(second, AliasKind::EnumMembers);
+}
+
+/// A key the registry positively rules out never reaches the emitting path: `enum_members()` on it
+/// resolves through the alias to a type that has no such method, and rustc blames the attribute for
+/// a method the author never wrote.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_map_key_known_to_lack_enum_members_names_the_requirement() {
+    register_alias_info(
+        "KeyAlias",
+        "KeyAliasType",
+        "key_alias_type_schema",
+        AliasKind::NoEnumMembers,
+    );
+    let tokens = map_field_schema("HashMap<KeyAlias, String>").to_string();
+    assert!(
+        !tokens.contains("KeyAlias :: enum_members"),
+        "got: {tokens}"
+    );
+    assert!(tokens.starts_with("compile_error !"), "got: {tokens}");
+    assert!(
+        tokens.contains("a map key must be a plain"),
+        "got: {tokens}"
+    );
+    assert!(tokens.contains("KeyAlias"), "got: {tokens}");
+}
+
+/// The registry extension is a filter, never a rewrite: for every key that compiled before it —
+/// a plain enum, an alias of one, or a name this expansion cannot classify — the emitted tokens
+/// are the ones an unregistered key has always produced.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_map_key_that_may_have_enum_members_expands_exactly_as_before() {
+    let unregistered = map_field_schema("HashMap<Slot, String>").to_string();
+    for kind in [AliasKind::EnumMembers, AliasKind::Unknown] {
+        register_alias_info("Slot", "Slot", "slot_schema", kind);
+        assert_eq!(
+            map_field_schema("HashMap<Slot, String>").to_string(),
+            unregistered
+        );
+    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,9 +7,27 @@ use syn::{Attribute, Expr, Field, Lit, Meta, Variant};
 #[cfg(any(feature = "typescript", feature = "zod"))]
 use syn::{ItemEnum, ItemStruct};
 
+/// Whether a registered Rust ident, *written as a type path*, resolves to something carrying an
+/// inherent `enum_members()` — the enumeration the JSON-schema map-key expansion calls. Only a
+/// plain unit enum gets that method, and a type path sees straight through an alias, so an alias
+/// answers for whatever it targets rather than for itself.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AliasKind {
+    /// A plain unit enum, or an alias chain ending in one.
+    EnumMembers,
+    /// Provably has none: a struct, a branded newtype, a non-plain enum, or an alias whose target
+    /// is a primitive, a collection, or one of those.
+    NoEnumMembers,
+    /// Undecidable at this expansion — an alias naming a type that was not registered before it.
+    Unknown,
+}
+
 #[derive(Clone)]
 pub struct AliasInfo {
     pub export_name: String,
+    #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+    pub kind: AliasKind,
     #[cfg(feature = "jsonschema")]
     pub module_name: String,
 }
@@ -19,7 +37,12 @@ thread_local! {
 }
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-pub fn register_alias_info(rust_ident: &str, export_name: &str, module_name: &str) {
+pub fn register_alias_info(
+    rust_ident: &str,
+    export_name: &str,
+    module_name: &str,
+    kind: AliasKind,
+) {
     #[cfg(not(feature = "jsonschema"))]
     let _: &_ = &module_name;
     ALIAS_INFO.with(|map| {
@@ -27,6 +50,7 @@ pub fn register_alias_info(rust_ident: &str, export_name: &str, module_name: &st
             rust_ident.to_owned(),
             AliasInfo {
                 export_name: export_name.to_owned(),
+                kind,
                 #[cfg(feature = "jsonschema")]
                 module_name: module_name.to_owned(),
             },

--- a/tests/alias_reference_tests/tests.rs
+++ b/tests/alias_reference_tests/tests.rs
@@ -33,6 +33,21 @@ pub struct UsesAliasAsMapValue {
     pub by_slot: HashMap<DocumentSlot, ReferencedDocumentId>,
 }
 
+#[model_schema()]
+pub type DocumentSlotAlias = DocumentSlot;
+
+#[model_schema()]
+pub type DocumentSlotAliasChain = DocumentSlotAlias;
+
+/// A map key written as an alias: the generated `enum_members()` call is a *type path*, so it
+/// resolves through every link of the chain back to the enum that has the method.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct UsesAliasAsMapKey {
+    pub by_chained_slot: HashMap<DocumentSlotAliasChain, ReferencedDocumentId>,
+    pub by_slot: HashMap<DocumentSlotAlias, ReferencedDocumentId>,
+}
+
 #[test]
 fn struct_referencing_an_alias_expands_in_this_feature_combination() {
     let value = UsesAliasByValue {
@@ -53,6 +68,20 @@ fn struct_referencing_an_alias_expands_in_this_feature_combination() {
     assert_eq!(
         map.by_slot.get(&DocumentSlot::Primary),
         Some(&"doc-3".to_owned())
+    );
+}
+
+#[test]
+fn struct_keying_a_map_by_an_alias_of_an_enum_expands_in_this_feature_combination() {
+    let mut by_slot = HashMap::new();
+    by_slot.insert(DocumentSlot::Secondary, "doc-4".to_owned());
+    let keyed = UsesAliasAsMapKey {
+        by_slot,
+        by_chained_slot: HashMap::new(),
+    };
+    assert_eq!(
+        keyed.by_slot.get(&DocumentSlot::Secondary),
+        Some(&"doc-4".to_owned())
     );
 }
 
@@ -79,6 +108,27 @@ fn alias_module_backs_the_map_value_reference() {
             by_slot.get("properties").unwrap().get(&slot).unwrap(),
             &alias_schema,
             "slot {slot} in: {by_slot}"
+        );
+    }
+}
+
+/// The alias key must enumerate the same members the enum itself would, at both link depths —
+/// nothing about the key going through an alias changes the object's properties.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn alias_keyed_map_enumerates_the_members_of_the_aliased_enum() {
+    let schema = UsesAliasAsMapKey::json_schema();
+    let properties = schema.get("properties").unwrap();
+    let alias_schema = referenced_document_id_type_schema::Schema::json_schema();
+    for field in ["by_slot", "by_chained_slot"] {
+        let keyed = properties.get(field).unwrap().get("properties").unwrap();
+        for slot in DocumentSlot::enum_members() {
+            assert_eq!(keyed.get(&slot).unwrap(), &alias_schema, "{field}: {keyed}");
+        }
+        assert_eq!(
+            keyed.as_object().unwrap().len(),
+            DocumentSlot::enum_members().len(),
+            "{field}: {keyed}"
         );
     }
 }

--- a/tests/chrono_tests/tests.rs
+++ b/tests/chrono_tests/tests.rs
@@ -35,6 +35,24 @@ struct DateMap {
     name: String,
 }
 
+// An enum-keyed map enumerates its keys, so every member carries the value schema outright
+// instead of the open `additionalProperties` the String-keyed `DateMap` above uses.
+#[model_schema()]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum ScheduleSlot {
+    Closing,
+    Opening,
+}
+
+#[model_schema()]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
+struct SlotSchedule {
+    dates: HashMap<ScheduleSlot, NaiveDate>,
+    timestamps: HashMap<ScheduleSlot, DateTime<Utc>>,
+}
+
 // Test struct with NaiveDate field.
 #[model_schema()]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -149,6 +167,12 @@ fn test_chrono_types_constructible() {
         name: String::new(),
     };
     assert!(date_map.events.is_empty());
+    let slot_schedule = SlotSchedule {
+        dates: HashMap::from([(ScheduleSlot::Opening, date), (ScheduleSlot::Closing, date)]),
+        timestamps: HashMap::new(),
+    };
+    assert_eq!(slot_schedule.dates.len(), 2);
+    assert!(slot_schedule.timestamps.is_empty());
     let values = [
         FixedValue::Alphanumeric(String::new()),
         FixedValue::Boolean(false),
@@ -421,6 +445,32 @@ fn test_vec_date_json_schema() {
     assert_eq!(dates_prop["type"], "array");
     assert_eq!(dates_prop["items"]["type"], "string");
     assert_eq!(dates_prop["items"]["format"], "date");
+}
+
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_enum_keyed_chrono_map_json_schema() {
+    let schema = SlotSchedule::json_schema();
+    let properties = schema["properties"].as_object().unwrap();
+
+    for (field_name, expected_format) in [("dates", "date"), ("timestamps", "date-time")] {
+        let field = &properties[field_name];
+        assert_eq!(field["type"], "object", "in: {field}");
+        assert_eq!(field["additionalProperties"], false, "in: {field}");
+        let members = ScheduleSlot::enum_members();
+        assert_eq!(
+            field["properties"].as_object().unwrap().len(),
+            members.len(),
+            "in: {field}"
+        );
+        for member in members {
+            assert_eq!(
+                field["properties"][&member],
+                serde_json::json!({ "type": "string", "format": expected_format }),
+                "member {member} in: {field}"
+            );
+        }
+    }
 }
 
 // ========== Enum Tests (Original Use Case) ==========

--- a/tests/collection_tests/tests.rs
+++ b/tests/collection_tests/tests.rs
@@ -30,6 +30,26 @@ struct HashMapWith64Bit {
     u64_map: HashMap<String, u64>,
 }
 
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum MetricSlot {
+    Daily,
+    Weekly,
+}
+
+// An enum-keyed map enumerates its keys, so every member carries the value schema outright
+// instead of the open `additionalProperties` a String-keyed map uses.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct EnumKeyedScalarValueMaps {
+    bool_value: HashMap<MetricSlot, bool>,
+    f64_value: HashMap<MetricSlot, f64>,
+    i64_value: HashMap<MetricSlot, i64>,
+    string_array: HashMap<MetricSlot, Vec<String>>,
+    string_value: HashMap<MetricSlot, String>,
+    u64_value: HashMap<MetricSlot, u64>,
+}
+
 // Test struct with collections
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -68,6 +88,29 @@ fn assert_hashmap_array_type(
         properties[field_name]["additionalProperties"]["items"]["type"],
         expected_item_type
     );
+}
+
+#[cfg(feature = "jsonschema")]
+fn assert_enum_keyed_map_value(
+    properties: &serde_json::Map<String, serde_json::Value>,
+    field_name: &str,
+    expected_value_schema: &serde_json::Value,
+) {
+    let field = &properties[field_name];
+    assert_eq!(field["type"], "object", "in: {field}");
+    assert_eq!(field["additionalProperties"], false, "in: {field}");
+    let members = MetricSlot::enum_members();
+    assert_eq!(
+        field["properties"].as_object().unwrap().len(),
+        members.len(),
+        "in: {field}"
+    );
+    for member in members {
+        assert_eq!(
+            &field["properties"][&member], expected_value_schema,
+            "member {member} in: {field}"
+        );
+    }
 }
 
 #[test]
@@ -197,6 +240,108 @@ fn test_comprehensive_hashmap_typescript_generation() {
     assert!(zod_schema.contains("i64_array: z.record(z.string(), z.array(z.number().int()))"));
     assert!(zod_schema.contains("f64_array: z.record(z.string(), z.array(z.number()))"));
     assert!(zod_schema.contains("bool_array: z.record(z.string(), z.array(z.boolean()))"));
+}
+
+#[test]
+fn test_enum_keyed_scalar_value_maps_constructible() {
+    let maps = EnumKeyedScalarValueMaps {
+        bool_value: HashMap::new(),
+        f64_value: HashMap::new(),
+        i64_value: HashMap::new(),
+        string_array: HashMap::new(),
+        string_value: HashMap::from([
+            (MetricSlot::Daily, "d".to_owned()),
+            (MetricSlot::Weekly, "w".to_owned()),
+        ]),
+        u64_value: HashMap::new(),
+    };
+    assert_eq!(
+        maps.string_value.get(&MetricSlot::Daily),
+        Some(&"d".to_owned())
+    );
+    assert_eq!(
+        maps.string_value.get(&MetricSlot::Weekly),
+        Some(&"w".to_owned())
+    );
+}
+
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_enum_keyed_scalar_value_maps_json_schema() {
+    let schema = EnumKeyedScalarValueMaps::json_schema();
+    let properties = schema["properties"].as_object().unwrap();
+
+    assert_enum_keyed_map_value(
+        properties,
+        "string_value",
+        &serde_json::json!({ "type": "string" }),
+    );
+    assert_enum_keyed_map_value(
+        properties,
+        "u64_value",
+        &serde_json::json!({ "type": "integer" }),
+    );
+    assert_enum_keyed_map_value(
+        properties,
+        "i64_value",
+        &serde_json::json!({ "type": "integer" }),
+    );
+    assert_enum_keyed_map_value(
+        properties,
+        "f64_value",
+        &serde_json::json!({ "type": "number" }),
+    );
+    assert_enum_keyed_map_value(
+        properties,
+        "bool_value",
+        &serde_json::json!({ "type": "boolean" }),
+    );
+    assert_enum_keyed_map_value(
+        properties,
+        "string_array",
+        &serde_json::json!({ "type": "array", "items": { "type": "string" } }),
+    );
+}
+
+#[test]
+#[cfg(all(feature = "typescript", feature = "zod"))]
+fn test_enum_keyed_scalar_value_maps_typescript_generation() {
+    let ts_definition = EnumKeyedScalarValueMaps::ts_definition();
+
+    assert!(
+        ts_definition.contains("string_value: Partial<Record<MetricSlot, string>>;"),
+        "Got: {ts_definition}"
+    );
+    assert!(
+        ts_definition.contains("u64_value: Partial<Record<MetricSlot, number>>;"),
+        "Got: {ts_definition}"
+    );
+    assert!(
+        ts_definition.contains("bool_value: Partial<Record<MetricSlot, boolean>>;"),
+        "Got: {ts_definition}"
+    );
+    assert!(
+        ts_definition.contains("string_array: Partial<Record<MetricSlot, Array<string>>>;"),
+        "Got: {ts_definition}"
+    );
+
+    let zod_schema = EnumKeyedScalarValueMaps::zod_schema();
+    assert!(
+        zod_schema.contains("string_value: z.record(MetricSlot$Schema, z.string())"),
+        "Got: {zod_schema}"
+    );
+    assert!(
+        zod_schema.contains("u64_value: z.record(MetricSlot$Schema, z.number().int())"),
+        "Got: {zod_schema}"
+    );
+    assert!(
+        zod_schema.contains("bool_value: z.record(MetricSlot$Schema, z.boolean())"),
+        "Got: {zod_schema}"
+    );
+    assert!(
+        zod_schema.contains("string_array: z.record(MetricSlot$Schema, z.array(z.string()))"),
+        "Got: {zod_schema}"
+    );
 }
 
 #[test]

--- a/tests/jsonschema_tests/tests.rs
+++ b/tests/jsonschema_tests/tests.rs
@@ -74,6 +74,16 @@ struct MapFields {
 
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone)]
+struct OpaqueFields {
+    name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    optional_payload: Option<serde_json::Value>,
+    payload: serde_json::Value,
+    payloads: Vec<serde_json::Value>,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 struct OptionalFields {
     #[serde(skip_serializing_if = "Option::is_none")]
     optional_bool: Option<bool>,
@@ -207,6 +217,25 @@ fn test_hashmap_generates_object_with_additional_properties() {
         properties["counts"]["additionalProperties"]["type"],
         "integer"
     );
+}
+
+#[test]
+fn test_opaque_value_fields_generate_permissive_schemas() {
+    let schema = OpaqueFields::json_schema();
+
+    let properties = schema["properties"].as_object().unwrap();
+
+    // An opaque field carries no type name, so it admits any value.
+    assert_eq!(properties["payload"], serde_json::json!({}));
+    assert_eq!(properties["optional_payload"], serde_json::json!({}));
+
+    assert_eq!(properties["payloads"]["type"], "array");
+    assert_eq!(properties["payloads"]["items"], serde_json::json!({}));
+
+    let required = schema["required"].as_array().unwrap();
+    assert!(required.contains(&Value::String("payload".to_owned())));
+    assert!(required.contains(&Value::String("payloads".to_owned())));
+    assert!(!required.contains(&Value::String("optional_payload".to_owned())));
 }
 
 #[test]

--- a/tests/mongodb_real_tests/tests.rs
+++ b/tests/mongodb_real_tests/tests.rs
@@ -23,6 +23,21 @@ struct RealDocument {
     title: String,
 }
 
+// An enum-keyed map enumerates its keys, so every member carries the value schema outright
+// instead of the open `additionalProperties` the String-keyed maps above use.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum RefSlot {
+    Author,
+    Reviewer,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct SlottedRefs {
+    by_slot: HashMap<RefSlot, ObjectId>,
+}
+
 // Basic struct with real ObjectId
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -202,6 +217,45 @@ fn test_real_objectid_json_schema_structure() {
     );
     assert_eq!(meta_additional_props["required"][0], "$oid");
     assert_eq!(meta_additional_props["additionalProperties"], false);
+}
+
+#[test]
+fn test_slotted_refs_constructible() {
+    let slotted = SlottedRefs {
+        by_slot: HashMap::from([
+            (RefSlot::Author, ObjectId::new()),
+            (RefSlot::Reviewer, ObjectId::new()),
+        ]),
+    };
+    assert_eq!(slotted.by_slot.len(), 2);
+}
+
+#[test]
+#[cfg(all(feature = "object_id", feature = "jsonschema"))]
+fn test_enum_keyed_objectid_map_json_schema() {
+    let schema = SlottedRefs::json_schema();
+    let by_slot = &schema["properties"]["by_slot"];
+
+    assert_eq!(by_slot["type"], "object");
+    assert_eq!(by_slot["additionalProperties"], false);
+    let members = RefSlot::enum_members();
+    assert_eq!(
+        by_slot["properties"].as_object().unwrap().len(),
+        members.len(),
+        "in: {by_slot}"
+    );
+    for member in members {
+        let value = &by_slot["properties"][&member];
+        assert_eq!(value["type"], "object", "member {member} in: {by_slot}");
+        assert_eq!(
+            value["properties"]["$oid"]["type"], "string",
+            "member {member} in: {by_slot}"
+        );
+        assert_eq!(
+            value["required"][0], "$oid",
+            "member {member} in: {by_slot}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
Stacked on #34; retargets as the stack merges.

The field-schema dispatcher's wildcard arm derived a schema module from the **field** name — `pub payload: serde_json::Value` failed with `E0433: cannot find module or crate payload_schema`.

- Phase 0 settled reachability with compiler proof in both directions: replacing the wildcard with `FieldDefType::Unknown` keeps every feature combination compiling (sufficient), deleting it yields `E0004` naming `Unknown` as the sole uncovered pattern (necessary). The arm catches exactly `Unknown`.
- `Unknown` has no type name to registry-resolve, so the arm now emits the crate's settled permissive rendering for opaque types (`{}`; `{"type":"array","items":{}}` for collections), matching TS `unknown` / Zod `z.unknown()`. The match is exhaustive by name — a future variant forces a decision instead of silently mis-naming.
- Red-first fixture: three opaque `Value` fields, three E0433s before, permissive schemas after.

Gates: `just check`, `just lint-all` (68/68), `just test` (full powerset) green.