### PR TITLE
fix: enum-keyed map values honor is_array for sibling types

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,7 +564,7 @@ error[E0277]: `Vec<String>` doesn't implement `std::fmt::Display`
    |                     ^^^^^^^^^^^ the trait `std::fmt::Display` is not implemented for `Vec<String>`
 ```
 
-Pass `no_display` for brands over container inner types. The brand then gets no `Display` impl and carries no such requirement; its schema and its serde transparency are unchanged. String constraints are a separate matter: `pattern`, `minLength`, and `maxLength` validate through `to_string()`, so a constrained brand needs a `Display` inner whether or not it passes `no_display`.
+Pass `no_display` for brands over container inner types. The brand then gets no `Display` impl and carries no such requirement; its schema and its serde transparency are unchanged. String constraints are a separate matter: `pattern`, `minLength`, and `maxLength` validate through `to_string()`, so a constrained brand needs a `Display` inner whether or not it passes `no_display` — and a container inner cannot carry them at all (see [Branded Newtype Validation Constraints](#branded-newtype-validation-constraints)).
 
 ```rust
 use tixschema::model_schema;
@@ -582,7 +582,9 @@ A generic brand carries the requirement as a `Display` bound on each type parame
 
 You can add `pattern`, `minLength`, and `maxLength` constraints directly on the `#[model_schema()]` attribute for branded newtypes. Constraints are enforced in three places: the generated Zod schema, serde deserialization, and a `validate()` method on the type.
 
-**This only works for `String` inner types.** Applying constraints to a non-String branded newtype (e.g., `u64`) produces a compile-time error.
+**The inner type has to be one whose schema is a string** — `String`, `PathBuf`, `ObjectId`, a chrono date/time type, another brand, or a generic parameter. A numeric, boolean, container (`Vec`, array, `HashMap`, tuple), or opaque (`serde_json::Value`) inner is rejected at expansion time, because the three constraints are string checks and each surface would read them differently: Zod's `.min`/`.max` become bounds on the value itself, JSON Schema ignores `minLength`/`maxLength`/`pattern` outside `"type": "string"`, and `validate()` measures the inner's `Display` rendering.
+
+**The inner type also has to implement `Display`,** since validation runs against `to_string()`. That holds whether or not the brand passes `no_display`: the flag drops the `Display` impl, not the requirement.
 
 ```rust
 #[model_schema(pattern = "^[a-z0-9_]+$", minLength = 3, maxLength = 50)]
@@ -650,7 +652,7 @@ pub struct ObjectIdStr(pub String);
 pub struct NonEmptyString(pub String);
 ```
 
-Compile-time error for non-String types:
+An inner type whose schema is not a string is rejected at the field:
 
 ```rust
 // This will NOT compile:
@@ -658,8 +660,40 @@ Compile-time error for non-String types:
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct BadNum(pub u64);
-// Error: model_schema constraints (pattern, minLength, maxLength) are only
-//        supported on String branded newtypes, but `BadNum` has inner type `u64`
+```
+
+```text
+error: model_schema: branded newtype `BadNum` applies string constraints (pattern, minLength,
+       maxLength) to a numeric inner type, which cannot carry them: ...
+ --> src/lib.rs:4:19
+  |
+4 | pub struct BadNum(pub u64);
+  |                   ^^^
+```
+
+An inner type the macro cannot resolve — another brand, a user type, a generic parameter — is
+admitted here and checked for `Display` instead, so a non-`Display` one is still reported at the
+field:
+
+```rust
+#[model_schema(no_display)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Tags(pub Vec<String>);
+
+// This will NOT compile either: `Tags` has no `Display` for `validate()` to render.
+#[model_schema(pattern = "^[a-z]+$")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct TagsBrand(pub Tags);
+```
+
+```text
+error[E0277]: `Tags` doesn't implement `std::fmt::Display`
+  --> src/lib.rs:12:26
+   |
+12 | pub struct TagsBrand(pub Tags);
+   |                          ^^^^ unsatisfied trait bound
 ```
 
 #### Doc Comments and Examples on Branded Newtypes

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -674,6 +674,88 @@ fn branded_option_inner_error(
         })
 }
 
+/// The `compile_error!` tokens for a branded newtype that applies `pattern`, `minLength`, or
+/// `maxLength` to an inner type whose schema is not a string, or `None` when the inner can carry
+/// them.
+///
+/// The three constraints are string checks on every surface the brand renders, and each surface
+/// reads them differently the moment the inner stops being a string. A `u64` inner with
+/// `minLength = 3` renders `z.number().int().min(3)`, where `.min` is a numeric bound that admits
+/// `42`; renders `{"type": "number", "minLength": 3}`, where `minLength` is a string-only keyword
+/// that goes inert and enforces nothing; and validates in Rust against `to_string()`, which
+/// demands three decimal digits and so rejects `42`. Zod also has no `z.regex` check to apply to a
+/// number schema at all. A container inner never reaches that disagreement — it has no `Display`
+/// to render.
+///
+/// A `SiblingType` inner — another brand, an unresolved user type, or a bare generic parameter —
+/// is admitted, because expansion cannot know its shape. That is why the constrained path asserts
+/// `Display` separately: the guard bounds the schema surfaces, the assertion bounds the Rust one.
+///
+/// Resolved through the same `get_field_def` call the renderers make, so the guard and the
+/// contract cannot disagree about what a shape is.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn branded_constraint_inner_error(
+    name: &Ident,
+    inner_field: &Field,
+    args: &ModelSchemaArgs,
+) -> Option<proc_macro2::TokenStream> {
+    if !args.has_string_constraints() {
+        return None;
+    }
+    let shape = non_string_inner_shape(&get_field_def("_inner", &inner_field.ty, ""))?;
+    Some(
+        syn::Error::new_spanned(
+            inner_field,
+            format!(
+                "model_schema: branded newtype `{name}` applies string constraints (pattern, \
+                 minLength, maxLength) to a {shape} inner type, which cannot carry them: Zod \
+                 reads `.min`/`.max` as bounds on the value itself and has no regex check for a \
+                 non-string schema, JSON Schema ignores `minLength`/`maxLength`/`pattern` outside \
+                 `\"type\": \"string\"`, and `validate()` measures the inner's `Display` \
+                 rendering — three surfaces, three answers. Brand a string-typed inner, or drop \
+                 the constraints."
+            ),
+        )
+        .to_compile_error(),
+    )
+}
+
+/// Names the non-string schema shape an inner type resolves to, or `None` when it renders as a
+/// string and so can carry the string constraints.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+const fn non_string_inner_shape(inner: &FieldDef) -> Option<&'static str> {
+    if inner.is_array {
+        return Some("container");
+    }
+    match &inner.field_type {
+        FieldDefType::Map(..) | FieldDefType::Tuple(..) => Some("container"),
+        FieldDefType::Boolean => Some("boolean"),
+        FieldDefType::U8
+        | FieldDefType::U16
+        | FieldDefType::U32
+        | FieldDefType::U64
+        | FieldDefType::I8
+        | FieldDefType::I16
+        | FieldDefType::I32
+        | FieldDefType::I64
+        | FieldDefType::Usize
+        | FieldDefType::Isize
+        | FieldDefType::F32
+        | FieldDefType::F64 => Some("numeric"),
+        FieldDefType::Unknown => Some("opaque"),
+        FieldDefType::String | FieldDefType::StringLiteral(_) | FieldDefType::SiblingType(..) => {
+            None
+        }
+        #[cfg(feature = "object_id")]
+        FieldDefType::ObjectId => None,
+        #[cfg(feature = "chrono")]
+        FieldDefType::NaiveDate
+        | FieldDefType::NaiveTime
+        | FieldDefType::NaiveDateTime
+        | FieldDefType::DateTime => None,
+    }
+}
+
 /// The `compile_error!` tokens for every `cfg_attr`-wrapped serde attribute a branded newtype
 /// carries: on the type and on its inner slot, which is positional and so has no name to print.
 #[cfg(all(
@@ -711,16 +793,25 @@ const fn branded_cfg_attr_guard_errors(
 }
 
 /// The `compile_error!` tokens for every guard a branded newtype violates: a `cfg_attr`-wrapped
-/// serde attribute on the type or on its inner slot, and an `Option` inner type.
+/// serde attribute on the type or on its inner slot, an `Option` inner type, and string
+/// constraints over an inner type that cannot carry them.
 ///
 /// The branded path renders the inner type straight into the brand instead of walking fields, so
 /// it has to collect these itself; the ordinary struct walk never sees a transparent newtype.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-fn branded_guard_errors(item_struct: &syn::ItemStruct) -> Vec<proc_macro2::TokenStream> {
+fn branded_guard_errors(
+    item_struct: &syn::ItemStruct,
+    args: &ModelSchemaArgs,
+) -> Vec<proc_macro2::TokenStream> {
     let inner_field = item_struct.fields.iter().next().unwrap();
     branded_cfg_attr_guard_errors(item_struct, inner_field)
         .into_iter()
         .chain(branded_option_inner_error(&item_struct.ident, inner_field))
+        .chain(branded_constraint_inner_error(
+            &item_struct.ident,
+            inner_field,
+            args,
+        ))
         .collect()
 }
 
@@ -1059,6 +1150,10 @@ fn build_branded_validation(
                 }
             }
         } else {
+            // Deliberately unspanned: a `to_string()` carrying the user's span is judged by the
+            // consumer's lints as hand-written, and on a `String` inner it is a redundant clone.
+            // The inner field's `Display` requirement is blamed by the static assertion instead,
+            // which is inert wherever it lands.
             quote! {
                 pub fn deserialize_value<'de, D>(deserializer: D) -> Result<#inner_ty, D::Error>
                 where
@@ -1379,8 +1474,12 @@ fn build_branded_display_impl(
     }
 }
 
-/// Builds a branded newtype's `Display` impl together with the static assertion guarding it, or
-/// nothing at all when the brand opted out with `no_display`.
+/// Builds a branded newtype's `Display` impl together with the static assertion guarding it.
+/// `no_display` drops the impl; it drops the assertion only when nothing else needs `Display`.
+///
+/// A constrained brand validates through `value.to_string()`, so the requirement outlives the impl
+/// the brand opted out of. Keeping the assertion is what turns that into an `E0277` at the inner
+/// field instead of the `E0599` the `to_string()` call raises against the attribute.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn build_branded_display_tokens(
     generics: &syn::Generics,
@@ -1388,10 +1487,19 @@ fn build_branded_display_tokens(
     inner_field: &Field,
     args: &ModelSchemaArgs,
 ) -> proc_macro2::TokenStream {
-    if args.no_display {
+    // Only the serde build emits the validation functions that call `to_string()`.
+    #[cfg(feature = "serde")]
+    let validation_needs_display = args.has_string_constraints();
+    #[cfg(not(feature = "serde"))]
+    let validation_needs_display = false;
+
+    if args.no_display && !validation_needs_display {
         return quote! {};
     }
     let display_assertion = build_branded_display_assertion(inner_field, generics);
+    if args.no_display {
+        return display_assertion;
+    }
     let display_impl = build_branded_display_impl(generics, name, inner_field);
     quote! {
         #display_assertion
@@ -1607,7 +1715,9 @@ fn assemble_branded_output(parts: &BrandedNewtypeOutput) -> TokenStream {
 fn process_branded_newtype(item_struct: syn::ItemStruct, args: &ModelSchemaArgs) -> TokenStream {
     // Checked before the type is registered in the alias registry: a rejected brand emits no
     // schema, so nothing else should be able to resolve a reference to one.
-    if let Some(output) = guard_failure_output(&item_struct, &branded_guard_errors(&item_struct)) {
+    if let Some(output) =
+        guard_failure_output(&item_struct, &branded_guard_errors(&item_struct, args))
+    {
         return output;
     }
 

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -3255,6 +3255,23 @@ fn write_tuple_multiple_variant_fields(
     let _: &_ = &&json_schema_variant_fields;
 }
 
+/// Arrays `item_schema` when the field is a `Vec`, and hands it back untouched otherwise.
+///
+/// Every value position that can hold a `Vec` — a field, a tuple element, an enum-keyed map member
+/// — carries the array-ness on the field itself rather than in its type, so the wrap belongs here
+/// once instead of in each renderer.
+#[cfg(feature = "jsonschema")]
+fn arrayed_json_schema_value(
+    fld: &FieldDef,
+    item_schema: proc_macro2::TokenStream,
+) -> proc_macro2::TokenStream {
+    if fld.is_array {
+        quote! { serde_json::json!({ "type": "array", "items": #item_schema }) }
+    } else {
+        item_schema
+    }
+}
+
 /// The JSON schema value expression for a field whose type renders inline as a scalar — arrayed
 /// when the field is a `Vec` — or `None` for the composite types (sibling references, maps,
 /// tuples, unknowns) that have no inline rendering.
@@ -3263,20 +3280,10 @@ fn write_tuple_multiple_variant_fields(
 /// value sits in, so each caller wraps this base itself.
 #[cfg(feature = "jsonschema")]
 fn scalar_field_json_schema_value(fld: &FieldDef) -> Option<proc_macro2::TokenStream> {
-    let schema = match &fld.field_type {
-        FieldDefType::String => {
-            if fld.is_array {
-                quote! { serde_json::json!({ "type": "array", "items": { "type": "string" } }) }
-            } else {
-                quote! { serde_json::json!({ "type": "string" }) }
-            }
-        }
+    let item_schema = match &fld.field_type {
+        FieldDefType::String => quote! { serde_json::json!({ "type": "string" }) },
         FieldDefType::StringLiteral(literal) => {
-            if fld.is_array {
-                quote! { serde_json::json!({ "type": "array", "items": { "type": "string", "const": #literal } }) }
-            } else {
-                quote! { serde_json::json!({ "type": "string", "const": #literal }) }
-            }
+            quote! { serde_json::json!({ "type": "string", "const": #literal }) }
         }
         FieldDefType::U8
         | FieldDefType::U16
@@ -3287,80 +3294,35 @@ fn scalar_field_json_schema_value(fld: &FieldDef) -> Option<proc_macro2::TokenSt
         | FieldDefType::I32
         | FieldDefType::I64
         | FieldDefType::Usize
-        | FieldDefType::Isize => {
-            if fld.is_array {
-                quote! { serde_json::json!({ "type": "array", "items": { "type": "integer" } }) }
-            } else {
-                quote! { serde_json::json!({ "type": "integer" }) }
-            }
-        }
-        FieldDefType::F32 | FieldDefType::F64 => {
-            if fld.is_array {
-                quote! { serde_json::json!({ "type": "array", "items": { "type": "number" } }) }
-            } else {
-                quote! { serde_json::json!({ "type": "number" }) }
-            }
-        }
-        FieldDefType::Boolean => {
-            if fld.is_array {
-                quote! { serde_json::json!({ "type": "array", "items": { "type": "boolean" } }) }
-            } else {
-                quote! { serde_json::json!({ "type": "boolean" }) }
-            }
-        }
+        | FieldDefType::Isize => quote! { serde_json::json!({ "type": "integer" }) },
+        FieldDefType::F32 | FieldDefType::F64 => quote! { serde_json::json!({ "type": "number" }) },
+        FieldDefType::Boolean => quote! { serde_json::json!({ "type": "boolean" }) },
         #[cfg(feature = "chrono")]
         FieldDefType::NaiveDate => {
-            if fld.is_array {
-                quote! { serde_json::json!({ "type": "array", "items": { "type": "string", "format": "date" } }) }
-            } else {
-                quote! { serde_json::json!({ "type": "string", "format": "date" }) }
-            }
+            quote! { serde_json::json!({ "type": "string", "format": "date" }) }
         }
         #[cfg(feature = "chrono")]
         FieldDefType::NaiveTime => {
-            if fld.is_array {
-                quote! { serde_json::json!({ "type": "array", "items": { "type": "string", "format": "time" } }) }
-            } else {
-                quote! { serde_json::json!({ "type": "string", "format": "time" }) }
-            }
+            quote! { serde_json::json!({ "type": "string", "format": "time" }) }
         }
         #[cfg(feature = "chrono")]
         FieldDefType::NaiveDateTime | FieldDefType::DateTime => {
-            if fld.is_array {
-                quote! { serde_json::json!({ "type": "array", "items": { "type": "string", "format": "date-time" } }) }
-            } else {
-                quote! { serde_json::json!({ "type": "string", "format": "date-time" }) }
-            }
+            quote! { serde_json::json!({ "type": "string", "format": "date-time" }) }
         }
         #[cfg(feature = "object_id")]
-        FieldDefType::ObjectId => {
-            if fld.is_array {
-                quote! { serde_json::json!({
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "$oid": { "type": "string", "pattern": "^[a-f\\d]{24}$" }
-                        },
-                        "required": ["$oid"]
-                    }
-                }) }
-            } else {
-                quote! { serde_json::json!({
-                    "type": "object",
-                    "properties": {
-                        "$oid": { "type": "string", "pattern": "^[a-f\\d]{24}$" }
-                    },
-                    "required": ["$oid"]
-                }) }
-            }
-        }
+        FieldDefType::ObjectId => quote! { serde_json::json!({
+            "type": "object",
+            "properties": {
+                "$oid": { "type": "string", "pattern": "^[a-f\\d]{24}$" }
+            },
+            "required": ["$oid"]
+        }) },
         FieldDefType::Unknown
         | FieldDefType::SiblingType(..)
         | FieldDefType::Map(..)
         | FieldDefType::Tuple(..) => return None,
     };
-    Some(schema)
+    Some(arrayed_json_schema_value(fld, item_schema))
 }
 
 /// Builds the base JSON schema for a tuple element, ignoring `is_optional`.
@@ -3816,7 +3778,9 @@ fn build_enum_key_map_value_binding(value: &FieldDef) -> Option<proc_macro2::Tok
         };
         let value_module_ident =
             proc_macro2::Ident::new(value_module_name.as_str(), proc_macro2::Span::call_site());
-        return Some(quote! { let value_schema = #value_module_ident::Schema::json_schema(); });
+        let sibling_schema =
+            arrayed_json_schema_value(value, quote! { #value_module_ident::Schema::json_schema() });
+        return Some(quote! { let value_schema = #sibling_schema; });
     }
 
     let scalar_schema = scalar_field_json_schema_value(value)?;

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -963,6 +963,27 @@ fn a_scalar_enum_keyed_map_value_expands_to_the_per_member_loop() {
     );
 }
 
+/// A `Vec` of siblings is the inner sibling with `is_array` set, so the member schema has to array
+/// the sibling's own schema — bound bare, it types the member as one sibling and turns away every
+/// payload serde produces.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_vec_sibling_enum_keyed_map_value_arrays_the_sibling_schema() {
+    let arrayed = map_field_schema("HashMap<Slot, Vec<Inner>>").to_string();
+    assert!(
+        arrayed.contains(
+            r#"let value_schema = serde_json :: json ! ({ "type" : "array" , "items" : inner_schema :: Schema :: json_schema () }) ;"#
+        ),
+        "got: {arrayed}"
+    );
+
+    let single = map_field_schema("HashMap<Slot, Inner>").to_string();
+    assert!(
+        single.contains("let value_schema = inner_schema :: Schema :: json_schema () ;"),
+        "got: {single}"
+    );
+}
+
 /// The kind an alias registers is its *target's* answer, because a type path resolves through the
 /// alias. `Vec<Slot>` is the collection, not the enum it holds; a target this expansion has not
 /// seen registered is `Unknown`, which is not a negative.

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -442,10 +442,130 @@ fn alias_ts_definition_method_carries_no_cfg_attribute() {
 /// Collects a branded newtype's guard failures as rendered `compile_error!` token strings.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn branded_errors(item: &syn::ItemStruct) -> Vec<String> {
-    branded_guard_errors(item)
+    branded_errors_with(item, &super::ModelSchemaArgs::default())
+}
+
+/// [`branded_errors`] for a brand carrying `model_schema` arguments.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn branded_errors_with(item: &syn::ItemStruct, args: &super::ModelSchemaArgs) -> Vec<String> {
+    branded_guard_errors(item, args)
         .iter()
         .map(ToString::to_string)
         .collect()
+}
+
+/// The `model_schema` arguments of a brand carrying a lone `pattern`.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn pattern_args() -> super::ModelSchemaArgs {
+    super::parse_model_schema_args(quote::quote! { pattern = "^[a-z]+$" })
+}
+
+/// Every constraint the guard reacts to, applied one at a time: `has_string_constraints` is an
+/// or over three independent fields, so a guard wired to only one of them would still pass a
+/// pattern-only probe.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn each_string_constraint_alone_rejects_a_numeric_inner() {
+    for args in [
+        quote::quote! { pattern = "^[a-z]+$" },
+        quote::quote! { minLength = 3 },
+        quote::quote! { maxLength = 8 },
+    ] {
+        let rendered = format!("{args}");
+        let errors = branded_errors_with(
+            &syn::parse_quote! {
+                #[serde(transparent)]
+                struct BadNum(pub u64);
+            },
+            &super::parse_model_schema_args(args),
+        );
+        assert_eq!(errors.len(), 1, "for {rendered}, got: {errors:?}");
+        assert!(errors[0].contains("numeric"), "got: {}", errors[0]);
+    }
+}
+
+/// The shapes whose surfaces read the string constraints as something other than a string check.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn string_constraints_over_a_non_string_inner_are_rejected() {
+    for (inner, shape) in [
+        ("u64", "numeric"),
+        ("i32", "numeric"),
+        ("f64", "numeric"),
+        ("bool", "boolean"),
+        ("Vec<String>", "container"),
+        ("[u8; 4]", "container"),
+        ("HashMap<String, String>", "container"),
+        ("(String, String)", "container"),
+        ("serde_json::Value", "opaque"),
+    ] {
+        let ty: syn::Type = syn::parse_str(inner).unwrap();
+        let errors = branded_errors_with(
+            &syn::parse_quote! {
+                #[serde(transparent)]
+                struct Branded(pub #ty);
+            },
+            &pattern_args(),
+        );
+        assert_eq!(errors.len(), 1, "for {inner}, got: {errors:?}");
+        assert!(errors[0].contains("compile_error"), "got: {}", errors[0]);
+        assert!(errors[0].contains("`Branded`"), "got: {}", errors[0]);
+        assert!(errors[0].contains(shape), "for {inner}, got: {}", errors[0]);
+    }
+}
+
+/// The inners that carry the constraints faithfully. A `SiblingType` — another brand, an
+/// unresolved user type, or a bare generic parameter — is admitted because expansion cannot know
+/// its shape; the constrained path's `Display` assertion is what covers it.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn string_constraints_over_a_string_shaped_inner_pass() {
+    for inner in ["String", "PathBuf", "ObjectId", "SomeOtherBrand", "T"] {
+        let ty: syn::Type = syn::parse_str(inner).unwrap();
+        let errors = branded_errors_with(
+            &syn::parse_quote! {
+                #[serde(transparent)]
+                struct Branded<T>(pub #ty);
+            },
+            &pattern_args(),
+        );
+        assert!(errors.is_empty(), "for {inner}, got: {errors:?}");
+    }
+}
+
+/// The guard reads the constraints, not the inner type: an unconstrained brand over any of the
+/// rejected shapes is the shipped `no_display` contract and stays accepted.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn an_unconstrained_brand_over_a_non_string_inner_passes() {
+    for inner in ["u64", "bool", "Vec<String>", "serde_json::Value"] {
+        let ty: syn::Type = syn::parse_str(inner).unwrap();
+        let errors = branded_errors(&syn::parse_quote! {
+            #[serde(transparent)]
+            struct Branded(pub #ty);
+        });
+        assert!(errors.is_empty(), "for {inner}, got: {errors:?}");
+    }
+}
+
+/// The message has to name the surfaces that disagree, or it reads as an arbitrary restriction.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn the_constraint_guard_message_names_the_constraints_and_the_surfaces() {
+    let errors = branded_errors_with(
+        &syn::parse_quote! {
+            #[serde(transparent)]
+            struct BadNum(pub u64);
+        },
+        &pattern_args(),
+    );
+    for needle in ["pattern", "minLength", "maxLength", "Zod", "JSON Schema"] {
+        assert!(
+            errors[0].contains(needle),
+            "{needle} missing: {}",
+            errors[0]
+        );
+    }
 }
 
 #[cfg(all(
@@ -637,6 +757,164 @@ fn generic_display_impl_bounds_every_type_parameter() {
     assert_eq!(
         tokens.to_string(),
         "impl < IdType : std :: fmt :: Display > std :: fmt :: Display for DocumentId < IdType > { fn fmt (& self , f : & mut std :: fmt :: Formatter < '_ >) -> std :: fmt :: Result { self . 0 . fmt (f) } }"
+    );
+}
+
+/// Builds the whole `Display` block — assertion plus impl — for the sole field of `source`.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn display_tokens(source: &str, args: &proc_macro2::TokenStream) -> String {
+    let item: syn::ItemStruct = syn::parse_str(source).unwrap();
+    let field = item.fields.iter().next().unwrap();
+    super::build_branded_display_tokens(
+        &item.generics,
+        &item.ident,
+        field,
+        &super::parse_model_schema_args(args.clone()),
+    )
+    .to_string()
+}
+
+/// `no_display` drops the `Display` impl, never the requirement: the constrained path validates
+/// through `value.to_string()`, so a brand that opted out still has to prove the inner is
+/// `Display` — at the field, not at the attribute.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn constraints_keep_the_display_assertion_when_the_brand_opts_out_of_the_impl() {
+    let tokens = display_tokens(
+        "pub struct Slugs(pub Tags);",
+        &quote::quote! { no_display, pattern = "^[a-z]+$" },
+    );
+    assert!(
+        tokens.contains("assert_display :: < Tags > ()"),
+        "got: {tokens}"
+    );
+    assert!(
+        !tokens.contains("impl std :: fmt :: Display"),
+        "got: {tokens}"
+    );
+}
+
+/// The three combinations that predate the constrained-path assertion keep their exact tokens.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn the_display_block_is_unchanged_for_every_pre_existing_combination() {
+    let assertion_and_impl = display_tokens("pub struct UserId(pub String);", &quote::quote! {});
+    assert!(
+        assertion_and_impl.contains("assert_display :: < String > ()")
+            && assertion_and_impl.contains("impl std :: fmt :: Display for UserId"),
+        "got: {assertion_and_impl}"
+    );
+    assert_eq!(
+        display_tokens(
+            "pub struct SlugId(pub String);",
+            &quote::quote! { pattern = "^[a-z]+$" }
+        ),
+        assertion_and_impl.replace("UserId", "SlugId"),
+        "a constrained brand that kept its impl emits what an unconstrained one does"
+    );
+    assert_eq!(
+        display_tokens(
+            "pub struct Tags(pub Vec<String>);",
+            &quote::quote! { no_display }
+        ),
+        "",
+        "an unconstrained opt-out emits neither half"
+    );
+}
+
+/// How many tokens of each `to_string()` call site a constrained brand expands to point back at
+/// the inner field. Built from parsed source, so a token that carries the inner type's span has a
+/// location to report and a macro-synthesized one does not.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+fn constrained_brand_inner_spanned_tokens(source: &str, inner: &str) -> (usize, usize) {
+    let item: syn::ItemStruct = syn::parse_str(source).unwrap();
+    let args = super::parse_model_schema_args(quote::quote! { pattern = "^[a-z]+$" });
+    let validation =
+        super::build_branded_validation(&args, false, &item.fields.iter().next().unwrap().ty)
+            .unwrap();
+    let module_ident = syn::Ident::new("slug_id_schema", proc_macro2::Span::call_site());
+    let (_, _, validate_method) = super::inject_branded_serde_attrs(
+        item,
+        Some(&validation),
+        false,
+        &[],
+        "slug_id_schema",
+        &module_ident,
+    );
+    let count = |tokens| {
+        located_source_texts(tokens)
+            .iter()
+            .filter(|text| text.as_str() == inner)
+            .count()
+    };
+    (count(&validation.1), count(&validate_method))
+}
+
+/// Neither `to_string()` the constrained path emits may carry the inner field's span. Spanned
+/// tokens are judged by the consumer's lints as if hand-written, and on a `String` inner
+/// `self.0.to_string()` is a redundant clone — the whole test suite fails on it. The `Display`
+/// requirement is blamed by the static assertion instead, whose tokens are inert wherever they
+/// land. Only the interpolated `#inner_ty` may point at the field here.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn neither_constrained_to_string_call_carries_the_inner_fields_span() {
+    let (deserializer, validate_method) =
+        constrained_brand_inner_spanned_tokens("pub struct SlugId(pub Tags);", "Tags");
+    assert_eq!(
+        deserializer, 2,
+        "the two interpolated type names and nothing else"
+    );
+    assert_eq!(
+        validate_method, 0,
+        "`validate()` interpolates no inner type"
+    );
+}
+
+/// The constrained path's generated text is what it has always been.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn the_constrained_path_renders_the_same_to_string_calls_it_always_has() {
+    let item: syn::ItemStruct = syn::parse_quote!(
+        pub struct SlugId(pub String);
+    );
+    let args = super::parse_model_schema_args(quote::quote! { pattern = "^[a-z]+$" });
+    let validation =
+        super::build_branded_validation(&args, false, &item.fields.iter().next().unwrap().ty)
+            .unwrap();
+    let module_ident = syn::Ident::new("slug_id_schema", proc_macro2::Span::call_site());
+    let (_, _, validate_method) = super::inject_branded_serde_attrs(
+        item,
+        Some(&validation),
+        false,
+        &[],
+        "slug_id_schema",
+        &module_ident,
+    );
+    assert!(
+        validation
+            .1
+            .to_string()
+            .contains("validate_value (& v . to_string ())"),
+        "got: {}",
+        validation.1
+    );
+    assert!(
+        validate_method
+            .to_string()
+            .contains("slug_id_schema :: validate_value (& self . 0 . to_string ())"),
+        "got: {validate_method}"
     );
 }
 

--- a/tests/branded_newtype_tests/tests.rs
+++ b/tests/branded_newtype_tests/tests.rs
@@ -699,6 +699,34 @@ mod branded_no_display_tests {
     }
 }
 
+// `no_display` drops the `Display` impl, not the `Display` requirement: a constrained brand
+// validates through `to_string()`, so its inner still has to render. Compiling this module is the
+// assertion that the combination is accepted and still wired to the constraints.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+mod constrained_no_display_tests {
+    use super::*;
+
+    #[model_schema(no_display, pattern = "^[a-z0-9_]+$", minLength = 3)]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct QuietSlug(pub String);
+
+    #[test]
+    fn test_constrained_no_display_brand_validates() {
+        QuietSlug("hello_world".to_owned()).validate().unwrap();
+        QuietSlug("NO".to_owned()).validate().unwrap_err();
+    }
+
+    #[test]
+    fn test_constrained_no_display_brand_enforces_constraints_through_serde() {
+        serde_json::from_str::<QuietSlug>("\"hello_world\"").unwrap();
+        serde_json::from_str::<QuietSlug>("\"NO\"").unwrap_err();
+    }
+}
+
 // zod=OFF, typescript=ON tests
 #[cfg(all(feature = "typescript", not(feature = "zod")))]
 mod no_zod_tests {

--- a/tests/collection_tests/tests.rs
+++ b/tests/collection_tests/tests.rs
@@ -50,6 +50,19 @@ struct EnumKeyedScalarValueMaps {
     u64_value: HashMap<MetricSlot, u64>,
 }
 
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct MetricSample {
+    label: String,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct EnumKeyedSiblingValueMaps {
+    sample_array: HashMap<MetricSlot, Vec<MetricSample>>,
+    sample_value: HashMap<MetricSlot, MetricSample>,
+}
+
 // Test struct with collections
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -88,6 +101,20 @@ fn assert_hashmap_array_type(
         properties[field_name]["additionalProperties"]["items"]["type"],
         expected_item_type
     );
+}
+
+/// The JSON Schema `type` a value carries on the wire, so an emitted schema can be held against
+/// what serde actually produces for it.
+#[cfg(feature = "jsonschema")]
+const fn json_type_name(value: &serde_json::Value) -> &'static str {
+    match *value {
+        serde_json::Value::Null => "null",
+        serde_json::Value::Bool(_) => "boolean",
+        serde_json::Value::Number(_) => "number",
+        serde_json::Value::String(_) => "string",
+        serde_json::Value::Array(_) => "array",
+        serde_json::Value::Object(_) => "object",
+    }
 }
 
 #[cfg(feature = "jsonschema")]
@@ -340,6 +367,90 @@ fn test_enum_keyed_scalar_value_maps_typescript_generation() {
     );
     assert!(
         zod_schema.contains("string_array: z.record(MetricSlot$Schema, z.array(z.string()))"),
+        "Got: {zod_schema}"
+    );
+}
+
+#[test]
+fn test_enum_keyed_sibling_value_maps_constructible() {
+    let maps = EnumKeyedSiblingValueMaps {
+        sample_array: HashMap::from([(
+            MetricSlot::Daily,
+            vec![MetricSample {
+                label: "d".to_owned(),
+            }],
+        )]),
+        sample_value: HashMap::new(),
+    };
+    assert_eq!(maps.sample_array[&MetricSlot::Daily].len(), 1);
+}
+
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_enum_keyed_sibling_value_maps_json_schema() {
+    let sample_schema = MetricSample::json_schema();
+    let schema = EnumKeyedSiblingValueMaps::json_schema();
+    let properties = schema["properties"].as_object().unwrap();
+
+    assert_enum_keyed_map_value(properties, "sample_value", &sample_schema);
+    assert_enum_keyed_map_value(
+        properties,
+        "sample_array",
+        &serde_json::json!({ "type": "array", "items": sample_schema }),
+    );
+}
+
+/// A `Vec` map value is an array of siblings on the wire, so the member schema has to admit that
+/// form and turn away the single sibling object a dropped array wrap would have accepted.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_enum_keyed_sibling_array_member_matches_the_serialized_form() {
+    let sample = MetricSample {
+        label: "d".to_owned(),
+    };
+    let maps = EnumKeyedSiblingValueMaps {
+        sample_array: HashMap::from([(MetricSlot::Daily, vec![sample.clone()])]),
+        sample_value: HashMap::new(),
+    };
+    let payload = serde_json::to_value(&maps).unwrap();
+    let member = &EnumKeyedSiblingValueMaps::json_schema()["properties"]["sample_array"]["properties"]
+        ["Daily"];
+
+    assert_eq!(
+        member["type"],
+        json_type_name(&payload["sample_array"]["Daily"]),
+        "in: {member}"
+    );
+    assert_eq!(member["items"], MetricSample::json_schema(), "in: {member}");
+    assert_ne!(
+        member["type"],
+        json_type_name(&serde_json::to_value(&sample).unwrap()),
+        "in: {member}"
+    );
+}
+
+#[test]
+#[cfg(all(feature = "typescript", feature = "zod"))]
+fn test_enum_keyed_sibling_value_maps_typescript_generation() {
+    let ts_definition = EnumKeyedSiblingValueMaps::ts_definition();
+
+    assert!(
+        ts_definition.contains("sample_value: Partial<Record<MetricSlot, MetricSample>>;"),
+        "Got: {ts_definition}"
+    );
+    assert!(
+        ts_definition.contains("sample_array: Partial<Record<MetricSlot, Array<MetricSample>>>;"),
+        "Got: {ts_definition}"
+    );
+
+    let zod_schema = EnumKeyedSiblingValueMaps::zod_schema();
+    assert!(
+        zod_schema.contains("sample_value: z.record(MetricSlot$Schema, MetricSample$Schema)"),
+        "Got: {zod_schema}"
+    );
+    assert!(
+        zod_schema
+            .contains("sample_array: z.record(MetricSlot$Schema, z.array(MetricSample$Schema))"),
         "Got: {zod_schema}"
     );
 }


### PR DESCRIPTION
Stacked on #36 (stack: #33 → #34 → #35 → #36 → this).

`HashMap<EnumKey, Vec<Sibling>>` emitted the bare sibling schema as the member type — valid JSON (array of siblings) rejected, a single bare object accepted.

- One shared `arrayed_json_schema_value` wrap now serves both the sibling arm and the scalar mapping; the scalar arms' per-variant array duplication collapsed into it (emitted schemas unchanged, token-pinned).
- TS/Zod audit: negative — both already honor `is_array` (`Array<MetricSample>` / `z.array(...)` passed pre-fix); now fixture-pinned so they can't regress.
- Red-first: json-schema fixtures failed with the bare object form before, 14 collection tests green after; non-array sibling binding byte-pinned.

Gates: `just check`, `just lint-all` (68/68), `just test` (full powerset) green.