### PR TITLE
fix: String-keyed map values route through the shared type table

### DIFF
--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -131,7 +131,8 @@ pub enum FieldDefType {
 ///
 /// Fields:
 /// - `is_optional`: In struct-field position, adds `| undefined` / `z.union([type, z.undefined()])`.
-///   In tuple-element position, adds `| null` / `z.nullable(type)` — a positional `None` serializes as `null`.
+///   In tuple-element and map-value position, adds `| null` / `z.nullable(type)` — neither slot can
+///   be dropped the way an object key can, so a `None` there serializes as `null`.
 /// - name: Safe field name (uses serde rename if feature enabled)
 /// - docs: Doc comments from Rust - included in generated TS as `JSDoc`
 /// - `field_type`: The core type classification (see `FieldDefType`)
@@ -294,22 +295,13 @@ impl FieldDef {
 
     /// Builds the TypeScript type before the struct-field optional wrap: the type match
     /// plus the `is_array` wrap. The `| undefined` wrap lives in `typescript_typename`.
-    /// An optional tuple element is null-flavored here (`{base} | null`): a positional
-    /// slot cannot be omitted, so serde emits `null` for a `None`.
     fn typescript_base(&self) -> String {
         let result = match &self.field_type {
             FieldDefType::Unknown => "unknown".to_owned(),
             FieldDefType::Tuple(lst) => {
                 let elements = lst
                     .iter()
-                    .map(|element| {
-                        let base = element.typescript_base();
-                        if element.is_optional {
-                            format!("{base} | null")
-                        } else {
-                            base
-                        }
-                    })
+                    .map(Self::typescript_slot_typename)
                     .collect::<Vec<_>>()
                     .join(", ");
                 format!("[{elements}]")
@@ -344,7 +336,7 @@ impl FieldDef {
                 format!(
                     "Partial<Record<{}, {}>>",
                     k.typescript_typename(),
-                    v.typescript_typename()
+                    v.typescript_slot_typename()
                 )
             }
             FieldDefType::Boolean => "boolean".to_owned(),
@@ -385,6 +377,19 @@ impl FieldDef {
         }
     }
 
+    /// The TypeScript type for a value in a slot that cannot be dropped — a tuple element or a
+    /// map entry. An `Option` there is null-flavored (`{base} | null`) rather than
+    /// undefined-flavored: only an object key can be omitted, so serde emits `null` for a `None`
+    /// in either position.
+    fn typescript_slot_typename(&self) -> String {
+        let base = self.typescript_base();
+        if self.is_optional {
+            format!("{base} | null")
+        } else {
+            base
+        }
+    }
+
     /// Generates the TypeScript type name for this field.
     ///
     /// This method is the core of TypeScript type generation. It recursively builds
@@ -393,8 +398,9 @@ impl FieldDef {
     /// Process:
     /// 1. Match on `field_type` to get base type
     /// 2. If `is_array`, wrap in Array<...>
-    /// 3. If `is_optional`: struct-field position adds `| undefined`; tuple-element position adds `| null`
-    ///    (a positional `None` serializes as `null`, so a tuple slot cannot be omitted like an object key)
+    /// 3. If `is_optional`: struct-field position adds `| undefined`; tuple-element and map-value
+    ///    positions add `| null` (neither can be omitted like an object key, so a `None` there
+    ///    serializes as `null`)
     ///
     /// Feature notes:
     /// - "`object_id"`: Uses special `ObjectId` type
@@ -420,9 +426,7 @@ impl FieldDef {
 
     /// Builds the Zod schema before the struct-field optional wrap: the type match, the
     /// `is_array` wrap, and the preprocess wrap. The
-    /// `z.union([…, z.undefined()]).prefault(undefined)` wrap lives in `zod_type`. An
-    /// optional tuple element is null-flavored here (`z.nullable({base})`): a positional
-    /// slot cannot be omitted, so serde emits `null` for a `None`.
+    /// `z.union([…, z.undefined()]).prefault(undefined)` wrap lives in `zod_type`.
     #[cfg(feature = "zod")]
     fn zod_base(&self) -> String {
         let result = match &self.field_type {
@@ -430,14 +434,7 @@ impl FieldDef {
             FieldDefType::Tuple(lst) => {
                 let elements = lst
                     .iter()
-                    .map(|element| {
-                        let base = element.zod_base();
-                        if element.is_optional {
-                            format!("z.nullable({base})")
-                        } else {
-                            base
-                        }
-                    })
+                    .map(Self::zod_slot_type)
                     .collect::<Vec<_>>()
                     .join(", ");
                 format!("z.tuple([{elements}])")
@@ -461,7 +458,7 @@ impl FieldDef {
                 }
             }
             FieldDefType::Map(k, v) => {
-                format!("z.record({}, {})", k.zod_type(), v.zod_type())
+                format!("z.record({}, {})", k.zod_type(), v.zod_slot_type())
             }
             FieldDefType::Boolean => "z.boolean()".to_owned(),
             FieldDefType::String => self.zod_string_type(),
@@ -529,6 +526,20 @@ impl FieldDef {
         result
     }
 
+    /// The Zod schema for a value in a slot that cannot be dropped — a tuple element or a map
+    /// entry. An `Option` there is null-flavored (`z.nullable({base})`) rather than
+    /// undefined-flavored: only an object key can be omitted, so serde emits `null` for a `None`
+    /// in either position.
+    #[cfg(feature = "zod")]
+    fn zod_slot_type(&self) -> String {
+        let base = self.zod_base();
+        if self.is_optional {
+            format!("z.nullable({base})")
+        } else {
+            base
+        }
+    }
+
     /// Builds the Zod schema string for a string field, applying any length/pattern constraints.
     #[cfg(feature = "zod")]
     fn zod_string_type(&self) -> String {
@@ -566,7 +577,8 @@ impl FieldDef {
     /// - For `ObjectId`: Uses regex validation for hex string
     /// - Wraps with `z.array()` if `is_array`
     /// - If `is_optional`: struct-field position wraps `z.union([type, z.undefined()])`;
-    ///   tuple-element position wraps `z.nullable(type)` (a positional `None` serializes as `null`)
+    ///   tuple-element and map-value positions wrap `z.nullable(type)` (neither can be omitted like
+    ///   an object key, so a `None` there serializes as `null`)
     ///
     /// Requires Zod v4 in frontend - generates v4-compatible syntax.
     /// See `notes/20250706_features.md` for Zod feature details.

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -3272,18 +3272,19 @@ fn arrayed_json_schema_value(
     }
 }
 
-/// The JSON schema value expression for a field whose type renders inline as a scalar — arrayed
-/// when the field is a `Vec` — or `None` for the composite types (sibling references, maps,
+/// The JSON schema literal for a type that renders inline as a scalar — the object body itself,
+/// which a caller writing inside a `serde_json::json!` inlines and one needing a standalone
+/// `serde_json::Value` wraps — or `None` for the composite types (sibling references, maps,
 /// tuples, unknowns) that have no inline rendering.
 ///
-/// `is_optional` is not consulted: how an absent value is expressed depends on the position the
-/// value sits in, so each caller wraps this base itself.
+/// Neither `is_array` nor `is_optional` is consulted: both describe the slot the value sits in,
+/// not its type, so each caller wraps this item itself.
 #[cfg(feature = "jsonschema")]
-fn scalar_field_json_schema_value(fld: &FieldDef) -> Option<proc_macro2::TokenStream> {
+fn scalar_field_json_schema_item(fld: &FieldDef) -> Option<proc_macro2::TokenStream> {
     let item_schema = match &fld.field_type {
-        FieldDefType::String => quote! { serde_json::json!({ "type": "string" }) },
+        FieldDefType::String => quote! { { "type": "string" } },
         FieldDefType::StringLiteral(literal) => {
-            quote! { serde_json::json!({ "type": "string", "const": #literal }) }
+            quote! { { "type": "string", "const": #literal } }
         }
         FieldDefType::U8
         | FieldDefType::U16
@@ -3294,35 +3295,50 @@ fn scalar_field_json_schema_value(fld: &FieldDef) -> Option<proc_macro2::TokenSt
         | FieldDefType::I32
         | FieldDefType::I64
         | FieldDefType::Usize
-        | FieldDefType::Isize => quote! { serde_json::json!({ "type": "integer" }) },
-        FieldDefType::F32 | FieldDefType::F64 => quote! { serde_json::json!({ "type": "number" }) },
-        FieldDefType::Boolean => quote! { serde_json::json!({ "type": "boolean" }) },
+        | FieldDefType::Isize => quote! { { "type": "integer" } },
+        FieldDefType::F32 | FieldDefType::F64 => quote! { { "type": "number" } },
+        FieldDefType::Boolean => quote! { { "type": "boolean" } },
         #[cfg(feature = "chrono")]
         FieldDefType::NaiveDate => {
-            quote! { serde_json::json!({ "type": "string", "format": "date" }) }
+            quote! { { "type": "string", "format": "date" } }
         }
         #[cfg(feature = "chrono")]
         FieldDefType::NaiveTime => {
-            quote! { serde_json::json!({ "type": "string", "format": "time" }) }
+            quote! { { "type": "string", "format": "time" } }
         }
         #[cfg(feature = "chrono")]
         FieldDefType::NaiveDateTime | FieldDefType::DateTime => {
-            quote! { serde_json::json!({ "type": "string", "format": "date-time" }) }
+            quote! { { "type": "string", "format": "date-time" } }
         }
         #[cfg(feature = "object_id")]
-        FieldDefType::ObjectId => quote! { serde_json::json!({
+        FieldDefType::ObjectId => quote! { {
             "type": "object",
             "properties": {
                 "$oid": { "type": "string", "pattern": "^[a-f\\d]{24}$" }
             },
             "required": ["$oid"]
-        }) },
+        } },
         FieldDefType::Unknown
         | FieldDefType::SiblingType(..)
         | FieldDefType::Map(..)
         | FieldDefType::Tuple(..) => return None,
     };
-    Some(arrayed_json_schema_value(fld, item_schema))
+    Some(item_schema)
+}
+
+/// The JSON schema value expression for a field whose type renders inline as a scalar — arrayed
+/// when the field is a `Vec` — or `None` for the composite types (sibling references, maps,
+/// tuples, unknowns) that have no inline rendering.
+///
+/// `is_optional` is not consulted: how an absent value is expressed depends on the position the
+/// value sits in, so each caller wraps this base itself.
+#[cfg(feature = "jsonschema")]
+fn scalar_field_json_schema_value(fld: &FieldDef) -> Option<proc_macro2::TokenStream> {
+    let item_schema = scalar_field_json_schema_item(fld)?;
+    Some(arrayed_json_schema_value(
+        fld,
+        quote! { serde_json::json!(#item_schema) },
+    ))
 }
 
 /// Builds the base JSON schema for a tuple element, ignoring `is_optional`.
@@ -3713,34 +3729,42 @@ fn build_map_scalar_value_schema(
     }
 }
 
+/// Wraps the shared scalar mapping as a `String`-keyed map's `additionalProperties`, or fails with
+/// a single diagnostic when the value type has no inline rendering.
+#[cfg(feature = "jsonschema")]
+fn build_map_inline_value_schema(
+    value: &FieldDef,
+    field_name_str: &str,
+) -> proc_macro2::TokenStream {
+    // Emitted instead of the property insertion, never alongside it: an insertion left in place
+    // hands the author a schema the expansion has already rejected.
+    let Some(item_schema) = scalar_field_json_schema_item(value) else {
+        let message = format!(
+            "field `{field_name_str}`: a tuple is not supported as a map value — give the value a `#[model_schema()]` struct instead"
+        );
+        return quote! { compile_error!(#message); };
+    };
+    build_map_scalar_value_schema(value, field_name_str, &item_schema)
+}
+
 /// Builds the JSON schema for a map whose key type is `String`, dispatching on the value type.
+///
+/// A `String` key enumerates nothing, so one `additionalProperties` schema stands for every
+/// member — and it is the value type's own rendering, which the key never widens.
 #[cfg(feature = "jsonschema")]
 fn build_string_key_map_value_schema(
     value: &FieldDef,
     field_name_str: &str,
 ) -> proc_macro2::TokenStream {
     match &value.field_type {
-        FieldDefType::String => {
-            build_map_scalar_value_schema(value, field_name_str, &quote! { { "type": "string" } })
+        FieldDefType::Map(inner_key, inner_value) => {
+            build_map_nested_map_value_schema(value, inner_key, inner_value, field_name_str)
         }
-        FieldDefType::U8
-        | FieldDefType::U16
-        | FieldDefType::U32
-        | FieldDefType::U64
-        | FieldDefType::I8
-        | FieldDefType::I16
-        | FieldDefType::I32
-        | FieldDefType::I64
-        | FieldDefType::Usize
-        | FieldDefType::Isize => {
-            build_map_scalar_value_schema(value, field_name_str, &quote! { { "type": "integer" } })
+        FieldDefType::SiblingType(value_type_name, value_args) => {
+            build_map_sibling_value_schema(value_type_name, value_args, field_name_str)
         }
-        FieldDefType::F32 | FieldDefType::F64 => {
-            build_map_scalar_value_schema(value, field_name_str, &quote! { { "type": "number" } })
-        }
-        FieldDefType::Boolean => {
-            build_map_scalar_value_schema(value, field_name_str, &quote! { { "type": "boolean" } })
-        }
+        // A map member's `$oid` object is closed and unpatterned, where the shared mapping's
+        // field-position rendering carries the hex pattern and leaves the object open.
         #[cfg(feature = "object_id")]
         FieldDefType::ObjectId => build_map_scalar_value_schema(
             value,
@@ -3752,22 +3776,35 @@ fn build_string_key_map_value_schema(
                 "additionalProperties": false
             } },
         ),
-        FieldDefType::Map(inner_key, inner_value) => {
-            build_map_nested_map_value_schema(value, inner_key, inner_value, field_name_str)
+        // An opaque value carries no type name to narrow with, so a member admits any value: the
+        // permissive empty schema, as in field position.
+        FieldDefType::Unknown => {
+            build_map_scalar_value_schema(value, field_name_str, &quote! { {} })
         }
-        FieldDefType::SiblingType(value_type_name, value_args) => {
-            build_map_sibling_value_schema(value_type_name, value_args, field_name_str)
-        }
-        _ => {
-            quote! {
-                properties.insert(#field_name_str.to_string(), {
-                    serde_json::json!({
-                        "type": "object",
-                        "additionalProperties": true
-                    })
-                });
-            }
-        }
+        // The shared mapping renders every type named here except a tuple, which lands on the lone
+        // diagnostic. Named exhaustively rather than caught by a wildcard: a new variant must be
+        // given a member schema, not silently widened into an open object.
+        FieldDefType::Boolean
+        | FieldDefType::F32
+        | FieldDefType::F64
+        | FieldDefType::I8
+        | FieldDefType::I16
+        | FieldDefType::I32
+        | FieldDefType::I64
+        | FieldDefType::Isize
+        | FieldDefType::String
+        | FieldDefType::StringLiteral(_)
+        | FieldDefType::Tuple(..)
+        | FieldDefType::U8
+        | FieldDefType::U16
+        | FieldDefType::U32
+        | FieldDefType::U64
+        | FieldDefType::Usize => build_map_inline_value_schema(value, field_name_str),
+        #[cfg(feature = "chrono")]
+        FieldDefType::DateTime
+        | FieldDefType::NaiveDate
+        | FieldDefType::NaiveDateTime
+        | FieldDefType::NaiveTime => build_map_inline_value_schema(value, field_name_str),
     }
 }
 

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -3334,21 +3334,28 @@ fn build_tuple_element_base_json_schema(fld: &FieldDef) -> proc_macro2::TokenStr
         .unwrap_or_else(|| quote! { serde_json::json!({ "type": "object" }) })
 }
 
-/// Builds JSON schema for a tuple element (used for single tuple and multi-tuple variants).
+/// The `anyOf [<base>, null]` form for a value in a slot that cannot be dropped — a tuple element
+/// or a map entry — or `None` when the value is not an `Option`. Only an object key can be
+/// omitted; in either of these positions serde writes a `None` as JSON `null`, so the schema has
+/// to admit it.
 ///
-/// An `Option` element renders as `anyOf [<base>, null]`: a tuple slot is positional, so
-/// serde serializes `None` as JSON `null` (the slot cannot be omitted the way an object key
-/// can).
+/// The tokens are a JSON value: a caller writing inside a `serde_json::json!` literal inlines
+/// them, one needing a standalone `serde_json::Value` wraps them in `serde_json::json!`.
+#[cfg(feature = "jsonschema")]
+fn nullable_slot_json_schema(
+    fld: &FieldDef,
+    base: &proc_macro2::TokenStream,
+) -> Option<proc_macro2::TokenStream> {
+    fld.is_optional
+        .then(|| quote! { { "anyOf": [#base, { "type": "null" }] } })
+}
+
+/// Builds JSON schema for a tuple element (used for single tuple and multi-tuple variants).
 #[cfg(feature = "jsonschema")]
 fn build_tuple_element_json_schema(fld: &FieldDef) -> proc_macro2::TokenStream {
     let base = build_tuple_element_base_json_schema(fld);
-    if fld.is_optional {
-        quote! {
-            serde_json::json!({ "anyOf": [#base, { "type": "null" }] })
-        }
-    } else {
-        base
-    }
+    nullable_slot_json_schema(fld, &base)
+        .map_or(base, |nullable| quote! { serde_json::json!(#nullable) })
 }
 
 /// Fallback JSON schema for map fields whose key type is not specially handled.
@@ -3420,17 +3427,21 @@ fn build_map_nested_map_value_schema(
             }
         };
 
+        let arrayed = quote! {
+            {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "additionalProperties": #inner_value_schema
+                }
+            }
+        };
+        let value_schema = nullable_slot_json_schema(value, &arrayed).unwrap_or(arrayed);
         quote! {
             properties.insert(#field_name_str.to_string(), {
                 serde_json::json!({
                     "type": "object",
-                    "additionalProperties": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "additionalProperties": #inner_value_schema
-                        }
-                    }
+                    "additionalProperties": #value_schema
                 })
             });
         }
@@ -3674,34 +3685,31 @@ fn build_map_sibling_value_schema(
 }
 
 /// Wraps a scalar JSON schema as a `String`-keyed map's `additionalProperties`,
-/// arraying it when the value field is a `Vec`.
+/// arraying it when the value field is a `Vec` and nullable when it is an `Option`.
 #[cfg(feature = "jsonschema")]
 fn build_map_scalar_value_schema(
     value: &FieldDef,
     field_name_str: &str,
     item_schema: &proc_macro2::TokenStream,
 ) -> proc_macro2::TokenStream {
-    if value.is_array {
+    let arrayed = if value.is_array {
         quote! {
-            properties.insert(#field_name_str.to_string(), {
-                serde_json::json!({
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "array",
-                        "items": #item_schema
-                    }
-                })
-            });
+            {
+                "type": "array",
+                "items": #item_schema
+            }
         }
     } else {
-        quote! {
-            properties.insert(#field_name_str.to_string(), {
-                serde_json::json!({
-                    "type": "object",
-                    "additionalProperties": #item_schema
-                })
-            });
-        }
+        item_schema.clone()
+    };
+    let value_schema = nullable_slot_json_schema(value, &arrayed).unwrap_or(arrayed);
+    quote! {
+        properties.insert(#field_name_str.to_string(), {
+            serde_json::json!({
+                "type": "object",
+                "additionalProperties": #value_schema
+            })
+        });
     }
 }
 
@@ -3767,7 +3775,7 @@ fn build_string_key_map_value_schema(
 /// when the value type has no rendering here.
 #[cfg(feature = "jsonschema")]
 fn build_enum_key_map_value_binding(value: &FieldDef) -> Option<proc_macro2::TokenStream> {
-    if let FieldDefType::SiblingType(value_type_name, value_lst) = &value.field_type
+    let base = if let FieldDefType::SiblingType(value_type_name, value_lst) = &value.field_type
         && value_lst.is_empty()
     {
         // For json_schema(), use the module pattern. An alias's module is named after
@@ -3778,13 +3786,14 @@ fn build_enum_key_map_value_binding(value: &FieldDef) -> Option<proc_macro2::Tok
         };
         let value_module_ident =
             proc_macro2::Ident::new(value_module_name.as_str(), proc_macro2::Span::call_site());
-        let sibling_schema =
-            arrayed_json_schema_value(value, quote! { #value_module_ident::Schema::json_schema() });
-        return Some(quote! { let value_schema = #sibling_schema; });
-    }
+        arrayed_json_schema_value(value, quote! { #value_module_ident::Schema::json_schema() })
+    } else {
+        scalar_field_json_schema_value(value)?
+    };
 
-    let scalar_schema = scalar_field_json_schema_value(value)?;
-    Some(quote! { let value_schema = #scalar_schema; })
+    let value_schema = nullable_slot_json_schema(value, &base)
+        .map_or(base, |nullable| quote! { serde_json::json!(#nullable) });
+    Some(quote! { let value_schema = #value_schema; })
 }
 
 #[cfg(feature = "jsonschema")]

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -984,6 +984,46 @@ fn a_vec_sibling_enum_keyed_map_value_arrays_the_sibling_schema() {
     );
 }
 
+/// A map entry cannot be dropped the way an object key can, so serde writes an `Option` value's
+/// `None` as JSON `null`. Both key paths have to admit it, and through the same seam: the enum-key
+/// branch materializes the nullable form as a `serde_json::Value`, the `String`-key branch inlines
+/// it as the map's `additionalProperties`.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn an_optional_map_value_is_nullable_on_both_key_paths() {
+    let enum_keyed = map_field_schema("HashMap<Slot, Option<String>>").to_string();
+    assert!(
+        enum_keyed.contains(
+            r#"let value_schema = serde_json :: json ! ({ "anyOf" : [serde_json :: json ! ({ "type" : "string" }) , { "type" : "null" }] }) ;"#
+        ),
+        "got: {enum_keyed}"
+    );
+
+    let string_keyed = map_field_schema("HashMap<String, Option<String>>").to_string();
+    assert!(
+        string_keyed.contains(
+            r#""additionalProperties" : { "anyOf" : [{ "type" : "string" } , { "type" : "null" }] }"#
+        ),
+        "got: {string_keyed}"
+    );
+}
+
+/// A non-`Option` map value is untouched by the nullable seam — on either key path the tokens are
+/// the ones the value type has always produced.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_required_map_value_carries_no_nullable_wrap() {
+    for map_type in [
+        "HashMap<Slot, String>",
+        "HashMap<Slot, Vec<Inner>>",
+        "HashMap<String, String>",
+        "HashMap<String, Vec<u64>>",
+    ] {
+        let tokens = map_field_schema(map_type).to_string();
+        assert!(!tokens.contains("anyOf"), "for {map_type}, got: {tokens}");
+    }
+}
+
 /// The kind an alias registers is its *target's* answer, because a type path resolves through the
 /// alias. `Vec<Slot>` is the collection, not the enum it holds; a target this expansion has not
 /// seen registered is `Unknown`, which is not a negative.

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -1103,3 +1103,96 @@ fn a_map_key_that_may_have_enum_members_expands_exactly_as_before() {
         );
     }
 }
+
+/// The `String`-key branch's output for a map value built by hand, for the value types no source
+/// type produces: the `literal` override rewrites a *field's* type, never a map value's.
+#[cfg(feature = "jsonschema")]
+fn string_key_map_value_schema(field_type: FieldDefType) -> String {
+    let ty: syn::Type = syn::parse_str("String").unwrap();
+    let mut value = super::get_field_def("m", &ty, "");
+    value.field_type = field_type;
+    super::build_string_key_map_value_schema(&value, "m").to_string()
+}
+
+/// A `String` key says nothing about the value it holds, so a value type the crate renders is
+/// rendered here too — the same mapping the field position uses, not an open member schema.
+#[cfg(all(feature = "chrono", feature = "jsonschema"))]
+#[test]
+fn a_chrono_string_keyed_map_value_keeps_its_format() {
+    for (map_type, format) in [
+        ("HashMap<String, NaiveDate>", "date"),
+        ("HashMap<String, NaiveTime>", "time"),
+        ("HashMap<String, NaiveDateTime>", "date-time"),
+        ("HashMap<String, DateTime<Utc>>", "date-time"),
+    ] {
+        let tokens = map_field_schema(map_type).to_string();
+        assert!(
+            tokens.contains(&format!(
+                r#""additionalProperties" : {{ "type" : "string" , "format" : "{format}" }}"#
+            )),
+            "for {map_type}, got: {tokens}"
+        );
+    }
+}
+
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_string_literal_string_keyed_map_value_keeps_its_const() {
+    let tokens = string_key_map_value_schema(FieldDefType::StringLiteral("Tixena".to_owned()));
+    assert!(
+        tokens.contains(r#""additionalProperties" : { "type" : "string" , "const" : "Tixena" }"#),
+        "got: {tokens}"
+    );
+}
+
+/// An opaque value has no type name to narrow with, so the member schema stays permissive — the
+/// empty schema the crate settled on, in both the bare and the collection form.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn an_opaque_string_keyed_map_value_stays_permissive() {
+    let tokens = string_key_map_value_schema(FieldDefType::Unknown);
+    assert!(
+        tokens.contains(r#""additionalProperties" : { }"#),
+        "got: {tokens}"
+    );
+}
+
+/// A value the branch cannot render must yield the `compile_error!` *instead of* the property
+/// insertion, so exactly one diagnostic reaches the author — and it names the field, which is all
+/// the author can act on.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn an_unsupported_string_keyed_map_value_emits_only_the_compile_error() {
+    let tokens = map_field_schema("HashMap<String, (String, u32)>").to_string();
+    assert!(tokens.starts_with("compile_error !"), "got: {tokens}");
+    assert!(!tokens.contains("properties . insert"), "got: {tokens}");
+    assert!(tokens.contains("field `m`"), "got: {tokens}");
+    assert!(
+        tokens.contains("a tuple is not supported as a map value"),
+        "got: {tokens}"
+    );
+}
+
+/// The value types the branch already rendered keep the tokens they have always produced: the
+/// shared mapping is a reuse of the same renderings, not a rewrite of them.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_scalar_string_keyed_map_value_expands_exactly_as_before() {
+    for (map_type, expected) in [
+        ("HashMap<String, String>", r#"{ "type" : "string" }"#),
+        ("HashMap<String, u64>", r#"{ "type" : "integer" }"#),
+        ("HashMap<String, i8>", r#"{ "type" : "integer" }"#),
+        ("HashMap<String, f32>", r#"{ "type" : "number" }"#),
+        ("HashMap<String, bool>", r#"{ "type" : "boolean" }"#),
+        (
+            "HashMap<String, Vec<String>>",
+            r#"{ "type" : "array" , "items" : { "type" : "string" } }"#,
+        ),
+    ] {
+        let tokens = map_field_schema(map_type).to_string();
+        assert!(
+            tokens.contains(&format!(r#""additionalProperties" : {expected}"#)),
+            "for {map_type}, got: {tokens}"
+        );
+    }
+}

--- a/tests/chrono_tests/tests.rs
+++ b/tests/chrono_tests/tests.rs
@@ -36,7 +36,7 @@ struct DateMap {
 }
 
 // An enum-keyed map enumerates its keys, so every member carries the value schema outright
-// instead of the open `additionalProperties` the String-keyed `DateMap` above uses.
+// instead of the single `additionalProperties` the String-keyed `DateMap` above carries.
 #[model_schema()]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -51,6 +51,20 @@ enum ScheduleSlot {
 struct SlotSchedule {
     dates: HashMap<ScheduleSlot, NaiveDate>,
     timestamps: HashMap<ScheduleSlot, DateTime<Utc>>,
+}
+
+// A String-keyed map has no key list to enumerate, so one `additionalProperties` schema stands for
+// every member — and it is the value type's own rendering, arrayed and nullable as the value is.
+#[model_schema()]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
+struct ChronoValueMaps {
+    dates: HashMap<String, NaiveDate>,
+    local_datetimes: HashMap<String, NaiveDateTime>,
+    optional_dates: HashMap<String, Option<NaiveDate>>,
+    times: HashMap<String, NaiveTime>,
+    timestamps: HashMap<String, DateTime<Utc>>,
+    windows: HashMap<String, Vec<NaiveTime>>,
 }
 
 // Test struct with NaiveDate field.
@@ -173,6 +187,20 @@ fn test_chrono_types_constructible() {
     };
     assert_eq!(slot_schedule.dates.len(), 2);
     assert!(slot_schedule.timestamps.is_empty());
+    let chrono_value_maps = ChronoValueMaps {
+        dates: HashMap::from([("opening".to_owned(), date)]),
+        local_datetimes: HashMap::new(),
+        optional_dates: HashMap::from([("closing".to_owned(), None)]),
+        times: HashMap::new(),
+        timestamps: HashMap::new(),
+        windows: HashMap::from([("opening".to_owned(), vec![time])]),
+    };
+    assert_eq!(chrono_value_maps.dates.len(), 1);
+    assert_eq!(chrono_value_maps.optional_dates["closing"], None);
+    assert_eq!(chrono_value_maps.windows["opening"], vec![time]);
+    assert!(chrono_value_maps.local_datetimes.is_empty());
+    assert!(chrono_value_maps.timestamps.is_empty());
+    assert!(chrono_value_maps.times.is_empty());
     let values = [
         FixedValue::Alphanumeric(String::new()),
         FixedValue::Boolean(false),
@@ -471,6 +499,61 @@ fn test_enum_keyed_chrono_map_json_schema() {
             );
         }
     }
+}
+
+/// A chrono value is rendered where the map's members are described, exactly as it is in field
+/// position: a `String` key opens the set of member names, never the schema those members carry.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_string_keyed_chrono_map_json_schema() {
+    let schema = ChronoValueMaps::json_schema();
+    let properties = schema["properties"].as_object().unwrap();
+
+    for (field_name, expected_value_schema) in [
+        (
+            "dates",
+            serde_json::json!({ "type": "string", "format": "date" }),
+        ),
+        (
+            "local_datetimes",
+            serde_json::json!({ "type": "string", "format": "date-time" }),
+        ),
+        (
+            "optional_dates",
+            serde_json::json!({
+                "anyOf": [{ "type": "string", "format": "date" }, { "type": "null" }]
+            }),
+        ),
+        (
+            "times",
+            serde_json::json!({ "type": "string", "format": "time" }),
+        ),
+        (
+            "timestamps",
+            serde_json::json!({ "type": "string", "format": "date-time" }),
+        ),
+        (
+            "windows",
+            serde_json::json!({
+                "type": "array",
+                "items": { "type": "string", "format": "time" }
+            }),
+        ),
+    ] {
+        let field = &properties[field_name];
+        assert_eq!(field["type"], "object", "in: {field}");
+        assert_eq!(
+            field["additionalProperties"], expected_value_schema,
+            "in: {field}"
+        );
+    }
+
+    let events = &DateMap::json_schema()["properties"]["events"];
+    assert_eq!(
+        events["additionalProperties"],
+        serde_json::json!({ "type": "string", "format": "date-time" }),
+        "in: {events}"
+    );
 }
 
 // ========== Enum Tests (Original Use Case) ==========

--- a/tests/collection_tests/tests.rs
+++ b/tests/collection_tests/tests.rs
@@ -63,6 +63,15 @@ struct EnumKeyedSiblingValueMaps {
     sample_value: HashMap<MetricSlot, MetricSample>,
 }
 
+// A map entry cannot be dropped the way an object key can, so an `Option` value is spelled `null`
+// on the wire rather than omitted — the same twin type on both key paths pins that both agree.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct OptionalMapValues {
+    enum_keyed: HashMap<MetricSlot, Option<String>>,
+    string_keyed: HashMap<String, Option<String>>,
+}
+
 // Test struct with collections
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -171,6 +180,11 @@ fn test_collection_structs_constructible() {
         tags: Vec::new(),
     };
     assert!(with_collections.id.is_empty());
+    let optional_values = OptionalMapValues {
+        enum_keyed: HashMap::from([(MetricSlot::Daily, None)]),
+        string_keyed: HashMap::from([("k".to_owned(), None)]),
+    };
+    assert_eq!(optional_values.enum_keyed[&MetricSlot::Daily], None);
 }
 
 #[test]
@@ -232,6 +246,22 @@ fn test_comprehensive_hashmap_json_schema() {
     assert_hashmap_array_type(properties, "i64_array", "integer");
     assert_hashmap_array_type(properties, "f64_array", "number");
     assert_hashmap_array_type(properties, "bool_array", "boolean");
+
+    // An `Option` value is nullable rather than absent — the array wrap sits inside the union,
+    // because the `Option` is the outer one in `Option<Vec<T>>`.
+    assert_eq!(
+        properties["optional_u64"]["additionalProperties"],
+        serde_json::json!({ "anyOf": [{ "type": "integer" }, { "type": "null" }] })
+    );
+    assert_eq!(
+        properties["optional_u64_array"]["additionalProperties"],
+        serde_json::json!({
+            "anyOf": [
+                { "type": "array", "items": { "type": "integer" } },
+                { "type": "null" }
+            ]
+        })
+    );
 }
 
 #[test]
@@ -267,6 +297,28 @@ fn test_comprehensive_hashmap_typescript_generation() {
     assert!(zod_schema.contains("i64_array: z.record(z.string(), z.array(z.number().int()))"));
     assert!(zod_schema.contains("f64_array: z.record(z.string(), z.array(z.number()))"));
     assert!(zod_schema.contains("bool_array: z.record(z.string(), z.array(z.boolean()))"));
+
+    // An `Option` map value is null-flavored, not undefined-flavored: the entry it sits in cannot
+    // be dropped, so serde writes the `None` as `null`.
+    assert!(
+        ts_definition.contains("optional_u64: Partial<Record<string, number | null>>;"),
+        "Got: {ts_definition}"
+    );
+    assert!(
+        ts_definition
+            .contains("optional_u64_array: Partial<Record<string, Array<number> | null>>;"),
+        "Got: {ts_definition}"
+    );
+    assert!(
+        zod_schema.contains("optional_u64: z.record(z.string(), z.nullable(z.number().int()))"),
+        "Got: {zod_schema}"
+    );
+    assert!(
+        zod_schema.contains(
+            "optional_u64_array: z.record(z.string(), z.nullable(z.array(z.number().int())))"
+        ),
+        "Got: {zod_schema}"
+    );
 }
 
 #[test]
@@ -451,6 +503,62 @@ fn test_enum_keyed_sibling_value_maps_typescript_generation() {
     assert!(
         zod_schema
             .contains("sample_array: z.record(MetricSlot$Schema, z.array(MetricSample$Schema))"),
+        "Got: {zod_schema}"
+    );
+}
+
+/// A map entry carries its `None` as JSON `null`: unlike an object key, an entry cannot be dropped,
+/// so the schema has to admit the null serde writes. Both key paths render the same nullable form,
+/// the one a tuple slot already uses for the same reason.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_optional_map_values_admit_the_null_serde_writes() {
+    let values = OptionalMapValues {
+        enum_keyed: HashMap::from([(MetricSlot::Daily, None)]),
+        string_keyed: HashMap::from([("k".to_owned(), None)]),
+    };
+    let payload = serde_json::to_value(&values).unwrap();
+    assert_eq!(json_type_name(&payload["enum_keyed"]["Daily"]), "null");
+    assert_eq!(json_type_name(&payload["string_keyed"]["k"]), "null");
+
+    let nullable_string = serde_json::json!({
+        "anyOf": [{ "type": "string" }, { "type": "null" }]
+    });
+    let schema = OptionalMapValues::json_schema();
+    let properties = schema["properties"].as_object().unwrap();
+
+    assert_enum_keyed_map_value(properties, "enum_keyed", &nullable_string);
+    assert_eq!(properties["string_keyed"]["type"], "object");
+    assert_eq!(
+        properties["string_keyed"]["additionalProperties"], nullable_string,
+        "in: {}",
+        properties["string_keyed"]
+    );
+}
+
+/// A map value is null-flavored rather than undefined-flavored, on both key paths: `Partial<Record>`
+/// already lets a key be missing, but a key that *is* present carries the `null` serde writes for a
+/// `None`, so the value type has to admit it.
+#[test]
+#[cfg(all(feature = "typescript", feature = "zod"))]
+fn test_optional_map_values_are_null_flavored_on_both_key_paths() {
+    let ts_definition = OptionalMapValues::ts_definition();
+    assert!(
+        ts_definition.contains("enum_keyed: Partial<Record<MetricSlot, string | null>>;"),
+        "Got: {ts_definition}"
+    );
+    assert!(
+        ts_definition.contains("string_keyed: Partial<Record<string, string | null>>;"),
+        "Got: {ts_definition}"
+    );
+
+    let zod_schema = OptionalMapValues::zod_schema();
+    assert!(
+        zod_schema.contains("enum_keyed: z.record(MetricSlot$Schema, z.nullable(z.string()))"),
+        "Got: {zod_schema}"
+    );
+    assert!(
+        zod_schema.contains("string_keyed: z.record(z.string(), z.nullable(z.string()))"),
         "Got: {zod_schema}"
     );
 }

--- a/tests/jsonschema_tests/tests.rs
+++ b/tests/jsonschema_tests/tests.rs
@@ -84,6 +84,13 @@ struct OpaqueFields {
 
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone)]
+struct OpaqueValueMaps {
+    payload_lists: HashMap<String, Vec<serde_json::Value>>,
+    payloads: HashMap<String, serde_json::Value>,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 struct OptionalFields {
     #[serde(skip_serializing_if = "Option::is_none")]
     optional_bool: Option<bool>,
@@ -236,6 +243,26 @@ fn test_opaque_value_fields_generate_permissive_schemas() {
     assert!(required.contains(&Value::String("payload".to_owned())));
     assert!(required.contains(&Value::String("payloads".to_owned())));
     assert!(!required.contains(&Value::String("optional_payload".to_owned())));
+}
+
+#[test]
+fn test_opaque_map_values_generate_permissive_schemas() {
+    let schema = OpaqueValueMaps::json_schema();
+
+    let properties = schema["properties"].as_object().unwrap();
+
+    // An opaque value carries no type name here either, so every member admits any value.
+    assert_eq!(properties["payloads"]["type"], "object");
+    assert_eq!(
+        properties["payloads"]["additionalProperties"],
+        serde_json::json!({})
+    );
+
+    assert_eq!(properties["payload_lists"]["type"], "object");
+    assert_eq!(
+        properties["payload_lists"]["additionalProperties"],
+        serde_json::json!({ "type": "array", "items": {} })
+    );
 }
 
 #[test]


### PR DESCRIPTION
Stacked on #38 (stack: #33 → … → #38 → this).

`HashMap<String, NaiveDate>` emitted `{"type":"object","additionalProperties":true}` — the String-key value dispatcher's `_` arm swallowed the chrono four, StringLiteral, Tuple, and Unknown.

- The dispatch is now exhaustive by name, reading the SAME factored table as the enum-key path (`scalar_field_json_schema_item` returns the bare literal; the wrap moved to one seam, so every existing caller's tokens are unchanged by construction — pinned by a before/after-green byte-identity test).
- chrono values emit their real `format` schemas; `Vec`/`Option` array and nullable through the shared seams; `Unknown` keeps the crate's permissive form; an unsupported value (tuple) early-returns ONE named diagnostic.
- The sibling-value arm's `additionalProperties: true` behavior is deliberately untouched (separate task) — moved in the match, not rewritten.

Gates: `just check`, `just lint-all` (68/68), `just test` (full powerset) green.