### PR TITLE
fix: String-keyed sibling map values emit the sibling schema

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -3366,12 +3366,36 @@ fn nullable_slot_json_schema(
         .then(|| quote! { { "anyOf": [#base, { "type": "null" }] } })
 }
 
+/// [`nullable_slot_json_schema`] for a caller that needs a standalone `serde_json::Value`: the
+/// nullable form is a literal fragment, so it is wrapped, while `base` already is such a value.
+#[cfg(feature = "jsonschema")]
+fn nullable_slot_json_schema_value(
+    fld: &FieldDef,
+    base: proc_macro2::TokenStream,
+) -> proc_macro2::TokenStream {
+    nullable_slot_json_schema(fld, &base)
+        .map_or(base, |nullable| quote! { serde_json::json!(#nullable) })
+}
+
+/// The schema module a sibling type's `Schema::json_schema()` lives in.
+///
+/// An alias's module is named after its registered export name, which the raw ident does not
+/// reproduce, so the registry answers first. A name it does not hold is one this expansion has not
+/// seen — a type expanded later, or one from another crate — and takes the naming every
+/// `#[model_schema()]` type follows.
+#[cfg(feature = "jsonschema")]
+fn sibling_schema_module_ident(name: &str) -> Ident {
+    let module_name = match lookup_alias_info(name) {
+        Some(alias) => alias.module_name,
+        None => format!("{}_schema", to_snake_case(&safe_type_name(name))),
+    };
+    Ident::new(module_name.as_str(), proc_macro2::Span::call_site())
+}
+
 /// Builds JSON schema for a tuple element (used for single tuple and multi-tuple variants).
 #[cfg(feature = "jsonschema")]
 fn build_tuple_element_json_schema(fld: &FieldDef) -> proc_macro2::TokenStream {
-    let base = build_tuple_element_base_json_schema(fld);
-    nullable_slot_json_schema(fld, &base)
-        .map_or(base, |nullable| quote! { serde_json::json!(#nullable) })
+    nullable_slot_json_schema_value(fld, build_tuple_element_base_json_schema(fld))
 }
 
 /// Fallback JSON schema for map fields whose key type is not specially handled.
@@ -3674,8 +3698,13 @@ fn build_map_vec_value_schema(
 }
 
 /// Builds the JSON schema for a map whose `String`-keyed value is a sibling/custom type.
+///
+/// The member is the sibling's own schema, as it is in field position and on the enum-key path.
+/// `is_array` and `is_optional` describe the slot rather than the type, so the array and nullable
+/// wraps are applied here over that one schema.
 #[cfg(feature = "jsonschema")]
 fn build_map_sibling_value_schema(
+    value: &FieldDef,
     value_type_name: &str,
     value_args: &[FieldDef],
     field_name_str: &str,
@@ -3686,17 +3715,21 @@ fn build_map_sibling_value_schema(
 
     // Handle Vec<T> as map value
     if value_type_name == "Vec" && value_args.len() == 1 {
-        build_map_vec_value_schema(&value_args[0], field_name_str)
-    } else {
-        // Other SiblingType cases - fallback to generic
-        quote! {
-            properties.insert(#field_name_str.to_string(), {
-                serde_json::json!({
-                    "type": "object",
-                    "additionalProperties": true
-                })
-            });
-        }
+        return build_map_vec_value_schema(&value_args[0], field_name_str);
+    }
+
+    let value_module_ident = sibling_schema_module_ident(value_type_name);
+    let value_schema = nullable_slot_json_schema_value(
+        value,
+        arrayed_json_schema_value(value, quote! { #value_module_ident::Schema::json_schema() }),
+    );
+    quote! {
+        properties.insert(#field_name_str.to_string(), {
+            serde_json::json!({
+                "type": "object",
+                "additionalProperties": #value_schema
+            })
+        });
     }
 }
 
@@ -3761,7 +3794,7 @@ fn build_string_key_map_value_schema(
             build_map_nested_map_value_schema(value, inner_key, inner_value, field_name_str)
         }
         FieldDefType::SiblingType(value_type_name, value_args) => {
-            build_map_sibling_value_schema(value_type_name, value_args, field_name_str)
+            build_map_sibling_value_schema(value, value_type_name, value_args, field_name_str)
         }
         // A map member's `$oid` object is closed and unpatterned, where the shared mapping's
         // field-position rendering carries the hex pattern and leaves the object open.
@@ -3815,21 +3848,13 @@ fn build_enum_key_map_value_binding(value: &FieldDef) -> Option<proc_macro2::Tok
     let base = if let FieldDefType::SiblingType(value_type_name, value_lst) = &value.field_type
         && value_lst.is_empty()
     {
-        // For json_schema(), use the module pattern. An alias's module is named after
-        // its registered export name, which the raw ident does not reproduce.
-        let value_module_name = match lookup_alias_info(value_type_name) {
-            Some(alias) => alias.module_name,
-            None => format!("{}_schema", to_snake_case(&safe_type_name(value_type_name))),
-        };
-        let value_module_ident =
-            proc_macro2::Ident::new(value_module_name.as_str(), proc_macro2::Span::call_site());
+        let value_module_ident = sibling_schema_module_ident(value_type_name);
         arrayed_json_schema_value(value, quote! { #value_module_ident::Schema::json_schema() })
     } else {
         scalar_field_json_schema_value(value)?
     };
 
-    let value_schema = nullable_slot_json_schema(value, &base)
-        .map_or(base, |nullable| quote! { serde_json::json!(#nullable) });
+    let value_schema = nullable_slot_json_schema_value(value, base);
     Some(quote! { let value_schema = #value_schema; })
 }
 
@@ -4100,22 +4125,11 @@ fn build_sibling_type_field_schema(
                 })
             });
         }
-    } else if let Some(alias) = lookup_alias_info(name) {
-        // Handles both non-generic sibling types (lst.is_empty()) and
-        // generic branded wrappers like DocumentTypeId<String>.
-        // For transparent newtypes the JSON schema is defined on the
-        // wrapper type's own schema module; type params don't affect it.
-        let module_ident =
-            proc_macro2::Ident::new(alias.module_name.as_str(), proc_macro2::Span::call_site());
-        let type_json_schema = quote! { #module_ident::Schema::json_schema() };
-        generate_type_schema(fld, field_name_str, &type_json_schema)
     } else {
-        // Fallback: Use module pattern for types that may be defined elsewhere.
-        // The type should have been registered - generate a module reference.
-        let safe_name = safe_type_name(name);
-        let module_name = format!("{}_schema", to_snake_case(&safe_name));
-        let module_ident =
-            proc_macro2::Ident::new(module_name.as_str(), proc_macro2::Span::call_site());
+        // Covers both non-generic sibling types (lst.is_empty()) and generic branded wrappers
+        // like DocumentTypeId<String>: for a transparent newtype the JSON schema is defined on
+        // the wrapper type's own schema module, and type params don't affect it.
+        let module_ident = sibling_schema_module_ident(name);
         let type_json_schema = quote! { #module_ident::Schema::json_schema() };
         generate_type_schema(fld, field_name_str, &type_json_schema)
     }
@@ -4915,11 +4929,7 @@ fn generate_json_schema_method(
 #[cfg(feature = "jsonschema")]
 fn flatten_field_json_schema_ref(fld: &FieldDef) -> proc_macro2::TokenStream {
     if let FieldDefType::SiblingType(name, _) = &fld.field_type {
-        let module_name = match lookup_alias_info(name) {
-            Some(alias) => alias.module_name,
-            None => format!("{}_schema", to_snake_case(&safe_type_name(name))),
-        };
-        let module_ident = Ident::new(&module_name, proc_macro2::Span::call_site());
+        let module_ident = sibling_schema_module_ident(name);
         quote! { #module_ident::Schema::json_schema() }
     } else {
         quote! { serde_json::json!({ "type": "object" }) }

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -1196,3 +1196,93 @@ fn a_scalar_string_keyed_map_value_expands_exactly_as_before() {
         );
     }
 }
+
+/// The value half of a map type, parsed from the map type's source.
+#[cfg(feature = "jsonschema")]
+fn map_value_def(map_type: &str) -> super::FieldDef {
+    let ty: syn::Type = syn::parse_str(map_type).unwrap();
+    let field = super::get_field_def("m", &ty, "");
+    let value = if let FieldDefType::Map(_, value) = &field.field_type {
+        Some(value.as_ref().clone())
+    } else {
+        None
+    };
+    value.unwrap()
+}
+
+/// `Vec`-ness rides on the `FieldDef`, never in the type name: the parser collapses `Vec<T>` to
+/// `T` with `is_array` set. A map value's type name is therefore the sibling's own in both forms,
+/// so a member schema predicated on a `Vec` type name can never fire.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_vec_sibling_map_value_parses_as_the_sibling_with_is_array_set() {
+    for (map_type, is_array) in [
+        ("HashMap<String, Inner>", false),
+        ("HashMap<String, Vec<Inner>>", true),
+    ] {
+        let value = map_value_def(map_type);
+        assert_eq!(value.is_array, is_array, "for {map_type}");
+        assert!(
+            matches!(&value.field_type, FieldDefType::SiblingType(name, args) if name == "Inner" && args.is_empty()),
+            "for {map_type}, got: {:?}",
+            value.field_type
+        );
+    }
+}
+
+/// A `String` key enumerates nothing, so the member schema is the value type's own — for a sibling
+/// that is its schema module, arrayed when the value is a `Vec` and nullable when it is an
+/// `Option`, exactly as the enum-key path binds its member.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_sibling_string_keyed_map_value_emits_the_sibling_schema() {
+    for (map_type, expected) in [
+        (
+            "HashMap<String, Inner>",
+            "inner_schema :: Schema :: json_schema ()",
+        ),
+        (
+            "HashMap<String, Vec<Inner>>",
+            r#"serde_json :: json ! ({ "type" : "array" , "items" : inner_schema :: Schema :: json_schema () })"#,
+        ),
+        (
+            "HashMap<String, Option<Inner>>",
+            r#"serde_json :: json ! ({ "anyOf" : [inner_schema :: Schema :: json_schema () , { "type" : "null" }] })"#,
+        ),
+        (
+            "HashMap<String, Option<Vec<Inner>>>",
+            r#"serde_json :: json ! ({ "anyOf" : [serde_json :: json ! ({ "type" : "array" , "items" : inner_schema :: Schema :: json_schema () }) , { "type" : "null" }] })"#,
+        ),
+    ] {
+        let tokens = map_field_schema(map_type).to_string();
+        assert!(
+            tokens.contains(&format!(r#""additionalProperties" : {expected}"#)),
+            "for {map_type}, got: {tokens}"
+        );
+        assert!(
+            !tokens.contains(r#""additionalProperties" : true"#),
+            "for {map_type}, got: {tokens}"
+        );
+    }
+}
+
+/// An alias's schema module is named after its registered export name, which the raw ident does
+/// not reproduce — the reference has to come from the registry or it names a module that was never
+/// emitted.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn an_aliased_string_keyed_map_value_resolves_its_module_through_the_registry() {
+    register_alias_info(
+        "Inner",
+        "InnerType",
+        "inner_type_schema",
+        AliasKind::NoEnumMembers,
+    );
+    for map_type in ["HashMap<String, Inner>", "HashMap<String, Vec<Inner>>"] {
+        let tokens = map_field_schema(map_type).to_string();
+        assert!(
+            tokens.contains("inner_type_schema :: Schema :: json_schema ()"),
+            "for {map_type}, got: {tokens}"
+        );
+    }
+}

--- a/tests/collection_tests/tests.rs
+++ b/tests/collection_tests/tests.rs
@@ -63,6 +63,28 @@ struct EnumKeyedSiblingValueMaps {
     sample_value: HashMap<MetricSlot, MetricSample>,
 }
 
+// A String key enumerates nothing, so one `additionalProperties` schema stands for every member —
+// and it is the value type's own, which is what the enum-keyed twin above spells out per key.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct StringKeyedSiblingValueMaps {
+    optional_sample: HashMap<String, Option<MetricSample>>,
+    sample_array: HashMap<String, Vec<MetricSample>>,
+    sample_value: HashMap<String, MetricSample>,
+}
+
+/// An alias of a sibling: its schema module is named after the registered export name, not the
+/// alias ident, so the member reference has to be resolved through the registry.
+#[model_schema()]
+type MetricSampleRef = MetricSample;
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct StringKeyedAliasValueMaps {
+    sample_array: HashMap<String, Vec<MetricSampleRef>>,
+    sample_value: HashMap<String, MetricSampleRef>,
+}
+
 // A map entry cannot be dropped the way an object key can, so an `Option` value is spelled `null`
 // on the wire rather than omitted — the same twin type on both key paths pins that both agree.
 #[model_schema()]
@@ -503,6 +525,189 @@ fn test_enum_keyed_sibling_value_maps_typescript_generation() {
     assert!(
         zod_schema
             .contains("sample_array: z.record(MetricSlot$Schema, z.array(MetricSample$Schema))"),
+        "Got: {zod_schema}"
+    );
+}
+
+#[test]
+fn test_string_keyed_sibling_value_maps_constructible() {
+    let maps = StringKeyedSiblingValueMaps {
+        optional_sample: HashMap::from([("m".to_owned(), None)]),
+        sample_array: HashMap::from([(
+            "d".to_owned(),
+            vec![MetricSample {
+                label: "d".to_owned(),
+            }],
+        )]),
+        sample_value: HashMap::new(),
+    };
+    assert_eq!(maps.sample_array["d"].len(), 1);
+    assert_eq!(maps.optional_sample["m"], None);
+}
+
+/// A `String` key never widens the value: the member is the sibling's own schema, arrayed when the
+/// value is a `Vec` and nullable when it is an `Option` — the same schema the enum-key path writes
+/// under each key, never the open object that admits every payload alike.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_string_keyed_sibling_value_maps_json_schema() {
+    let sample_schema = MetricSample::json_schema();
+    let schema = StringKeyedSiblingValueMaps::json_schema();
+    let properties = schema["properties"].as_object().unwrap();
+
+    for (field_name, expected) in [
+        ("sample_value", sample_schema.clone()),
+        (
+            "sample_array",
+            serde_json::json!({ "type": "array", "items": sample_schema }),
+        ),
+        (
+            "optional_sample",
+            serde_json::json!({ "anyOf": [sample_schema, { "type": "null" }] }),
+        ),
+    ] {
+        let field = &properties[field_name];
+        assert_eq!(field["type"], "object", "in: {field}");
+        assert_eq!(field["additionalProperties"], expected, "in: {field}");
+    }
+}
+
+/// The member schema is held against what serde writes: an array of siblings for the `Vec` field,
+/// a single sibling object for the plain one. An open member would have accepted either.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_string_keyed_sibling_members_match_the_serialized_form() {
+    let sample = MetricSample {
+        label: "d".to_owned(),
+    };
+    let maps = StringKeyedSiblingValueMaps {
+        optional_sample: HashMap::from([("m".to_owned(), None)]),
+        sample_array: HashMap::from([("d".to_owned(), vec![sample.clone()])]),
+        sample_value: HashMap::from([("s".to_owned(), sample)]),
+    };
+    let payload = serde_json::to_value(&maps).unwrap();
+    let schema = StringKeyedSiblingValueMaps::json_schema();
+
+    let arrayed = &schema["properties"]["sample_array"]["additionalProperties"];
+    assert_eq!(
+        arrayed["type"],
+        json_type_name(&payload["sample_array"]["d"]),
+        "in: {arrayed}"
+    );
+    assert_eq!(
+        arrayed["items"],
+        MetricSample::json_schema(),
+        "in: {arrayed}"
+    );
+
+    let single = &schema["properties"]["sample_value"]["additionalProperties"];
+    assert_eq!(
+        single["type"],
+        json_type_name(&payload["sample_value"]["s"]),
+        "in: {single}"
+    );
+    assert_eq!(*single, MetricSample::json_schema(), "in: {single}");
+
+    let optional = &schema["properties"]["optional_sample"]["additionalProperties"];
+    assert_eq!(
+        optional["anyOf"][1]["type"],
+        json_type_name(&payload["optional_sample"]["m"]),
+        "in: {optional}"
+    );
+}
+
+#[test]
+#[cfg(all(feature = "typescript", feature = "zod"))]
+fn test_string_keyed_sibling_value_maps_typescript_generation() {
+    let ts_definition = StringKeyedSiblingValueMaps::ts_definition();
+
+    assert!(
+        ts_definition.contains("sample_value: Partial<Record<string, MetricSample>>;"),
+        "Got: {ts_definition}"
+    );
+    assert!(
+        ts_definition.contains("sample_array: Partial<Record<string, Array<MetricSample>>>;"),
+        "Got: {ts_definition}"
+    );
+    assert!(
+        ts_definition.contains("optional_sample: Partial<Record<string, MetricSample | null>>;"),
+        "Got: {ts_definition}"
+    );
+
+    let zod_schema = StringKeyedSiblingValueMaps::zod_schema();
+    assert!(
+        zod_schema.contains("sample_value: z.record(z.string(), MetricSample$Schema)"),
+        "Got: {zod_schema}"
+    );
+    assert!(
+        zod_schema.contains("sample_array: z.record(z.string(), z.array(MetricSample$Schema))"),
+        "Got: {zod_schema}"
+    );
+    assert!(
+        zod_schema
+            .contains("optional_sample: z.record(z.string(), z.nullable(MetricSample$Schema))"),
+        "Got: {zod_schema}"
+    );
+}
+
+#[test]
+fn test_string_keyed_alias_value_maps_constructible() {
+    let maps = StringKeyedAliasValueMaps {
+        sample_array: HashMap::new(),
+        sample_value: HashMap::from([(
+            "s".to_owned(),
+            MetricSampleRef {
+                label: "s".to_owned(),
+            },
+        )]),
+    };
+    assert_eq!(maps.sample_value["s"].label, "s");
+}
+
+/// An alias's schema module is named after its registered export name, so the member reference is
+/// only resolvable through the registry — deriving it from the alias ident names a module that was
+/// never emitted, and the expansion no longer compiles.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_string_keyed_alias_value_maps_resolve_the_registered_module() {
+    let alias_schema = metric_sample_ref_type_schema::Schema::json_schema();
+    let schema = StringKeyedAliasValueMaps::json_schema();
+    let properties = schema["properties"].as_object().unwrap();
+
+    assert_eq!(
+        properties["sample_value"]["additionalProperties"], alias_schema,
+        "in: {schema}"
+    );
+    assert_eq!(
+        properties["sample_array"]["additionalProperties"],
+        serde_json::json!({ "type": "array", "items": alias_schema }),
+        "in: {schema}"
+    );
+}
+
+#[test]
+#[cfg(all(feature = "typescript", feature = "zod"))]
+fn test_string_keyed_alias_value_maps_typescript_generation() {
+    let ts_definition = StringKeyedAliasValueMaps::ts_definition();
+
+    assert!(
+        ts_definition.contains("sample_value: Partial<Record<string, MetricSampleRefType>>;"),
+        "Got: {ts_definition}"
+    );
+    assert!(
+        ts_definition
+            .contains("sample_array: Partial<Record<string, Array<MetricSampleRefType>>>;"),
+        "Got: {ts_definition}"
+    );
+
+    let zod_schema = StringKeyedAliasValueMaps::zod_schema();
+    assert!(
+        zod_schema.contains("sample_value: z.record(z.string(), MetricSampleRefType$Schema)"),
+        "Got: {zod_schema}"
+    );
+    assert!(
+        zod_schema
+            .contains("sample_array: z.record(z.string(), z.array(MetricSampleRefType$Schema))"),
         "Got: {zod_schema}"
     );
 }

--- a/tests/edge_cases_tests/tests.rs
+++ b/tests/edge_cases_tests/tests.rs
@@ -68,12 +68,16 @@ struct OriginalBugReproduction {
     string_to_vec_string: HashMap<String, Vec<String>>,
 }
 
+// A named map value is rendered as the schema module its own `#[model_schema()]` expansion emits,
+// so an alias standing in a map value has to carry the attribute like any other referenced type.
 #[cfg(all(test, any(feature = "typescript", feature = "zod", feature = "serde")))]
 // Inner value type for the optional deeply nested map.
+#[model_schema()]
 type OptionalNestedValue = Vec<Option<HashMap<String, Option<Vec<i64>>>>>;
 
 #[cfg(all(test, any(feature = "typescript", feature = "zod", feature = "serde")))]
 // Inner value type for the quadruple nested map.
+#[model_schema()]
 type QuadrupleNestedValue = Vec<HashMap<String, Vec<HashMap<String, u64>>>>;
 
 #[cfg(all(test, any(feature = "typescript", feature = "zod", feature = "serde")))]


### PR DESCRIPTION
Stacked on #39 (stack: #33 → … → #39 → this).

`HashMap<String, Sibling>` and `HashMap<String, Vec<Sibling>>` emitted `additionalProperties: true` — the sibling schema never appeared. Root cause, proven before fixing: the `Vec` branch required `SiblingType("Vec", [inner])`, a shape the parser cannot construct (it collapses `Vec<T>` into `is_array` on the inner def — probe output on the task). The arm was entered; its predicate could never hold.

- Sibling values now emit `<module>::Schema::json_schema()` as `additionalProperties`, arrayed/nullable via the shared seams; module resolution registry-first (`sibling_schema_module_ident`, replacing four hand-rolled copies; `nullable_slot_json_schema_value` replacing three).
- Red-first: four probe forms all emitted `true` before; json-schema/TS/Zod/serialized-form fixtures pin plain, `Vec`, `Option`, and aliased siblings after.
- Two edge-case fixtures needed `#[model_schema()]` on aliases that were plain `type` before (their raw-E0433 diagnostic is filed separately); the dead-predicate call is deliberately left in place so the unreachable-builders task keeps its subject intact.

Gates: `just check`, `just test` (full powerset) green.
