### PR TITLE
fix: Option map values render nullable on every surface

### DIFF
--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -131,7 +131,8 @@ pub enum FieldDefType {
 ///
 /// Fields:
 /// - `is_optional`: In struct-field position, adds `| undefined` / `z.union([type, z.undefined()])`.
-///   In tuple-element position, adds `| null` / `z.nullable(type)` — a positional `None` serializes as `null`.
+///   In tuple-element and map-value position, adds `| null` / `z.nullable(type)` — neither slot can
+///   be dropped the way an object key can, so a `None` there serializes as `null`.
 /// - name: Safe field name (uses serde rename if feature enabled)
 /// - docs: Doc comments from Rust - included in generated TS as `JSDoc`
 /// - `field_type`: The core type classification (see `FieldDefType`)
@@ -294,22 +295,13 @@ impl FieldDef {
 
     /// Builds the TypeScript type before the struct-field optional wrap: the type match
     /// plus the `is_array` wrap. The `| undefined` wrap lives in `typescript_typename`.
-    /// An optional tuple element is null-flavored here (`{base} | null`): a positional
-    /// slot cannot be omitted, so serde emits `null` for a `None`.
     fn typescript_base(&self) -> String {
         let result = match &self.field_type {
             FieldDefType::Unknown => "unknown".to_owned(),
             FieldDefType::Tuple(lst) => {
                 let elements = lst
                     .iter()
-                    .map(|element| {
-                        let base = element.typescript_base();
-                        if element.is_optional {
-                            format!("{base} | null")
-                        } else {
-                            base
-                        }
-                    })
+                    .map(Self::typescript_slot_typename)
                     .collect::<Vec<_>>()
                     .join(", ");
                 format!("[{elements}]")
@@ -344,7 +336,7 @@ impl FieldDef {
                 format!(
                     "Partial<Record<{}, {}>>",
                     k.typescript_typename(),
-                    v.typescript_typename()
+                    v.typescript_slot_typename()
                 )
             }
             FieldDefType::Boolean => "boolean".to_owned(),
@@ -385,6 +377,19 @@ impl FieldDef {
         }
     }
 
+    /// The TypeScript type for a value in a slot that cannot be dropped — a tuple element or a
+    /// map entry. An `Option` there is null-flavored (`{base} | null`) rather than
+    /// undefined-flavored: only an object key can be omitted, so serde emits `null` for a `None`
+    /// in either position.
+    fn typescript_slot_typename(&self) -> String {
+        let base = self.typescript_base();
+        if self.is_optional {
+            format!("{base} | null")
+        } else {
+            base
+        }
+    }
+
     /// Generates the TypeScript type name for this field.
     ///
     /// This method is the core of TypeScript type generation. It recursively builds
@@ -393,8 +398,9 @@ impl FieldDef {
     /// Process:
     /// 1. Match on `field_type` to get base type
     /// 2. If `is_array`, wrap in Array<...>
-    /// 3. If `is_optional`: struct-field position adds `| undefined`; tuple-element position adds `| null`
-    ///    (a positional `None` serializes as `null`, so a tuple slot cannot be omitted like an object key)
+    /// 3. If `is_optional`: struct-field position adds `| undefined`; tuple-element and map-value
+    ///    positions add `| null` (neither can be omitted like an object key, so a `None` there
+    ///    serializes as `null`)
     ///
     /// Feature notes:
     /// - "`object_id"`: Uses special `ObjectId` type
@@ -420,9 +426,7 @@ impl FieldDef {
 
     /// Builds the Zod schema before the struct-field optional wrap: the type match, the
     /// `is_array` wrap, and the preprocess wrap. The
-    /// `z.union([…, z.undefined()]).prefault(undefined)` wrap lives in `zod_type`. An
-    /// optional tuple element is null-flavored here (`z.nullable({base})`): a positional
-    /// slot cannot be omitted, so serde emits `null` for a `None`.
+    /// `z.union([…, z.undefined()]).prefault(undefined)` wrap lives in `zod_type`.
     #[cfg(feature = "zod")]
     fn zod_base(&self) -> String {
         let result = match &self.field_type {
@@ -430,14 +434,7 @@ impl FieldDef {
             FieldDefType::Tuple(lst) => {
                 let elements = lst
                     .iter()
-                    .map(|element| {
-                        let base = element.zod_base();
-                        if element.is_optional {
-                            format!("z.nullable({base})")
-                        } else {
-                            base
-                        }
-                    })
+                    .map(Self::zod_slot_type)
                     .collect::<Vec<_>>()
                     .join(", ");
                 format!("z.tuple([{elements}])")
@@ -461,7 +458,7 @@ impl FieldDef {
                 }
             }
             FieldDefType::Map(k, v) => {
-                format!("z.record({}, {})", k.zod_type(), v.zod_type())
+                format!("z.record({}, {})", k.zod_type(), v.zod_slot_type())
             }
             FieldDefType::Boolean => "z.boolean()".to_owned(),
             FieldDefType::String => self.zod_string_type(),
@@ -529,6 +526,20 @@ impl FieldDef {
         result
     }
 
+    /// The Zod schema for a value in a slot that cannot be dropped — a tuple element or a map
+    /// entry. An `Option` there is null-flavored (`z.nullable({base})`) rather than
+    /// undefined-flavored: only an object key can be omitted, so serde emits `null` for a `None`
+    /// in either position.
+    #[cfg(feature = "zod")]
+    fn zod_slot_type(&self) -> String {
+        let base = self.zod_base();
+        if self.is_optional {
+            format!("z.nullable({base})")
+        } else {
+            base
+        }
+    }
+
     /// Builds the Zod schema string for a string field, applying any length/pattern constraints.
     #[cfg(feature = "zod")]
     fn zod_string_type(&self) -> String {
@@ -566,7 +577,8 @@ impl FieldDef {
     /// - For `ObjectId`: Uses regex validation for hex string
     /// - Wraps with `z.array()` if `is_array`
     /// - If `is_optional`: struct-field position wraps `z.union([type, z.undefined()])`;
-    ///   tuple-element position wraps `z.nullable(type)` (a positional `None` serializes as `null`)
+    ///   tuple-element and map-value positions wrap `z.nullable(type)` (neither can be omitted like
+    ///   an object key, so a `None` there serializes as `null`)
     ///
     /// Requires Zod v4 in frontend - generates v4-compatible syntax.
     /// See `notes/20250706_features.md` for Zod feature details.

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -3334,21 +3334,28 @@ fn build_tuple_element_base_json_schema(fld: &FieldDef) -> proc_macro2::TokenStr
         .unwrap_or_else(|| quote! { serde_json::json!({ "type": "object" }) })
 }
 
-/// Builds JSON schema for a tuple element (used for single tuple and multi-tuple variants).
+/// The `anyOf [<base>, null]` form for a value in a slot that cannot be dropped — a tuple element
+/// or a map entry — or `None` when the value is not an `Option`. Only an object key can be
+/// omitted; in either of these positions serde writes a `None` as JSON `null`, so the schema has
+/// to admit it.
 ///
-/// An `Option` element renders as `anyOf [<base>, null]`: a tuple slot is positional, so
-/// serde serializes `None` as JSON `null` (the slot cannot be omitted the way an object key
-/// can).
+/// The tokens are a JSON value: a caller writing inside a `serde_json::json!` literal inlines
+/// them, one needing a standalone `serde_json::Value` wraps them in `serde_json::json!`.
+#[cfg(feature = "jsonschema")]
+fn nullable_slot_json_schema(
+    fld: &FieldDef,
+    base: &proc_macro2::TokenStream,
+) -> Option<proc_macro2::TokenStream> {
+    fld.is_optional
+        .then(|| quote! { { "anyOf": [#base, { "type": "null" }] } })
+}
+
+/// Builds JSON schema for a tuple element (used for single tuple and multi-tuple variants).
 #[cfg(feature = "jsonschema")]
 fn build_tuple_element_json_schema(fld: &FieldDef) -> proc_macro2::TokenStream {
     let base = build_tuple_element_base_json_schema(fld);
-    if fld.is_optional {
-        quote! {
-            serde_json::json!({ "anyOf": [#base, { "type": "null" }] })
-        }
-    } else {
-        base
-    }
+    nullable_slot_json_schema(fld, &base)
+        .map_or(base, |nullable| quote! { serde_json::json!(#nullable) })
 }
 
 /// Fallback JSON schema for map fields whose key type is not specially handled.
@@ -3420,17 +3427,21 @@ fn build_map_nested_map_value_schema(
             }
         };
 
+        let arrayed = quote! {
+            {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "additionalProperties": #inner_value_schema
+                }
+            }
+        };
+        let value_schema = nullable_slot_json_schema(value, &arrayed).unwrap_or(arrayed);
         quote! {
             properties.insert(#field_name_str.to_string(), {
                 serde_json::json!({
                     "type": "object",
-                    "additionalProperties": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "additionalProperties": #inner_value_schema
-                        }
-                    }
+                    "additionalProperties": #value_schema
                 })
             });
         }
@@ -3674,34 +3685,31 @@ fn build_map_sibling_value_schema(
 }
 
 /// Wraps a scalar JSON schema as a `String`-keyed map's `additionalProperties`,
-/// arraying it when the value field is a `Vec`.
+/// arraying it when the value field is a `Vec` and nullable when it is an `Option`.
 #[cfg(feature = "jsonschema")]
 fn build_map_scalar_value_schema(
     value: &FieldDef,
     field_name_str: &str,
     item_schema: &proc_macro2::TokenStream,
 ) -> proc_macro2::TokenStream {
-    if value.is_array {
+    let arrayed = if value.is_array {
         quote! {
-            properties.insert(#field_name_str.to_string(), {
-                serde_json::json!({
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "array",
-                        "items": #item_schema
-                    }
-                })
-            });
+            {
+                "type": "array",
+                "items": #item_schema
+            }
         }
     } else {
-        quote! {
-            properties.insert(#field_name_str.to_string(), {
-                serde_json::json!({
-                    "type": "object",
-                    "additionalProperties": #item_schema
-                })
-            });
-        }
+        item_schema.clone()
+    };
+    let value_schema = nullable_slot_json_schema(value, &arrayed).unwrap_or(arrayed);
+    quote! {
+        properties.insert(#field_name_str.to_string(), {
+            serde_json::json!({
+                "type": "object",
+                "additionalProperties": #value_schema
+            })
+        });
     }
 }
 
@@ -3767,7 +3775,7 @@ fn build_string_key_map_value_schema(
 /// when the value type has no rendering here.
 #[cfg(feature = "jsonschema")]
 fn build_enum_key_map_value_binding(value: &FieldDef) -> Option<proc_macro2::TokenStream> {
-    if let FieldDefType::SiblingType(value_type_name, value_lst) = &value.field_type
+    let base = if let FieldDefType::SiblingType(value_type_name, value_lst) = &value.field_type
         && value_lst.is_empty()
     {
         // For json_schema(), use the module pattern. An alias's module is named after
@@ -3778,13 +3786,14 @@ fn build_enum_key_map_value_binding(value: &FieldDef) -> Option<proc_macro2::Tok
         };
         let value_module_ident =
             proc_macro2::Ident::new(value_module_name.as_str(), proc_macro2::Span::call_site());
-        let sibling_schema =
-            arrayed_json_schema_value(value, quote! { #value_module_ident::Schema::json_schema() });
-        return Some(quote! { let value_schema = #sibling_schema; });
-    }
+        arrayed_json_schema_value(value, quote! { #value_module_ident::Schema::json_schema() })
+    } else {
+        scalar_field_json_schema_value(value)?
+    };
 
-    let scalar_schema = scalar_field_json_schema_value(value)?;
-    Some(quote! { let value_schema = #scalar_schema; })
+    let value_schema = nullable_slot_json_schema(value, &base)
+        .map_or(base, |nullable| quote! { serde_json::json!(#nullable) });
+    Some(quote! { let value_schema = #value_schema; })
 }
 
 #[cfg(feature = "jsonschema")]

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -984,6 +984,46 @@ fn a_vec_sibling_enum_keyed_map_value_arrays_the_sibling_schema() {
     );
 }
 
+/// A map entry cannot be dropped the way an object key can, so serde writes an `Option` value's
+/// `None` as JSON `null`. Both key paths have to admit it, and through the same seam: the enum-key
+/// branch materializes the nullable form as a `serde_json::Value`, the `String`-key branch inlines
+/// it as the map's `additionalProperties`.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn an_optional_map_value_is_nullable_on_both_key_paths() {
+    let enum_keyed = map_field_schema("HashMap<Slot, Option<String>>").to_string();
+    assert!(
+        enum_keyed.contains(
+            r#"let value_schema = serde_json :: json ! ({ "anyOf" : [serde_json :: json ! ({ "type" : "string" }) , { "type" : "null" }] }) ;"#
+        ),
+        "got: {enum_keyed}"
+    );
+
+    let string_keyed = map_field_schema("HashMap<String, Option<String>>").to_string();
+    assert!(
+        string_keyed.contains(
+            r#""additionalProperties" : { "anyOf" : [{ "type" : "string" } , { "type" : "null" }] }"#
+        ),
+        "got: {string_keyed}"
+    );
+}
+
+/// A non-`Option` map value is untouched by the nullable seam — on either key path the tokens are
+/// the ones the value type has always produced.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_required_map_value_carries_no_nullable_wrap() {
+    for map_type in [
+        "HashMap<Slot, String>",
+        "HashMap<Slot, Vec<Inner>>",
+        "HashMap<String, String>",
+        "HashMap<String, Vec<u64>>",
+    ] {
+        let tokens = map_field_schema(map_type).to_string();
+        assert!(!tokens.contains("anyOf"), "for {map_type}, got: {tokens}");
+    }
+}
+
 /// The kind an alias registers is its *target's* answer, because a type path resolves through the
 /// alias. `Vec<Slot>` is the collection, not the enum it holds; a target this expansion has not
 /// seen registered is `Unknown`, which is not a negative.

--- a/tests/collection_tests/tests.rs
+++ b/tests/collection_tests/tests.rs
@@ -63,6 +63,15 @@ struct EnumKeyedSiblingValueMaps {
     sample_value: HashMap<MetricSlot, MetricSample>,
 }
 
+// A map entry cannot be dropped the way an object key can, so an `Option` value is spelled `null`
+// on the wire rather than omitted — the same twin type on both key paths pins that both agree.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct OptionalMapValues {
+    enum_keyed: HashMap<MetricSlot, Option<String>>,
+    string_keyed: HashMap<String, Option<String>>,
+}
+
 // Test struct with collections
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -171,6 +180,11 @@ fn test_collection_structs_constructible() {
         tags: Vec::new(),
     };
     assert!(with_collections.id.is_empty());
+    let optional_values = OptionalMapValues {
+        enum_keyed: HashMap::from([(MetricSlot::Daily, None)]),
+        string_keyed: HashMap::from([("k".to_owned(), None)]),
+    };
+    assert_eq!(optional_values.enum_keyed[&MetricSlot::Daily], None);
 }
 
 #[test]
@@ -232,6 +246,22 @@ fn test_comprehensive_hashmap_json_schema() {
     assert_hashmap_array_type(properties, "i64_array", "integer");
     assert_hashmap_array_type(properties, "f64_array", "number");
     assert_hashmap_array_type(properties, "bool_array", "boolean");
+
+    // An `Option` value is nullable rather than absent — the array wrap sits inside the union,
+    // because the `Option` is the outer one in `Option<Vec<T>>`.
+    assert_eq!(
+        properties["optional_u64"]["additionalProperties"],
+        serde_json::json!({ "anyOf": [{ "type": "integer" }, { "type": "null" }] })
+    );
+    assert_eq!(
+        properties["optional_u64_array"]["additionalProperties"],
+        serde_json::json!({
+            "anyOf": [
+                { "type": "array", "items": { "type": "integer" } },
+                { "type": "null" }
+            ]
+        })
+    );
 }
 
 #[test]
@@ -267,6 +297,28 @@ fn test_comprehensive_hashmap_typescript_generation() {
     assert!(zod_schema.contains("i64_array: z.record(z.string(), z.array(z.number().int()))"));
     assert!(zod_schema.contains("f64_array: z.record(z.string(), z.array(z.number()))"));
     assert!(zod_schema.contains("bool_array: z.record(z.string(), z.array(z.boolean()))"));
+
+    // An `Option` map value is null-flavored, not undefined-flavored: the entry it sits in cannot
+    // be dropped, so serde writes the `None` as `null`.
+    assert!(
+        ts_definition.contains("optional_u64: Partial<Record<string, number | null>>;"),
+        "Got: {ts_definition}"
+    );
+    assert!(
+        ts_definition
+            .contains("optional_u64_array: Partial<Record<string, Array<number> | null>>;"),
+        "Got: {ts_definition}"
+    );
+    assert!(
+        zod_schema.contains("optional_u64: z.record(z.string(), z.nullable(z.number().int()))"),
+        "Got: {zod_schema}"
+    );
+    assert!(
+        zod_schema.contains(
+            "optional_u64_array: z.record(z.string(), z.nullable(z.array(z.number().int())))"
+        ),
+        "Got: {zod_schema}"
+    );
 }
 
 #[test]
@@ -451,6 +503,62 @@ fn test_enum_keyed_sibling_value_maps_typescript_generation() {
     assert!(
         zod_schema
             .contains("sample_array: z.record(MetricSlot$Schema, z.array(MetricSample$Schema))"),
+        "Got: {zod_schema}"
+    );
+}
+
+/// A map entry carries its `None` as JSON `null`: unlike an object key, an entry cannot be dropped,
+/// so the schema has to admit the null serde writes. Both key paths render the same nullable form,
+/// the one a tuple slot already uses for the same reason.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_optional_map_values_admit_the_null_serde_writes() {
+    let values = OptionalMapValues {
+        enum_keyed: HashMap::from([(MetricSlot::Daily, None)]),
+        string_keyed: HashMap::from([("k".to_owned(), None)]),
+    };
+    let payload = serde_json::to_value(&values).unwrap();
+    assert_eq!(json_type_name(&payload["enum_keyed"]["Daily"]), "null");
+    assert_eq!(json_type_name(&payload["string_keyed"]["k"]), "null");
+
+    let nullable_string = serde_json::json!({
+        "anyOf": [{ "type": "string" }, { "type": "null" }]
+    });
+    let schema = OptionalMapValues::json_schema();
+    let properties = schema["properties"].as_object().unwrap();
+
+    assert_enum_keyed_map_value(properties, "enum_keyed", &nullable_string);
+    assert_eq!(properties["string_keyed"]["type"], "object");
+    assert_eq!(
+        properties["string_keyed"]["additionalProperties"], nullable_string,
+        "in: {}",
+        properties["string_keyed"]
+    );
+}
+
+/// A map value is null-flavored rather than undefined-flavored, on both key paths: `Partial<Record>`
+/// already lets a key be missing, but a key that *is* present carries the `null` serde writes for a
+/// `None`, so the value type has to admit it.
+#[test]
+#[cfg(all(feature = "typescript", feature = "zod"))]
+fn test_optional_map_values_are_null_flavored_on_both_key_paths() {
+    let ts_definition = OptionalMapValues::ts_definition();
+    assert!(
+        ts_definition.contains("enum_keyed: Partial<Record<MetricSlot, string | null>>;"),
+        "Got: {ts_definition}"
+    );
+    assert!(
+        ts_definition.contains("string_keyed: Partial<Record<string, string | null>>;"),
+        "Got: {ts_definition}"
+    );
+
+    let zod_schema = OptionalMapValues::zod_schema();
+    assert!(
+        zod_schema.contains("enum_keyed: z.record(MetricSlot$Schema, z.nullable(z.string()))"),
+        "Got: {zod_schema}"
+    );
+    assert!(
+        zod_schema.contains("string_keyed: z.record(z.string(), z.nullable(z.string()))"),
         "Got: {zod_schema}"
     );
 }


### PR DESCRIPTION
Stacked on #37 (stack: #33 → #34 → #35 → #36 → #37 → this).

`HashMap<K, Option<V>>` produces `{"k": null}` by construction — an entry cannot be omitted — yet json-schema dropped the `Option` entirely and TS/Zod rendered the absent form (`V | undefined`, `prefault(undefined)`), so every surface rejected the null the type itself writes.

- One policy seam (`nullable_slot_json_schema` + `typescript_slot_typename`/`zod_slot_type`) decides that an `Option` in an unomittable slot renders nullable; tuple slots (already correct — byte-identical), enum-keyed and String-keyed map values all route through it, killing the inlined duplicates.
- Red-first on both key paths; `{"k": null}` validates; non-`Option` values pinned unchanged. `Option<Vec<T>>` keeps the crate's established Option-outside reading (`anyOf[array, null]`).

Gates: `just check`, `just lint-all` (68/68), `just test` (full powerset) green.