### PR TITLE
fix: one recursive member dispatcher for String-keyed map values

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -3412,333 +3412,67 @@ fn map_key_fallback_schema(field_name_str: &str, key: &FieldDef) -> proc_macro2:
     }
 }
 
-/// Builds the JSON schema for a map whose `String`-keyed value is itself a map.
+/// The member schema for a `String`-keyed map whose value is itself a map: an object whose own
+/// members carry the inner value's rendering, or `None` when that value has no rendering here.
+///
+/// Only a `String` inner key opens a member set this dispatcher describes; an inner key of any
+/// other type names members this branch does not enumerate, so those members stay unconstrained —
+/// the value is still known to be an object, which is what the map guarantees.
 #[cfg(feature = "jsonschema")]
-fn build_map_nested_map_value_schema(
-    value: &FieldDef,
+fn build_map_nested_map_member_schema(
     inner_key: &FieldDef,
     inner_value: &FieldDef,
-    field_name_str: &str,
-) -> proc_macro2::TokenStream {
+) -> Option<proc_macro2::TokenStream> {
     log::trace!(
-        "Map Value is another Map => inner_key: {:?}, inner_value: {:?}, is_array: {}",
-        inner_key,
-        inner_value,
-        value.is_array
+        "Map Value is another Map => inner_key: {inner_key:?}, inner_value: {inner_value:?}"
     );
 
-    // Handle Vec<HashMap<String, T>> case
-    if value.is_array && matches!(inner_key.field_type, FieldDefType::String) {
-        let inner_value_schema = match &inner_value.field_type {
-            FieldDefType::U8
-            | FieldDefType::U16
-            | FieldDefType::U32
-            | FieldDefType::U64
-            | FieldDefType::I8
-            | FieldDefType::I16
-            | FieldDefType::I32
-            | FieldDefType::I64
-            | FieldDefType::Usize
-            | FieldDefType::Isize => {
-                quote! { { "type": "integer" } }
-            }
-            FieldDefType::F32 | FieldDefType::F64 => {
-                quote! { { "type": "number" } }
-            }
-            FieldDefType::String => {
-                quote! { { "type": "string" } }
-            }
-            FieldDefType::Boolean => {
-                quote! { { "type": "boolean" } }
-            }
-            #[cfg(feature = "object_id")]
-            FieldDefType::ObjectId => {
-                quote! { {
-                    "type": "object",
-                    "properties": {
-                        "$oid": { "type": "string" }
-                    },
-                    "required": ["$oid"],
-                    "additionalProperties": false
-                } }
-            }
-            _ => {
-                quote! { true }
-            }
-        };
-
-        let arrayed = quote! {
-            {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "additionalProperties": #inner_value_schema
-                }
-            }
-        };
-        let value_schema = nullable_slot_json_schema(value, &arrayed).unwrap_or(arrayed);
-        quote! {
-            properties.insert(#field_name_str.to_string(), {
-                serde_json::json!({
-                    "type": "object",
-                    "additionalProperties": #value_schema
-                })
-            });
-        }
+    let inner_member = if matches!(inner_key.field_type, FieldDefType::String) {
+        build_map_member_schema(inner_value)?
     } else {
-        // Fallback for non-array Maps or complex cases
-        quote! {
-            properties.insert(#field_name_str.to_string(), {
-                serde_json::json!({
-                    "type": "object",
-                    "additionalProperties": true
-                })
-            });
-        }
-    }
-}
-
-/// JSON schema fragment for the value type of an innermost `Vec<HashMap<String, T>>` map.
-#[cfg(feature = "jsonschema")]
-fn map_inner_value_item_schema(inner_value: &FieldDef) -> proc_macro2::TokenStream {
-    match &inner_value.field_type {
-        FieldDefType::U8
-        | FieldDefType::U16
-        | FieldDefType::U32
-        | FieldDefType::U64
-        | FieldDefType::I8
-        | FieldDefType::I16
-        | FieldDefType::I32
-        | FieldDefType::I64
-        | FieldDefType::Usize
-        | FieldDefType::Isize => quote! { { "type": "integer" } },
-        FieldDefType::F32 | FieldDefType::F64 => quote! { { "type": "number" } },
-        FieldDefType::String => quote! { { "type": "string" } },
-        FieldDefType::Boolean => quote! { { "type": "boolean" } },
-        FieldDefType::Unknown
-        | FieldDefType::SiblingType(..)
-        | FieldDefType::Map(..)
-        | FieldDefType::Tuple(..)
-        | FieldDefType::StringLiteral(_) => quote! { true },
-        #[cfg(feature = "object_id")]
-        FieldDefType::ObjectId => quote! { true },
-        #[cfg(feature = "chrono")]
-        FieldDefType::NaiveDate
-        | FieldDefType::NaiveTime
-        | FieldDefType::NaiveDateTime
-        | FieldDefType::DateTime => quote! { true },
-    }
-}
-
-/// JSON schema for a map whose `String`-keyed value is `Vec<HashMap<inner_key, inner_value>>`.
-#[cfg(feature = "jsonschema")]
-fn build_map_vec_of_map_value_schema(
-    inner_key: &FieldDef,
-    inner_value: &FieldDef,
-    field_name_str: &str,
-) -> proc_macro2::TokenStream {
-    let generic = quote! {
-        properties.insert(#field_name_str.to_string(), {
-            serde_json::json!({
-                "type": "object",
-                "additionalProperties": true
-            })
-        });
+        quote! { true }
     };
-    match &inner_key.field_type {
-        FieldDefType::String => {
-            let inner_value_schema = map_inner_value_item_schema(inner_value);
-            quote! {
-                properties.insert(#field_name_str.to_string(), {
-                    serde_json::json!({
-                        "type": "object",
-                        "additionalProperties": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "additionalProperties": #inner_value_schema
-                            }
-                        }
-                    })
-                });
-            }
-        }
-        FieldDefType::Unknown
-        | FieldDefType::SiblingType(..)
-        | FieldDefType::Map(..)
-        | FieldDefType::Tuple(..)
-        | FieldDefType::Boolean
-        | FieldDefType::StringLiteral(_)
-        | FieldDefType::U8
-        | FieldDefType::U16
-        | FieldDefType::U32
-        | FieldDefType::U64
-        | FieldDefType::I8
-        | FieldDefType::I16
-        | FieldDefType::I32
-        | FieldDefType::I64
-        | FieldDefType::Usize
-        | FieldDefType::Isize
-        | FieldDefType::F32
-        | FieldDefType::F64 => generic,
-        #[cfg(feature = "object_id")]
-        FieldDefType::ObjectId => generic,
-        #[cfg(feature = "chrono")]
-        FieldDefType::NaiveDate
-        | FieldDefType::NaiveTime
-        | FieldDefType::NaiveDateTime
-        | FieldDefType::DateTime => generic,
-    }
+    Some(quote! { { "type": "object", "additionalProperties": #inner_member } })
 }
 
-/// JSON schema for a map whose `String`-keyed value is `Vec<T>`.
-#[cfg(feature = "jsonschema")]
-fn build_map_vec_value_schema(
-    inner_type: &FieldDef,
-    field_name_str: &str,
-) -> proc_macro2::TokenStream {
-    match &inner_type.field_type {
-        // Vec<HashMap<String, T>>
-        FieldDefType::Map(inner_key, inner_value) => {
-            build_map_vec_of_map_value_schema(inner_key, inner_value, field_name_str)
-        }
-        FieldDefType::U8
-        | FieldDefType::U16
-        | FieldDefType::U32
-        | FieldDefType::U64
-        | FieldDefType::I8
-        | FieldDefType::I16
-        | FieldDefType::I32
-        | FieldDefType::I64
-        | FieldDefType::Usize
-        | FieldDefType::Isize => {
-            quote! {
-                properties.insert(#field_name_str.to_string(), {
-                    serde_json::json!({
-                        "type": "object",
-                        "additionalProperties": {
-                            "type": "array",
-                            "items": { "type": "integer" }
-                        }
-                    })
-                });
-            }
-        }
-        FieldDefType::F32 | FieldDefType::F64 => {
-            quote! {
-                properties.insert(#field_name_str.to_string(), {
-                    serde_json::json!({
-                        "type": "object",
-                        "additionalProperties": {
-                            "type": "array",
-                            "items": { "type": "number" }
-                        }
-                    })
-                });
-            }
-        }
-        FieldDefType::String => {
-            quote! {
-                properties.insert(#field_name_str.to_string(), {
-                    serde_json::json!({
-                        "type": "object",
-                        "additionalProperties": {
-                            "type": "array",
-                            "items": { "type": "string" }
-                        }
-                    })
-                });
-            }
-        }
-        FieldDefType::Boolean => {
-            quote! {
-                properties.insert(#field_name_str.to_string(), {
-                    serde_json::json!({
-                        "type": "object",
-                        "additionalProperties": {
-                            "type": "array",
-                            "items": { "type": "boolean" }
-                        }
-                    })
-                });
-            }
-        }
-        #[cfg(feature = "object_id")]
-        FieldDefType::ObjectId => {
-            quote! {
-                properties.insert(#field_name_str.to_string(), {
-                    serde_json::json!({
-                        "type": "object",
-                        "additionalProperties": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "$oid": { "type": "string" }
-                                },
-                                "required": ["$oid"],
-                                "additionalProperties": false
-                            }
-                        }
-                    })
-                });
-            }
-        }
-        _ => {
-            quote! {
-                properties.insert(#field_name_str.to_string(), {
-                    serde_json::json!({
-                        "type": "object",
-                        "additionalProperties": true
-                    })
-                });
-            }
-        }
-    }
-}
-
-/// Builds the JSON schema for a map whose `String`-keyed value is a sibling/custom type.
+/// The member schema for a `String`-keyed map whose value is a sibling/custom type.
 ///
 /// The member is the sibling's own schema, as it is in field position and on the enum-key path.
 /// `is_array` and `is_optional` describe the slot rather than the type, so the array and nullable
 /// wraps are applied here over that one schema.
 #[cfg(feature = "jsonschema")]
-fn build_map_sibling_value_schema(
+fn build_map_sibling_member_schema(
     value: &FieldDef,
     value_type_name: &str,
     value_args: &[FieldDef],
-    field_name_str: &str,
-) -> proc_macro2::TokenStream {
+) -> Option<proc_macro2::TokenStream> {
     log::trace!(
         "Map Value SiblingType => value_type_name: {value_type_name}, value_args: {value_args:?}"
     );
 
-    // Handle Vec<T> as map value
-    if value_type_name == "Vec" && value_args.len() == 1 {
-        return build_map_vec_value_schema(&value_args[0], field_name_str);
+    // The parser collapses `Vec<T>` to `T` with `is_array` set, so a `Vec` type name reaches here
+    // only on a value built by hand: move the array-ness onto the element and dispatch that, which
+    // is the same member schema the collapsed form renders.
+    if value_type_name == "Vec"
+        && let [element] = value_args
+    {
+        let mut arrayed = element.clone();
+        arrayed.is_array = true;
+        return build_map_member_schema(&arrayed);
     }
 
     let value_module_ident = sibling_schema_module_ident(value_type_name);
-    let value_schema = nullable_slot_json_schema_value(
+    Some(nullable_slot_json_schema_value(
         value,
         arrayed_json_schema_value(value, quote! { #value_module_ident::Schema::json_schema() }),
-    );
-    quote! {
-        properties.insert(#field_name_str.to_string(), {
-            serde_json::json!({
-                "type": "object",
-                "additionalProperties": #value_schema
-            })
-        });
-    }
+    ))
 }
 
-/// Wraps a scalar JSON schema as a `String`-keyed map's `additionalProperties`,
-/// arraying it when the value field is a `Vec` and nullable when it is an `Option`.
+/// Wraps a member's base schema for the slot it sits in — arrayed when the value is a `Vec`,
+/// nullable when it is an `Option`.
 #[cfg(feature = "jsonschema")]
-fn build_map_scalar_value_schema(
+fn map_member_slot_schema(
     value: &FieldDef,
-    field_name_str: &str,
     item_schema: &proc_macro2::TokenStream,
 ) -> proc_macro2::TokenStream {
     let arrayed = if value.is_array {
@@ -3751,72 +3485,45 @@ fn build_map_scalar_value_schema(
     } else {
         item_schema.clone()
     };
-    let value_schema = nullable_slot_json_schema(value, &arrayed).unwrap_or(arrayed);
-    quote! {
-        properties.insert(#field_name_str.to_string(), {
-            serde_json::json!({
-                "type": "object",
-                "additionalProperties": #value_schema
-            })
-        });
-    }
+    nullable_slot_json_schema(value, &arrayed).unwrap_or(arrayed)
 }
 
-/// Wraps the shared scalar mapping as a `String`-keyed map's `additionalProperties`, or fails with
-/// a single diagnostic when the value type has no inline rendering.
-#[cfg(feature = "jsonschema")]
-fn build_map_inline_value_schema(
-    value: &FieldDef,
-    field_name_str: &str,
-) -> proc_macro2::TokenStream {
-    // Emitted instead of the property insertion, never alongside it: an insertion left in place
-    // hands the author a schema the expansion has already rejected.
-    let Some(item_schema) = scalar_field_json_schema_item(value) else {
-        let message = format!(
-            "field `{field_name_str}`: a tuple is not supported as a map value — give the value a `#[model_schema()]` struct instead"
-        );
-        return quote! { compile_error!(#message); };
-    };
-    build_map_scalar_value_schema(value, field_name_str, &item_schema)
-}
-
-/// Builds the JSON schema for a map whose key type is `String`, dispatching on the value type.
+/// The `additionalProperties` schema every member of a `String`-keyed map carries, or `None` when
+/// the value type has no rendering here.
 ///
-/// A `String` key enumerates nothing, so one `additionalProperties` schema stands for every
-/// member — and it is the value type's own rendering, which the key never widens.
+/// A map value is dispatched through this same function, so the members of a nested map carry the
+/// inner value type's own rendering at every depth rather than an open object.
+///
+/// A tuple is the only value the mapping cannot render, at any depth: the callers turn that `None`
+/// into the single diagnostic naming the field.
 #[cfg(feature = "jsonschema")]
-fn build_string_key_map_value_schema(
-    value: &FieldDef,
-    field_name_str: &str,
-) -> proc_macro2::TokenStream {
+fn build_map_member_schema(value: &FieldDef) -> Option<proc_macro2::TokenStream> {
     match &value.field_type {
-        FieldDefType::Map(inner_key, inner_value) => {
-            build_map_nested_map_value_schema(value, inner_key, inner_value, field_name_str)
-        }
+        FieldDefType::Map(inner_key, inner_value) => Some(map_member_slot_schema(
+            value,
+            &build_map_nested_map_member_schema(inner_key, inner_value)?,
+        )),
         FieldDefType::SiblingType(value_type_name, value_args) => {
-            build_map_sibling_value_schema(value, value_type_name, value_args, field_name_str)
+            build_map_sibling_member_schema(value, value_type_name, value_args)
         }
         // A map member's `$oid` object is closed and unpatterned, where the shared mapping's
         // field-position rendering carries the hex pattern and leaves the object open.
         #[cfg(feature = "object_id")]
-        FieldDefType::ObjectId => build_map_scalar_value_schema(
+        FieldDefType::ObjectId => Some(map_member_slot_schema(
             value,
-            field_name_str,
             &quote! { {
                 "type": "object",
                 "properties": { "$oid": { "type": "string" } },
                 "required": ["$oid"],
                 "additionalProperties": false
             } },
-        ),
+        )),
         // An opaque value carries no type name to narrow with, so a member admits any value: the
         // permissive empty schema, as in field position.
-        FieldDefType::Unknown => {
-            build_map_scalar_value_schema(value, field_name_str, &quote! { {} })
-        }
-        // The shared mapping renders every type named here except a tuple, which lands on the lone
-        // diagnostic. Named exhaustively rather than caught by a wildcard: a new variant must be
-        // given a member schema, not silently widened into an open object.
+        FieldDefType::Unknown => Some(map_member_slot_schema(value, &quote! { {} })),
+        // The shared mapping renders every type named here except a tuple, which is the lone
+        // `None`. Named exhaustively rather than caught by a wildcard: a new variant must be given
+        // a member schema, not silently widened into an open object.
         FieldDefType::Boolean
         | FieldDefType::F32
         | FieldDefType::F64
@@ -3832,12 +3539,45 @@ fn build_string_key_map_value_schema(
         | FieldDefType::U16
         | FieldDefType::U32
         | FieldDefType::U64
-        | FieldDefType::Usize => build_map_inline_value_schema(value, field_name_str),
+        | FieldDefType::Usize => Some(map_member_slot_schema(
+            value,
+            &scalar_field_json_schema_item(value)?,
+        )),
         #[cfg(feature = "chrono")]
         FieldDefType::DateTime
         | FieldDefType::NaiveDate
         | FieldDefType::NaiveDateTime
-        | FieldDefType::NaiveTime => build_map_inline_value_schema(value, field_name_str),
+        | FieldDefType::NaiveTime => Some(map_member_slot_schema(
+            value,
+            &scalar_field_json_schema_item(value)?,
+        )),
+    }
+}
+
+/// Builds the JSON schema for a map whose key type is `String`, dispatching on the value type.
+///
+/// A `String` key enumerates nothing, so one `additionalProperties` schema stands for every
+/// member — and it is the value type's own rendering, which the key never widens.
+#[cfg(feature = "jsonschema")]
+fn build_string_key_map_value_schema(
+    value: &FieldDef,
+    field_name_str: &str,
+) -> proc_macro2::TokenStream {
+    // Emitted instead of the property insertion, never alongside it: an insertion left in place
+    // hands the author a schema the expansion has already rejected.
+    let Some(value_schema) = build_map_member_schema(value) else {
+        let message = format!(
+            "field `{field_name_str}`: a tuple is not supported as a map value — give the value a `#[model_schema()]` struct instead"
+        );
+        return quote! { compile_error!(#message); };
+    };
+    quote! {
+        properties.insert(#field_name_str.to_string(), {
+            serde_json::json!({
+                "type": "object",
+                "additionalProperties": #value_schema
+            })
+        });
     }
 }
 

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -1197,6 +1197,209 @@ fn a_scalar_string_keyed_map_value_expands_exactly_as_before() {
     }
 }
 
+/// The `String`-key branch's output for a nested map value built by hand: a `String`-keyed inner
+/// map holding `inner_type`, bare or behind a `Vec`, for the inner value types no source type
+/// produces.
+#[cfg(feature = "jsonschema")]
+fn nested_string_key_map_value_schema(inner_type: FieldDefType, is_array: bool) -> String {
+    let ty: syn::Type = syn::parse_str("String").unwrap();
+    let inner_key = super::get_field_def("m", &ty, "");
+    let mut inner_value = inner_key.clone();
+    inner_value.field_type = inner_type;
+    let mut value = inner_key.clone();
+    value.field_type = FieldDefType::Map(Box::new(inner_key), Box::new(inner_value));
+    value.is_array = is_array;
+    super::build_string_key_map_value_schema(&value, "m").to_string()
+}
+
+/// A map value that is itself a map is dispatched the same way at every depth: the members of the
+/// inner map carry the inner value type's own rendering. A member schema that stops at the outer
+/// map describes nothing about what the map holds.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_nested_string_keyed_map_value_renders_its_inner_members() {
+    for (map_type, expected) in [
+        (
+            "HashMap<String, HashMap<String, String>>",
+            r#"{ "type" : "object" , "additionalProperties" : { "type" : "string" } }"#,
+        ),
+        (
+            "HashMap<String, HashMap<String, Vec<u64>>>",
+            r#"{ "type" : "object" , "additionalProperties" : { "type" : "array" , "items" : { "type" : "integer" } } }"#,
+        ),
+        (
+            "HashMap<String, HashMap<String, Option<bool>>>",
+            r#"{ "type" : "object" , "additionalProperties" : { "anyOf" : [{ "type" : "boolean" } , { "type" : "null" }] } }"#,
+        ),
+        (
+            "HashMap<String, HashMap<String, HashMap<String, f64>>>",
+            r#"{ "type" : "object" , "additionalProperties" : { "type" : "object" , "additionalProperties" : { "type" : "number" } } }"#,
+        ),
+        (
+            "HashMap<String, HashMap<String, Inner>>",
+            r#"{ "type" : "object" , "additionalProperties" : inner_schema :: Schema :: json_schema () }"#,
+        ),
+        (
+            "HashMap<String, Option<HashMap<String, String>>>",
+            r#"{ "anyOf" : [{ "type" : "object" , "additionalProperties" : { "type" : "string" } } , { "type" : "null" }] }"#,
+        ),
+    ] {
+        let tokens = map_field_schema(map_type).to_string();
+        assert!(
+            tokens.contains(&format!(r#""additionalProperties" : {expected}"#)),
+            "for {map_type}, got: {tokens}"
+        );
+        assert!(
+            !tokens.contains(r#""additionalProperties" : true"#),
+            "for {map_type}, got: {tokens}"
+        );
+    }
+}
+
+/// A `Vec` of maps arrays the same member schema the bare inner map renders — the array wrap sits
+/// between the two dispatches, it does not replace the inner one.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_vec_of_maps_string_keyed_map_value_renders_its_inner_members() {
+    for (map_type, expected) in [
+        (
+            "HashMap<String, Vec<HashMap<String, String>>>",
+            r#"{ "type" : "array" , "items" : { "type" : "object" , "additionalProperties" : { "type" : "string" } } }"#,
+        ),
+        (
+            "HashMap<String, Vec<HashMap<String, u64>>>",
+            r#"{ "type" : "array" , "items" : { "type" : "object" , "additionalProperties" : { "type" : "integer" } } }"#,
+        ),
+        (
+            "HashMap<String, Vec<HashMap<String, Inner>>>",
+            r#"{ "type" : "array" , "items" : { "type" : "object" , "additionalProperties" : inner_schema :: Schema :: json_schema () } }"#,
+        ),
+    ] {
+        let tokens = map_field_schema(map_type).to_string();
+        assert!(
+            tokens.contains(&format!(r#""additionalProperties" : {expected}"#)),
+            "for {map_type}, got: {tokens}"
+        );
+        assert!(
+            !tokens.contains(r#""additionalProperties" : true"#),
+            "for {map_type}, got: {tokens}"
+        );
+    }
+}
+
+/// A chrono value keeps the format it carries in field position however deep the nesting goes: the
+/// depth is the map's, never the value type's.
+#[cfg(all(feature = "chrono", feature = "jsonschema"))]
+#[test]
+fn a_nested_chrono_map_value_keeps_its_format() {
+    for (map_type, expected) in [
+        (
+            "HashMap<String, HashMap<String, NaiveDate>>",
+            r#"{ "type" : "object" , "additionalProperties" : { "type" : "string" , "format" : "date" } }"#,
+        ),
+        (
+            "HashMap<String, HashMap<String, NaiveTime>>",
+            r#"{ "type" : "object" , "additionalProperties" : { "type" : "string" , "format" : "time" } }"#,
+        ),
+        (
+            "HashMap<String, Vec<HashMap<String, DateTime<Utc>>>>",
+            r#"{ "type" : "array" , "items" : { "type" : "object" , "additionalProperties" : { "type" : "string" , "format" : "date-time" } } }"#,
+        ),
+    ] {
+        let tokens = map_field_schema(map_type).to_string();
+        assert!(
+            tokens.contains(&format!(r#""additionalProperties" : {expected}"#)),
+            "for {map_type}, got: {tokens}"
+        );
+        assert!(
+            !tokens.contains(r#""additionalProperties" : true"#),
+            "for {map_type}, got: {tokens}"
+        );
+    }
+}
+
+/// The inner value types no source type produces reach the same mapping as the outer ones, whether
+/// the inner map stands alone or behind a `Vec`.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_nested_string_literal_map_value_keeps_its_const() {
+    let inner_member = r#"{ "type" : "object" , "additionalProperties" : { "type" : "string" , "const" : "Tixena" } }"#;
+    let bare =
+        nested_string_key_map_value_schema(FieldDefType::StringLiteral("Tixena".to_owned()), false);
+    assert!(
+        bare.contains(&format!(r#""additionalProperties" : {inner_member}"#)),
+        "got: {bare}"
+    );
+
+    let arrayed =
+        nested_string_key_map_value_schema(FieldDefType::StringLiteral("Tixena".to_owned()), true);
+    assert!(
+        arrayed.contains(&format!(
+            r#""additionalProperties" : {{ "type" : "array" , "items" : {inner_member} }}"#
+        )),
+        "got: {arrayed}"
+    );
+}
+
+/// A nested `ObjectId` member carries the closed `$oid` object the outer member carries.
+#[cfg(all(feature = "object_id", feature = "jsonschema"))]
+#[test]
+fn a_nested_object_id_map_value_keeps_its_oid_object() {
+    let inner_member = r#"{ "type" : "object" , "additionalProperties" : { "type" : "object" , "properties" : { "$oid" : { "type" : "string" } } , "required" : ["$oid"] , "additionalProperties" : false } }"#;
+    let bare = nested_string_key_map_value_schema(FieldDefType::ObjectId, false);
+    assert!(
+        bare.contains(&format!(r#""additionalProperties" : {inner_member}"#)),
+        "got: {bare}"
+    );
+
+    let arrayed = nested_string_key_map_value_schema(FieldDefType::ObjectId, true);
+    assert!(
+        arrayed.contains(&format!(
+            r#""additionalProperties" : {{ "type" : "array" , "items" : {inner_member} }}"#
+        )),
+        "got: {arrayed}"
+    );
+}
+
+/// An inner key type this branch does not enumerate leaves the inner members open — but the member
+/// is still known to be an object, which is more than an unconstrained value says.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_nested_map_under_an_unenumerated_key_still_renders_as_an_object() {
+    let tokens = map_field_schema("HashMap<String, HashMap<Slot, String>>").to_string();
+    assert!(
+        tokens.contains(
+            r#""additionalProperties" : { "type" : "object" , "additionalProperties" : true }"#
+        ),
+        "got: {tokens}"
+    );
+}
+
+/// A value the mapping cannot render fails wherever it sits: nested behind a map, the tuple is
+/// still a map value, and widening it to an open member would hide the rejection.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn an_unsupported_nested_map_value_emits_only_the_compile_error() {
+    for map_type in [
+        "HashMap<String, HashMap<String, (String, u32)>>",
+        "HashMap<String, Vec<HashMap<String, (String, u32)>>>",
+    ] {
+        let tokens = map_field_schema(map_type).to_string();
+        assert!(
+            tokens.starts_with("compile_error !"),
+            "for {map_type}, got: {tokens}"
+        );
+        assert!(
+            !tokens.contains("properties . insert"),
+            "for {map_type}, got: {tokens}"
+        );
+        assert!(
+            tokens.contains("a tuple is not supported as a map value"),
+            "for {map_type}, got: {tokens}"
+        );
+    }
+}
+
 /// The value half of a map type, parsed from the map type's source.
 #[cfg(feature = "jsonschema")]
 fn map_value_def(map_type: &str) -> super::FieldDef {

--- a/tests/chrono_tests/tests.rs
+++ b/tests/chrono_tests/tests.rs
@@ -67,6 +67,17 @@ struct ChronoValueMaps {
     windows: HashMap<String, Vec<NaiveTime>>,
 }
 
+// A chrono value keeps the rendering it has in field position however deep the map nesting goes:
+// the depth belongs to the map, never to the value type.
+#[model_schema()]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
+struct NestedChronoMaps {
+    dates_by_group: HashMap<String, HashMap<String, NaiveDate>>,
+    timestamps_by_run: HashMap<String, HashMap<String, DateTime<Utc>>>,
+    window_batches: HashMap<String, Vec<HashMap<String, NaiveTime>>>,
+}
+
 // Test struct with NaiveDate field.
 #[model_schema()]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -198,6 +209,23 @@ fn test_chrono_types_constructible() {
     assert_eq!(chrono_value_maps.dates.len(), 1);
     assert_eq!(chrono_value_maps.optional_dates["closing"], None);
     assert_eq!(chrono_value_maps.windows["opening"], vec![time]);
+    let nested_chrono_maps = NestedChronoMaps {
+        dates_by_group: HashMap::from([(
+            "opening".to_owned(),
+            HashMap::from([("first".to_owned(), date)]),
+        )]),
+        timestamps_by_run: HashMap::new(),
+        window_batches: HashMap::from([(
+            "opening".to_owned(),
+            vec![HashMap::from([("first".to_owned(), time)])],
+        )]),
+    };
+    assert_eq!(nested_chrono_maps.dates_by_group["opening"]["first"], date);
+    assert_eq!(
+        nested_chrono_maps.window_batches["opening"][0]["first"],
+        time
+    );
+    assert!(nested_chrono_maps.timestamps_by_run.is_empty());
     assert!(chrono_value_maps.local_datetimes.is_empty());
     assert!(chrono_value_maps.timestamps.is_empty());
     assert!(chrono_value_maps.times.is_empty());
@@ -554,6 +582,78 @@ fn test_string_keyed_chrono_map_json_schema() {
         serde_json::json!({ "type": "string", "format": "date-time" }),
         "in: {events}"
     );
+}
+
+/// A nested map's members reach the same chrono mapping the outer members reach: the format is the
+/// value type's, and no depth of nesting is allowed to drop it.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_nested_string_keyed_chrono_map_json_schema() {
+    let schema = NestedChronoMaps::json_schema();
+    let properties = schema["properties"].as_object().unwrap();
+
+    for (field_name, expected_value_schema) in [
+        (
+            "dates_by_group",
+            serde_json::json!({
+                "type": "object",
+                "additionalProperties": { "type": "string", "format": "date" }
+            }),
+        ),
+        (
+            "timestamps_by_run",
+            serde_json::json!({
+                "type": "object",
+                "additionalProperties": { "type": "string", "format": "date-time" }
+            }),
+        ),
+        (
+            "window_batches",
+            serde_json::json!({
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "additionalProperties": { "type": "string", "format": "time" }
+                }
+            }),
+        ),
+    ] {
+        let field = &properties[field_name];
+        assert_eq!(field["type"], "object", "in: {field}");
+        assert_eq!(
+            field["additionalProperties"], expected_value_schema,
+            "in: {field}"
+        );
+    }
+}
+
+/// TypeScript and Zod recurse through a map value on their own, so a nested chrono value keeps its
+/// rendering on those surfaces too — pinned so the three stay in step.
+#[test]
+#[cfg(all(feature = "typescript", feature = "zod"))]
+fn test_nested_string_keyed_chrono_map_typescript_and_zod() {
+    let ts_definition = NestedChronoMaps::ts_definition();
+    for expected in [
+        "dates_by_group: Partial<Record<string, Partial<Record<string, string>>>>;",
+        "timestamps_by_run: Partial<Record<string, Partial<Record<string, Date>>>>;",
+        "window_batches: Partial<Record<string, Array<Partial<Record<string, string>>>>>;",
+    ] {
+        assert!(
+            ts_definition.contains(expected),
+            "missing {expected}, got: {ts_definition}"
+        );
+    }
+
+    let zod_schema = NestedChronoMaps::zod_schema();
+    for expected in [
+        "dates_by_group: z.record(z.string(), z.record(z.string(), z.iso.date())),",
+        "timestamps_by_run: z.record(z.string(), z.record(z.string(), z.coerce.date())),",
+    ] {
+        assert!(
+            zod_schema.contains(expected),
+            "missing {expected}, got: {zod_schema}"
+        );
+    }
 }
 
 // ========== Enum Tests (Original Use Case) ==========

--- a/tests/edge_cases_tests/tests.rs
+++ b/tests/edge_cases_tests/tests.rs
@@ -120,6 +120,28 @@ struct SimpleComplexTest {
         feature = "serde"
     )
 ))]
+// A map value that is itself a map is described at every level: the outer members are inner maps,
+// and those maps' own members carry the value type's schema.
+#[model_schema()]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
+struct NestedStringKeyedMaps {
+    counts_by_group: HashMap<String, HashMap<String, u64>>,
+    labels_by_group: HashMap<String, HashMap<String, String>>,
+    rows_by_group: HashMap<String, Vec<HashMap<String, String>>>,
+    scores_by_group: HashMap<String, HashMap<String, Option<f64>>>,
+    tallies_by_region: HashMap<String, HashMap<String, HashMap<String, u64>>>,
+}
+
+#[cfg(all(
+    test,
+    any(
+        feature = "typescript",
+        feature = "jsonschema",
+        feature = "zod",
+        feature = "serde"
+    )
+))]
 #[model_schema()]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq)]
@@ -156,6 +178,24 @@ fn test_edge_case_structs_constructible() {
         string_to_vec_string: HashMap::new(),
     };
     assert!(original.problematic_map.is_empty());
+    let nested = NestedStringKeyedMaps {
+        counts_by_group: HashMap::new(),
+        labels_by_group: HashMap::from([(
+            "first".to_owned(),
+            HashMap::from([("a".to_owned(), "one".to_owned())]),
+        )]),
+        rows_by_group: HashMap::new(),
+        scores_by_group: HashMap::from([(
+            "first".to_owned(),
+            HashMap::from([("a".to_owned(), None)]),
+        )]),
+        tallies_by_region: HashMap::new(),
+    };
+    assert_eq!(nested.labels_by_group["first"]["a"], "one");
+    assert_eq!(nested.scores_by_group["first"]["a"], None);
+    assert!(nested.counts_by_group.is_empty());
+    assert!(nested.rows_by_group.is_empty());
+    assert!(nested.tallies_by_region.is_empty());
     let simple = SimpleComplexTest {
         nested_map_of_arrays: HashMap::new(),
     };
@@ -386,4 +426,98 @@ fn test_quadruple_nested_maps_compilation_serde() {
     // Check TypeScript contains our fields (exact types may be complex)
     assert!(ts_definition.contains("quadruple_nested"));
     assert!(ts_definition.contains("optional_nested"));
+}
+
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_nested_string_keyed_maps_json_schema() {
+    let schema = NestedStringKeyedMaps::json_schema();
+    let properties = schema["properties"].as_object().unwrap();
+
+    for (field_name, expected_value_schema) in [
+        (
+            "counts_by_group",
+            serde_json::json!({
+                "type": "object",
+                "additionalProperties": { "type": "integer" }
+            }),
+        ),
+        (
+            "labels_by_group",
+            serde_json::json!({
+                "type": "object",
+                "additionalProperties": { "type": "string" }
+            }),
+        ),
+        (
+            "rows_by_group",
+            serde_json::json!({
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "additionalProperties": { "type": "string" }
+                }
+            }),
+        ),
+        (
+            "scores_by_group",
+            serde_json::json!({
+                "type": "object",
+                "additionalProperties": {
+                    "anyOf": [{ "type": "number" }, { "type": "null" }]
+                }
+            }),
+        ),
+        (
+            "tallies_by_region",
+            serde_json::json!({
+                "type": "object",
+                "additionalProperties": {
+                    "type": "object",
+                    "additionalProperties": { "type": "integer" }
+                }
+            }),
+        ),
+    ] {
+        let field = &properties[field_name];
+        assert_eq!(field["type"], "object", "in: {field}");
+        assert_eq!(
+            field["additionalProperties"], expected_value_schema,
+            "in: {field}"
+        );
+    }
+}
+
+/// TypeScript and Zod recurse through a map value on their own, so the nesting they render is the
+/// one the JSON schema now describes — pinned here so the three surfaces stay in step.
+#[test]
+#[cfg(all(feature = "typescript", feature = "zod"))]
+fn test_nested_string_keyed_maps_typescript_and_zod() {
+    let ts_definition = NestedStringKeyedMaps::ts_definition();
+    for expected in [
+        "counts_by_group: Partial<Record<string, Partial<Record<string, number>>>>;",
+        "labels_by_group: Partial<Record<string, Partial<Record<string, string>>>>;",
+        "rows_by_group: Partial<Record<string, Array<Partial<Record<string, string>>>>>;",
+        "scores_by_group: Partial<Record<string, Partial<Record<string, number | null>>>>;",
+        "tallies_by_region: Partial<Record<string, Partial<Record<string, Partial<Record<string, number>>>>>>;",
+    ] {
+        assert!(
+            ts_definition.contains(expected),
+            "missing {expected}, got: {ts_definition}"
+        );
+    }
+
+    let zod_schema = NestedStringKeyedMaps::zod_schema();
+    for expected in [
+        "counts_by_group: z.record(z.string(), z.record(z.string(), z.number().int())),",
+        "labels_by_group: z.record(z.string(), z.record(z.string(), z.string())),",
+        "rows_by_group: z.record(z.string(), z.array(z.record(z.string(), z.string()))),",
+        "scores_by_group: z.record(z.string(), z.record(z.string(), z.nullable(z.number()))),",
+        "tallies_by_region: z.record(z.string(), z.record(z.string(), z.record(z.string(), z.number().int()))),",
+    ] {
+        assert!(
+            zod_schema.contains(expected),
+            "missing {expected}, got: {zod_schema}"
+        );
+    }
 }

--- a/tests/mongodb_real_tests/tests.rs
+++ b/tests/mongodb_real_tests/tests.rs
@@ -38,6 +38,15 @@ struct SlottedRefs {
     by_slot: HashMap<RefSlot, ObjectId>,
 }
 
+// A map value that is itself a map carries the same closed `$oid` object its members would carry
+// one level up.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct NestedRefMaps {
+    ids_by_group: HashMap<String, HashMap<String, ObjectId>>,
+    run_batches: HashMap<String, Vec<HashMap<String, ObjectId>>>,
+}
+
 // Basic struct with real ObjectId
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -220,6 +229,20 @@ fn test_real_objectid_json_schema_structure() {
 }
 
 #[test]
+fn test_nested_ref_maps_constructible() {
+    let oid = ObjectId::new();
+    let nested = NestedRefMaps {
+        ids_by_group: HashMap::from([("first".to_owned(), HashMap::from([("a".to_owned(), oid)]))]),
+        run_batches: HashMap::from([(
+            "first".to_owned(),
+            vec![HashMap::from([("a".to_owned(), oid)])],
+        )]),
+    };
+    assert_eq!(nested.ids_by_group["first"]["a"], oid);
+    assert_eq!(nested.run_batches["first"][0]["a"], oid);
+}
+
+#[test]
 fn test_slotted_refs_constructible() {
     let slotted = SlottedRefs {
         by_slot: HashMap::from([
@@ -254,6 +277,48 @@ fn test_enum_keyed_objectid_map_json_schema() {
         assert_eq!(
             value["required"][0], "$oid",
             "member {member} in: {by_slot}"
+        );
+    }
+}
+
+/// The member schema a nested map carries is the value type's own — for an `ObjectId` the closed
+/// `$oid` object, at whatever depth the map nests.
+#[test]
+#[cfg(all(feature = "object_id", feature = "jsonschema"))]
+fn test_nested_objectid_map_json_schema() {
+    let schema = NestedRefMaps::json_schema();
+    let properties = schema["properties"].as_object().unwrap();
+    let oid_member = serde_json::json!({
+        "type": "object",
+        "properties": { "$oid": { "type": "string" } },
+        "required": ["$oid"],
+        "additionalProperties": false
+    });
+
+    for (field_name, expected_value_schema) in [
+        (
+            "ids_by_group",
+            serde_json::json!({
+                "type": "object",
+                "additionalProperties": oid_member
+            }),
+        ),
+        (
+            "run_batches",
+            serde_json::json!({
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "additionalProperties": oid_member
+                }
+            }),
+        ),
+    ] {
+        let field = &properties[field_name];
+        assert_eq!(field["type"], "object", "in: {field}");
+        assert_eq!(
+            field["additionalProperties"], expected_value_schema,
+            "in: {field}"
         );
     }
 }


### PR DESCRIPTION
Stacked on #40 (stack: #33 → … → #40 → this).

`HashMap<String, HashMap<String, T>>` said nothing about its members (`additionalProperties: true`), and the Vec-of-map inner dispatch widened chrono/StringLiteral/ObjectId the same way. Root structure: four parallel value matches under the String-key dispatcher, each with its own member-schema logic.

- One recursive `build_map_member_schema` now serves every map member; the nested-map arm re-enters it, so nesting resolves at any depth. Six redundant builders deleted — including the three parser-unreachable `Vec`-name builders and their duplicate scalar tables (the fix-one-miss-others breeding ground).
- Tuples stay the only unrenderable value and now fail at any depth instead of widening.
- TS/Zod already recursed; pinned three-deep including chrono and inner-`Option` null flavor. Non-nested tokens byte-identical, all pre-existing pins untouched.

Gates: `just check`, `just lint-all` (68/68), `just test` (full powerset) green.