### PR TITLE
fix: HashSet elements render through the shared type dispatch

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -136,6 +136,19 @@ struct FieldValidationCode {
     pub validate_body: proc_macro2::TokenStream,
 }
 
+/// A map member's rendering with the slot wraps still to apply: a `json!` literal fragment, which
+/// only a caller writing inside `serde_json::json!` can inline, or a standalone `serde_json::Value`
+/// expression, which either caller can take as it stands.
+///
+/// The form rides on the item because the two wrap differently, and a caller that needs a value can
+/// always lift a fragment into one — so one dispatcher serves both the `String`-key path, which
+/// inlines its member as `additionalProperties`, and the enum-key path, which binds it.
+#[cfg(feature = "jsonschema")]
+enum MapMemberItem {
+    Fragment(proc_macro2::TokenStream),
+    Value(proc_macro2::TokenStream),
+}
+
 #[derive(Default, Clone)]
 struct ModelSchemaArgs {
     max_length: Option<usize>,
@@ -155,6 +168,26 @@ struct VariantParts {
     optional_fields: Vec<String>,
     schema_code: String,
     type_code: String,
+}
+
+#[cfg(feature = "jsonschema")]
+impl MapMemberItem {
+    /// The item wrapped for its slot, kept in the form it arrived in.
+    fn into_member_schema(self, value: &FieldDef) -> proc_macro2::TokenStream {
+        match self {
+            Self::Fragment(fragment) => map_member_slot_schema(value, &fragment),
+            Self::Value(item_value) => map_member_slot_value(value, item_value),
+        }
+    }
+
+    /// The item wrapped for its slot as a standalone `serde_json::Value`.
+    fn into_member_value(self, value: &FieldDef) -> proc_macro2::TokenStream {
+        let item_value = match self {
+            Self::Fragment(fragment) => quote! { serde_json::json!(#fragment) },
+            Self::Value(item_value) => item_value,
+        };
+        map_member_slot_value(value, item_value)
+    }
 }
 
 impl ModelSchemaArgs {
@@ -3435,39 +3468,6 @@ fn build_map_nested_map_member_schema(
     Some(quote! { { "type": "object", "additionalProperties": #inner_member } })
 }
 
-/// The member schema for a `String`-keyed map whose value is a sibling/custom type.
-///
-/// The member is the sibling's own schema, as it is in field position and on the enum-key path.
-/// `is_array` and `is_optional` describe the slot rather than the type, so the array and nullable
-/// wraps are applied here over that one schema.
-#[cfg(feature = "jsonschema")]
-fn build_map_sibling_member_schema(
-    value: &FieldDef,
-    value_type_name: &str,
-    value_args: &[FieldDef],
-) -> Option<proc_macro2::TokenStream> {
-    log::trace!(
-        "Map Value SiblingType => value_type_name: {value_type_name}, value_args: {value_args:?}"
-    );
-
-    // The parser collapses `Vec<T>` to `T` with `is_array` set, so a `Vec` type name reaches here
-    // only on a value built by hand: move the array-ness onto the element and dispatch that, which
-    // is the same member schema the collapsed form renders.
-    if value_type_name == "Vec"
-        && let [element] = value_args
-    {
-        let mut arrayed = element.clone();
-        arrayed.is_array = true;
-        return build_map_member_schema(&arrayed);
-    }
-
-    let value_module_ident = sibling_schema_module_ident(value_type_name);
-    Some(nullable_slot_json_schema_value(
-        value,
-        arrayed_json_schema_value(value, quote! { #value_module_ident::Schema::json_schema() }),
-    ))
-}
-
 /// Wraps a member's base schema for the slot it sits in — arrayed when the value is a `Vec`,
 /// nullable when it is an `Option`.
 #[cfg(feature = "jsonschema")]
@@ -3488,8 +3488,38 @@ fn map_member_slot_schema(
     nullable_slot_json_schema(value, &arrayed).unwrap_or(arrayed)
 }
 
-/// The `additionalProperties` schema every member of a `String`-keyed map carries, or `None` when
-/// the value type has no rendering here.
+/// [`map_member_slot_schema`] for a member already materialized as a `serde_json::Value`: each wrap
+/// materializes a value of its own instead of nesting inside the one `serde_json::json!` a literal
+/// fragment sits in.
+#[cfg(feature = "jsonschema")]
+fn map_member_slot_value(
+    value: &FieldDef,
+    item_value: proc_macro2::TokenStream,
+) -> proc_macro2::TokenStream {
+    nullable_slot_json_schema_value(value, arrayed_json_schema_value(value, item_value))
+}
+
+/// The `FieldDef` a map value dispatches as.
+///
+/// The parser collapses `Vec<T>` to `T` with `is_array` set, so a `Vec` type name reaches a map
+/// value only on a value built by hand: moving the array-ness onto the element puts that value in
+/// the one form every parsed `Vec` value already arrives in, at whatever nesting it was written.
+#[cfg(feature = "jsonschema")]
+fn normalized_map_value(value: &FieldDef) -> FieldDef {
+    let mut normalized = value.clone();
+    while let FieldDefType::SiblingType(value_type_name, value_args) = &normalized.field_type
+        && value_type_name == "Vec"
+        && let [element] = value_args.as_slice()
+    {
+        let mut arrayed = element.clone();
+        arrayed.is_array = true;
+        normalized = arrayed;
+    }
+    normalized
+}
+
+/// The rendering every member of a map carries, with the slot wraps left to the caller, or `None`
+/// when the value type has no rendering here.
 ///
 /// A map value is dispatched through this same function, so the members of a nested map carry the
 /// inner value type's own rendering at every depth rather than an open object.
@@ -3497,30 +3527,32 @@ fn map_member_slot_schema(
 /// A tuple is the only value the mapping cannot render, at any depth: the callers turn that `None`
 /// into the single diagnostic naming the field.
 #[cfg(feature = "jsonschema")]
-fn build_map_member_schema(value: &FieldDef) -> Option<proc_macro2::TokenStream> {
-    match &value.field_type {
-        FieldDefType::Map(inner_key, inner_value) => Some(map_member_slot_schema(
-            value,
-            &build_map_nested_map_member_schema(inner_key, inner_value)?,
-        )),
+fn build_map_member_item(value: &FieldDef) -> Option<MapMemberItem> {
+    Some(match &value.field_type {
+        FieldDefType::Map(inner_key, inner_value) => {
+            MapMemberItem::Fragment(build_map_nested_map_member_schema(inner_key, inner_value)?)
+        }
+        // The member is the sibling's own schema, as it is in field position — an expression, not a
+        // literal, so it is already the value form.
         FieldDefType::SiblingType(value_type_name, value_args) => {
-            build_map_sibling_member_schema(value, value_type_name, value_args)
+            log::trace!(
+                "Map Value SiblingType => value_type_name: {value_type_name}, value_args: {value_args:?}"
+            );
+            let value_module_ident = sibling_schema_module_ident(value_type_name);
+            MapMemberItem::Value(quote! { #value_module_ident::Schema::json_schema() })
         }
         // A map member's `$oid` object is closed and unpatterned, where the shared mapping's
         // field-position rendering carries the hex pattern and leaves the object open.
         #[cfg(feature = "object_id")]
-        FieldDefType::ObjectId => Some(map_member_slot_schema(
-            value,
-            &quote! { {
-                "type": "object",
-                "properties": { "$oid": { "type": "string" } },
-                "required": ["$oid"],
-                "additionalProperties": false
-            } },
-        )),
+        FieldDefType::ObjectId => MapMemberItem::Fragment(quote! { {
+            "type": "object",
+            "properties": { "$oid": { "type": "string" } },
+            "required": ["$oid"],
+            "additionalProperties": false
+        } }),
         // An opaque value carries no type name to narrow with, so a member admits any value: the
         // permissive empty schema, as in field position.
-        FieldDefType::Unknown => Some(map_member_slot_schema(value, &quote! { {} })),
+        FieldDefType::Unknown => MapMemberItem::Fragment(quote! { {} }),
         // The shared mapping renders every type named here except a tuple, which is the lone
         // `None`. Named exhaustively rather than caught by a wildcard: a new variant must be given
         // a member schema, not silently widened into an open object.
@@ -3539,19 +3571,35 @@ fn build_map_member_schema(value: &FieldDef) -> Option<proc_macro2::TokenStream>
         | FieldDefType::U16
         | FieldDefType::U32
         | FieldDefType::U64
-        | FieldDefType::Usize => Some(map_member_slot_schema(
-            value,
-            &scalar_field_json_schema_item(value)?,
-        )),
+        | FieldDefType::Usize => MapMemberItem::Fragment(scalar_field_json_schema_item(value)?),
         #[cfg(feature = "chrono")]
         FieldDefType::DateTime
         | FieldDefType::NaiveDate
         | FieldDefType::NaiveDateTime
-        | FieldDefType::NaiveTime => Some(map_member_slot_schema(
-            value,
-            &scalar_field_json_schema_item(value)?,
-        )),
-    }
+        | FieldDefType::NaiveTime => MapMemberItem::Fragment(scalar_field_json_schema_item(value)?),
+    })
+}
+
+/// The `additionalProperties` schema every member of a `String`-keyed map carries, or `None` when
+/// the value type has no rendering here.
+#[cfg(feature = "jsonschema")]
+fn build_map_member_schema(value: &FieldDef) -> Option<proc_macro2::TokenStream> {
+    let normalized = normalized_map_value(value);
+    Some(build_map_member_item(&normalized)?.into_member_schema(&normalized))
+}
+
+/// The one diagnostic a map value the mapping cannot render produces, on either key path.
+///
+/// It replaces the branch's whole output rather than joining it: an emission left in place hands
+/// the author a schema the expansion has already rejected, and on the enum-key path a second error
+/// on the `value_schema` the failed binding never bound — macro-internal state the author cannot
+/// act on. The field and the type are what the author can act on, so the message names both.
+#[cfg(feature = "jsonschema")]
+fn unsupported_map_value_error(field_name_str: &str) -> proc_macro2::TokenStream {
+    let message = format!(
+        "field `{field_name_str}`: a tuple is not supported as a map value — give the value a `#[model_schema()]` struct instead"
+    );
+    quote! { compile_error!(#message); }
 }
 
 /// Builds the JSON schema for a map whose key type is `String`, dispatching on the value type.
@@ -3563,13 +3611,8 @@ fn build_string_key_map_value_schema(
     value: &FieldDef,
     field_name_str: &str,
 ) -> proc_macro2::TokenStream {
-    // Emitted instead of the property insertion, never alongside it: an insertion left in place
-    // hands the author a schema the expansion has already rejected.
     let Some(value_schema) = build_map_member_schema(value) else {
-        let message = format!(
-            "field `{field_name_str}`: a tuple is not supported as a map value — give the value a `#[model_schema()]` struct instead"
-        );
-        return quote! { compile_error!(#message); };
+        return unsupported_map_value_error(field_name_str);
     };
     quote! {
         properties.insert(#field_name_str.to_string(), {
@@ -3581,20 +3624,31 @@ fn build_string_key_map_value_schema(
     }
 }
 
+/// [`build_map_member_item`] for a member of an enum-keyed map, which differs for exactly one value
+/// type: an `ObjectId` member here carries the field-position `$oid` object — patterned, and open —
+/// where a `String`-keyed member carries the closed, unpatterned one. Which of the two a map member
+/// should carry is unsettled, so each key path keeps the rendering it has.
+#[cfg(feature = "jsonschema")]
+fn build_enum_key_map_member_item(value: &FieldDef) -> Option<MapMemberItem> {
+    #[cfg(feature = "object_id")]
+    if matches!(value.field_type, FieldDefType::ObjectId) {
+        return Some(MapMemberItem::Fragment(scalar_field_json_schema_item(
+            value,
+        )?));
+    }
+    build_map_member_item(value)
+}
+
 /// Binds `value_schema` — the JSON schema every member of an enum-keyed map carries — or `None`
 /// when the value type has no rendering here.
+///
+/// The member is the one the `String`-key path renders, materialized as a `serde_json::Value` for
+/// the insertion loop to clone per key, so which values a map may hold is the value type's answer
+/// rather than the key path's.
 #[cfg(feature = "jsonschema")]
 fn build_enum_key_map_value_binding(value: &FieldDef) -> Option<proc_macro2::TokenStream> {
-    let base = if let FieldDefType::SiblingType(value_type_name, value_lst) = &value.field_type
-        && value_lst.is_empty()
-    {
-        let value_module_ident = sibling_schema_module_ident(value_type_name);
-        arrayed_json_schema_value(value, quote! { #value_module_ident::Schema::json_schema() })
-    } else {
-        scalar_field_json_schema_value(value)?
-    };
-
-    let value_schema = nullable_slot_json_schema_value(value, base);
+    let normalized = normalized_map_value(value);
+    let value_schema = build_enum_key_map_member_item(&normalized)?.into_member_value(&normalized);
     Some(quote! { let value_schema = #value_schema; })
 }
 
@@ -3628,11 +3682,8 @@ fn build_map_field_schema(
             let key_type_name_ident =
                 proc_macro2::Ident::new(key_type_name.as_str(), proc_macro2::Span::call_site());
 
-            // The compile_error! replaces the branch's output rather than joining it: left in
-            // place, the insertion loop below reads a `value_schema` the failed binding never
-            // bound, and the author gets a second E0425 naming macro-internal state.
             let Some(value_schema_code) = build_enum_key_map_value_binding(value) else {
-                return quote! { compile_error!("Unsupported map value type"); };
+                return unsupported_map_value_error(field_name_str);
             };
 
             quote! {

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -3886,6 +3886,22 @@ fn build_boolean_field_schema(fld: &FieldDef, field_name_str: &str) -> proc_macr
     }
 }
 
+/// The element of a collection wrapper, as the field the wrapper's own serialization makes it.
+///
+/// A `Vec<T>` and a `HashSet<T>` both write a JSON array of `T`, so the element carries the
+/// array-ness and answers for what the array holds. The field's own constraints ride along: a
+/// `Vec<T>` field applies them to its items, and a generic argument carries none of its own.
+#[cfg(feature = "jsonschema")]
+fn collection_element_field(fld: &FieldDef, element: &FieldDef) -> FieldDef {
+    let mut arrayed = element.clone();
+    arrayed.name.clone_from(&fld.name);
+    arrayed.is_array = true;
+    arrayed
+        .model_schema_prop_meta
+        .clone_from(&fld.model_schema_prop_meta);
+    arrayed
+}
+
 /// Builds the JSON schema for a `SiblingType` field (references to other generated types).
 #[cfg(feature = "jsonschema")]
 fn build_sibling_type_field_schema(
@@ -3895,17 +3911,14 @@ fn build_sibling_type_field_schema(
     lst: &[FieldDef],
 ) -> proc_macro2::TokenStream {
     log::trace!("SiblingType => name: {name}, lst: {lst:?}");
-    if (name == "Vec" || name == "HashSet") && lst.len() == 1 {
-        quote! {
-            properties.insert(#field_name_str.to_string(), {
-                serde_json::json!({
-                    "type": "array",
-                    "items": {
-                        "type": "string", // This would need to be mapped based on inner_type
-                    }
-                })
-            });
-        }
+    // The element is dispatched as the arrayed field it stands for, so a set renders exactly as the
+    // `Vec` of the same element does — element by element, at every type. A parsed `Vec<T>` field
+    // never arrives here, the parser having already handed it over in that arrayed form; a `Vec`
+    // spelled at this position is the same wrapper, and takes the same path.
+    if let [element] = lst
+        && (name == "Vec" || name == "HashSet")
+    {
+        build_field_type_schema(&collection_element_field(fld, element), field_name_str)
     } else if (name == "HashMap" || name == "BTreeMap") && lst.len() == 2 {
         log::trace!("HashMap => field_name: {field_name_str}, lst: {lst:?}");
         quote! {
@@ -4056,17 +4069,18 @@ fn build_unknown_field_schema(fld: &FieldDef, field_name_str: &str) -> proc_macr
     }
 }
 
-/// Builds JSON schema for a field.
+/// The `properties` insertion a field's type produces, without the `required` push.
+///
+/// The name is passed rather than read off `fld`: a collection element is dispatched through here
+/// standing in for the field it is the element of, and inserts under that field's name.
 #[cfg(feature = "jsonschema")]
-fn build_field_schema(fld: &FieldDef) -> proc_macro2::TokenStream {
-    let field_name = &fld.name;
-    let field_name_str = field_name.clone();
+fn build_field_type_schema(fld: &FieldDef, field_name_str: &str) -> proc_macro2::TokenStream {
     let field_type = &fld.field_type;
 
-    let schema_code = match field_type {
-        FieldDefType::String => build_string_field_schema(fld, &field_name_str),
+    match field_type {
+        FieldDefType::String => build_string_field_schema(fld, field_name_str),
         FieldDefType::StringLiteral(literal) => {
-            build_string_literal_field_schema(fld, &field_name_str, literal)
+            build_string_literal_field_schema(fld, field_name_str, literal)
         }
         FieldDefType::U32
         | FieldDefType::U16
@@ -4077,34 +4091,41 @@ fn build_field_schema(fld: &FieldDef) -> proc_macro2::TokenStream {
         | FieldDefType::I32
         | FieldDefType::I64
         | FieldDefType::Usize
-        | FieldDefType::Isize => build_numeric_field_schema(fld, &field_name_str, "integer"),
+        | FieldDefType::Isize => build_numeric_field_schema(fld, field_name_str, "integer"),
         FieldDefType::F32 | FieldDefType::F64 => {
-            build_numeric_field_schema(fld, &field_name_str, "number")
+            build_numeric_field_schema(fld, field_name_str, "number")
         }
-        FieldDefType::Boolean => build_boolean_field_schema(fld, &field_name_str),
+        FieldDefType::Boolean => build_boolean_field_schema(fld, field_name_str),
         #[cfg(feature = "object_id")]
-        FieldDefType::ObjectId => build_object_id_field_schema(fld, &field_name_str),
+        FieldDefType::ObjectId => build_object_id_field_schema(fld, field_name_str),
         #[cfg(feature = "chrono")]
-        FieldDefType::NaiveDate => build_string_format_field_schema(fld, &field_name_str, "date"),
+        FieldDefType::NaiveDate => build_string_format_field_schema(fld, field_name_str, "date"),
         #[cfg(feature = "chrono")]
-        FieldDefType::NaiveTime => build_string_format_field_schema(fld, &field_name_str, "time"),
+        FieldDefType::NaiveTime => build_string_format_field_schema(fld, field_name_str, "time"),
         #[cfg(feature = "chrono")]
         FieldDefType::NaiveDateTime => {
-            build_string_format_field_schema(fld, &field_name_str, "date-time")
+            build_string_format_field_schema(fld, field_name_str, "date-time")
         }
         #[cfg(feature = "chrono")]
         FieldDefType::DateTime => {
-            build_string_format_field_schema(fld, &field_name_str, "date-time")
+            build_string_format_field_schema(fld, field_name_str, "date-time")
         }
         FieldDefType::SiblingType(name, lst) => {
-            build_sibling_type_field_schema(fld, &field_name_str, name, lst)
+            build_sibling_type_field_schema(fld, field_name_str, name, lst)
         }
-        FieldDefType::Map(key, value) => build_map_field_schema(key, value, &field_name_str),
-        FieldDefType::Tuple(lst) => build_tuple_field_schema(fld, &field_name_str, lst),
+        FieldDefType::Map(key, value) => build_map_field_schema(key, value, field_name_str),
+        FieldDefType::Tuple(lst) => build_tuple_field_schema(fld, field_name_str, lst),
         // Named exhaustively rather than caught by a wildcard: a new variant must be given a
         // schema here, not silently routed to whatever the last arm happens to emit.
-        FieldDefType::Unknown => build_unknown_field_schema(fld, &field_name_str),
-    };
+        FieldDefType::Unknown => build_unknown_field_schema(fld, field_name_str),
+    }
+}
+
+/// Builds JSON schema for a field.
+#[cfg(feature = "jsonschema")]
+fn build_field_schema(fld: &FieldDef) -> proc_macro2::TokenStream {
+    let field_name_str = fld.name.clone();
+    let schema_code = build_field_type_schema(fld, &field_name_str);
 
     let required_code = if fld.is_optional {
         quote! {}

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -935,20 +935,159 @@ fn map_field_schema(map_type: &str) -> proc_macro2::TokenStream {
 /// A value type the enum-key branch cannot render must yield the `compile_error!` *instead of* the
 /// per-member insertion loop: leaving the loop in place adds an E0425 on the `value_schema` the
 /// failed arm never bound, and that second error names macro-internal state the author cannot act on.
+/// The diagnostic names the field and the type, as the `String`-key branch's does — a message that
+/// names neither leaves the author nothing to act on.
 #[cfg(feature = "jsonschema")]
 #[test]
 fn an_unsupported_enum_keyed_map_value_emits_only_the_compile_error() {
     for map_type in [
-        "HashMap<Slot, HashMap<String, String>>",
-        "HashMap<Slot, Wrapper<String>>",
         "HashMap<Slot, (String, u32)>",
+        "HashMap<Slot, HashMap<String, (String, u32)>>",
+        "HashMap<Slot, Vec<HashMap<String, (String, u32)>>>",
     ] {
-        assert_eq!(
-            map_field_schema(map_type).to_string(),
-            r#"compile_error ! ("Unsupported map value type") ;"#,
-            "for {map_type}"
+        let tokens = map_field_schema(map_type).to_string();
+        assert!(
+            tokens.starts_with("compile_error !"),
+            "for {map_type}, got: {tokens}"
+        );
+        assert!(
+            !tokens.contains("enum_members"),
+            "for {map_type}, got: {tokens}"
+        );
+        assert!(
+            !tokens.contains("properties . insert"),
+            "for {map_type}, got: {tokens}"
+        );
+        assert!(
+            tokens.contains("field `m`"),
+            "for {map_type}, got: {tokens}"
+        );
+        assert!(
+            tokens.contains("a tuple is not supported as a map value"),
+            "for {map_type}, got: {tokens}"
         );
     }
+}
+
+/// The enum-key branch's binding for a map value built by hand, for the value types no source type
+/// produces.
+#[cfg(feature = "jsonschema")]
+fn enum_key_map_value_binding(field_type: FieldDefType) -> String {
+    let ty: syn::Type = syn::parse_str("String").unwrap();
+    let mut value = super::get_field_def("m", &ty, "");
+    value.field_type = field_type;
+    super::build_enum_key_map_value_binding(&value)
+        .unwrap()
+        .to_string()
+}
+
+/// A key that enumerates its members says nothing about what each member holds, so an enum-keyed
+/// member is the member the `String`-key path renders — materialized as a `serde_json::Value` for
+/// the insertion loop, and recursing to the same depth.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_nested_enum_keyed_map_value_renders_its_inner_members() {
+    for (map_type, expected) in [
+        (
+            "HashMap<Slot, HashMap<String, String>>",
+            r#"serde_json :: json ! ({ "type" : "object" , "additionalProperties" : { "type" : "string" } })"#,
+        ),
+        (
+            "HashMap<Slot, HashMap<String, Vec<u64>>>",
+            r#"serde_json :: json ! ({ "type" : "object" , "additionalProperties" : { "type" : "array" , "items" : { "type" : "integer" } } })"#,
+        ),
+        (
+            "HashMap<Slot, HashMap<String, HashMap<String, f64>>>",
+            r#"serde_json :: json ! ({ "type" : "object" , "additionalProperties" : { "type" : "object" , "additionalProperties" : { "type" : "number" } } })"#,
+        ),
+        (
+            "HashMap<Slot, HashMap<String, Inner>>",
+            r#"serde_json :: json ! ({ "type" : "object" , "additionalProperties" : inner_schema :: Schema :: json_schema () })"#,
+        ),
+        (
+            "HashMap<Slot, Vec<HashMap<String, String>>>",
+            r#"serde_json :: json ! ({ "type" : "array" , "items" : serde_json :: json ! ({ "type" : "object" , "additionalProperties" : { "type" : "string" } }) })"#,
+        ),
+        (
+            "HashMap<Slot, Option<HashMap<String, String>>>",
+            r#"serde_json :: json ! ({ "anyOf" : [serde_json :: json ! ({ "type" : "object" , "additionalProperties" : { "type" : "string" } }) , { "type" : "null" }] })"#,
+        ),
+    ] {
+        let tokens = map_field_schema(map_type).to_string();
+        assert!(
+            tokens.contains(&format!("let value_schema = {expected} ;")),
+            "for {map_type}, got: {tokens}"
+        );
+        assert!(
+            tokens.contains("Slot :: enum_members ()"),
+            "for {map_type}, got: {tokens}"
+        );
+    }
+}
+
+/// A generic sibling is a map value the `String`-key path renders through its schema module, so the
+/// enum-key path renders it there too.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_generic_sibling_enum_keyed_map_value_emits_the_sibling_schema() {
+    let tokens = map_field_schema("HashMap<Slot, Wrapper<String>>").to_string();
+    assert!(
+        tokens.contains("let value_schema = wrapper_schema :: Schema :: json_schema () ;"),
+        "got: {tokens}"
+    );
+}
+
+/// An opaque value has no type name to narrow with on either key path, so the member stays
+/// permissive rather than collapsing the whole field to a diagnostic.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn an_opaque_enum_keyed_map_value_stays_permissive() {
+    let tokens = enum_key_map_value_binding(FieldDefType::Unknown);
+    assert_eq!(tokens, "let value_schema = serde_json :: json ! ({ }) ;");
+}
+
+/// A string literal keeps the `const` it carries on the `String`-key path.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_string_literal_enum_keyed_map_value_keeps_its_const() {
+    let tokens = enum_key_map_value_binding(FieldDefType::StringLiteral("Tixena".to_owned()));
+    assert_eq!(
+        tokens,
+        r#"let value_schema = serde_json :: json ! ({ "type" : "string" , "const" : "Tixena" }) ;"#
+    );
+}
+
+/// A chrono value keeps the format it carries in field position, as it does under a `String` key.
+#[cfg(all(feature = "chrono", feature = "jsonschema"))]
+#[test]
+fn a_chrono_enum_keyed_map_value_keeps_its_format() {
+    for (map_type, format) in [
+        ("HashMap<Slot, NaiveDate>", "date"),
+        ("HashMap<Slot, NaiveTime>", "time"),
+        ("HashMap<Slot, NaiveDateTime>", "date-time"),
+        ("HashMap<Slot, DateTime<Utc>>", "date-time"),
+    ] {
+        let tokens = map_field_schema(map_type).to_string();
+        assert!(
+            tokens.contains(&format!(
+                r#"let value_schema = serde_json :: json ! ({{ "type" : "string" , "format" : "{format}" }}) ;"#
+            )),
+            "for {map_type}, got: {tokens}"
+        );
+    }
+}
+
+/// An `ObjectId` is the one value the two key paths spell differently: a `String`-keyed member
+/// carries a closed, unpatterned `$oid` object where an enum-keyed member carries the field-position
+/// form. Pinned so the divergence stays a decision rather than a drift.
+#[cfg(all(feature = "object_id", feature = "jsonschema"))]
+#[test]
+fn an_object_id_enum_keyed_map_value_keeps_the_field_position_oid_object() {
+    let tokens = enum_key_map_value_binding(FieldDefType::ObjectId);
+    assert_eq!(
+        tokens,
+        r#"let value_schema = serde_json :: json ! ({ "type" : "object" , "properties" : { "$oid" : { "type" : "string" , "pattern" : "^[a-f\\d]{24}$" } } , "required" : ["$oid"] }) ;"#
+    );
 }
 
 #[cfg(feature = "jsonschema")]

--- a/tests/collection_tests/tests.rs
+++ b/tests/collection_tests/tests.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use tixschema::model_schema;
 
 // Test comprehensive HashMap scenarios with various value types
@@ -123,6 +123,44 @@ struct UserWithCollections {
     metadata: HashMap<String, String>,
     scores: Vec<u32>,
     tags: Vec<String>,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+struct MetricTag {
+    label: String,
+}
+
+/// An alias of a set element: the element's schema module is named after the registered export
+/// name, so the reference has to be resolved through the registry rather than from the ident.
+#[model_schema()]
+type MetricTagRef = MetricTag;
+
+// A `HashSet<T>` and a `Vec<T>` both serialize as a JSON array of `T`, so the element decides what
+// the array holds on either one. The twin structs below carry the same element types under both
+// spellings; the tests hold every field of one against its twin.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct SetElementFields {
+    aliased_tags: HashSet<MetricTagRef>,
+    big_ids: HashSet<u64>,
+    #[model_schema_prop(minLength = 3)]
+    constrained_labels: HashSet<String>,
+    labels: HashSet<String>,
+    sibling_tags: HashSet<MetricTag>,
+    small_ids: HashSet<u32>,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct VecElementFields {
+    aliased_tags: Vec<MetricTagRef>,
+    big_ids: Vec<u64>,
+    #[model_schema_prop(minLength = 3)]
+    constrained_labels: Vec<String>,
+    labels: Vec<String>,
+    sibling_tags: Vec<MetricTag>,
+    small_ids: Vec<u32>,
 }
 
 #[cfg(feature = "jsonschema")]
@@ -955,4 +993,126 @@ fn test_hashmap_with_64bit_ts_definition() {
     assert!(zod_schema.contains("u64_map: z.record(z.string(), z.number().int())"));
     assert!(zod_schema.contains("i64_map: z.record(z.string(), z.number().int())"));
     assert!(zod_schema.contains("mixed_map: z.record(z.string(), z.array(z.number().int()))"));
+}
+
+#[test]
+fn test_element_fields_constructible_under_both_spellings() {
+    let tag = MetricTag {
+        label: "a".to_owned(),
+    };
+    let sets = SetElementFields {
+        aliased_tags: HashSet::from([tag.clone()]),
+        big_ids: HashSet::from([9_u64]),
+        constrained_labels: HashSet::from(["abc".to_owned()]),
+        labels: HashSet::from(["t".to_owned()]),
+        sibling_tags: HashSet::from([tag.clone()]),
+        small_ids: HashSet::from([7_u32]),
+    };
+    assert!(sets.small_ids.contains(&7));
+    assert!(sets.big_ids.contains(&9));
+
+    let vecs = VecElementFields {
+        aliased_tags: vec![tag.clone()],
+        big_ids: vec![9],
+        constrained_labels: vec!["abc".to_owned()],
+        labels: vec!["t".to_owned()],
+        sibling_tags: vec![tag],
+        small_ids: vec![7],
+    };
+    assert_eq!(vecs.small_ids, [7]);
+    assert_eq!(vecs.big_ids, [9]);
+}
+
+/// A set writes a JSON array of its element, so the element decides what the array holds — the
+/// hardcoded `string` items every set once carried described only the sets of strings.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_set_element_json_schema() {
+    let sets = SetElementFields {
+        aliased_tags: HashSet::new(),
+        big_ids: HashSet::from([9_u64]),
+        constrained_labels: HashSet::new(),
+        labels: HashSet::new(),
+        sibling_tags: HashSet::new(),
+        small_ids: HashSet::from([7_u32]),
+    };
+    let payload = serde_json::to_value(&sets).unwrap();
+    let schema = SetElementFields::json_schema();
+    let properties = schema["properties"].as_object().unwrap();
+
+    for numeric in ["big_ids", "small_ids"] {
+        let field = &properties[numeric];
+        assert_eq!(
+            field["type"],
+            json_type_name(&payload[numeric]),
+            "in: {field}"
+        );
+        assert_eq!(
+            field["items"],
+            serde_json::json!({ "type": "integer" }),
+            "in: {field}"
+        );
+    }
+
+    assert_eq!(
+        properties["labels"],
+        serde_json::json!({ "type": "array", "items": { "type": "string" } })
+    );
+
+    // A constraint written on the field constrains what the array holds, there being nothing else
+    // for it to reach — the element is where it lands, as it does on the `Vec` spelling.
+    assert_eq!(
+        properties["constrained_labels"],
+        serde_json::json!({
+            "type": "array",
+            "items": { "type": "string", "minLength": 3_u32 }
+        })
+    );
+
+    assert_eq!(
+        properties["sibling_tags"]["items"],
+        MetricTag::json_schema(),
+        "in: {}",
+        properties["sibling_tags"]
+    );
+}
+
+/// A `HashSet<T>` and a `Vec<T>` serialize alike, so they describe alike — element by element, at
+/// every element type. An alias element is the case the naming cannot be guessed for: its schema
+/// module is the registered one, which is why the twin below compiles at all.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_set_elements_render_as_vec_elements() {
+    let set_schema = SetElementFields::json_schema();
+    let vec_schema = VecElementFields::json_schema();
+
+    assert_eq!(set_schema["properties"], vec_schema["properties"]);
+    assert_eq!(set_schema["required"], vec_schema["required"]);
+}
+
+/// The TypeScript and Zod surfaces write the Rust container name through verbatim — `HashSet<T>` is
+/// neither a TypeScript type nor a Zod schema expression. Pinned as it stands so that the JSON
+/// schema agreeing with `Vec` is not read as those two having been settled with it.
+#[test]
+#[cfg(all(feature = "typescript", feature = "zod"))]
+fn test_set_element_typescript_generation() {
+    let ts_definition = SetElementFields::ts_definition();
+    for spelling in [
+        "aliased_tags: HashSet<MetricTagRefType>;",
+        "sibling_tags: HashSet<MetricTag>;",
+        "labels: HashSet<string>;",
+        "small_ids: HashSet<number>;",
+    ] {
+        assert!(ts_definition.contains(spelling), "Got: {ts_definition}");
+    }
+
+    let zod_schema = SetElementFields::zod_schema();
+    for spelling in [
+        "aliased_tags: HashSet<MetricTagRefType>,",
+        "sibling_tags: HashSet<MetricTag>,",
+        "labels: HashSet<string>,",
+        "small_ids: HashSet<number>,",
+    ] {
+        assert!(zod_schema.contains(spelling), "Got: {zod_schema}");
+    }
 }

--- a/tests/collection_tests/tests.rs
+++ b/tests/collection_tests/tests.rs
@@ -63,6 +63,27 @@ struct EnumKeyedSiblingValueMaps {
     sample_value: HashMap<MetricSlot, MetricSample>,
 }
 
+// A key that enumerates its members says nothing about what each member holds, so a value that is
+// itself a map is described at every level here exactly as it is under the String key of the twin
+// below — the key path decides which keys exist, never which values are renderable.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct EnumKeyedNestedMapValues {
+    counts: HashMap<MetricSlot, HashMap<String, u64>>,
+    labels: HashMap<MetricSlot, HashMap<String, String>>,
+    rows: HashMap<MetricSlot, Vec<HashMap<String, String>>>,
+    samples: HashMap<MetricSlot, HashMap<String, MetricSample>>,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct StringKeyedNestedMapValues {
+    counts: HashMap<String, HashMap<String, u64>>,
+    labels: HashMap<String, HashMap<String, String>>,
+    rows: HashMap<String, Vec<HashMap<String, String>>>,
+    samples: HashMap<String, HashMap<String, MetricSample>>,
+}
+
 // A String key enumerates nothing, so one `additionalProperties` schema stands for every member —
 // and it is the value type's own, which is what the enum-keyed twin above spells out per key.
 #[model_schema()]
@@ -501,6 +522,124 @@ fn test_enum_keyed_sibling_array_member_matches_the_serialized_form() {
         json_type_name(&serde_json::to_value(&sample).unwrap()),
         "in: {member}"
     );
+}
+
+#[test]
+fn test_nested_map_values_constructible_on_both_key_paths() {
+    let enum_keyed = EnumKeyedNestedMapValues {
+        counts: HashMap::new(),
+        labels: HashMap::from([(
+            MetricSlot::Daily,
+            HashMap::from([("a".to_owned(), "one".to_owned())]),
+        )]),
+        rows: HashMap::new(),
+        samples: HashMap::new(),
+    };
+    assert_eq!(enum_keyed.labels[&MetricSlot::Daily]["a"], "one");
+
+    let string_keyed = StringKeyedNestedMapValues {
+        counts: HashMap::new(),
+        labels: HashMap::from([(
+            "daily".to_owned(),
+            HashMap::from([("a".to_owned(), "one".to_owned())]),
+        )]),
+        rows: HashMap::new(),
+        samples: HashMap::new(),
+    };
+    assert_eq!(string_keyed.labels["daily"]["a"], "one");
+}
+
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_enum_keyed_nested_map_values_json_schema() {
+    let schema = EnumKeyedNestedMapValues::json_schema();
+    let properties = schema["properties"].as_object().unwrap();
+
+    assert_enum_keyed_map_value(
+        properties,
+        "counts",
+        &serde_json::json!({
+            "type": "object",
+            "additionalProperties": { "type": "integer" }
+        }),
+    );
+    assert_enum_keyed_map_value(
+        properties,
+        "labels",
+        &serde_json::json!({
+            "type": "object",
+            "additionalProperties": { "type": "string" }
+        }),
+    );
+    assert_enum_keyed_map_value(
+        properties,
+        "rows",
+        &serde_json::json!({
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": { "type": "string" }
+            }
+        }),
+    );
+    assert_enum_keyed_map_value(
+        properties,
+        "samples",
+        &serde_json::json!({
+            "type": "object",
+            "additionalProperties": MetricSample::json_schema()
+        }),
+    );
+}
+
+/// Both key paths render a map value through the same member dispatcher, so the member an enum key
+/// spells out per key and the one a `String` key states once are the same schema — the twin types
+/// hold that to the value types, field by field.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_enum_keyed_nested_map_values_match_their_string_keyed_members() {
+    let string_keyed = StringKeyedNestedMapValues::json_schema();
+    let enum_keyed = EnumKeyedNestedMapValues::json_schema();
+    let properties = enum_keyed["properties"].as_object().unwrap();
+
+    for field_name in ["counts", "labels", "rows", "samples"] {
+        let member = &string_keyed["properties"][field_name]["additionalProperties"];
+        assert_ne!(*member, serde_json::json!(true), "for {field_name}");
+        assert_enum_keyed_map_value(properties, field_name, member);
+    }
+}
+
+/// TypeScript and Zod recurse through a map value whatever the key is, so the nesting they render
+/// under an enum key is the one the JSON schema now describes — pinned so the three surfaces stay
+/// in step.
+#[test]
+#[cfg(all(feature = "typescript", feature = "zod"))]
+fn test_enum_keyed_nested_map_values_typescript_generation() {
+    let ts_definition = EnumKeyedNestedMapValues::ts_definition();
+    for expected in [
+        "counts: Partial<Record<MetricSlot, Partial<Record<string, number>>>>;",
+        "labels: Partial<Record<MetricSlot, Partial<Record<string, string>>>>;",
+        "rows: Partial<Record<MetricSlot, Array<Partial<Record<string, string>>>>>;",
+        "samples: Partial<Record<MetricSlot, Partial<Record<string, MetricSample>>>>;",
+    ] {
+        assert!(
+            ts_definition.contains(expected),
+            "missing {expected}, got: {ts_definition}"
+        );
+    }
+
+    let zod_schema = EnumKeyedNestedMapValues::zod_schema();
+    for expected in [
+        "counts: z.record(MetricSlot$Schema, z.record(z.string(), z.number().int())),",
+        "labels: z.record(MetricSlot$Schema, z.record(z.string(), z.string())),",
+        "rows: z.record(MetricSlot$Schema, z.array(z.record(z.string(), z.string()))),",
+        "samples: z.record(MetricSlot$Schema, z.record(z.string(), MetricSample$Schema)),",
+    ] {
+        assert!(
+            zod_schema.contains(expected),
+            "missing {expected}, got: {zod_schema}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
Stacked on #42 (stack: #33 → … → #42 → this).

`HashSet<u32>` emitted `{"type":"array","items":{"type":"string"}}` — the `(Vec|HashSet)` sibling branch hardcoded string items and threw the element `FieldDef` away. Collapse-check finding (recorded before fixing): the parser collapses one-argument `Vec` into `is_array`, so the branch's `Vec` half was dead — only `HashSet` ever fired it, which is why non-String elements went unnoticed.

- The element re-enters the full per-type dispatch (`build_field_type_schema` split from its `required`-push wrapper, taking the field name as a parameter), so `HashSet<T>` renders exactly as `Vec<T>` — twin fixtures assert property-for-property equality across six element types, with meta propagation (`minLength`) separately verified red.
- `HashSet<String>` pinned byte-for-byte at its previous output; TS/Zod pinned as they stand (their own `HashSet` verbatim-passthrough defect is filed separately).

Gates: `just check`, `just lint-all` (68/68), `just test` (full powerset) green.