### PR TITLE
fix: set wrappers render array forms on TypeScript and Zod

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ pub struct UserWithOptionals {
 
 ### Collections and Maps
 
-`Vec<T>` becomes `Array<T>`. Only `HashMap<String, T>` is supported (non-string keys will cause compilation errors).
+`Vec<T>` becomes `Array<T>`, and so does `HashSet<T>`: a set is written as a JSON array of its element, so it is typed and validated as that array. Only `HashMap<String, T>` is supported (non-string keys will cause compilation errors).
 
 ```rust
 use std::collections::HashMap;

--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -160,6 +160,22 @@ pub struct FieldDef {
 }
 
 impl FieldDef {
+    /// The element of a collection wrapper, as the field the wrapper's own serialization makes it.
+    ///
+    /// A `Vec<T>` and a set of `T` both write a JSON array of `T`, so the element carries the
+    /// array-ness and answers for what the array holds. The field's own constraints ride along:
+    /// they have nothing but the element to land on, exactly as on the `Vec` spelling, which the
+    /// parser hands over already collapsed onto its element.
+    pub fn collection_element_field(&self, element: &Self) -> Self {
+        let mut arrayed = element.clone();
+        arrayed.name.clone_from(&self.name);
+        arrayed.is_array = true;
+        arrayed
+            .model_schema_prop_meta
+            .clone_from(&self.model_schema_prop_meta);
+        arrayed
+    }
+
     #[cfg(feature = "zod")]
     /// Checks if this field contains a reference to the given type name.
     ///
@@ -307,7 +323,13 @@ impl FieldDef {
                 format!("[{elements}]")
             }
             FieldDefType::SiblingType(name, lst) => {
-                if let Some(info) = lookup_alias_info(name) {
+                if let [element] = lst.as_slice()
+                    && is_set_wrapper(name)
+                {
+                    // The element re-enters the whole per-type rendering as the arrayed field it
+                    // stands for, so a set renders exactly as the `Vec` of that element does.
+                    self.collection_element_field(element).typescript_base()
+                } else if let Some(info) = lookup_alias_info(name) {
                     if lst.is_empty() {
                         info.export_name
                     } else {
@@ -424,11 +446,13 @@ impl FieldDef {
         }
     }
 
-    /// Builds the Zod schema before the struct-field optional wrap: the type match, the
-    /// `is_array` wrap, and the preprocess wrap. The
-    /// `z.union([…, z.undefined()]).prefault(undefined)` wrap lives in `zod_type`.
+    /// The type match plus the `is_array` wrap, before the preprocess wrap.
+    ///
+    /// A set's element re-enters the rendering here rather than at `zod_base`: it carries a copy of
+    /// the field's own metadata, and the preprocess wrap belongs once, outside the array — where
+    /// the `Vec` spelling of the same field puts it.
     #[cfg(feature = "zod")]
-    fn zod_base(&self) -> String {
+    fn zod_array_base(&self) -> String {
         let result = match &self.field_type {
             FieldDefType::Unknown => "z.unknown()".to_owned(),
             FieldDefType::Tuple(lst) => {
@@ -440,7 +464,11 @@ impl FieldDef {
                 format!("z.tuple([{elements}])")
             }
             FieldDefType::SiblingType(name, lst) => {
-                if let Some(info) = lookup_alias_info(name) {
+                if let [element] = lst.as_slice()
+                    && is_set_wrapper(name)
+                {
+                    self.collection_element_field(element).zod_array_base()
+                } else if let Some(info) = lookup_alias_info(name) {
                     // Always reference the $Schema, regardless of generic params.
                     // For branded wrappers like DocumentTypeId<String>, the Zod
                     // schema is defined on the wrapper itself.
@@ -491,11 +519,19 @@ impl FieldDef {
                 }
             }
         };
-        let array_result = if self.is_array {
+        if self.is_array {
             format!("z.array({result})")
         } else {
             result
-        };
+        }
+    }
+
+    /// Builds the Zod schema before the struct-field optional wrap: the type match, the
+    /// `is_array` wrap, and the preprocess wrap. The
+    /// `z.union([…, z.undefined()]).prefault(undefined)` wrap lives in `zod_type`.
+    #[cfg(feature = "zod")]
+    fn zod_base(&self) -> String {
+        let array_result = self.zod_array_base();
 
         // Wrap with preprocess if specified
         if let Some(meta) = &self.model_schema_prop_meta
@@ -590,6 +626,14 @@ impl FieldDef {
             pre_result
         }
     }
+}
+
+/// The std set wrappers, which each write a JSON array of their element.
+///
+/// `Vec` is absent because it never reaches a wrapper name: the parser collapses it onto its
+/// element with `is_array` set, long before anything asks what the wrapper is called.
+fn is_set_wrapper(name: &str) -> bool {
+    matches!(name, "BTreeSet" | "HashSet")
 }
 
 /// Classifies a `syn::Variant` into its `VariantKind`.
@@ -943,3 +987,6 @@ fn handle_datetime_generic_type(safe_name: String, field_docs: &str) -> FieldDef
         model_schema_prop_meta: None,
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/field_type/tests.rs
+++ b/src/field_type/tests.rs
@@ -1,0 +1,140 @@
+use super::{FieldDef, FieldDefType};
+
+/// The wrappers whose fields write a JSON array of their element. Rendered here directly rather
+/// than through a fixture, since a `BTreeSet` field does not yet reach every surface.
+const SET_WRAPPERS: [&str; 2] = ["BTreeSet", "HashSet"];
+
+fn field(field_type: FieldDefType) -> FieldDef {
+    FieldDef {
+        array_num: None,
+        docs: String::new(),
+        field_type,
+        is_array: false,
+        is_optional: false,
+        model_schema_prop_meta: None,
+        name: "items".to_owned(),
+    }
+}
+
+fn set_of(wrapper: &str, element: FieldDefType) -> FieldDef {
+    field(FieldDefType::SiblingType(
+        wrapper.to_owned(),
+        vec![field(element)],
+    ))
+}
+
+#[test]
+fn test_set_wrappers_render_as_typescript_arrays() {
+    for wrapper in SET_WRAPPERS {
+        assert_eq!(
+            set_of(wrapper, FieldDefType::U32).typescript_typename(),
+            "Array<number>",
+            "for: {wrapper}"
+        );
+        assert_eq!(
+            set_of(wrapper, FieldDefType::String).typescript_typename(),
+            "Array<string>",
+            "for: {wrapper}"
+        );
+        assert_eq!(
+            set_of(
+                wrapper,
+                FieldDefType::SiblingType("MetricTag".to_owned(), vec![])
+            )
+            .typescript_typename(),
+            "Array<MetricTag>",
+            "for: {wrapper}"
+        );
+    }
+}
+
+#[test]
+#[cfg(feature = "zod")]
+fn test_set_wrappers_render_as_zod_arrays() {
+    for wrapper in SET_WRAPPERS {
+        assert_eq!(
+            set_of(wrapper, FieldDefType::U32).zod_type(),
+            "z.array(z.number().int())",
+            "for: {wrapper}"
+        );
+        assert_eq!(
+            set_of(wrapper, FieldDefType::String).zod_type(),
+            "z.array(z.string())",
+            "for: {wrapper}"
+        );
+        assert_eq!(
+            set_of(
+                wrapper,
+                FieldDefType::SiblingType("MetricTag".to_owned(), vec![])
+            )
+            .zod_type(),
+            "z.array(MetricTag$Schema)",
+            "for: {wrapper}"
+        );
+    }
+}
+
+/// A slot — a tuple element or a map entry — holds the same array a field does, and an `Option`
+/// there is the null-flavored one the slot always uses, applied to that array rather than inside it.
+#[test]
+fn test_set_in_a_slot_renders_as_the_array_it_writes() {
+    for wrapper in SET_WRAPPERS {
+        let set = set_of(wrapper, FieldDefType::String);
+        assert_eq!(
+            set.typescript_slot_typename(),
+            "Array<string>",
+            "for: {wrapper}"
+        );
+        #[cfg(feature = "zod")]
+        assert_eq!(set.zod_slot_type(), "z.array(z.string())", "for: {wrapper}");
+
+        let mut optional = set;
+        optional.is_optional = true;
+        assert_eq!(
+            optional.typescript_slot_typename(),
+            "Array<string> | null",
+            "for: {wrapper}"
+        );
+        #[cfg(feature = "zod")]
+        assert_eq!(
+            optional.zod_slot_type(),
+            "z.nullable(z.array(z.string()))",
+            "for: {wrapper}"
+        );
+    }
+}
+
+/// A set inside a `Vec` is two arrays on the wire, so it is two on the surfaces: the wrapper's own
+/// array wrap is the element's, and the field it sits in keeps the wrap the parser gave it.
+#[test]
+fn test_set_within_an_array_field_nests_both_wraps() {
+    for wrapper in SET_WRAPPERS {
+        let mut nested = set_of(wrapper, FieldDefType::U32);
+        nested.is_array = true;
+        assert_eq!(
+            nested.typescript_typename(),
+            "Array<Array<number>>",
+            "for: {wrapper}"
+        );
+        #[cfg(feature = "zod")]
+        assert_eq!(
+            nested.zod_type(),
+            "z.array(z.array(z.number().int()))",
+            "for: {wrapper}"
+        );
+    }
+}
+
+/// An `Option` around a set is the field's own, not the array's: the wrapper answers for what the
+/// array holds and nothing about whether the key is there.
+#[test]
+fn test_optional_set_field_keeps_the_field_level_optionality() {
+    let mut optional = set_of("HashSet", FieldDefType::String);
+    optional.is_optional = true;
+    assert_eq!(optional.typescript_typename(), "Array<string> | undefined");
+    #[cfg(feature = "zod")]
+    assert_eq!(
+        optional.zod_type(),
+        "z.union([z.array(z.string()), z.undefined()]).prefault(undefined)"
+    );
+}

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -3886,22 +3886,6 @@ fn build_boolean_field_schema(fld: &FieldDef, field_name_str: &str) -> proc_macr
     }
 }
 
-/// The element of a collection wrapper, as the field the wrapper's own serialization makes it.
-///
-/// A `Vec<T>` and a `HashSet<T>` both write a JSON array of `T`, so the element carries the
-/// array-ness and answers for what the array holds. The field's own constraints ride along: a
-/// `Vec<T>` field applies them to its items, and a generic argument carries none of its own.
-#[cfg(feature = "jsonschema")]
-fn collection_element_field(fld: &FieldDef, element: &FieldDef) -> FieldDef {
-    let mut arrayed = element.clone();
-    arrayed.name.clone_from(&fld.name);
-    arrayed.is_array = true;
-    arrayed
-        .model_schema_prop_meta
-        .clone_from(&fld.model_schema_prop_meta);
-    arrayed
-}
-
 /// Builds the JSON schema for a `SiblingType` field (references to other generated types).
 #[cfg(feature = "jsonschema")]
 fn build_sibling_type_field_schema(
@@ -3918,7 +3902,7 @@ fn build_sibling_type_field_schema(
     if let [element] = lst
         && (name == "Vec" || name == "HashSet")
     {
-        build_field_type_schema(&collection_element_field(fld, element), field_name_str)
+        build_field_type_schema(&fld.collection_element_field(element), field_name_str)
     } else if (name == "HashMap" || name == "BTreeMap") && lst.len() == 2 {
         log::trace!("HashMap => field_name: {field_name_str}, lst: {lst:?}");
         quote! {

--- a/tests/collection_tests/tests.rs
+++ b/tests/collection_tests/tests.rs
@@ -147,6 +147,8 @@ struct SetElementFields {
     #[model_schema_prop(minLength = 3)]
     constrained_labels: HashSet<String>,
     labels: HashSet<String>,
+    #[model_schema_prop(preprocess = ["trim"])]
+    preprocessed_labels: HashSet<String>,
     sibling_tags: HashSet<MetricTag>,
     small_ids: HashSet<u32>,
 }
@@ -159,6 +161,8 @@ struct VecElementFields {
     #[model_schema_prop(minLength = 3)]
     constrained_labels: Vec<String>,
     labels: Vec<String>,
+    #[model_schema_prop(preprocess = ["trim"])]
+    preprocessed_labels: Vec<String>,
     sibling_tags: Vec<MetricTag>,
     small_ids: Vec<u32>,
 }
@@ -1005,6 +1009,7 @@ fn test_element_fields_constructible_under_both_spellings() {
         big_ids: HashSet::from([9_u64]),
         constrained_labels: HashSet::from(["abc".to_owned()]),
         labels: HashSet::from(["t".to_owned()]),
+        preprocessed_labels: HashSet::from(["t".to_owned()]),
         sibling_tags: HashSet::from([tag.clone()]),
         small_ids: HashSet::from([7_u32]),
     };
@@ -1016,6 +1021,7 @@ fn test_element_fields_constructible_under_both_spellings() {
         big_ids: vec![9],
         constrained_labels: vec!["abc".to_owned()],
         labels: vec!["t".to_owned()],
+        preprocessed_labels: vec!["t".to_owned()],
         sibling_tags: vec![tag],
         small_ids: vec![7],
     };
@@ -1033,6 +1039,7 @@ fn test_set_element_json_schema() {
         big_ids: HashSet::from([9_u64]),
         constrained_labels: HashSet::new(),
         labels: HashSet::new(),
+        preprocessed_labels: HashSet::new(),
         sibling_tags: HashSet::new(),
         small_ids: HashSet::from([7_u32]),
     };
@@ -1090,29 +1097,69 @@ fn test_set_elements_render_as_vec_elements() {
     assert_eq!(set_schema["required"], vec_schema["required"]);
 }
 
-/// The TypeScript and Zod surfaces write the Rust container name through verbatim — `HashSet<T>` is
-/// neither a TypeScript type nor a Zod schema expression. Pinned as it stands so that the JSON
-/// schema agreeing with `Vec` is not read as those two having been settled with it.
+/// A set writes a JSON array of its element, so the TypeScript type is the array of whatever the
+/// element renders as — the Rust container name is not a TypeScript type at all. The aliased
+/// element is the case the naming cannot be guessed for: it resolves through the registry.
 #[test]
-#[cfg(all(feature = "typescript", feature = "zod"))]
+#[cfg(feature = "typescript")]
 fn test_set_element_typescript_generation() {
     let ts_definition = SetElementFields::ts_definition();
     for spelling in [
-        "aliased_tags: HashSet<MetricTagRefType>;",
-        "sibling_tags: HashSet<MetricTag>;",
-        "labels: HashSet<string>;",
-        "small_ids: HashSet<number>;",
+        "aliased_tags: Array<MetricTagRefType>;",
+        "big_ids: Array<number>;",
+        "constrained_labels: Array<string>;",
+        "labels: Array<string>;",
+        "preprocessed_labels: Array<string>;",
+        "sibling_tags: Array<MetricTag>;",
+        "small_ids: Array<number>;",
     ] {
         assert!(ts_definition.contains(spelling), "Got: {ts_definition}");
     }
+}
 
+/// The Zod schema of a set is the array schema of its element, constraints and all — the container
+/// name is not a Zod expression, and an element schema is what `z.array` has to be handed.
+#[test]
+#[cfg(feature = "zod")]
+fn test_set_element_zod_generation() {
     let zod_schema = SetElementFields::zod_schema();
     for spelling in [
-        "aliased_tags: HashSet<MetricTagRefType>,",
-        "sibling_tags: HashSet<MetricTag>,",
-        "labels: HashSet<string>,",
-        "small_ids: HashSet<number>,",
+        "aliased_tags: z.array(MetricTagRefType$Schema),",
+        "big_ids: z.array(z.number().int()),",
+        "constrained_labels: z.array(z.string().min(3)),",
+        "labels: z.array(z.string()),",
+        // The preprocess wrap belongs once, outside the array — where the `Vec` spelling puts it.
+        "preprocessed_labels: z.preprocess(trim, z.array(z.string())),",
+        "sibling_tags: z.array(MetricTag$Schema),",
+        "small_ids: z.array(z.number().int()),",
     ] {
         assert!(zod_schema.contains(spelling), "Got: {zod_schema}");
     }
+}
+
+/// Whatever a set field renders as, it is not the Rust wrapper's name: neither surface has any
+/// meaning for it, so the name surviving anywhere into the output is a syntax error in the output.
+#[test]
+#[cfg(any(feature = "typescript", feature = "zod"))]
+fn test_no_set_wrapper_name_survives_into_generated_output() {
+    let mut generated = String::new();
+    #[cfg(feature = "typescript")]
+    generated.push_str(&SetElementFields::ts_definition());
+    #[cfg(feature = "zod")]
+    generated.push_str(&SetElementFields::zod_schema());
+
+    for wrapper in ["HashSet", "BTreeSet"] {
+        assert!(!generated.contains(wrapper), "Got: {generated}");
+    }
+}
+
+/// A `HashSet<T>` and a `Vec<T>` serialize alike, so their Zod schemas validate alike — field for
+/// field, at every element type, once the type's own name is set aside.
+#[test]
+#[cfg(feature = "zod")]
+fn test_set_fields_validate_as_vec_fields() {
+    assert_eq!(
+        SetElementFields::zod_schema().replace("SetElementFields", "VecElementFields"),
+        VecElementFields::zod_schema()
+    );
 }


### PR DESCRIPTION
Stacked on #43 (stack: #33 → … → #43 → this).

`HashSet<u32>` was written **verbatim** into generated output — `labels: HashSet<string>;` in TypeScript, the same spelling in Zod — syntactically invalid on both surfaces.

- Set-like wrappers (HashSet, BTreeSet) now render `Array<T>` / `z.array(T)` with the element through the shared per-type rendering; PR 43's element helper moved onto `FieldDef`, serving all three surfaces. Grep-proof test: no set-wrapper name remains in generated output.
- `zod_base` split so a field's `preprocess` wraps once, outside the array — the element carries copied metadata (how `minLength` reaches items), which would have applied the preprocess twice. Pinned on both twins.
- Evidence-justified narrowing, recorded on the task: BTreeSet is pinned by unit tests over the renderers rather than a fixture, because its field-position json-schema path is a separate filed bug (E0433) that every jsonschema combo would hit.

Gates: `just check`, `just lint-all` (68/68), `just test` (full powerset) green.
