### PR TITLE
fix: one sequence-wrapper predicate for all three surfaces

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,5 @@ redundant_test_prefix = "allow"
 # Integer division is used safely for threshold calculations and tests.
 integer_division = "allow"
 integer_division_remainder_used = "allow"
-# HashSet iteration order is irrelevant for set-comparison operations.
-iter_over_hash_type = "allow"
 # HashSet parameters use the default hasher; generalization adds complexity for no benefit.
 implicit_hasher = "allow"

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ pub struct UserWithOptionals {
 
 ### Collections and Maps
 
-`Vec<T>` becomes `Array<T>`, and so does `HashSet<T>`: a set is written as a JSON array of its element, so it is typed and validated as that array. Only `HashMap<String, T>` is supported (non-string keys will cause compilation errors).
+`Vec<T>` becomes `Array<T>`, and so does every other std wrapper serde writes as a JSON array of its element: `VecDeque<T>`, `LinkedList<T>`, `BinaryHeap<T>`, `HashSet<T>`, and `BTreeSet<T>`. Each is that array on the wire, so each is typed and validated as that array — the element decides what the array holds. Only `HashMap<String, T>` is supported (non-string keys will cause compilation errors).
 
 ```rust
 use std::collections::HashMap;

--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -234,6 +234,64 @@ impl FieldDef {
         }
     }
 
+    /// Replaces every reference to one of the enclosing item's type parameters with the opaque
+    /// type.
+    ///
+    /// A parameter names no type at expansion — the instantiation names one, and the schema is
+    /// written once for every instantiation. So a parameter describes as an opaque value does,
+    /// which leaves the shape it sits in — a tuple's arity, an array, a map's keys — described.
+    ///
+    /// Recurses through `SiblingType` generics, `Map` keys/values, and `Tuple` elements.
+    #[cfg(feature = "jsonschema")]
+    pub fn erase_type_parameters(&mut self, parameters: &[String]) {
+        if let FieldDefType::SiblingType(name, _) = &self.field_type
+            && parameters.iter().any(|parameter| parameter == name)
+        {
+            self.field_type = FieldDefType::Unknown;
+            return;
+        }
+        match &mut self.field_type {
+            FieldDefType::SiblingType(_, generics) => {
+                for generic in generics.iter_mut() {
+                    generic.erase_type_parameters(parameters);
+                }
+            }
+            FieldDefType::Map(key, value) => {
+                key.erase_type_parameters(parameters);
+                value.erase_type_parameters(parameters);
+            }
+            FieldDefType::Tuple(elements) => {
+                for element in elements.iter_mut() {
+                    element.erase_type_parameters(parameters);
+                }
+            }
+            // Leaf types name no parameter.
+            FieldDefType::Unknown
+            | FieldDefType::StringLiteral(_)
+            | FieldDefType::Boolean
+            | FieldDefType::String
+            | FieldDefType::U8
+            | FieldDefType::U16
+            | FieldDefType::U32
+            | FieldDefType::U64
+            | FieldDefType::I8
+            | FieldDefType::I16
+            | FieldDefType::I32
+            | FieldDefType::I64
+            | FieldDefType::Usize
+            | FieldDefType::Isize
+            | FieldDefType::F32
+            | FieldDefType::F64 => {}
+            #[cfg(feature = "object_id")]
+            FieldDefType::ObjectId => {}
+            #[cfg(feature = "chrono")]
+            FieldDefType::NaiveDate
+            | FieldDefType::NaiveTime
+            | FieldDefType::NaiveDateTime
+            | FieldDefType::DateTime => {}
+        }
+    }
+
     #[cfg(feature = "chrono")]
     fn has_as_number(&self) -> bool {
         self.model_schema_prop_meta

--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -324,7 +324,7 @@ impl FieldDef {
             }
             FieldDefType::SiblingType(name, lst) => {
                 if let [element] = lst.as_slice()
-                    && is_set_wrapper(name)
+                    && is_sequence_wrapper(name)
                 {
                     // The element re-enters the whole per-type rendering as the arrayed field it
                     // stands for, so a set renders exactly as the `Vec` of that element does.
@@ -465,7 +465,7 @@ impl FieldDef {
             }
             FieldDefType::SiblingType(name, lst) => {
                 if let [element] = lst.as_slice()
-                    && is_set_wrapper(name)
+                    && is_sequence_wrapper(name)
                 {
                     self.collection_element_field(element).zod_array_base()
                 } else if let Some(info) = lookup_alias_info(name) {
@@ -628,12 +628,18 @@ impl FieldDef {
     }
 }
 
-/// The std set wrappers, which each write a JSON array of their element.
+/// The one list of std wrappers the crate renders as arrays, shared by every surface.
 ///
-/// `Vec` is absent because it never reaches a wrapper name: the parser collapses it onto its
-/// element with `is_array` set, long before anything asks what the wrapper is called.
-fn is_set_wrapper(name: &str) -> bool {
-    matches!(name, "BTreeSet" | "HashSet")
+/// Membership is decided on the wire and nothing else: serde writes each of these as a JSON array
+/// of its single element type, so each describes as the `Vec` of that element does. The maps are
+/// absent because they write objects; `Vec` is listed even though the parser collapses it onto its
+/// element with `is_array` set long before anything asks a wrapper's name, so that a `Vec` written
+/// where a wrapper name is read still takes the wrapper path.
+pub fn is_sequence_wrapper(name: &str) -> bool {
+    matches!(
+        name,
+        "BTreeSet" | "BinaryHeap" | "HashSet" | "LinkedList" | "Vec" | "VecDeque"
+    )
 }
 
 /// Classifies a `syn::Variant` into its `VariantKind`.

--- a/src/field_type/tests.rs
+++ b/src/field_type/tests.rs
@@ -1,8 +1,14 @@
 use super::{FieldDef, FieldDefType};
 
-/// The wrappers whose fields write a JSON array of their element. Rendered here directly rather
-/// than through a fixture, since a `BTreeSet` field does not yet reach every surface.
-const SET_WRAPPERS: [&str; 2] = ["BTreeSet", "HashSet"];
+/// The wrappers whose fields write a JSON array of their element, named here as they reach the
+/// renderers — `Vec` excluded, the parser having collapsed it long before.
+const SEQUENCE_WRAPPERS: [&str; 5] = [
+    "BTreeSet",
+    "BinaryHeap",
+    "HashSet",
+    "LinkedList",
+    "VecDeque",
+];
 
 fn field(field_type: FieldDefType) -> FieldDef {
     FieldDef {
@@ -16,7 +22,7 @@ fn field(field_type: FieldDefType) -> FieldDef {
     }
 }
 
-fn set_of(wrapper: &str, element: FieldDefType) -> FieldDef {
+fn sequence_of(wrapper: &str, element: FieldDefType) -> FieldDef {
     field(FieldDefType::SiblingType(
         wrapper.to_owned(),
         vec![field(element)],
@@ -24,20 +30,20 @@ fn set_of(wrapper: &str, element: FieldDefType) -> FieldDef {
 }
 
 #[test]
-fn test_set_wrappers_render_as_typescript_arrays() {
-    for wrapper in SET_WRAPPERS {
+fn test_sequence_wrappers_render_as_typescript_arrays() {
+    for wrapper in SEQUENCE_WRAPPERS {
         assert_eq!(
-            set_of(wrapper, FieldDefType::U32).typescript_typename(),
+            sequence_of(wrapper, FieldDefType::U32).typescript_typename(),
             "Array<number>",
             "for: {wrapper}"
         );
         assert_eq!(
-            set_of(wrapper, FieldDefType::String).typescript_typename(),
+            sequence_of(wrapper, FieldDefType::String).typescript_typename(),
             "Array<string>",
             "for: {wrapper}"
         );
         assert_eq!(
-            set_of(
+            sequence_of(
                 wrapper,
                 FieldDefType::SiblingType("MetricTag".to_owned(), vec![])
             )
@@ -50,20 +56,20 @@ fn test_set_wrappers_render_as_typescript_arrays() {
 
 #[test]
 #[cfg(feature = "zod")]
-fn test_set_wrappers_render_as_zod_arrays() {
-    for wrapper in SET_WRAPPERS {
+fn test_sequence_wrappers_render_as_zod_arrays() {
+    for wrapper in SEQUENCE_WRAPPERS {
         assert_eq!(
-            set_of(wrapper, FieldDefType::U32).zod_type(),
+            sequence_of(wrapper, FieldDefType::U32).zod_type(),
             "z.array(z.number().int())",
             "for: {wrapper}"
         );
         assert_eq!(
-            set_of(wrapper, FieldDefType::String).zod_type(),
+            sequence_of(wrapper, FieldDefType::String).zod_type(),
             "z.array(z.string())",
             "for: {wrapper}"
         );
         assert_eq!(
-            set_of(
+            sequence_of(
                 wrapper,
                 FieldDefType::SiblingType("MetricTag".to_owned(), vec![])
             )
@@ -77,18 +83,22 @@ fn test_set_wrappers_render_as_zod_arrays() {
 /// A slot — a tuple element or a map entry — holds the same array a field does, and an `Option`
 /// there is the null-flavored one the slot always uses, applied to that array rather than inside it.
 #[test]
-fn test_set_in_a_slot_renders_as_the_array_it_writes() {
-    for wrapper in SET_WRAPPERS {
-        let set = set_of(wrapper, FieldDefType::String);
+fn test_sequence_in_a_slot_renders_as_the_array_it_writes() {
+    for wrapper in SEQUENCE_WRAPPERS {
+        let sequence = sequence_of(wrapper, FieldDefType::String);
         assert_eq!(
-            set.typescript_slot_typename(),
+            sequence.typescript_slot_typename(),
             "Array<string>",
             "for: {wrapper}"
         );
         #[cfg(feature = "zod")]
-        assert_eq!(set.zod_slot_type(), "z.array(z.string())", "for: {wrapper}");
+        assert_eq!(
+            sequence.zod_slot_type(),
+            "z.array(z.string())",
+            "for: {wrapper}"
+        );
 
-        let mut optional = set;
+        let mut optional = sequence;
         optional.is_optional = true;
         assert_eq!(
             optional.typescript_slot_typename(),
@@ -104,12 +114,12 @@ fn test_set_in_a_slot_renders_as_the_array_it_writes() {
     }
 }
 
-/// A set inside a `Vec` is two arrays on the wire, so it is two on the surfaces: the wrapper's own
+/// A sequence wrapper inside a `Vec` is two arrays on the wire, so it is two on the surfaces: the wrapper's own
 /// array wrap is the element's, and the field it sits in keeps the wrap the parser gave it.
 #[test]
-fn test_set_within_an_array_field_nests_both_wraps() {
-    for wrapper in SET_WRAPPERS {
-        let mut nested = set_of(wrapper, FieldDefType::U32);
+fn test_sequence_within_an_array_field_nests_both_wraps() {
+    for wrapper in SEQUENCE_WRAPPERS {
+        let mut nested = sequence_of(wrapper, FieldDefType::U32);
         nested.is_array = true;
         assert_eq!(
             nested.typescript_typename(),
@@ -125,11 +135,11 @@ fn test_set_within_an_array_field_nests_both_wraps() {
     }
 }
 
-/// An `Option` around a set is the field's own, not the array's: the wrapper answers for what the
+/// An `Option` around a sequence wrapper is the field's own, not the array's: the wrapper answers for what the
 /// array holds and nothing about whether the key is there.
 #[test]
-fn test_optional_set_field_keeps_the_field_level_optionality() {
-    let mut optional = set_of("HashSet", FieldDefType::String);
+fn test_optional_sequence_field_keeps_the_field_level_optionality() {
+    let mut optional = sequence_of("HashSet", FieldDefType::String);
     optional.is_optional = true;
     assert_eq!(optional.typescript_typename(), "Array<string> | undefined");
     #[cfg(feature = "zod")]

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -42,6 +42,9 @@ use crate::features::serde::{SerdeFieldMeta, SerdeTypeMeta};
 #[cfg(feature = "serde")]
 use crate::field_type::{parse_serde_field_attributes, parse_serde_type_attributes};
 
+#[cfg(feature = "jsonschema")]
+use crate::field_type::is_sequence_wrapper;
+
 use crate::features::model_schema_prop::parse_model_schema_prop_attributes;
 
 #[cfg(feature = "serde")]
@@ -3895,12 +3898,12 @@ fn build_sibling_type_field_schema(
     lst: &[FieldDef],
 ) -> proc_macro2::TokenStream {
     log::trace!("SiblingType => name: {name}, lst: {lst:?}");
-    // The element is dispatched as the arrayed field it stands for, so a set renders exactly as the
-    // `Vec` of the same element does — element by element, at every type. A parsed `Vec<T>` field
-    // never arrives here, the parser having already handed it over in that arrayed form; a `Vec`
-    // spelled at this position is the same wrapper, and takes the same path.
+    // The element is dispatched as the arrayed field it stands for, so a sequence wrapper renders
+    // exactly as the `Vec` of the same element does — element by element, at every type. Which
+    // wrappers those are is the surfaces' one shared answer, so no name reaches one surface as an
+    // array and another as a schema module of its own.
     if let [element] = lst
-        && (name == "Vec" || name == "HashSet")
+        && is_sequence_wrapper(name)
     {
         build_field_type_schema(&fld.collection_element_field(element), field_name_str)
     } else if (name == "HashMap" || name == "BTreeMap") && lst.len() == 2 {

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -2,7 +2,6 @@ extern crate alloc;
 
 use alloc::borrow::ToOwned;
 use core::fmt::Write as _;
-use std::collections::HashMap;
 
 use proc_macro::TokenStream;
 use quote::quote;
@@ -73,13 +72,23 @@ use crate::utils::to_snake_case;
 
 use crate::rename_rule::resolve_rename_rule;
 
-/// Per-variant data collected from a discriminated enum: field defs, doc strings, and variant
-/// kinds (each keyed by serialized discriminator value), plus the collected serde validators and
+/// One variant of a discriminated enum, carrying everything its union member is rendered from.
+struct DiscriminatedVariant {
+    discriminator_value: String,
+    docs: String,
+    field_defs: Vec<FieldDef>,
+    kind: VariantKind,
+}
+
+/// Per-variant data collected from a discriminated enum, plus the collected serde validators and
 /// the `compile_error!` tokens for any field-level guard violations.
+///
+/// The variants are a sequence, not a map: their order is the enum's declaration order and it
+/// reaches the emitted output verbatim (JSON-schema `oneOf`, the TypeScript union, the Zod
+/// `discriminatedUnion`). Any hash-ordered container here would re-randomize that output per
+/// build.
 type DiscriminatedVariantData = (
-    HashMap<String, Vec<FieldDef>>,
-    HashMap<String, String>,
-    HashMap<String, VariantKind>,
+    Vec<DiscriminatedVariant>,
     Vec<proc_macro2::TokenStream>,
     Vec<proc_macro2::TokenStream>,
 );
@@ -152,6 +161,32 @@ enum MapMemberItem {
     Value(proc_macro2::TokenStream),
 }
 
+/// Why a value in a slot has no rendering. Each shape carries its own diagnostic, and the field
+/// name the message needs belongs to the caller rather than to the dispatch, so the reason travels
+/// out and the message is formatted once at the top.
+#[cfg(feature = "jsonschema")]
+#[derive(Debug)]
+enum MapMemberRejection {
+    /// A map key the registry proves carries no `enum_members()`, named so the author can act on it.
+    NonEnumKey(String),
+    Tuple,
+}
+
+/// What a map key opens: one open member set, the members it enumerates, or nothing this expansion
+/// can narrow.
+///
+/// Every position a map is written in reads its key through this one classification, so a key
+/// cannot enumerate its members in field position and stay open in a slot.
+#[cfg(feature = "jsonschema")]
+enum MapKeyPath<'key> {
+    /// A key named by a type path, whose `enum_members()` become the object's keys.
+    Enumerated(&'key str),
+    /// A `String` key, which enumerates nothing — one schema stands for every member.
+    Open,
+    /// A key this expansion cannot narrow, leaving the members unconstrained.
+    Unnarrowed,
+}
+
 #[derive(Default, Clone)]
 struct ModelSchemaArgs {
     max_length: Option<usize>,
@@ -185,11 +220,16 @@ impl MapMemberItem {
 
     /// The item wrapped for its slot as a standalone `serde_json::Value`.
     fn into_member_value(self, value: &FieldDef) -> proc_macro2::TokenStream {
-        let item_value = match self {
+        map_member_slot_value(value, self.into_value())
+    }
+
+    /// The item as a standalone `serde_json::Value`, with no slot wrap applied — a fragment lifted
+    /// into the `serde_json::json!` a value form already is.
+    fn into_value(self) -> proc_macro2::TokenStream {
+        match self {
             Self::Fragment(fragment) => quote! { serde_json::json!(#fragment) },
             Self::Value(item_value) => item_value,
-        };
-        map_member_slot_value(value, item_value)
+        }
     }
 }
 
@@ -316,7 +356,8 @@ fn process_type_alias(item_type: ItemType, args: &ModelSchemaArgs) -> TokenStrea
     register_alias_info(&rust_ident_str, &export_name, &module_name, kind);
 
     let ts_method = generate_alias_ts_definition_method(&alias, &export_name, &alias_field_def);
-    let json_schema_method = generate_alias_json_schema_stub();
+    let json_schema_method =
+        generate_alias_json_schema_method(&alias, &export_name, &alias_field_def);
     let zod_method = generate_alias_zod_method(&export_name, &alias_field_def);
 
     let output = quote! {
@@ -2228,16 +2269,13 @@ fn process_plain_enum(
 }
 
 /// Processes each variant of a discriminated enum, returning per-variant field defs, doc strings,
-/// and variant kinds (keyed by serialized discriminator value), plus the collected serde
-/// validation functions.
+/// and variant kinds in declaration order, plus the collected serde validation functions.
 fn collect_discriminated_variants(
     item_enum: &mut syn::ItemEnum,
     rename_all: Option<&str>,
     enum_module_name_opt: Option<&str>,
 ) -> DiscriminatedVariantData {
-    let mut field_defs_by_variant: HashMap<String, Vec<FieldDef>> = HashMap::new();
-    let mut docs_by_variant: HashMap<String, String> = HashMap::new();
-    let mut kinds_by_variant: HashMap<String, VariantKind> = HashMap::new();
+    let mut variants: Vec<DiscriminatedVariant> = Vec::new();
     let mut enum_validation_fns: Vec<proc_macro2::TokenStream> = Vec::new();
     let mut guard_errors: Vec<proc_macro2::TokenStream> = Vec::new();
     let enum_type_name = item_enum.ident.to_string();
@@ -2265,8 +2303,6 @@ fn collect_discriminated_variants(
             field_defs.push(f_def);
         }
 
-        field_defs_by_variant.insert(final_name.clone(), field_defs);
-        kinds_by_variant.insert(final_name.clone(), variant_kind);
         let discriminator_docs = get_variant_docs(item).map_or_else(
             || {
                 [final_name.clone(), String::new()]
@@ -2285,16 +2321,15 @@ fn collect_discriminated_variants(
                     .join("\n")
             },
         );
-        docs_by_variant.insert(final_name, discriminator_docs);
+        variants.push(DiscriminatedVariant {
+            discriminator_value: final_name,
+            docs: discriminator_docs,
+            field_defs,
+            kind: variant_kind,
+        });
     }
 
-    (
-        field_defs_by_variant,
-        docs_by_variant,
-        kinds_by_variant,
-        enum_validation_fns,
-        guard_errors,
-    )
+    (variants, enum_validation_fns, guard_errors)
 }
 
 /// Renders the TypeScript type fragments, Zod schema fragments (with optional-field lists), and
@@ -2303,24 +2338,21 @@ fn render_discriminated_variants(
     tag_name: &str,
     content_name: &str,
     item_name: &str,
-    field_defs_by_variant: HashMap<String, Vec<FieldDef>>,
-    docs_by_variant: &HashMap<String, String>,
-    kinds_by_variant: &HashMap<String, VariantKind>,
+    variants: &[DiscriminatedVariant],
 ) -> RenderedVariants {
     let mut type_code_items = Vec::new();
     let mut schema_code_items = Vec::new();
     let mut json_schema_variants: Vec<proc_macro2::TokenStream> = Vec::new();
 
-    for (discriminator_value, field_defs) in field_defs_by_variant {
-        let variant_kind = &kinds_by_variant[&discriminator_value];
+    for variant in variants {
         let (variant_type_code, variant_schema_code, optional_fields, json_schema_variant) =
             generate_variant_code(
                 tag_name,
                 content_name,
-                &discriminator_value,
-                &field_defs,
-                variant_kind,
-                &docs_by_variant[&discriminator_value],
+                &variant.discriminator_value,
+                &variant.field_defs,
+                &variant.kind,
+                &variant.docs,
                 item_name,
             );
         type_code_items.push(variant_type_code);
@@ -2381,20 +2413,13 @@ fn process_discriminated_enum(
     let enum_module_name_opt = None;
 
     // Bind both result tuples whole so feature-gated field access marks them used (no per-element
-    // guards): `variants` = (field_defs, docs, kinds, validation_fns, guard_errors);
+    // guards): `variants` = (variants, validation_fns, guard_errors);
     // `rendered` = (ts, zod, json).
     let variants = collect_discriminated_variants(&mut item_enum, rename_all, enum_module_name_opt);
-    if let Some(output) = guard_failure_output(&item_enum, &variants.4) {
+    if let Some(output) = guard_failure_output(&item_enum, &variants.2) {
         return output;
     }
-    let rendered = render_discriminated_variants(
-        tag_name,
-        content_name,
-        item_name,
-        variants.0,
-        &variants.1,
-        &variants.2,
-    );
+    let rendered = render_discriminated_variants(tag_name, content_name, item_name, &variants.0);
     #[cfg(not(any(feature = "typescript", feature = "zod", feature = "jsonschema")))]
     let _: &_ = &(name, &rendered);
 
@@ -2469,7 +2494,7 @@ fn process_discriminated_enum(
             &module_ident,
             name,
             &schema_impl_items,
-            &variants.3,
+            &variants.1,
             &delegate_impl_items,
         )
     }
@@ -3140,7 +3165,13 @@ fn push_single_tuple_json_field(
     fld: &FieldDef,
 ) {
     let content_name_str = content_name.to_owned();
-    let field_schema = build_tuple_element_json_schema(fld);
+    let field_schema = match build_tuple_element_json_schema(fld) {
+        Ok(field_schema) => field_schema,
+        Err(rejection) => {
+            json_schema_variant_fields.push(map_member_rejection_error(content_name, &rejection));
+            return;
+        }
+    };
     json_schema_variant_fields.push(quote! {
         properties.insert(#content_name_str.to_string(), #field_schema);
         required.push(serde_json::Value::String(#content_name_str.to_string()));
@@ -3272,20 +3303,26 @@ fn write_tuple_multiple_variant_fields(
     #[cfg(feature = "jsonschema")]
     {
         let content_name_str = content_name.to_owned();
-        let tuple_schemas: Vec<proc_macro2::TokenStream> = field_defs
+        match field_defs
             .iter()
             .map(build_tuple_element_json_schema)
-            .collect();
-        json_schema_variant_fields.push(quote! {
-            properties.insert(#content_name_str.to_string(), {
-                serde_json::json!({
-                    "type": "array",
-                    "prefixItems": [#(#tuple_schemas),*],
-                    "items": false
-                })
-            });
-            required.push(serde_json::Value::String(#content_name_str.to_string()));
-        });
+            .collect::<Result<Vec<_>, _>>()
+        {
+            Ok(tuple_schemas) => json_schema_variant_fields.push(quote! {
+                properties.insert(#content_name_str.to_string(), {
+                    serde_json::json!({
+                        "type": "array",
+                        "prefixItems": [#(#tuple_schemas),*],
+                        "items": false
+                    })
+                });
+                required.push(serde_json::Value::String(#content_name_str.to_string()));
+            }),
+            Err(rejection) => {
+                json_schema_variant_fields
+                    .push(map_member_rejection_error(content_name, &rejection));
+            }
+        }
     }
     #[cfg(not(feature = "jsonschema"))]
     let _: &_ = &&json_schema_variant_fields;
@@ -3362,28 +3399,46 @@ fn scalar_field_json_schema_item(fld: &FieldDef) -> Option<proc_macro2::TokenStr
     Some(item_schema)
 }
 
-/// The JSON schema value expression for a field whose type renders inline as a scalar — arrayed
-/// when the field is a `Vec` — or `None` for the composite types (sibling references, maps,
-/// tuples, unknowns) that have no inline rendering.
+/// [`build_map_member_item`] for a tuple element, which differs for exactly two value types.
 ///
-/// `is_optional` is not consulted: how an absent value is expressed depends on the position the
-/// value sits in, so each caller wraps this base itself.
+/// An `ObjectId` here carries the field-position `$oid` object — patterned, and open — where a
+/// `String`-keyed map member carries the closed, unpatterned one; which of the two a slot should
+/// carry is unsettled, so this position keeps the rendering it has. A tuple renders as the
+/// fixed-arity array its own field position renders, which is the one value the map path has no
+/// renderer for: an element is dispatched by the tuple builder itself, so the nesting costs
+/// nothing but the recursion.
+///
+/// Every other value is the member the map path renders, at every depth, so a type describes the
+/// same in either slot.
 #[cfg(feature = "jsonschema")]
-fn scalar_field_json_schema_value(fld: &FieldDef) -> Option<proc_macro2::TokenStream> {
-    let item_schema = scalar_field_json_schema_item(fld)?;
-    Some(arrayed_json_schema_value(
-        fld,
-        quote! { serde_json::json!(#item_schema) },
-    ))
+fn build_tuple_element_item(value: &FieldDef) -> Result<MapMemberItem, MapMemberRejection> {
+    #[cfg(feature = "object_id")]
+    if matches!(value.field_type, FieldDefType::ObjectId) {
+        return Ok(MapMemberItem::Fragment(scalar_slot_item(value)?));
+    }
+    if let FieldDefType::Tuple(elements) = &value.field_type {
+        return Ok(MapMemberItem::Value(tuple_json_schema_value(elements)?));
+    }
+    build_map_member_item(value)
 }
 
-/// Builds the base JSON schema for a tuple element, ignoring `is_optional`.
+/// Builds the base JSON schema for a tuple element, ignoring `is_optional`, or `None` when the
+/// element holds a value the dispatch cannot render.
 ///
-/// The nullable wrap is applied by `build_tuple_element_json_schema`.
+/// The element is dispatched in the form its slot normalizes it to, so a sequence wrapper here
+/// describes as the `Vec` of the same element does. Everything else is the map path's member
+/// dispatch: a sibling is carried by the same reference the field and map-member positions carry,
+/// a map carries its own members' renderings, and an opaque value carries the permissive empty
+/// schema field position carries — so the type an element holds is described by that type wherever
+/// it is named. The nullable wrap is applied by `build_tuple_element_json_schema`, off the element
+/// as it was written.
 #[cfg(feature = "jsonschema")]
-fn build_tuple_element_base_json_schema(fld: &FieldDef) -> proc_macro2::TokenStream {
-    scalar_field_json_schema_value(fld)
-        .unwrap_or_else(|| quote! { serde_json::json!({ "type": "object" }) })
+fn build_tuple_element_base_json_schema(
+    fld: &FieldDef,
+) -> Result<proc_macro2::TokenStream, MapMemberRejection> {
+    let value = normalized_slot_value(fld);
+    let item = build_tuple_element_item(&value)?;
+    Ok(arrayed_json_schema_value(&value, item.into_value()))
 }
 
 /// The `anyOf [<base>, null]` form for a value in a slot that cannot be dropped — a tuple element
@@ -3428,47 +3483,141 @@ fn sibling_schema_module_ident(name: &str) -> Ident {
     Ident::new(module_name.as_str(), proc_macro2::Span::call_site())
 }
 
-/// Builds JSON schema for a tuple element (used for single tuple and multi-tuple variants).
+/// A sibling's own schema as a standalone `serde_json::Value` expression: the module the reference
+/// resolves to, asked for the schema it publishes.
+///
+/// Every position that carries a sibling by reference — a field, a map member, a tuple element, a
+/// flattened base — emits this one call, so a type cannot describe as itself in one position and as
+/// an open object in another.
 #[cfg(feature = "jsonschema")]
-fn build_tuple_element_json_schema(fld: &FieldDef) -> proc_macro2::TokenStream {
-    nullable_slot_json_schema_value(fld, build_tuple_element_base_json_schema(fld))
+fn sibling_json_schema_value(name: &str) -> proc_macro2::TokenStream {
+    let module_ident = sibling_schema_module_ident(name);
+    quote! { #module_ident::Schema::json_schema() }
+}
+
+/// Builds JSON schema for a tuple element (used for tuple fields and for tuple variants), or the
+/// rejection when the element holds a value the dispatch cannot render — which the callers turn
+/// into the single diagnostic naming the field.
+///
+/// An alias's target is rendered through here too: an alias names a type, and this is the dispatch
+/// total over the types the crate renders, so what the alias publishes is what a field written as
+/// the target would carry.
+#[cfg(feature = "jsonschema")]
+fn build_tuple_element_json_schema(
+    fld: &FieldDef,
+) -> Result<proc_macro2::TokenStream, MapMemberRejection> {
+    Ok(nullable_slot_json_schema_value(
+        fld,
+        build_tuple_element_base_json_schema(fld)?,
+    ))
+}
+
+/// The fixed-arity array a tuple describes as — the form serde writes it in — or the rejection when
+/// any element holds a value the dispatch cannot render.
+///
+/// A tuple field and a tuple nested in a slot are the same array, so both are built here rather
+/// than each spelling the bounds itself.
+#[cfg(feature = "jsonschema")]
+fn tuple_json_schema_value(
+    elements: &[FieldDef],
+) -> Result<proc_macro2::TokenStream, MapMemberRejection> {
+    let arity = elements.len();
+    let element_schemas = elements
+        .iter()
+        .map(build_tuple_element_json_schema)
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(quote! {
+        serde_json::json!({
+            "type": "array",
+            "prefixItems": [#(#element_schemas),*],
+            "items": false,
+            "minItems": #arity,
+            "maxItems": #arity
+        })
+    })
+}
+
+/// The classification every position reads a map key through.
+///
+/// Only a bare type path can name an enum: a generic spelling is a type this expansion has no
+/// `enum_members()` for, and every other type names keys the schema cannot enumerate.
+#[cfg(feature = "jsonschema")]
+const fn map_key_path(key: &FieldDef) -> MapKeyPath<'_> {
+    match &key.field_type {
+        FieldDefType::String => MapKeyPath::Open,
+        FieldDefType::SiblingType(key_type_name, args) if args.is_empty() => {
+            MapKeyPath::Enumerated(key_type_name.as_str())
+        }
+        FieldDefType::SiblingType(..)
+        | FieldDefType::Unknown
+        | FieldDefType::Map(..)
+        | FieldDefType::Tuple(..)
+        | FieldDefType::Boolean
+        | FieldDefType::StringLiteral(_)
+        | FieldDefType::U8
+        | FieldDefType::U16
+        | FieldDefType::U32
+        | FieldDefType::U64
+        | FieldDefType::I8
+        | FieldDefType::I16
+        | FieldDefType::I32
+        | FieldDefType::I64
+        | FieldDefType::Usize
+        | FieldDefType::Isize
+        | FieldDefType::F32
+        | FieldDefType::F64 => MapKeyPath::Unnarrowed,
+        #[cfg(feature = "object_id")]
+        FieldDefType::ObjectId => MapKeyPath::Unnarrowed,
+        #[cfg(feature = "chrono")]
+        FieldDefType::DateTime
+        | FieldDefType::NaiveDate
+        | FieldDefType::NaiveDateTime
+        | FieldDefType::NaiveTime => MapKeyPath::Unnarrowed,
+    }
+}
+
+/// The `json!` literal a map whose keys cannot be narrowed describes as: an object, with nothing
+/// said about its members. Written once so field and slot positions state the same thing.
+#[cfg(feature = "jsonschema")]
+fn unnarrowed_key_map_json_schema_item() -> proc_macro2::TokenStream {
+    quote! { { "type": "object", "additionalProperties": true } }
 }
 
 /// Fallback JSON schema for map fields whose key type is not specially handled.
 #[cfg(feature = "jsonschema")]
 fn map_key_fallback_schema(field_name_str: &str, key: &FieldDef) -> proc_macro2::TokenStream {
     log::trace!("Map Key Type {:?}", key.field_type);
+    let item = unnarrowed_key_map_json_schema_item();
     quote! {
         properties.insert(#field_name_str.to_string(), {
-            serde_json::json!({
-                "type": "object",
-                "additionalProperties": true
-            })
+            serde_json::json!(#item)
         });
     }
 }
 
-/// The member schema for a `String`-keyed map whose value is itself a map: an object whose own
-/// members carry the inner value's rendering, or `None` when that value has no rendering here.
-///
-/// Only a `String` inner key opens a member set this dispatcher describes; an inner key of any
-/// other type names members this branch does not enumerate, so those members stay unconstrained —
-/// the value is still known to be an object, which is what the map guarantees.
+/// The rendering a map whose value is itself a map carries, dispatched on the inner key exactly as
+/// the field position dispatches on the outer one.
 #[cfg(feature = "jsonschema")]
-fn build_map_nested_map_member_schema(
+fn build_nested_map_member_item(
     inner_key: &FieldDef,
     inner_value: &FieldDef,
-) -> Option<proc_macro2::TokenStream> {
+) -> Result<MapMemberItem, MapMemberRejection> {
     log::trace!(
         "Map Value is another Map => inner_key: {inner_key:?}, inner_value: {inner_value:?}"
     );
 
-    let inner_member = if matches!(inner_key.field_type, FieldDefType::String) {
-        build_map_member_schema(inner_value)?
-    } else {
-        quote! { true }
-    };
-    Some(quote! { { "type": "object", "additionalProperties": #inner_member } })
+    Ok(match map_key_path(inner_key) {
+        MapKeyPath::Enumerated(key_type_name) => {
+            MapMemberItem::Value(enum_key_map_json_schema_value(key_type_name, inner_value)?)
+        }
+        MapKeyPath::Open => {
+            let inner_member = build_map_member_schema(inner_value)?;
+            MapMemberItem::Fragment(
+                quote! { { "type": "object", "additionalProperties": #inner_member } },
+            )
+        }
+        MapKeyPath::Unnarrowed => MapMemberItem::Fragment(unnarrowed_key_map_json_schema_item()),
+    })
 }
 
 /// Wraps a member's base schema for the slot it sits in — arrayed when the value is a `Vec`,
@@ -3502,47 +3651,56 @@ fn map_member_slot_value(
     nullable_slot_json_schema_value(value, arrayed_json_schema_value(value, item_value))
 }
 
-/// The `FieldDef` a map value dispatches as.
+/// The `FieldDef` a value in a slot — a map member, a tuple element — dispatches as.
 ///
-/// The parser collapses `Vec<T>` to `T` with `is_array` set, so a `Vec` type name reaches a map
-/// value only on a value built by hand: moving the array-ness onto the element puts that value in
-/// the one form every parsed `Vec` value already arrives in, at whatever nesting it was written.
+/// Every sequence wrapper writes a JSON array of its element, so the value describes as the `Vec`
+/// of that element does: the array-ness moves onto the element, which is the one form a parsed
+/// `Vec` value already arrives in, at whatever nesting it was written. Which wrappers those are is
+/// the surfaces' one shared answer, so no name reaches a slot as an array on one surface and a
+/// schema module of its own on another.
+///
+/// Nullability is carried across rather than taken from the element: a slot cannot be dropped the
+/// way an object key can, so a `None` on either side of the wrapper is written as `null` and the
+/// member schema has to admit it.
 #[cfg(feature = "jsonschema")]
-fn normalized_map_value(value: &FieldDef) -> FieldDef {
+fn normalized_slot_value(value: &FieldDef) -> FieldDef {
     let mut normalized = value.clone();
-    while let FieldDefType::SiblingType(value_type_name, value_args) = &normalized.field_type
-        && value_type_name == "Vec"
-        && let [element] = value_args.as_slice()
+    while let FieldDefType::SiblingType(wrapper_name, wrapper_args) = &normalized.field_type
+        && is_sequence_wrapper(wrapper_name)
+        && let [element] = wrapper_args.as_slice()
     {
-        let mut arrayed = element.clone();
-        arrayed.is_array = true;
+        let mut arrayed = normalized.collection_element_field(element);
+        arrayed.is_optional |= normalized.is_optional;
         normalized = arrayed;
     }
     normalized
 }
 
-/// The rendering every member of a map carries, with the slot wraps left to the caller, or `None`
-/// when the value type has no rendering here.
+/// The rendering a value in a slot carries, with the slot wraps left to the caller, or the
+/// rejection when the value type has no rendering here.
 ///
-/// A map value is dispatched through this same function, so the members of a nested map carry the
-/// inner value type's own rendering at every depth rather than an open object.
+/// A map value is dispatched through this same function, so a nested map carries the rendering its
+/// own key and value types give it at every depth rather than an open object. A tuple element is
+/// dispatched through it too (via [`build_tuple_element_item`]), so the two slot positions cannot
+/// disagree about what a type describes as.
 ///
-/// A tuple is the only value the mapping cannot render, at any depth: the callers turn that `None`
-/// into the single diagnostic naming the field.
+/// A tuple is the one value type the mapping cannot render — a tuple element overrides that arm
+/// with the array its own field position renders, a map member has no such renderer — and a nested
+/// map can be turned away for its key. Either way the callers turn the rejection into the single
+/// diagnostic naming the field.
 #[cfg(feature = "jsonschema")]
-fn build_map_member_item(value: &FieldDef) -> Option<MapMemberItem> {
-    Some(match &value.field_type {
+fn build_map_member_item(value: &FieldDef) -> Result<MapMemberItem, MapMemberRejection> {
+    Ok(match &value.field_type {
         FieldDefType::Map(inner_key, inner_value) => {
-            MapMemberItem::Fragment(build_map_nested_map_member_schema(inner_key, inner_value)?)
+            build_nested_map_member_item(inner_key, inner_value)?
         }
         // The member is the sibling's own schema, as it is in field position — an expression, not a
         // literal, so it is already the value form.
         FieldDefType::SiblingType(value_type_name, value_args) => {
             log::trace!(
-                "Map Value SiblingType => value_type_name: {value_type_name}, value_args: {value_args:?}"
+                "Slot SiblingType => value_type_name: {value_type_name}, value_args: {value_args:?}"
             );
-            let value_module_ident = sibling_schema_module_ident(value_type_name);
-            MapMemberItem::Value(quote! { #value_module_ident::Schema::json_schema() })
+            MapMemberItem::Value(sibling_json_schema_value(value_type_name))
         }
         // A map member's `$oid` object is closed and unpatterned, where the shared mapping's
         // field-position rendering carries the hex pattern and leaves the object open.
@@ -3574,34 +3732,60 @@ fn build_map_member_item(value: &FieldDef) -> Option<MapMemberItem> {
         | FieldDefType::U16
         | FieldDefType::U32
         | FieldDefType::U64
-        | FieldDefType::Usize => MapMemberItem::Fragment(scalar_field_json_schema_item(value)?),
+        | FieldDefType::Usize => MapMemberItem::Fragment(scalar_slot_item(value)?),
         #[cfg(feature = "chrono")]
         FieldDefType::DateTime
         | FieldDefType::NaiveDate
         | FieldDefType::NaiveDateTime
-        | FieldDefType::NaiveTime => MapMemberItem::Fragment(scalar_field_json_schema_item(value)?),
+        | FieldDefType::NaiveTime => MapMemberItem::Fragment(scalar_slot_item(value)?),
     })
 }
 
-/// The `additionalProperties` schema every member of a `String`-keyed map carries, or `None` when
-/// the value type has no rendering here.
+/// [`scalar_field_json_schema_item`] for a slot, where a tuple is the one type reaching it with no
+/// inline rendering — every other type the scalar mapping names renders there.
 #[cfg(feature = "jsonschema")]
-fn build_map_member_schema(value: &FieldDef) -> Option<proc_macro2::TokenStream> {
-    let normalized = normalized_map_value(value);
-    Some(build_map_member_item(&normalized)?.into_member_schema(&normalized))
+fn scalar_slot_item(fld: &FieldDef) -> Result<proc_macro2::TokenStream, MapMemberRejection> {
+    scalar_field_json_schema_item(fld).ok_or(MapMemberRejection::Tuple)
 }
 
-/// The one diagnostic a map value the mapping cannot render produces, on either key path.
+/// The `additionalProperties` schema every member of a `String`-keyed map carries, or the rejection
+/// when the value type has no rendering here.
+#[cfg(feature = "jsonschema")]
+fn build_map_member_schema(
+    value: &FieldDef,
+) -> Result<proc_macro2::TokenStream, MapMemberRejection> {
+    let normalized = normalized_slot_value(value);
+    Ok(build_map_member_item(&normalized)?.into_member_schema(&normalized))
+}
+
+/// What a value the mapping cannot render is reported as. The `subject` names where the value was
+/// written — a field, an alias — which is what the author can act on and all that differs between
+/// those positions, so the reasons are worded once.
+#[cfg(feature = "jsonschema")]
+fn map_member_rejection_message(subject: &str, rejection: &MapMemberRejection) -> String {
+    match rejection {
+        MapMemberRejection::NonEnumKey(key_type_name) => format!(
+            "{subject}: a map key must be a plain `#[model_schema()]` enum, whose members become the object's keys — `{key_type_name}` resolves to a type with no `enum_members()`"
+        ),
+        MapMemberRejection::Tuple => format!(
+            "{subject}: a tuple is not supported as a map value — give the value a `#[model_schema()]` struct instead"
+        ),
+    }
+}
+
+/// The one diagnostic a slot the mapping cannot render produces — on either key path, at any depth,
+/// and in a tuple slot the value is reached through.
 ///
 /// It replaces the branch's whole output rather than joining it: an emission left in place hands
 /// the author a schema the expansion has already rejected, and on the enum-key path a second error
 /// on the `value_schema` the failed binding never bound — macro-internal state the author cannot
-/// act on. The field and the type are what the author can act on, so the message names both.
+/// act on. The field and the type are what the author can act on, so each message names both.
 #[cfg(feature = "jsonschema")]
-fn unsupported_map_value_error(field_name_str: &str) -> proc_macro2::TokenStream {
-    let message = format!(
-        "field `{field_name_str}`: a tuple is not supported as a map value — give the value a `#[model_schema()]` struct instead"
-    );
+fn map_member_rejection_error(
+    field_name_str: &str,
+    rejection: &MapMemberRejection,
+) -> proc_macro2::TokenStream {
+    let message = map_member_rejection_message(&format!("field `{field_name_str}`"), rejection);
     quote! { compile_error!(#message); }
 }
 
@@ -3614,8 +3798,9 @@ fn build_string_key_map_value_schema(
     value: &FieldDef,
     field_name_str: &str,
 ) -> proc_macro2::TokenStream {
-    let Some(value_schema) = build_map_member_schema(value) else {
-        return unsupported_map_value_error(field_name_str);
+    let value_schema = match build_map_member_schema(value) {
+        Ok(value_schema) => value_schema,
+        Err(rejection) => return map_member_rejection_error(field_name_str, &rejection),
     };
     quote! {
         properties.insert(#field_name_str.to_string(), {
@@ -3632,27 +3817,58 @@ fn build_string_key_map_value_schema(
 /// where a `String`-keyed member carries the closed, unpatterned one. Which of the two a map member
 /// should carry is unsettled, so each key path keeps the rendering it has.
 #[cfg(feature = "jsonschema")]
-fn build_enum_key_map_member_item(value: &FieldDef) -> Option<MapMemberItem> {
+fn build_enum_key_map_member_item(value: &FieldDef) -> Result<MapMemberItem, MapMemberRejection> {
     #[cfg(feature = "object_id")]
     if matches!(value.field_type, FieldDefType::ObjectId) {
-        return Some(MapMemberItem::Fragment(scalar_field_json_schema_item(
-            value,
-        )?));
+        return Ok(MapMemberItem::Fragment(scalar_slot_item(value)?));
     }
     build_map_member_item(value)
 }
 
-/// Binds `value_schema` — the JSON schema every member of an enum-keyed map carries — or `None`
-/// when the value type has no rendering here.
+/// The object an enum-keyed map describes as, as a standalone `serde_json::Value` expression: one
+/// property per member the key enumerates, each carrying the value type's own rendering, and closed
+/// to every other key. `Err` when the value has no rendering here, or when the registry proves the
+/// key carries no members.
 ///
-/// The member is the one the `String`-key path renders, materialized as a `serde_json::Value` for
-/// the insertion loop to clone per key, so which values a map may hold is the value type's answer
-/// rather than the key path's.
+/// The members are built by a block rather than spelled into a literal — only the expansion's own
+/// runtime knows them — and the block is bound inside a `serde_json::json!`, which makes the whole
+/// emission an expression. That is what lets one rendering serve every position a map is written
+/// in: a field's insertion, a member of an enclosing map, a tuple's `prefixItems` slot. A key that
+/// enumerates its members therefore enumerates them at any depth.
+///
+/// The key is written as a *type path*, which resolves through any alias, so an alias of a non-enum
+/// lands on a type with no `enum_members()` and rustc blames `#[model_schema()]` for a method the
+/// author never wrote. Only a target the registry positively rules out is turned away here: an
+/// unregistered name — a foreign type, or one expanded after this struct — stays on the emitting
+/// path, where it behaves as it always has.
 #[cfg(feature = "jsonschema")]
-fn build_enum_key_map_value_binding(value: &FieldDef) -> Option<proc_macro2::TokenStream> {
-    let normalized = normalized_map_value(value);
-    let value_schema = build_enum_key_map_member_item(&normalized)?.into_member_value(&normalized);
-    Some(quote! { let value_schema = #value_schema; })
+fn enum_key_map_json_schema_value(
+    key_type_name: &str,
+    value: &FieldDef,
+) -> Result<proc_macro2::TokenStream, MapMemberRejection> {
+    if lookup_alias_info(key_type_name)
+        .is_some_and(|key_alias| key_alias.kind == AliasKind::NoEnumMembers)
+    {
+        return Err(MapMemberRejection::NonEnumKey(key_type_name.to_owned()));
+    }
+
+    let normalized = normalized_slot_value(value);
+    let member_value = build_enum_key_map_member_item(&normalized)?.into_member_value(&normalized);
+    let key_type_name_ident = Ident::new(key_type_name, proc_macro2::Span::call_site());
+    Ok(quote! {
+        serde_json::json!({
+            "type": "object",
+            "properties": ({
+                let value_schema = #member_value;
+                let mut map_properties = serde_json::Map::new();
+                for enum_key in #key_type_name_ident::enum_members() {
+                    map_properties.insert(enum_key.to_string(), value_schema.clone());
+                }
+                map_properties
+            }),
+            "additionalProperties": false
+        })
+    })
 }
 
 #[cfg(feature = "jsonschema")]
@@ -3663,78 +3879,17 @@ fn build_map_field_schema(
 ) -> proc_macro2::TokenStream {
     log::trace!("Map => field_name: {field_name_str}, key: {key:?}, value: {value:?}");
 
-    match &key.field_type {
-        FieldDefType::String => build_string_key_map_value_schema(value, field_name_str),
-        FieldDefType::SiblingType(key_type_name, lst) if lst.is_empty() => {
-            // The loop below writes the key as a *type path*, which resolves through any alias, so
-            // an alias of a non-enum lands on a type with no `enum_members()` and rustc blames
-            // `#[model_schema()]` for a missing method the author never wrote. Only a target the
-            // registry positively rules out is rejected here: an unregistered name (a foreign type,
-            // or one expanded after this struct) stays on the emitting path, where it behaves as it
-            // always has.
-            if let Some(key_alias) = lookup_alias_info(key_type_name)
-                && key_alias.kind == AliasKind::NoEnumMembers
-            {
-                let message = format!(
-                    "field `{field_name_str}`: a map key must be a plain `#[model_schema()]` enum, whose members become the object's keys — `{key_type_name}` resolves to a type with no `enum_members()`"
-                );
-                return quote! { compile_error!(#message); };
-            }
-
-            // For enum_members(), we call the type directly (delegation works)
-            let key_type_name_ident =
-                proc_macro2::Ident::new(key_type_name.as_str(), proc_macro2::Span::call_site());
-
-            let Some(value_schema_code) = build_enum_key_map_value_binding(value) else {
-                return unsupported_map_value_error(field_name_str);
-            };
-
-            quote! {
-                let mut map_properties = serde_json::Map::new();
-
-                #value_schema_code
-
-                for enum_key in #key_type_name_ident::enum_members() {
-                    map_properties.insert(enum_key.to_string(), value_schema.clone());
-                }
-
-                let mut json_schema_def = serde_json::json!({
-                    "type": "object",
-                    "properties": map_properties,
-                    "additionalProperties": false
-                });
-
-                properties.insert(#field_name_str.to_string(), {
-                    json_schema_def
-                });
+    match map_key_path(key) {
+        MapKeyPath::Enumerated(key_type_name) => {
+            match enum_key_map_json_schema_value(key_type_name, value) {
+                Ok(map_schema) => quote! {
+                    properties.insert(#field_name_str.to_string(), #map_schema);
+                },
+                Err(rejection) => map_member_rejection_error(field_name_str, &rejection),
             }
         }
-
-        FieldDefType::SiblingType(..)
-        | FieldDefType::Unknown
-        | FieldDefType::Map(..)
-        | FieldDefType::Tuple(..)
-        | FieldDefType::Boolean
-        | FieldDefType::StringLiteral(_)
-        | FieldDefType::U8
-        | FieldDefType::U16
-        | FieldDefType::U32
-        | FieldDefType::U64
-        | FieldDefType::I8
-        | FieldDefType::I16
-        | FieldDefType::I32
-        | FieldDefType::I64
-        | FieldDefType::Usize
-        | FieldDefType::Isize
-        | FieldDefType::F32
-        | FieldDefType::F64 => map_key_fallback_schema(field_name_str, key),
-        #[cfg(feature = "object_id")]
-        FieldDefType::ObjectId => map_key_fallback_schema(field_name_str, key),
-        #[cfg(feature = "chrono")]
-        FieldDefType::NaiveDate
-        | FieldDefType::NaiveTime
-        | FieldDefType::NaiveDateTime
-        | FieldDefType::DateTime => map_key_fallback_schema(field_name_str, key),
+        MapKeyPath::Open => build_string_key_map_value_schema(value, field_name_str),
+        MapKeyPath::Unnarrowed => map_key_fallback_schema(field_name_str, key),
     }
 }
 
@@ -3920,9 +4075,7 @@ fn build_sibling_type_field_schema(
         // Covers both non-generic sibling types (lst.is_empty()) and generic branded wrappers
         // like DocumentTypeId<String>: for a transparent newtype the JSON schema is defined on
         // the wrapper type's own schema module, and type params don't affect it.
-        let module_ident = sibling_schema_module_ident(name);
-        let type_json_schema = quote! { #module_ident::Schema::json_schema() };
-        generate_type_schema(fld, field_name_str, &type_json_schema)
+        generate_type_schema(fld, field_name_str, &sibling_json_schema_value(name))
     }
 }
 
@@ -3991,29 +4144,24 @@ fn build_string_format_field_schema(
 
 /// Builds JSON schema for a tuple struct field.
 ///
-/// A Rust tuple field `(A, B, ...)` serializes (via serde) as a fixed-length
-/// JSON array, so it is rendered as `{ "type": "array", "prefixItems": [...],
-/// "items": false, "minItems": N, "maxItems": N }`. This mirrors the tuple
-/// **variant** path (`write_tuple_multiple_variant_fields`) and reuses the same
-/// per-element schema builder (`build_tuple_element_json_schema`).
+/// A Rust tuple field `(A, B, ...)` serializes (via serde) as a fixed-length JSON array, which is
+/// what [`tuple_json_schema_value`] renders — the same array a tuple nested in a slot renders, so
+/// the two positions cannot drift apart. The tuple **variant** path
+/// (`write_tuple_multiple_variant_fields`) shares the per-element builder but spells its own array,
+/// without the arity bounds.
+///
+/// An element the dispatch cannot render replaces the whole insertion with the lone diagnostic,
+/// as an unrenderable map value does: a schema left in place would describe a field the expansion
+/// has already rejected.
 #[cfg(feature = "jsonschema")]
 fn build_tuple_field_schema(
     fld: &FieldDef,
     field_name_str: &str,
     lst: &[FieldDef],
 ) -> proc_macro2::TokenStream {
-    let arity = lst.len();
-    let element_schemas: Vec<proc_macro2::TokenStream> =
-        lst.iter().map(build_tuple_element_json_schema).collect();
-
-    let tuple_schema = quote! {
-        serde_json::json!({
-            "type": "array",
-            "prefixItems": [#(#element_schemas),*],
-            "items": false,
-            "minItems": #arity,
-            "maxItems": #arity
-        })
+    let tuple_schema = match tuple_json_schema_value(lst) {
+        Ok(tuple_schema) => tuple_schema,
+        Err(rejection) => return map_member_rejection_error(field_name_str, &rejection),
     };
 
     if fld.is_array {
@@ -4728,8 +4876,7 @@ fn generate_json_schema_method(
 #[cfg(feature = "jsonschema")]
 fn flatten_field_json_schema_ref(fld: &FieldDef) -> proc_macro2::TokenStream {
     if let FieldDefType::SiblingType(name, _) = &fld.field_type {
-        let module_ident = sibling_schema_module_ident(name);
-        quote! { #module_ident::Schema::json_schema() }
+        sibling_json_schema_value(name)
     } else {
         quote! { serde_json::json!({ "type": "object" }) }
     }
@@ -5123,15 +5270,67 @@ fn generate_ts_alias_method(
     }
 }
 
+/// The alias target as the JSON mapping reads it: every reference to one of the alias's own type
+/// parameters replaced by the opaque type.
+///
+/// A parameter names no type until the alias is instantiated, and every position that references an
+/// alias references it uninstantiated — a field written as `Pair<A, B>` carries the alias module's
+/// one schema. So a parameter admits any value, as an opaque field does, while the shape around it
+/// — arity, array-ness, a map's keys — is still described.
+#[cfg(feature = "jsonschema")]
+fn alias_json_schema_field_def(alias: &ItemType, field_def: &FieldDef) -> FieldDef {
+    let parameters: Vec<String> = alias
+        .generics
+        .params
+        .iter()
+        .filter_map(|param| match param {
+            syn::GenericParam::Type(tp) => Some(tp.ident.to_string()),
+            syn::GenericParam::Const(_) | syn::GenericParam::Lifetime(_) => None,
+        })
+        .collect();
+    let mut erased = field_def.clone();
+    erased.erase_type_parameters(&parameters);
+    erased
+}
+
+/// The diagnostic an alias whose target the dispatch cannot render emits, in place of the whole
+/// `json_schema()` body.
+///
+/// It replaces the body rather than joining it: a schema left there would describe a type the
+/// expansion has already rejected, and every slot naming the alias would carry it. The tokens are
+/// the body's tail expression — no trailing semicolon, so the method's return type raises no second
+/// error on top of the one the author can act on.
+#[cfg(feature = "jsonschema")]
+fn alias_json_schema_rejection(
+    export_name: &str,
+    rejection: &MapMemberRejection,
+) -> proc_macro2::TokenStream {
+    let message = map_member_rejection_message(&format!("type alias `{export_name}`"), rejection);
+    quote! { compile_error!(#message) }
+}
+
+/// Builds the alias module's `json_schema()`, or nothing when `jsonschema` is off.
+///
+/// An alias names a type, so it publishes that type's own schema: the target `FieldDef` — the one
+/// the TypeScript and Zod methods render from — through the dispatch a positional slot uses, that
+/// being the dispatch total over the types the crate renders and the one whose `ObjectId` is the
+/// field-position object. So the alias describes what a field written as the target describes. A
+/// sibling target is carried by the shared reference, which resolves through the registry: an alias
+/// of an alias lands on the type at the end of the chain, and an alias of a type that never
+/// expanded fails on the module it names, exactly as a field of that type does.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-fn generate_alias_json_schema_stub() -> proc_macro2::TokenStream {
+fn generate_alias_json_schema_method(
+    alias: &ItemType,
+    export_name: &str,
+    field_def: &FieldDef,
+) -> proc_macro2::TokenStream {
     #[cfg(feature = "jsonschema")]
     {
+        let body = build_tuple_element_json_schema(&alias_json_schema_field_def(alias, field_def))
+            .unwrap_or_else(|rejection| alias_json_schema_rejection(export_name, &rejection));
         quote! {
             pub fn json_schema() -> serde_json::Value {
-                serde_json::json!({
-                    "warning": "JSON schema generation for aliases is not yet supported"
-                })
+                #body
             }
         }
     }
@@ -5139,6 +5338,7 @@ fn generate_alias_json_schema_stub() -> proc_macro2::TokenStream {
     {
         // Nothing in this build references an alias module's `json_schema()`; the sibling
         // reference that would (`flatten_field_json_schema_ref`) is itself jsonschema-gated.
+        let _: &_ = &(alias, export_name, field_def);
         quote! {}
     }
 }

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -1628,3 +1628,47 @@ fn an_aliased_string_keyed_map_value_resolves_its_module_through_the_registry() 
         );
     }
 }
+
+/// A field spelled as a wrapper around `u32`, built rather than parsed: the parser collapses a
+/// `Vec` onto its element before any wrapper name is read, so the `Vec` spelling of a wrapper name
+/// can only be put in front of the dispatch this way.
+#[cfg(feature = "jsonschema")]
+fn wrapped_u32_field_schema(wrapper: &str) -> String {
+    let element = super::get_field_def("", &syn::parse_quote!(u32), "");
+    let field = super::FieldDef {
+        array_num: None,
+        docs: String::new(),
+        field_type: FieldDefType::SiblingType(wrapper.to_owned(), vec![element]),
+        is_array: false,
+        is_optional: false,
+        model_schema_prop_meta: None,
+        name: "items".to_owned(),
+    };
+    super::build_field_type_schema(&field, "items").to_string()
+}
+
+/// Every wrapper serde writes as a JSON array describes as the `Vec` of its element does, that
+/// being the whole reason each is covered. One list answers for all of them, so none can fall
+/// through to a schema module of its own — a module the expansion never emits.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn every_sequence_wrapper_describes_as_the_vec_of_its_element() {
+    let parsed: syn::Type = syn::parse_quote!(Vec<u32>);
+    let expected =
+        super::build_field_type_schema(&super::get_field_def("items", &parsed, ""), "items")
+            .to_string();
+    for wrapper in [
+        "BTreeSet",
+        "BinaryHeap",
+        "HashSet",
+        "LinkedList",
+        "Vec",
+        "VecDeque",
+    ] {
+        assert_eq!(
+            wrapped_u32_field_schema(wrapper),
+            expected,
+            "for: {wrapper}"
+        );
+    }
+}

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -1,4 +1,7 @@
-use super::{FieldDefType, validate_as_number_flag, validate_ts_optional_flag};
+use super::{
+    FieldDefType, collect_discriminated_variants, render_discriminated_variants,
+    validate_as_number_flag, validate_ts_optional_flag,
+};
 
 #[cfg(feature = "serde")]
 use super::{
@@ -12,6 +15,20 @@ use super::{AliasKind, branded_guard_errors, register_alias_info};
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 use syn::spanned::Spanned as _;
+
+/// The variants of [`rendered_discriminated_union`]'s enum, in the order they are declared.
+const DECLARED_VARIANTS: [&str; 6] = ["Upload", "Generate", "Delete", "Rename", "Move", "Archive"];
+
+/// The covered wrappers, under the names a dispatch reads them by.
+#[cfg(feature = "jsonschema")]
+const SEQUENCE_WRAPPERS: [&str; 6] = [
+    "BTreeSet",
+    "BinaryHeap",
+    "HashSet",
+    "LinkedList",
+    "Vec",
+    "VecDeque",
+];
 
 #[test]
 fn ts_optional_ok_on_option_field() {
@@ -412,9 +429,88 @@ fn discriminated_enum_ts_definition_carries_no_cfg_attribute() {
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
-fn alias_json_schema_stub_carries_no_cfg_attribute() {
-    let tokens = super::generate_alias_json_schema_stub();
-    assert_no_cfg_attribute(&tokens, "generate_alias_json_schema_stub");
+fn alias_json_schema_method_carries_no_cfg_attribute() {
+    let alias: syn::ItemType = syn::parse_quote!(
+        pub type AliasIdent = String;
+    );
+    let field_def = super::get_field_def("AliasType", &alias.ty, "");
+    let tokens = super::generate_alias_json_schema_method(&alias, "AliasType", &field_def);
+    assert_no_cfg_attribute(&tokens, "generate_alias_json_schema_method");
+}
+
+/// An alias whose target the dispatch cannot render fails the way a field of that target does: one
+/// diagnostic, naming the alias and the reason, in place of the whole body. A schema left there
+/// would be carried by every slot the alias fills.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn an_alias_of_an_unrenderable_target_emits_only_the_compile_error() {
+    for alias_source in [
+        "pub type Rows = HashMap<String, (u32, u32)>;",
+        "pub type Rows = Vec<HashMap<String, (u32, u32)>>;",
+        "pub type Rows = (String, HashMap<String, (u32, u32)>);",
+    ] {
+        let alias: syn::ItemType = syn::parse_str(alias_source).unwrap();
+        let field_def = super::get_field_def("RowsType", &alias.ty, "");
+        let tokens =
+            super::generate_alias_json_schema_method(&alias, "RowsType", &field_def).to_string();
+        assert!(
+            tokens.contains("compile_error !"),
+            "for {alias_source}, got: {tokens}"
+        );
+        assert!(
+            tokens.contains("type alias `RowsType`"),
+            "for {alias_source}, got: {tokens}"
+        );
+        assert!(
+            tokens.contains("a tuple is not supported as a map value"),
+            "for {alias_source}, got: {tokens}"
+        );
+        assert!(
+            !tokens.contains("json !"),
+            "for {alias_source}, got: {tokens}"
+        );
+    }
+}
+
+/// A type parameter reaches the mapping as a named type, and a name is carried by a reference to
+/// the schema module it registered — a module no expansion emits for a parameter. So the parameter
+/// is erased wherever it can be written, or the alias names a module that does not exist.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn an_alias_type_parameter_is_erased_at_every_depth() {
+    for alias_source in [
+        "pub type Holder<V> = V;",
+        "pub type Holder<V> = Vec<V>;",
+        "pub type Holder<V> = Option<V>;",
+        "pub type Holder<V> = (String, V);",
+        "pub type Holder<V> = HashMap<String, V>;",
+        "pub type Holder<V> = HashMap<String, Vec<V>>;",
+    ] {
+        let alias: syn::ItemType = syn::parse_str(alias_source).unwrap();
+        let field_def = super::get_field_def("HolderType", &alias.ty, "");
+        let tokens =
+            super::generate_alias_json_schema_method(&alias, "HolderType", &field_def).to_string();
+        assert!(
+            !tokens.contains("Schema :: json_schema ()"),
+            "for {alias_source}, got: {tokens}"
+        );
+    }
+}
+
+/// The stub this replaced answered every alias with an object carrying a lone `warning` key, which
+/// under JSON Schema constrains nothing — every slot naming an alias accepted every payload. No
+/// emission may carry one again.
+#[test]
+fn no_json_schema_emission_carries_a_warning_key() {
+    for (file, source) in [
+        ("model_schema.rs", include_str!("../model_schema.rs")),
+        (
+            "features/jsonschema.rs",
+            include_str!("../features/jsonschema.rs"),
+        ),
+    ] {
+        assert!(!source.contains("\"warning\""), "in: {file}");
+    }
 }
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
@@ -969,14 +1065,14 @@ fn an_unsupported_enum_keyed_map_value_emits_only_the_compile_error() {
     }
 }
 
-/// The enum-key branch's binding for a map value built by hand, for the value types no source type
+/// The enum-key branch's rendering for a map value built by hand, for the value types no source type
 /// produces.
 #[cfg(feature = "jsonschema")]
 fn enum_key_map_value_binding(field_type: FieldDefType) -> String {
     let ty: syn::Type = syn::parse_str("String").unwrap();
     let mut value = super::get_field_def("m", &ty, "");
     value.field_type = field_type;
-    super::build_enum_key_map_value_binding(&value)
+    super::enum_key_map_json_schema_value("Slot", &value)
         .unwrap()
         .to_string()
 }
@@ -1043,7 +1139,10 @@ fn a_generic_sibling_enum_keyed_map_value_emits_the_sibling_schema() {
 #[test]
 fn an_opaque_enum_keyed_map_value_stays_permissive() {
     let tokens = enum_key_map_value_binding(FieldDefType::Unknown);
-    assert_eq!(tokens, "let value_schema = serde_json :: json ! ({ }) ;");
+    assert!(
+        tokens.contains("let value_schema = serde_json :: json ! ({ }) ;"),
+        "got: {tokens}"
+    );
 }
 
 /// A string literal keeps the `const` it carries on the `String`-key path.
@@ -1051,9 +1150,11 @@ fn an_opaque_enum_keyed_map_value_stays_permissive() {
 #[test]
 fn a_string_literal_enum_keyed_map_value_keeps_its_const() {
     let tokens = enum_key_map_value_binding(FieldDefType::StringLiteral("Tixena".to_owned()));
-    assert_eq!(
-        tokens,
-        r#"let value_schema = serde_json :: json ! ({ "type" : "string" , "const" : "Tixena" }) ;"#
+    assert!(
+        tokens.contains(
+            r#"let value_schema = serde_json :: json ! ({ "type" : "string" , "const" : "Tixena" }) ;"#
+        ),
+        "got: {tokens}"
     );
 }
 
@@ -1084,9 +1185,11 @@ fn a_chrono_enum_keyed_map_value_keeps_its_format() {
 #[test]
 fn an_object_id_enum_keyed_map_value_keeps_the_field_position_oid_object() {
     let tokens = enum_key_map_value_binding(FieldDefType::ObjectId);
-    assert_eq!(
-        tokens,
-        r#"let value_schema = serde_json :: json ! ({ "type" : "object" , "properties" : { "$oid" : { "type" : "string" , "pattern" : "^[a-f\\d]{24}$" } } , "required" : ["$oid"] }) ;"#
+    assert!(
+        tokens.contains(
+            r#"let value_schema = serde_json :: json ! ({ "type" : "object" , "properties" : { "$oid" : { "type" : "string" , "pattern" : "^[a-f\\d]{24}$" } } , "required" : ["$oid"] }) ;"#
+        ),
+        "got: {tokens}"
     );
 }
 
@@ -1500,18 +1603,198 @@ fn a_nested_object_id_map_value_keeps_its_oid_object() {
     );
 }
 
-/// An inner key type this branch does not enumerate leaves the inner members open — but the member
-/// is still known to be an object, which is more than an unconstrained value says.
+/// The rendering an enum-keyed map carries in every position, spelled out for a key of the given
+/// name and a member of the given tokens.
+#[cfg(feature = "jsonschema")]
+fn enum_key_map_rendering(key_type_name: &str, member: &str) -> String {
+    format!(
+        r#"serde_json :: json ! ({{ "type" : "object" , "properties" : ({{ let value_schema = {member} ; let mut map_properties = serde_json :: Map :: new () ; for enum_key in {key_type_name} :: enum_members () {{ map_properties . insert (enum_key . to_string () , value_schema . clone ()) ; }} map_properties }}) , "additionalProperties" : false }})"#
+    )
+}
+
+/// Which keys a map has is the key type's answer wherever the map is written, so an inner key that
+/// enumerates its members enumerates them under an outer `String` key too — the position the map
+/// sits in cannot decide whether its keys are known.
 #[cfg(feature = "jsonschema")]
 #[test]
-fn a_nested_map_under_an_unenumerated_key_still_renders_as_an_object() {
+fn a_nested_map_under_an_enumerating_key_expands_its_members() {
     let tokens = map_field_schema("HashMap<String, HashMap<Slot, String>>").to_string();
+    let inner = enum_key_map_rendering("Slot", r#"serde_json :: json ! ({ "type" : "string" })"#);
     assert!(
-        tokens.contains(
-            r#""additionalProperties" : { "type" : "object" , "additionalProperties" : true }"#
-        ),
+        tokens.contains(&format!(r#""additionalProperties" : {inner}"#)),
         "got: {tokens}"
     );
+    assert!(
+        !tokens.contains(r#""additionalProperties" : true"#),
+        "got: {tokens}"
+    );
+}
+
+/// And under an outer key that enumerates too: each level asks its own key type, so a two-level map
+/// spells both member sets out rather than stopping at the first.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_nested_map_under_two_enumerating_keys_expands_both_member_sets() {
+    let tokens = map_field_schema("HashMap<Slot, HashMap<Bucket, u64>>").to_string();
+    let inner =
+        enum_key_map_rendering("Bucket", r#"serde_json :: json ! ({ "type" : "integer" })"#);
+    assert!(
+        tokens.contains(&enum_key_map_rendering("Slot", &inner)),
+        "got: {tokens}"
+    );
+    assert!(
+        !tokens.contains(r#""additionalProperties" : true"#),
+        "got: {tokens}"
+    );
+}
+
+/// The slot wraps sit outside the map's own rendering, as they do for every other member: a `Vec` of
+/// enum-keyed maps is an array of the object each one describes as, and an `Option` admits `null`
+/// beside it.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_wrapped_nested_enum_keyed_map_keeps_its_members_inside_the_slot_wrap() {
+    let inner = enum_key_map_rendering("Slot", r#"serde_json :: json ! ({ "type" : "string" })"#);
+    for (map_type, expected) in [
+        (
+            "HashMap<String, Vec<HashMap<Slot, String>>>",
+            format!(r#"serde_json :: json ! ({{ "type" : "array" , "items" : {inner} }})"#),
+        ),
+        (
+            "HashMap<String, Option<HashMap<Slot, String>>>",
+            format!(r#"serde_json :: json ! ({{ "anyOf" : [{inner} , {{ "type" : "null" }}] }})"#),
+        ),
+    ] {
+        let tokens = map_field_schema(map_type).to_string();
+        assert!(
+            tokens.contains(&format!(r#""additionalProperties" : {expected}"#)),
+            "for {map_type}, got: {tokens}"
+        );
+    }
+}
+
+/// An enum-keyed map in a tuple slot is the same map, so it carries the same rendering: the slot
+/// dispatch reaches the one emission rather than falling back to the open object.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn an_enum_keyed_map_tuple_element_expands_its_members() {
+    let expected =
+        enum_key_map_rendering("Slot", r#"serde_json :: json ! ({ "type" : "integer" })"#);
+    for field_type in [
+        "(String, HashMap<Slot, u32>)",
+        "(String, HashMap<String, HashMap<Slot, u32>>)",
+    ] {
+        let tokens = tuple_field_schema(field_type);
+        assert!(
+            tokens.contains(&expected),
+            "for {field_type}, got: {tokens}"
+        );
+        assert!(
+            !tokens.contains(r#""additionalProperties" : true"#),
+            "for {field_type}, got: {tokens}"
+        );
+    }
+}
+
+/// An inner key the registry positively rules out is rejected where the outer one is: reaching the
+/// emitting path at depth resolves `enum_members()` through the alias onto a type that has no such
+/// method, and rustc blames the attribute for a method the author never wrote.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_nested_map_key_known_to_lack_enum_members_names_the_requirement() {
+    register_alias_info(
+        "KeyAlias",
+        "KeyAliasType",
+        "key_alias_type_schema",
+        AliasKind::NoEnumMembers,
+    );
+    for map_type in [
+        "HashMap<String, HashMap<KeyAlias, String>>",
+        "HashMap<Slot, HashMap<KeyAlias, String>>",
+        "HashMap<String, Vec<HashMap<KeyAlias, String>>>",
+    ] {
+        let tokens = map_field_schema(map_type).to_string();
+        assert!(
+            !tokens.contains("KeyAlias :: enum_members"),
+            "for {map_type}, got: {tokens}"
+        );
+        assert!(
+            tokens.starts_with("compile_error !"),
+            "for {map_type}, got: {tokens}"
+        );
+        assert!(
+            !tokens.contains("properties . insert"),
+            "for {map_type}, got: {tokens}"
+        );
+        assert!(
+            tokens.contains("a map key must be a plain"),
+            "for {map_type}, got: {tokens}"
+        );
+        assert!(tokens.contains("KeyAlias"), "for {map_type}, got: {tokens}");
+    }
+}
+
+/// The guard reaches a tuple slot too, that being another position the map is dispatched through.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_tuple_element_map_key_known_to_lack_enum_members_names_the_requirement() {
+    register_alias_info(
+        "KeyAlias",
+        "KeyAliasType",
+        "key_alias_type_schema",
+        AliasKind::NoEnumMembers,
+    );
+    let tokens = tuple_field_schema("(String, HashMap<KeyAlias, String>)");
+    assert!(tokens.starts_with("compile_error !"), "got: {tokens}");
+    assert!(
+        tokens.contains("a map key must be a plain"),
+        "got: {tokens}"
+    );
+    assert!(tokens.contains("field `t`"), "got: {tokens}");
+}
+
+/// The one emission answers for every position a map can sit in, so the object `HashMap<Slot, T>`
+/// describes as in field position is the object it describes as nested under either key flavor and
+/// in a tuple slot. Held against the field-position rendering, which is the one that has always
+/// enumerated — depth cannot widen what the key already settled.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn an_enum_keyed_map_renders_the_same_in_every_position() {
+    let expected =
+        enum_key_map_rendering("Slot", r#"serde_json :: json ! ({ "type" : "string" })"#);
+    assert!(
+        map_field_schema("HashMap<Slot, String>")
+            .to_string()
+            .contains(&expected),
+        "field position lost its enumeration"
+    );
+    for position in [
+        map_field_schema("HashMap<String, HashMap<Slot, String>>").to_string(),
+        map_field_schema("HashMap<Slot, HashMap<Slot, String>>").to_string(),
+        tuple_field_schema("(String, HashMap<Slot, String>)"),
+    ] {
+        assert!(position.contains(&expected), "got: {position}");
+    }
+}
+
+/// An inner key this expansion cannot narrow leaves the inner members open — the member is still
+/// known to be an object, which is what the map guarantees, and it is what the same key states in
+/// field position.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_nested_map_under_an_unenumerable_key_still_renders_as_an_object() {
+    for map_type in [
+        "HashMap<String, HashMap<u32, String>>",
+        "HashMap<String, HashMap<Wrapper<Slot>, String>>",
+    ] {
+        let tokens = map_field_schema(map_type).to_string();
+        assert!(
+            tokens.contains(
+                r#""additionalProperties" : { "type" : "object" , "additionalProperties" : true }"#
+            ),
+            "for {map_type}, got: {tokens}"
+        );
+    }
 }
 
 /// A value the mapping cannot render fails wherever it sits: nested behind a map, the tuple is
@@ -1629,13 +1912,13 @@ fn an_aliased_string_keyed_map_value_resolves_its_module_through_the_registry() 
     }
 }
 
-/// A field spelled as a wrapper around `u32`, built rather than parsed: the parser collapses a
+/// A value spelled as a wrapper around `u32`, built rather than parsed: the parser collapses a
 /// `Vec` onto its element before any wrapper name is read, so the `Vec` spelling of a wrapper name
-/// can only be put in front of the dispatch this way.
+/// can only be put in front of a dispatch this way.
 #[cfg(feature = "jsonschema")]
-fn wrapped_u32_field_schema(wrapper: &str) -> String {
+fn wrapped_u32_value(wrapper: &str) -> super::FieldDef {
     let element = super::get_field_def("", &syn::parse_quote!(u32), "");
-    let field = super::FieldDef {
+    super::FieldDef {
         array_num: None,
         docs: String::new(),
         field_type: FieldDefType::SiblingType(wrapper.to_owned(), vec![element]),
@@ -1643,8 +1926,13 @@ fn wrapped_u32_field_schema(wrapper: &str) -> String {
         is_optional: false,
         model_schema_prop_meta: None,
         name: "items".to_owned(),
-    };
-    super::build_field_type_schema(&field, "items").to_string()
+    }
+}
+
+/// The `Vec<u32>` value every wrapper spelling of the same thing is held against.
+#[cfg(feature = "jsonschema")]
+fn parsed_u32_vec_value() -> super::FieldDef {
+    super::get_field_def("items", &syn::parse_quote!(Vec<u32>), "")
 }
 
 /// Every wrapper serde writes as a JSON array describes as the `Vec` of its element does, that
@@ -1653,22 +1941,214 @@ fn wrapped_u32_field_schema(wrapper: &str) -> String {
 #[cfg(feature = "jsonschema")]
 #[test]
 fn every_sequence_wrapper_describes_as_the_vec_of_its_element() {
-    let parsed: syn::Type = syn::parse_quote!(Vec<u32>);
-    let expected =
-        super::build_field_type_schema(&super::get_field_def("items", &parsed, ""), "items")
-            .to_string();
-    for wrapper in [
-        "BTreeSet",
-        "BinaryHeap",
-        "HashSet",
-        "LinkedList",
-        "Vec",
-        "VecDeque",
-    ] {
+    let expected = super::build_field_type_schema(&parsed_u32_vec_value(), "items").to_string();
+    for wrapper in SEQUENCE_WRAPPERS {
         assert_eq!(
-            wrapped_u32_field_schema(wrapper),
+            super::build_field_type_schema(&wrapped_u32_value(wrapper), "items").to_string(),
             expected,
             "for: {wrapper}"
+        );
+    }
+}
+
+/// And in the two slot positions, where a value is dispatched instead of a field: a map member and
+/// a tuple element each hold whatever the value writes, so each describes a covered wrapper as the
+/// `Vec` of its element too — a slot reached by a name the field position covers alone is a slot
+/// that renders an array on one surface and a schema module of its own on another.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn every_sequence_wrapper_describes_as_the_vec_of_its_element_in_a_slot() {
+    let parsed = parsed_u32_vec_value();
+    let expected_member = super::build_map_member_schema(&parsed).unwrap().to_string();
+    let expected_element = super::build_tuple_element_json_schema(&parsed)
+        .unwrap()
+        .to_string();
+    for wrapper in SEQUENCE_WRAPPERS {
+        let value = wrapped_u32_value(wrapper);
+        assert_eq!(
+            super::build_map_member_schema(&value).unwrap().to_string(),
+            expected_member,
+            "for: {wrapper}"
+        );
+        assert_eq!(
+            super::build_tuple_element_json_schema(&value)
+                .unwrap()
+                .to_string(),
+            expected_element,
+            "for: {wrapper}"
+        );
+    }
+}
+
+/// A sibling is carried by reference in every position that holds one, so the two slot positions
+/// name one schema module and wrap it the same way — a tuple element that fell back to the open
+/// object would admit values the same type in a map member rejects.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_sibling_slot_carries_the_schema_module_reference() {
+    let spellings: [syn::Type; 4] = [
+        syn::parse_quote!(MetricTag),
+        syn::parse_quote!(Vec<MetricTag>),
+        syn::parse_quote!(HashSet<MetricTag>),
+        syn::parse_quote!(Option<BTreeSet<MetricTag>>),
+    ];
+    for value in &spellings {
+        let parsed = super::get_field_def("tag", value, "");
+        let element = super::build_tuple_element_json_schema(&parsed)
+            .unwrap()
+            .to_string();
+        assert!(element.contains("metric_tag_schema"), "Got: {element}");
+        assert_eq!(
+            element,
+            super::build_map_member_schema(&parsed).unwrap().to_string()
+        );
+    }
+}
+
+/// The tuple-field insertion for a field type built by hand.
+#[cfg(feature = "jsonschema")]
+fn tuple_field_schema(field_type: &str) -> String {
+    let ty: syn::Type = syn::parse_str(field_type).unwrap();
+    super::build_field_type_schema(&super::get_field_def("t", &ty, ""), "t").to_string()
+}
+
+/// A tuple element reaching a map the dispatch cannot render fails the way the map field itself
+/// does: one diagnostic naming the field and the type, in place of the whole insertion. An open
+/// object left there would describe a field the expansion has already rejected.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_tuple_element_holding_an_unrenderable_map_emits_only_the_compile_error() {
+    for field_type in [
+        "(String, HashMap<String, (u32, u32)>)",
+        "(String, Vec<HashMap<String, (u32, u32)>>)",
+        "(String, (u32, HashMap<String, (u32, u32)>))",
+    ] {
+        let tokens = tuple_field_schema(field_type);
+        assert!(
+            tokens.starts_with("compile_error !"),
+            "for {field_type}, got: {tokens}"
+        );
+        assert!(
+            !tokens.contains("properties . insert"),
+            "for {field_type}, got: {tokens}"
+        );
+        assert!(
+            tokens.contains("field `t`"),
+            "for {field_type}, got: {tokens}"
+        );
+        assert!(
+            tokens.contains("a tuple is not supported as a map value"),
+            "for {field_type}, got: {tokens}"
+        );
+    }
+}
+
+/// The `ObjectId` divergence is frozen by position, so routing the tuple element through the map
+/// path's dispatch must not migrate it onto the `String`-keyed member's closed, unpatterned `$oid`
+/// object: the element keeps the patterned, open field-position form it has always carried.
+#[cfg(all(feature = "object_id", feature = "jsonschema"))]
+#[test]
+fn an_object_id_tuple_element_keeps_the_field_position_oid_object() {
+    let parsed = super::get_field_def("id", &syn::parse_quote!(ObjectId), "");
+    assert_eq!(
+        super::build_tuple_element_json_schema(&parsed)
+            .unwrap()
+            .to_string(),
+        r#"serde_json :: json ! ({ "type" : "object" , "properties" : { "$oid" : { "type" : "string" , "pattern" : "^[a-f\\d]{24}$" } } , "required" : ["$oid"] })"#
+    );
+}
+
+/// A slot cannot be dropped the way an object key can, so a `None` in one is written as `null` —
+/// and the wrapper the `None` stands around does not change that. The nullability belongs to the
+/// slot, and survives the wrapper being normalized away.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn an_optional_sequence_wrapper_member_stays_nullable() {
+    let mut optional_set = wrapped_u32_value("HashSet");
+    optional_set.is_optional = true;
+    let mut optional_vec = parsed_u32_vec_value();
+    optional_vec.is_optional = true;
+    assert_eq!(
+        super::build_map_member_schema(&optional_set)
+            .unwrap()
+            .to_string(),
+        super::build_map_member_schema(&optional_vec)
+            .unwrap()
+            .to_string()
+    );
+}
+
+/// Runs a fixed discriminated enum through the real collect/render pipeline, returning its
+/// TypeScript member fragments, Zod member fragments, and JSON-schema member fragments.
+///
+/// Rebuilt from scratch on every call so repeated calls exercise whatever ordering the collection
+/// stage imposes, not a single cached traversal.
+fn rendered_discriminated_union() -> (Vec<String>, Vec<String>, Vec<String>) {
+    let mut item: syn::ItemEnum = syn::parse_quote! {
+        enum Action {
+            Upload { path: String },
+            Generate,
+            Delete(String),
+            Rename { from: String, to: String },
+            Move(String, String),
+            Archive,
+        }
+    };
+    let variants = collect_discriminated_variants(&mut item, None, Some("action_schema"));
+    let rendered = render_discriminated_variants("type", "value", "Action", &variants.0);
+    (
+        rendered.0,
+        rendered
+            .1
+            .into_iter()
+            .map(|(schema_code, _optional)| schema_code)
+            .collect(),
+        rendered.2.iter().map(ToString::to_string).collect(),
+    )
+}
+
+/// Union member order is semantic, not cosmetic: serde tries untagged members in declaration
+/// order, so the emitted union must carry that same order on every surface.
+#[test]
+fn discriminated_union_members_follow_declaration_order() {
+    let (ts_members, zod_members, json_members) = rendered_discriminated_union();
+    assert_eq!(ts_members.len(), DECLARED_VARIANTS.len());
+    assert_eq!(zod_members.len(), DECLARED_VARIANTS.len());
+    assert_eq!(json_members.len(), DECLARED_VARIANTS.len());
+
+    for (position, declared) in DECLARED_VARIANTS.iter().enumerate() {
+        assert!(
+            ts_members[position].contains(&format!("type: \"{declared}\";")),
+            "TypeScript member {position} is not `{declared}`: {}",
+            ts_members[position]
+        );
+        assert!(
+            zod_members[position].contains(&format!("type: z.literal(\"{declared}\")")),
+            "Zod member {position} is not `{declared}`: {}",
+            zod_members[position]
+        );
+        #[cfg(feature = "jsonschema")]
+        assert!(
+            json_members[position].contains(&format!("\"const\" : \"{declared}\"")),
+            "JSON-schema member {position} is not `{declared}`: {}",
+            json_members[position]
+        );
+    }
+}
+
+/// Every per-variant collection feeding emission must be order-preserving. A hash-ordered one
+/// reseeds per instance, so the same source expands to a different union on each build — which
+/// this catches by rendering the same enum repeatedly inside one process.
+#[test]
+fn discriminated_union_rendering_is_stable_across_runs() {
+    const RUNS: usize = 32;
+
+    let first = rendered_discriminated_union();
+    for run in 1..RUNS {
+        assert_eq!(
+            rendered_discriminated_union(),
+            first,
+            "run {run} rendered a different union than run 0"
         );
     }
 }

--- a/tests/alias_reference_tests/tests.rs
+++ b/tests/alias_reference_tests/tests.rs
@@ -48,6 +48,15 @@ pub struct UsesAliasAsMapKey {
     pub by_slot: HashMap<DocumentSlotAlias, ReferencedDocumentId>,
 }
 
+#[model_schema()]
+pub type ReferencedDocumentIds = Vec<ReferencedDocumentId>;
+
+#[model_schema()]
+pub type DocumentIdsByName = HashMap<String, ReferencedDocumentId>;
+
+#[model_schema()]
+pub type DocumentIdsBySlot = HashMap<DocumentSlot, ReferencedDocumentId>;
+
 #[test]
 fn struct_referencing_an_alias_expands_in_this_feature_combination() {
     let value = UsesAliasByValue {
@@ -68,6 +77,21 @@ fn struct_referencing_an_alias_expands_in_this_feature_combination() {
     assert_eq!(
         map.by_slot.get(&DocumentSlot::Primary),
         Some(&"doc-3".to_owned())
+    );
+}
+
+#[test]
+fn collection_aliases_expand_in_this_feature_combination() {
+    let ids: ReferencedDocumentIds = vec!["doc-5".to_owned()];
+    assert_eq!(ids, vec!["doc-5".to_owned()]);
+
+    let by_name: DocumentIdsByName = HashMap::from([("n".to_owned(), "doc-6".to_owned())]);
+    assert_eq!(by_name.get("n"), Some(&"doc-6".to_owned()));
+
+    let by_slot: DocumentIdsBySlot = HashMap::from([(DocumentSlot::Primary, "doc-7".to_owned())]);
+    assert_eq!(
+        by_slot.get(&DocumentSlot::Primary),
+        Some(&"doc-7".to_owned())
     );
 }
 
@@ -130,6 +154,93 @@ fn alias_keyed_map_enumerates_the_members_of_the_aliased_enum() {
             DocumentSlot::enum_members().len(),
             "{field}: {keyed}"
         );
+    }
+}
+
+/// An alias names a type, so the schema it publishes is that type's own — the same one the scalar
+/// mapping gives a field written as the target directly.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn an_aliased_scalar_publishes_the_targets_schema() {
+    assert_eq!(
+        referenced_document_id_type_schema::Schema::json_schema(),
+        serde_json::json!({ "type": "string" })
+    );
+}
+
+/// A sibling target is carried by the one reference every position that names it carries, so the
+/// alias and the type it names describe the same values.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn an_aliased_sibling_publishes_the_siblings_own_schema() {
+    assert_eq!(
+        document_slot_alias_type_schema::Schema::json_schema(),
+        document_slot_schema::Schema::json_schema()
+    );
+}
+
+/// The reference resolves through the registry, which answers with whatever the named alias
+/// registered — so a chain of aliases lands on the enum at the end of it rather than on a link.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn an_alias_of_an_alias_resolves_to_the_type_at_the_end_of_the_chain() {
+    assert_eq!(
+        document_slot_alias_chain_type_schema::Schema::json_schema(),
+        document_slot_schema::Schema::json_schema()
+    );
+}
+
+#[cfg(feature = "jsonschema")]
+#[test]
+fn an_aliased_sequence_publishes_the_array_of_its_element() {
+    assert_eq!(
+        referenced_document_ids_type_schema::Schema::json_schema(),
+        serde_json::json!({
+            "type": "array",
+            "items": referenced_document_id_type_schema::Schema::json_schema()
+        })
+    );
+}
+
+/// A map target describes as its own key and value do, at the alias exactly as in field position:
+/// a `String` key leaves the members open under one value schema, an enum key enumerates them.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn an_aliased_map_publishes_the_object_its_key_and_value_describe() {
+    let member = referenced_document_id_type_schema::Schema::json_schema();
+    assert_eq!(
+        document_ids_by_name_type_schema::Schema::json_schema(),
+        serde_json::json!({ "type": "object", "additionalProperties": member })
+    );
+
+    let by_slot = document_ids_by_slot_type_schema::Schema::json_schema();
+    let properties = by_slot.get("properties").unwrap();
+    for slot in DocumentSlot::enum_members() {
+        assert_eq!(properties.get(&slot).unwrap(), &member, "in: {by_slot}");
+    }
+    assert_eq!(
+        properties.as_object().unwrap().len(),
+        DocumentSlot::enum_members().len(),
+        "in: {by_slot}"
+    );
+    assert_eq!(by_slot["additionalProperties"], false, "in: {by_slot}");
+}
+
+/// The stub this replaced answered every alias with an object carrying a lone `warning` key, which
+/// under JSON Schema constrains nothing and so accepts every payload a slot could hold.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn no_alias_publishes_a_schema_that_validates_nothing() {
+    for schema in [
+        referenced_document_id_type_schema::Schema::json_schema(),
+        referenced_document_ids_type_schema::Schema::json_schema(),
+        document_slot_alias_type_schema::Schema::json_schema(),
+        document_slot_alias_chain_type_schema::Schema::json_schema(),
+        document_ids_by_name_type_schema::Schema::json_schema(),
+        document_ids_by_slot_type_schema::Schema::json_schema(),
+    ] {
+        assert!(schema.get("warning").is_none(), "got: {schema}");
+        assert!(schema.get("type").is_some(), "got: {schema}");
     }
 }
 

--- a/tests/collection_tests.rs
+++ b/tests/collection_tests.rs
@@ -1,3 +1,5 @@
+extern crate alloc;
+
 #[cfg(test)]
 #[path = "collection_tests/tests.rs"]
 mod tests;

--- a/tests/collection_tests/tests.rs
+++ b/tests/collection_tests/tests.rs
@@ -97,6 +97,35 @@ struct StringKeyedNestedMapValues {
     samples: HashMap<String, HashMap<String, MetricSample>>,
 }
 
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum MetricBucket {
+    High,
+    Low,
+}
+
+/// The enum-keyed map every position below is held against: the field-position rendering, which is
+/// the one that has always enumerated its key.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct BucketKeyedMap {
+    counts: HashMap<MetricBucket, u64>,
+    samples: HashMap<MetricBucket, MetricSample>,
+}
+
+// Which keys a map has is its key type's answer wherever the map is written, so an enum-keyed map
+// enumerates its members nested under either outer key flavor and behind either slot wrap — the
+// depth a map sits at cannot decide whether its keys are known.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct NestedEnumKeyedMapValues {
+    arrayed: HashMap<String, Vec<HashMap<MetricBucket, u64>>>,
+    enum_keyed_outer: HashMap<MetricSlot, HashMap<MetricBucket, u64>>,
+    optional: HashMap<String, Option<HashMap<MetricBucket, u64>>>,
+    siblings: HashMap<MetricSlot, HashMap<MetricBucket, MetricSample>>,
+    string_keyed_outer: HashMap<String, HashMap<MetricBucket, u64>>,
+}
+
 // A String key enumerates nothing, so one `additionalProperties` schema stands for every member —
 // and it is the value type's own, which is what the enum-keyed twin above spells out per key.
 #[model_schema()]
@@ -225,11 +254,101 @@ struct VecElementFields {
     small_ids: Vec<u32>,
 }
 
+// A slot — a map member, a tuple element — cannot be dropped the way an object key can, so it
+// holds whatever the value writes, and a covered wrapper writes the array its element decides. The
+// twin below carries the `Vec` spelling of the same slots, which is what each set slot is held
+// against: the key path, the element type and the nesting are the same on both.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct SetSlotValues {
+    aliased_tags: HashMap<String, BTreeSet<MetricTagRef>>,
+    enum_keyed_ids: HashMap<MetricSlot, HashSet<u32>>,
+    enum_keyed_tags: HashMap<MetricSlot, BTreeSet<MetricTag>>,
+    labels: HashMap<String, BTreeSet<String>>,
+    optional_ids: HashMap<String, Option<HashSet<u32>>>,
+    sibling_tags: HashMap<String, HashSet<MetricTag>>,
+    small_ids: HashMap<String, HashSet<u32>>,
+    tuple_ids: (String, HashSet<u32>),
+    tuple_labels: (u32, BTreeSet<String>),
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct VecSlotValues {
+    aliased_tags: HashMap<String, Vec<MetricTagRef>>,
+    enum_keyed_ids: HashMap<MetricSlot, Vec<u32>>,
+    enum_keyed_tags: HashMap<MetricSlot, Vec<MetricTag>>,
+    labels: HashMap<String, Vec<String>>,
+    optional_ids: HashMap<String, Option<Vec<u32>>>,
+    sibling_tags: HashMap<String, Vec<MetricTag>>,
+    small_ids: HashMap<String, Vec<u32>>,
+    tuple_ids: (String, Vec<u32>),
+    tuple_labels: (u32, Vec<String>),
+}
+
+// A sibling is carried by reference wherever it sits, so a tuple element names the schema module a
+// field and a map member name — under a sequence wrapper, the array of that reference, the wrapper
+// having normalized onto the element like any other.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct SiblingSlotValues {
+    bare: (String, MetricTag),
+    setted: (String, HashSet<MetricTag>),
+    vecced: (String, Vec<MetricTag>),
+}
+
 fn one<T, C>(item: T) -> C
 where
     C: FromIterator<T>,
 {
     once(item).collect()
+}
+
+fn metric_tag() -> MetricTag {
+    MetricTag {
+        label: "a".to_owned(),
+    }
+}
+
+/// One populated `SetSlotValues`, with a single member in every slot the fixture opens — one
+/// member, so the wire it writes is a value the `Vec` twin's wire can be held against outright
+/// rather than a shape a set's iteration order could reorder.
+fn set_slot_values() -> SetSlotValues {
+    SetSlotValues {
+        aliased_tags: HashMap::from([("k".to_owned(), one(metric_tag()))]),
+        enum_keyed_ids: HashMap::from([(MetricSlot::Daily, one(7_u32))]),
+        enum_keyed_tags: HashMap::from([(MetricSlot::Daily, one(metric_tag()))]),
+        labels: HashMap::from([("k".to_owned(), one("t".to_owned()))]),
+        optional_ids: HashMap::from([("k".to_owned(), Some(one(7_u32)))]),
+        sibling_tags: HashMap::from([("k".to_owned(), one(metric_tag()))]),
+        small_ids: HashMap::from([("k".to_owned(), one(7_u32))]),
+        tuple_ids: ("t".to_owned(), one(7_u32)),
+        tuple_labels: (7, one("t".to_owned())),
+    }
+}
+
+/// The same members under the `Vec` spelling of every slot.
+fn vec_slot_values() -> VecSlotValues {
+    VecSlotValues {
+        aliased_tags: HashMap::from([("k".to_owned(), one(metric_tag()))]),
+        enum_keyed_ids: HashMap::from([(MetricSlot::Daily, one(7_u32))]),
+        enum_keyed_tags: HashMap::from([(MetricSlot::Daily, one(metric_tag()))]),
+        labels: HashMap::from([("k".to_owned(), one("t".to_owned()))]),
+        optional_ids: HashMap::from([("k".to_owned(), Some(one(7_u32)))]),
+        sibling_tags: HashMap::from([("k".to_owned(), one(metric_tag()))]),
+        small_ids: HashMap::from([("k".to_owned(), one(7_u32))]),
+        tuple_ids: ("t".to_owned(), one(7_u32)),
+        tuple_labels: (7, one("t".to_owned())),
+    }
+}
+
+/// The same sibling in each slot the fixture opens: bare, and under each wrapper spelling.
+fn sibling_slot_values() -> SiblingSlotValues {
+    SiblingSlotValues {
+        bare: ("t".to_owned(), metric_tag()),
+        setted: ("t".to_owned(), one(metric_tag())),
+        vecced: ("t".to_owned(), vec![metric_tag()]),
+    }
 }
 
 /// The `name: Type;` lines of a generated TypeScript definition, the `JSDoc` blocks around them
@@ -821,6 +940,153 @@ fn test_enum_keyed_nested_map_values_typescript_generation() {
     }
 }
 
+/// The rendering `HashMap<MetricBucket, u64>` carries in field position — the one every nested
+/// position is held against, because field position is where an enum key has always enumerated.
+#[cfg(feature = "jsonschema")]
+fn bucket_keyed_count_map() -> serde_json::Value {
+    BucketKeyedMap::json_schema()["properties"]["counts"].clone()
+}
+
+#[test]
+fn test_nested_enum_keyed_map_values_constructible() {
+    let nested = NestedEnumKeyedMapValues {
+        arrayed: HashMap::new(),
+        enum_keyed_outer: HashMap::from([(
+            MetricSlot::Daily,
+            HashMap::from([(MetricBucket::Low, 3_u64)]),
+        )]),
+        optional: HashMap::from([("a".to_owned(), None)]),
+        siblings: HashMap::new(),
+        string_keyed_outer: HashMap::from([(
+            "a".to_owned(),
+            HashMap::from([(MetricBucket::High, 7_u64)]),
+        )]),
+    };
+    assert_eq!(
+        nested.enum_keyed_outer[&MetricSlot::Daily][&MetricBucket::Low],
+        3
+    );
+    assert_eq!(nested.string_keyed_outer["a"][&MetricBucket::High], 7);
+    assert_eq!(nested.optional["a"], None);
+
+    let field_position = BucketKeyedMap {
+        counts: HashMap::from([(MetricBucket::High, 7_u64)]),
+        samples: HashMap::new(),
+    };
+    assert_eq!(field_position.counts[&MetricBucket::High], 7);
+}
+
+/// An enum-keyed map is the same object wherever it is written: nested under a `String` key, under
+/// an enum key, and behind either slot wrap, it carries the members its own key enumerates rather
+/// than the open object a position that could not reach the key would leave.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_nested_enum_keyed_map_values_enumerate_their_inner_key() {
+    let expected = bucket_keyed_count_map();
+    assert_eq!(expected["additionalProperties"], false, "in: {expected}");
+    assert_eq!(
+        expected["properties"].as_object().unwrap().len(),
+        MetricBucket::enum_members().len(),
+        "in: {expected}"
+    );
+
+    let schema = NestedEnumKeyedMapValues::json_schema();
+    let properties = &schema["properties"];
+
+    assert_eq!(
+        properties["string_keyed_outer"]["additionalProperties"], expected,
+        "in: {}",
+        properties["string_keyed_outer"]
+    );
+    assert_eq!(
+        properties["arrayed"]["additionalProperties"]["items"], expected,
+        "in: {}",
+        properties["arrayed"]
+    );
+    assert_eq!(
+        properties["optional"]["additionalProperties"],
+        serde_json::json!({ "anyOf": [expected, { "type": "null" }] }),
+        "in: {}",
+        properties["optional"]
+    );
+    for member in MetricSlot::enum_members() {
+        assert_eq!(
+            properties["enum_keyed_outer"]["properties"][&member], expected,
+            "member {member} in: {}",
+            properties["enum_keyed_outer"]
+        );
+        assert_eq!(
+            properties["siblings"]["properties"][&member],
+            BucketKeyedMap::json_schema()["properties"]["samples"],
+            "member {member} in: {}",
+            properties["siblings"]
+        );
+    }
+}
+
+/// The enumerated members are the keys serde actually writes, so a payload's inner keys are named
+/// by the schema rather than admitted by an open member set.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_nested_enum_keyed_map_members_match_the_serialized_keys() {
+    let nested = NestedEnumKeyedMapValues {
+        arrayed: HashMap::new(),
+        enum_keyed_outer: HashMap::new(),
+        optional: HashMap::new(),
+        siblings: HashMap::new(),
+        string_keyed_outer: HashMap::from([(
+            "a".to_owned(),
+            HashMap::from([(MetricBucket::High, 7_u64)]),
+        )]),
+    };
+    let payload = serde_json::to_value(&nested).unwrap();
+    let written = payload["string_keyed_outer"]["a"].as_object().unwrap();
+    let member = &NestedEnumKeyedMapValues::json_schema()["properties"]["string_keyed_outer"]["additionalProperties"];
+
+    for key in written.keys() {
+        assert_eq!(
+            member["properties"][key],
+            serde_json::json!({ "type": "integer" }),
+            "key {key} in: {member}"
+        );
+    }
+}
+
+/// TypeScript and Zod recurse through a map value whatever the key is, at whatever depth, so the
+/// members the JSON schema now spells out under a nested enum key are the ones those two surfaces
+/// have always named — pinned so the three stay in step.
+#[test]
+#[cfg(all(feature = "typescript", feature = "zod"))]
+fn test_nested_enum_keyed_map_values_typescript_generation() {
+    let ts_definition = NestedEnumKeyedMapValues::ts_definition();
+    for expected in [
+        "arrayed: Partial<Record<string, Array<Partial<Record<MetricBucket, number>>>>>;",
+        "enum_keyed_outer: Partial<Record<MetricSlot, Partial<Record<MetricBucket, number>>>>;",
+        "optional: Partial<Record<string, Partial<Record<MetricBucket, number>> | null>>;",
+        "siblings: Partial<Record<MetricSlot, Partial<Record<MetricBucket, MetricSample>>>>;",
+        "string_keyed_outer: Partial<Record<string, Partial<Record<MetricBucket, number>>>>;",
+    ] {
+        assert!(
+            ts_definition.contains(expected),
+            "missing {expected}, got: {ts_definition}"
+        );
+    }
+
+    let zod_schema = NestedEnumKeyedMapValues::zod_schema();
+    for expected in [
+        "arrayed: z.record(z.string(), z.array(z.record(MetricBucket$Schema, z.number().int()))),",
+        "enum_keyed_outer: z.record(MetricSlot$Schema, z.record(MetricBucket$Schema, z.number().int())),",
+        "optional: z.record(z.string(), z.nullable(z.record(MetricBucket$Schema, z.number().int()))),",
+        "siblings: z.record(MetricSlot$Schema, z.record(MetricBucket$Schema, MetricSample$Schema)),",
+        "string_keyed_outer: z.record(z.string(), z.record(MetricBucket$Schema, z.number().int())),",
+    ] {
+        assert!(
+            zod_schema.contains(expected),
+            "missing {expected}, got: {zod_schema}"
+        );
+    }
+}
+
 #[test]
 #[cfg(all(feature = "typescript", feature = "zod"))]
 fn test_enum_keyed_sibling_value_maps_typescript_generation() {
@@ -1395,4 +1661,185 @@ fn test_every_covered_wrapper_validates_as_the_vec_spelling() {
             "for: {wrapper}"
         );
     }
+}
+
+/// A set in a slot writes the JSON array its element decides, exactly as the `Vec` spelling of the
+/// same slot writes it — the whole reason a set slot may be held against that twin below. Read off
+/// what serde produces: the two payloads are one value, arrays and all.
+#[test]
+fn test_a_set_slot_writes_what_the_vec_slot_writes() {
+    let payload = serde_json::to_value(set_slot_values()).unwrap();
+    assert_eq!(payload, serde_json::to_value(vec_slot_values()).unwrap());
+
+    for field in [
+        "aliased_tags",
+        "enum_keyed_ids",
+        "enum_keyed_tags",
+        "labels",
+        "optional_ids",
+        "sibling_tags",
+        "small_ids",
+    ] {
+        for (key, member) in payload[field].as_object().unwrap() {
+            assert!(member.is_array(), "{field}[{key}] wrote: {member}");
+        }
+    }
+    for field in ["tuple_ids", "tuple_labels"] {
+        let slots = payload[field].as_array().unwrap();
+        assert!(
+            slots.last().unwrap().is_array(),
+            "{field} wrote: {payload:?}"
+        );
+    }
+}
+
+/// A slot holding a value that is no sequence writes what that value writes — an object here — and
+/// a wrapped one writes the array of those objects, which is what the schemas below describe.
+#[test]
+fn test_a_sibling_slot_writes_the_object_its_value_writes() {
+    let payload = serde_json::to_value(sibling_slot_values()).unwrap();
+    assert!(payload["bare"][1].is_object(), "Got: {payload}");
+    for field in ["setted", "vecced"] {
+        assert_eq!(
+            payload[field][1],
+            serde_json::json!([metric_tag()]),
+            "{field} wrote: {payload}"
+        );
+    }
+}
+
+/// Writing the same array as the `Vec` spelling of the same slot, a set describes as one — on both
+/// map key paths and in a tuple element, at every element type the twin carries.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_set_slots_describe_as_the_vec_slot_twin() {
+    let set_schema = SetSlotValues::json_schema();
+    let vec_schema = VecSlotValues::json_schema();
+    assert_eq!(set_schema["properties"], vec_schema["properties"]);
+    assert_eq!(set_schema["required"], vec_schema["required"]);
+}
+
+/// What that description is, spelled out: the array of the element, in the member schema a
+/// `String`-keyed map carries and in the tuple element the same fixture opens.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_set_slots_describe_as_arrays_of_their_element() {
+    let properties = SetSlotValues::json_schema()["properties"].clone();
+    let integer_array = serde_json::json!({ "type": "array", "items": { "type": "integer" } });
+    assert_eq!(
+        properties["small_ids"]["additionalProperties"],
+        integer_array
+    );
+    assert_eq!(properties["tuple_ids"]["prefixItems"][1], integer_array);
+    assert_eq!(
+        properties["labels"]["additionalProperties"],
+        serde_json::json!({ "type": "array", "items": { "type": "string" } })
+    );
+    // A slot cannot be dropped, so a `None` there is `null` rather than an absent key.
+    assert_eq!(
+        properties["optional_ids"]["additionalProperties"],
+        serde_json::json!({ "anyOf": [integer_array, { "type": "null" }] })
+    );
+}
+
+/// A sibling in a tuple element describes as the sibling does — its own schema, the one a field and
+/// a map member reach for — rather than as the open object any value at all satisfies.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_a_sibling_tuple_slot_describes_as_the_sibling_it_holds() {
+    let properties = SiblingSlotValues::json_schema()["properties"].clone();
+    assert_eq!(
+        properties["bare"]["prefixItems"][1],
+        MetricTag::json_schema()
+    );
+    assert_ne!(
+        MetricTag::json_schema(),
+        serde_json::json!({ "type": "object" })
+    );
+}
+
+/// And under a wrapper, the array of that schema — the same array the wrapper writes, so a slot
+/// holding a sequence of siblings admits a sequence rather than any object at all.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_a_wrapped_sibling_tuple_slot_describes_as_the_array_of_that_sibling() {
+    let properties = SiblingSlotValues::json_schema()["properties"].clone();
+    let tag_array = serde_json::json!({ "type": "array", "items": MetricTag::json_schema() });
+    for field in ["setted", "vecced"] {
+        assert_eq!(
+            properties[field]["prefixItems"][1], tag_array,
+            "for: {field}"
+        );
+    }
+}
+
+/// The TypeScript surface, which names the sibling in every one of those slots already: pinned so
+/// the JSON schema above is held against a rendering that does not move under it.
+#[test]
+#[cfg(feature = "typescript")]
+fn test_sibling_tuple_slots_type_as_the_sibling_they_hold() {
+    let ts_definition = SiblingSlotValues::ts_definition();
+    for spelling in [
+        "bare: [string, MetricTag];",
+        "setted: [string, Array<MetricTag>];",
+        "vecced: [string, Array<MetricTag>];",
+    ] {
+        assert!(ts_definition.contains(spelling), "Got: {ts_definition}");
+    }
+}
+
+/// And the Zod surface, which validates each of them against the sibling's schema already.
+#[test]
+#[cfg(feature = "zod")]
+fn test_sibling_tuple_slots_validate_against_the_sibling_they_hold() {
+    let zod_schema = SiblingSlotValues::zod_schema();
+    for spelling in [
+        "bare: z.tuple([z.string(), MetricTag$Schema]),",
+        "setted: z.tuple([z.string(), z.array(MetricTag$Schema)]),",
+        "vecced: z.tuple([z.string(), z.array(MetricTag$Schema)]),",
+    ] {
+        assert!(zod_schema.contains(spelling), "Got: {zod_schema}");
+    }
+}
+
+/// The TypeScript surface, which types a set slot as the array of its element already: pinned here
+/// so the JSON schema above is held against a rendering that does not move under it.
+#[test]
+#[cfg(feature = "typescript")]
+fn test_set_slots_type_as_the_vec_slot_twin() {
+    let ts_definition = SetSlotValues::ts_definition();
+    for spelling in [
+        "aliased_tags: Partial<Record<string, Array<MetricTagRefType>>>;",
+        "enum_keyed_ids: Partial<Record<MetricSlot, Array<number>>>;",
+        "optional_ids: Partial<Record<string, Array<number> | null>>;",
+        "sibling_tags: Partial<Record<string, Array<MetricTag>>>;",
+        "tuple_ids: [string, Array<number>];",
+        "tuple_labels: [number, Array<string>];",
+    ] {
+        assert!(ts_definition.contains(spelling), "Got: {ts_definition}");
+    }
+    assert_eq!(
+        ts_field_declarations(&ts_definition.replace("SetSlotValues", "VecSlotValues")),
+        ts_field_declarations(&VecSlotValues::ts_definition())
+    );
+}
+
+/// And the Zod surface, which validates a set slot as that array already.
+#[test]
+#[cfg(feature = "zod")]
+fn test_set_slots_validate_as_the_vec_slot_twin() {
+    let zod_schema = SetSlotValues::zod_schema();
+    for spelling in [
+        "aliased_tags: z.record(z.string(), z.array(MetricTagRefType$Schema)),",
+        "enum_keyed_tags: z.record(MetricSlot$Schema, z.array(MetricTag$Schema)),",
+        "optional_ids: z.record(z.string(), z.nullable(z.array(z.number().int()))),",
+        "tuple_ids: z.tuple([z.string(), z.array(z.number().int())]),",
+        "tuple_labels: z.tuple([z.number().int(), z.array(z.string())]),",
+    ] {
+        assert!(zod_schema.contains(spelling), "Got: {zod_schema}");
+    }
+    assert_eq!(
+        zod_schema.replace("SetSlotValues", "VecSlotValues"),
+        VecSlotValues::zod_schema()
+    );
 }

--- a/tests/collection_tests/tests.rs
+++ b/tests/collection_tests/tests.rs
@@ -1,6 +1,19 @@
+use alloc::collections::{BTreeSet, BinaryHeap, VecDeque};
+use core::iter::once;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use tixschema::model_schema;
+
+/// The covered wrappers by the name a generated surface could leak. `Vec` is covered too but
+/// never arrives under its own name: the parser collapses it onto its element long before.
+#[cfg(any(feature = "typescript", feature = "zod"))]
+const SEQUENCE_WRAPPERS: [&str; 5] = [
+    "BTreeSet",
+    "BinaryHeap",
+    "HashSet",
+    "LinkedList",
+    "VecDeque",
+];
 
 // Test comprehensive HashMap scenarios with various value types
 #[model_schema()]
@@ -126,7 +139,7 @@ struct UserWithCollections {
 }
 
 #[model_schema()]
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct MetricTag {
     label: String,
 }
@@ -136,9 +149,11 @@ struct MetricTag {
 #[model_schema()]
 type MetricTagRef = MetricTag;
 
-// A `HashSet<T>` and a `Vec<T>` both serialize as a JSON array of `T`, so the element decides what
-// the array holds on either one. The twin structs below carry the same element types under both
-// spellings; the tests hold every field of one against its twin.
+// Every std wrapper serde writes as a JSON array of `T` — the criterion for covering one — puts
+// the element in charge of what the array holds. The twin structs below carry the same element
+// types under each covered spelling; the tests hold every field of one against its `Vec` twin.
+// `LinkedList` has no twin here, the crate's own lints forbidding it a value of one; it is covered
+// by name at the dispatch and in the renderers' unit tests instead.
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct SetElementFields {
@@ -155,6 +170,49 @@ struct SetElementFields {
 
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct BTreeSetElementFields {
+    aliased_tags: BTreeSet<MetricTagRef>,
+    big_ids: BTreeSet<u64>,
+    #[model_schema_prop(minLength = 3)]
+    constrained_labels: BTreeSet<String>,
+    labels: BTreeSet<String>,
+    #[model_schema_prop(preprocess = ["trim"])]
+    preprocessed_labels: BTreeSet<String>,
+    sibling_tags: BTreeSet<MetricTag>,
+    small_ids: BTreeSet<u32>,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct VecDequeElementFields {
+    aliased_tags: VecDeque<MetricTagRef>,
+    big_ids: VecDeque<u64>,
+    #[model_schema_prop(minLength = 3)]
+    constrained_labels: VecDeque<String>,
+    labels: VecDeque<String>,
+    #[model_schema_prop(preprocess = ["trim"])]
+    preprocessed_labels: VecDeque<String>,
+    sibling_tags: VecDeque<MetricTag>,
+    small_ids: VecDeque<u32>,
+}
+
+// `BinaryHeap` is the one covered wrapper with no `PartialEq`, so this twin cannot derive it.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct BinaryHeapElementFields {
+    aliased_tags: BinaryHeap<MetricTagRef>,
+    big_ids: BinaryHeap<u64>,
+    #[model_schema_prop(minLength = 3)]
+    constrained_labels: BinaryHeap<String>,
+    labels: BinaryHeap<String>,
+    #[model_schema_prop(preprocess = ["trim"])]
+    preprocessed_labels: BinaryHeap<String>,
+    sibling_tags: BinaryHeap<MetricTag>,
+    small_ids: BinaryHeap<u32>,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct VecElementFields {
     aliased_tags: Vec<MetricTagRef>,
     big_ids: Vec<u64>,
@@ -165,6 +223,85 @@ struct VecElementFields {
     preprocessed_labels: Vec<String>,
     sibling_tags: Vec<MetricTag>,
     small_ids: Vec<u32>,
+}
+
+fn one<T, C>(item: T) -> C
+where
+    C: FromIterator<T>,
+{
+    once(item).collect()
+}
+
+/// The `name: Type;` lines of a generated TypeScript definition, the `JSDoc` blocks around them
+/// left out — a member line is indented and terminated, where every comment line carries a `*`.
+#[cfg(feature = "typescript")]
+fn ts_field_declarations(definition: &str) -> Vec<String> {
+    definition
+        .lines()
+        .filter(|line| line.starts_with("  ") && line.ends_with(';'))
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+/// One populated instance of every wrapper twin the crate may hold, serialized.
+fn covered_wrapper_payloads() -> [(&'static str, serde_json::Value); 4] {
+    let tag = MetricTag {
+        label: "a".to_owned(),
+    };
+    [
+        (
+            "HashSet",
+            serde_json::to_value(SetElementFields {
+                aliased_tags: one(tag.clone()),
+                big_ids: one(9_u64),
+                constrained_labels: one("abc".to_owned()),
+                labels: one("t".to_owned()),
+                preprocessed_labels: one("t".to_owned()),
+                sibling_tags: one(tag.clone()),
+                small_ids: one(7_u32),
+            })
+            .unwrap(),
+        ),
+        (
+            "BTreeSet",
+            serde_json::to_value(BTreeSetElementFields {
+                aliased_tags: one(tag.clone()),
+                big_ids: one(9_u64),
+                constrained_labels: one("abc".to_owned()),
+                labels: one("t".to_owned()),
+                preprocessed_labels: one("t".to_owned()),
+                sibling_tags: one(tag.clone()),
+                small_ids: one(7_u32),
+            })
+            .unwrap(),
+        ),
+        (
+            "BinaryHeap",
+            serde_json::to_value(BinaryHeapElementFields {
+                aliased_tags: one(tag.clone()),
+                big_ids: one(9_u64),
+                constrained_labels: one("abc".to_owned()),
+                labels: one("t".to_owned()),
+                preprocessed_labels: one("t".to_owned()),
+                sibling_tags: one(tag.clone()),
+                small_ids: one(7_u32),
+            })
+            .unwrap(),
+        ),
+        (
+            "VecDeque",
+            serde_json::to_value(VecDequeElementFields {
+                aliased_tags: one(tag.clone()),
+                big_ids: one(9_u64),
+                constrained_labels: one("abc".to_owned()),
+                labels: one("t".to_owned()),
+                preprocessed_labels: one("t".to_owned()),
+                sibling_tags: one(tag),
+                small_ids: one(7_u32),
+            })
+            .unwrap(),
+        ),
+    ]
 }
 
 #[cfg(feature = "jsonschema")]
@@ -1139,16 +1276,18 @@ fn test_set_element_zod_generation() {
 
 /// Whatever a set field renders as, it is not the Rust wrapper's name: neither surface has any
 /// meaning for it, so the name surviving anywhere into the output is a syntax error in the output.
+/// The other covered wrappers name themselves in their own fixture's type name, so the equivalence
+/// with the `Vec` twin below is what says no wrapper name reached their output.
 #[test]
 #[cfg(any(feature = "typescript", feature = "zod"))]
-fn test_no_set_wrapper_name_survives_into_generated_output() {
+fn test_no_sequence_wrapper_name_survives_into_generated_output() {
     let mut generated = String::new();
     #[cfg(feature = "typescript")]
     generated.push_str(&SetElementFields::ts_definition());
     #[cfg(feature = "zod")]
     generated.push_str(&SetElementFields::zod_schema());
 
-    for wrapper in ["HashSet", "BTreeSet"] {
+    for wrapper in SEQUENCE_WRAPPERS {
         assert!(!generated.contains(wrapper), "Got: {generated}");
     }
 }
@@ -1162,4 +1301,98 @@ fn test_set_fields_validate_as_vec_fields() {
         SetElementFields::zod_schema().replace("SetElementFields", "VecElementFields"),
         VecElementFields::zod_schema()
     );
+}
+
+/// A wrapper is covered when serde writes it as a JSON array of its element — the whole criterion,
+/// and the reason the twins below may be held against the `Vec` spelling at all. Read off what
+/// serde actually produces, so the covered list answers to the wire rather than to a name.
+#[test]
+fn test_every_covered_wrapper_writes_a_json_array() {
+    for (wrapper, payload) in covered_wrapper_payloads() {
+        for (field, value) in payload.as_object().unwrap() {
+            assert!(value.is_array(), "{wrapper}::{field} wrote: {value}");
+        }
+    }
+}
+
+/// Writing the same array as the `Vec` spelling, every covered wrapper describes as it does —
+/// whole schema against whole schema, not one field at a time.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_every_covered_wrapper_describes_as_the_vec_spelling() {
+    let vec_schema = VecElementFields::json_schema();
+    for (wrapper, schema) in [
+        ("SetElementFields", SetElementFields::json_schema()),
+        (
+            "BTreeSetElementFields",
+            BTreeSetElementFields::json_schema(),
+        ),
+        (
+            "BinaryHeapElementFields",
+            BinaryHeapElementFields::json_schema(),
+        ),
+        (
+            "VecDequeElementFields",
+            VecDequeElementFields::json_schema(),
+        ),
+    ] {
+        assert_eq!(
+            schema["properties"], vec_schema["properties"],
+            "for: {wrapper}"
+        );
+        assert_eq!(schema["required"], vec_schema["required"], "for: {wrapper}");
+    }
+}
+
+/// The same holding on the TypeScript surface: with the fixture's own name set aside, a covered
+/// wrapper's field declarations are the `Vec` spelling's, so no wrapper name reached the output.
+/// Declarations rather than whole definitions, because the surrounding `JSDoc` differs for a reason
+/// of its own: a `Vec` field's doc comment is dropped where every other spelling keeps it.
+#[test]
+#[cfg(feature = "typescript")]
+fn test_every_covered_wrapper_types_as_the_vec_spelling() {
+    let vec_definition = ts_field_declarations(&VecElementFields::ts_definition());
+    for (wrapper, definition) in [
+        ("SetElementFields", SetElementFields::ts_definition()),
+        (
+            "BTreeSetElementFields",
+            BTreeSetElementFields::ts_definition(),
+        ),
+        (
+            "BinaryHeapElementFields",
+            BinaryHeapElementFields::ts_definition(),
+        ),
+        (
+            "VecDequeElementFields",
+            VecDequeElementFields::ts_definition(),
+        ),
+    ] {
+        assert_eq!(
+            ts_field_declarations(&definition.replace(wrapper, "VecElementFields")),
+            vec_definition,
+            "for: {wrapper}"
+        );
+    }
+}
+
+/// And on the Zod surface, constraints and preprocess wraps included.
+#[test]
+#[cfg(feature = "zod")]
+fn test_every_covered_wrapper_validates_as_the_vec_spelling() {
+    let vec_schema = VecElementFields::zod_schema();
+    for (wrapper, schema) in [
+        ("SetElementFields", SetElementFields::zod_schema()),
+        ("BTreeSetElementFields", BTreeSetElementFields::zod_schema()),
+        (
+            "BinaryHeapElementFields",
+            BinaryHeapElementFields::zod_schema(),
+        ),
+        ("VecDequeElementFields", VecDequeElementFields::zod_schema()),
+    ] {
+        assert_eq!(
+            schema.replace(wrapper, "VecElementFields"),
+            vec_schema,
+            "for: {wrapper}"
+        );
+    }
 }

--- a/tests/semantic_types_tests/tests.rs
+++ b/tests/semantic_types_tests/tests.rs
@@ -454,16 +454,113 @@ fn test_struct_with_alias_zod_schema() {
 // JSON Schema Tests
 // ========================================================================
 
+/// An alias publishes the schema of the type it names, so a slot filled by the alias validates
+/// exactly what the aliased type validates — the scalar mapping being the same one a field written
+/// as the target reads.
 #[test]
 #[cfg(all(feature = "jsonschema", feature = "typescript"))]
-fn test_alias_json_schema_exists() {
-    // JSON schema generation for aliases currently returns a stub
-    let json_schema = document_id_schema::Schema::json_schema();
+fn test_scalar_alias_json_schema() {
+    for (alias, schema, expected) in [
+        (
+            "DocumentId",
+            document_id_schema::Schema::json_schema(),
+            serde_json::json!({ "type": "string" }),
+        ),
+        (
+            "Revision",
+            revision_schema::Schema::json_schema(),
+            serde_json::json!({ "type": "integer" }),
+        ),
+        (
+            "Score",
+            score_schema::Schema::json_schema(),
+            serde_json::json!({ "type": "number" }),
+        ),
+        (
+            "IsActive",
+            is_active_schema::Schema::json_schema(),
+            serde_json::json!({ "type": "boolean" }),
+        ),
+    ] {
+        assert_eq!(schema, expected, "for {alias}");
+    }
+}
 
-    // Verify the method exists and returns a JSON value
-    assert!(
-        json_schema.is_object(),
-        "JSON schema should return an object"
+/// An alias cannot be dropped the way an optional object key can — a slot written as the alias is
+/// filled with the `null` serde writes for a `None`, so the schema has to admit it.
+#[test]
+#[cfg(all(feature = "jsonschema", feature = "typescript"))]
+fn test_optional_alias_json_schema() {
+    assert_eq!(
+        optional_note_schema::Schema::json_schema(),
+        serde_json::json!({ "anyOf": [{ "type": "string" }, { "type": "null" }] })
+    );
+}
+
+#[test]
+#[cfg(all(feature = "jsonschema", feature = "typescript"))]
+fn test_sequence_alias_json_schema() {
+    assert_eq!(
+        tags_schema::Schema::json_schema(),
+        serde_json::json!({ "type": "array", "items": { "type": "string" } })
+    );
+}
+
+/// A tuple is the fixed-arity array serde writes it as, at the alias exactly as in field position.
+#[test]
+#[cfg(all(feature = "jsonschema", feature = "typescript"))]
+fn test_tuple_alias_json_schema() {
+    assert_eq!(
+        compact_link_row_schema::Schema::json_schema(),
+        serde_json::json!({
+            "type": "array",
+            "prefixItems": [
+                { "anyOf": [{ "type": "string" }, { "type": "null" }] },
+                { "type": "array", "items": { "type": "integer" } },
+                { "type": "string" },
+                { "anyOf": [{ "type": "string" }, { "type": "null" }] }
+            ],
+            "items": false,
+            "minItems": 4_u64,
+            "maxItems": 4_u64
+        })
+    );
+}
+
+/// An alias of an alias carries the target's reference, which resolves through the registry — so
+/// the chain lands on the type at the end of it rather than on a link.
+#[test]
+#[cfg(all(feature = "jsonschema", feature = "typescript"))]
+fn test_nested_alias_json_schema() {
+    assert_eq!(
+        audit_id_schema::Schema::json_schema(),
+        order_id_schema::Schema::json_schema()
+    );
+    assert_eq!(
+        audit_id_schema::Schema::json_schema(),
+        serde_json::json!({ "type": "string" })
+    );
+}
+
+/// A type parameter names no type until the alias is instantiated, and every position that
+/// references an alias references it uninstantiated — so the parameter admits any value, while the
+/// shape around it is still described.
+#[test]
+#[cfg(all(feature = "jsonschema", feature = "typescript"))]
+fn test_generic_alias_json_schema() {
+    assert_eq!(
+        pair_schema::Schema::json_schema(),
+        serde_json::json!({
+            "type": "array",
+            "prefixItems": [{}, {}],
+            "items": false,
+            "minItems": 2_u64,
+            "maxItems": 2_u64
+        })
+    );
+    assert_eq!(
+        wrapper_schema::Schema::json_schema(),
+        serde_json::json!({ "anyOf": [{}, { "type": "null" }] })
     );
 }
 
@@ -481,6 +578,21 @@ fn test_struct_with_alias_json_schema() {
         schema["properties"].is_object(),
         "Should have properties. Got: {schema:?}"
     );
+
+    // A field written as an alias carries the alias module's schema, so what the field validates
+    // is what the alias publishes — every slot naming the alias agrees with every other.
+    for (field, alias_schema) in [
+        ("document_id", document_id_schema::Schema::json_schema()),
+        ("is_active", is_active_schema::Schema::json_schema()),
+        ("note", optional_note_schema::Schema::json_schema()),
+        ("revision", revision_schema::Schema::json_schema()),
+        ("score", score_schema::Schema::json_schema()),
+    ] {
+        assert_eq!(
+            schema["properties"][field], alias_schema,
+            "for {field} in: {schema}"
+        );
+    }
 }
 
 // ========================================================================

--- a/tests/tuple_field_tests/tests.rs
+++ b/tests/tuple_field_tests/tests.rs
@@ -1,5 +1,39 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 use tixschema::model_schema;
+
+/// A generated schema module reaches its siblings through the enclosing module, and a function body
+/// is not one, so a type another type references is declared here rather than inside a test.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct DocumentId {
+    pub id: String,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct WithSibling {
+    pub pair: (DocumentId, String),
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SlotKind {
+    Primary,
+    Secondary,
+}
+
+/// A map whose key enumerates its members, written in field position and in a tuple slot: the two
+/// hold the same type, so they must describe it the same way.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct EnumKeyedMapSlotRow {
+    pub field: HashMap<SlotKind, u32>,
+    pub nested_field: HashMap<String, HashMap<SlotKind, u32>>,
+    pub nested_slot: (String, HashMap<String, HashMap<SlotKind, u32>>),
+    pub slot: (String, HashMap<SlotKind, u32>),
+}
 
 /// Test 1 + 2 + 3: A `(String, String)` struct field renders as a tuple in
 /// TypeScript, Zod, and JSON Schema.
@@ -109,25 +143,20 @@ fn test_mixed_element_tuple_field_zod() {
     );
 }
 
-/// Test 5: A sibling/custom element type renders by reference.
+/// Test 5: A sibling/custom element type renders by reference — the type's own rendering on every
+/// surface, not the open object any value satisfies.
 #[test]
 fn test_sibling_element_tuple_field() {
-    #[model_schema()]
-    #[derive(Serialize, Deserialize, Debug, Clone)]
-    pub struct DocumentId {
-        pub id: String,
-    }
-
-    #[model_schema()]
-    #[derive(Serialize, Deserialize, Debug, Clone)]
-    pub struct WithSibling {
-        pub pair: (DocumentId, String),
-    }
-
     let ts = WithSibling::ts_definition();
     assert!(
         ts.contains("pair: [DocumentId, string]"),
         "Expected sibling element in TS tuple. Got: {ts}"
+    );
+
+    #[cfg(feature = "jsonschema")]
+    assert_eq!(
+        WithSibling::json_schema()["properties"]["pair"]["prefixItems"][0],
+        DocumentId::json_schema()
     );
 
     #[cfg(feature = "zod")]
@@ -380,4 +409,255 @@ fn test_tuple_element_option_serde_roundtrip() {
 
     let back: Row = serde_json::from_value(json).unwrap();
     assert_eq!(back, row, "null must deserialize back to None");
+}
+
+/// A map in a tuple slot describes as the same map does in field position — the object whose
+/// members carry the value type's own rendering — and recurses to the depth the map path recurses
+/// to. A slot that fell back to the open object would admit members the field position rejects.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn test_map_element_tuple_field_json_schema() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct MapSlotRow {
+        pub counts: HashMap<String, u32>,
+        pub nested: HashMap<String, HashMap<String, u32>>,
+        pub nested_slot: (String, HashMap<String, HashMap<String, u32>>),
+        pub slot: (String, HashMap<String, u32>),
+    }
+
+    let schema = MapSlotRow::json_schema();
+    let properties = &schema["properties"];
+
+    assert_eq!(
+        properties["slot"]["prefixItems"][1], properties["counts"],
+        "A map slot must describe as the map field does. Got: {}",
+        properties["slot"]["prefixItems"][1]
+    );
+    assert_eq!(
+        properties["slot"]["prefixItems"][1],
+        serde_json::json!({ "type": "object", "additionalProperties": { "type": "integer" } })
+    );
+    assert_eq!(
+        properties["nested_slot"]["prefixItems"][1], properties["nested"],
+        "A nested map slot must recurse as the nested map field does. Got: {}",
+        properties["nested_slot"]["prefixItems"][1]
+    );
+    assert_eq!(
+        properties["slot"]["prefixItems"][0],
+        serde_json::json!({ "type": "string" })
+    );
+}
+
+/// A key that enumerates its members enumerates them in a tuple slot too: the slot dispatch reaches
+/// the map's own rendering, so a slot cannot describe as an open object what the same type in field
+/// position describes as a fixed set of keys.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn test_enum_keyed_map_element_tuple_field_json_schema() {
+    let schema = EnumKeyedMapSlotRow::json_schema();
+    let properties = &schema["properties"];
+
+    let members = SlotKind::enum_members();
+    assert_eq!(properties["field"]["additionalProperties"], false);
+    assert_eq!(
+        properties["field"]["properties"].as_object().unwrap().len(),
+        members.len(),
+        "in: {}",
+        properties["field"]
+    );
+    for member in members {
+        assert_eq!(
+            properties["field"]["properties"][&member],
+            serde_json::json!({ "type": "integer" }),
+            "member {member} in: {}",
+            properties["field"]
+        );
+    }
+
+    assert_eq!(
+        properties["slot"]["prefixItems"][1], properties["field"],
+        "An enum-keyed map slot must describe as the map field does. Got: {}",
+        properties["slot"]["prefixItems"][1]
+    );
+    assert_eq!(
+        properties["nested_slot"]["prefixItems"][1], properties["nested_field"],
+        "A nested enum-keyed map slot must recurse as the nested map field does. Got: {}",
+        properties["nested_slot"]["prefixItems"][1]
+    );
+    assert_eq!(
+        properties["nested_field"]["additionalProperties"], properties["field"],
+        "Got: {}",
+        properties["nested_field"]
+    );
+}
+
+/// TypeScript and Zod already carry the key into a slot; pinned so the json-schema fix cannot be
+/// read as the only surface that owes the enum-keyed map its keys.
+#[test]
+fn test_enum_keyed_map_element_tuple_field_ts_and_zod() {
+    let ts = EnumKeyedMapSlotRow::ts_definition();
+    for expected in [
+        "slot: [string, Partial<Record<SlotKind, number>>]",
+        "nested_slot: [string, Partial<Record<string, Partial<Record<SlotKind, number>>>>]",
+    ] {
+        assert!(ts.contains(expected), "missing {expected}, got: {ts}");
+    }
+
+    #[cfg(feature = "zod")]
+    {
+        let zod = EnumKeyedMapSlotRow::zod_schema();
+        for expected in [
+            "slot: z.tuple([z.string(), z.record(SlotKind$Schema, z.number().int())])",
+            "nested_slot: z.tuple([z.string(), z.record(z.string(), z.record(SlotKind$Schema, z.number().int()))])",
+        ] {
+            assert!(zod.contains(expected), "missing {expected}, got: {zod}");
+        }
+    }
+}
+
+/// The sibling reference survives the map wrap inside a slot: a map of siblings in a tuple element
+/// names the same schema module the sibling names in every other position.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn test_map_of_siblings_element_tuple_field_json_schema() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct SiblingMapSlotRow {
+        pub slot: (String, HashMap<String, DocumentId>),
+    }
+
+    assert_eq!(
+        SiblingMapSlotRow::json_schema()["properties"]["slot"]["prefixItems"][1]["additionalProperties"],
+        DocumentId::json_schema()
+    );
+}
+
+/// TypeScript and Zod already recurse into a map slot; pinned so the json-schema fix cannot be
+/// read as the only surface that owes the map its rendering.
+#[test]
+fn test_map_element_tuple_field_ts_and_zod() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct MapSlotShape {
+        pub slot: (String, HashMap<String, u32>),
+    }
+
+    let ts = MapSlotShape::ts_definition();
+    assert!(
+        ts.contains("slot: [string, Partial<Record<string, number>>]"),
+        "Expected the map's own TS rendering in the slot. Got: {ts}"
+    );
+
+    #[cfg(feature = "zod")]
+    {
+        let zod = MapSlotShape::zod_schema();
+        assert!(
+            zod.contains("slot: z.tuple([z.string(), z.record(z.string(), z.number().int())])"),
+            "Expected the map's own Zod rendering in the slot. Got: {zod}"
+        );
+    }
+}
+
+/// A tuple in a tuple slot is the fixed-arity array the same tuple is in field position: serde
+/// writes both as a JSON array of the same length, so the slot carries the arity bounds too.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn test_nested_tuple_element_tuple_field_json_schema() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct NestedTupleRow {
+        pub inner: (u32, u32),
+        pub slot: (String, (u32, u32)),
+    }
+
+    let properties = &NestedTupleRow::json_schema()["properties"];
+    assert_eq!(
+        properties["slot"]["prefixItems"][1], properties["inner"],
+        "A nested tuple slot must describe as the tuple field does. Got: {}",
+        properties["slot"]["prefixItems"][1]
+    );
+    assert_eq!(
+        properties["slot"]["prefixItems"][1],
+        serde_json::json!({
+            "type": "array",
+            "prefixItems": [{ "type": "integer" }, { "type": "integer" }],
+            "items": false,
+            "minItems": 2_u64,
+            "maxItems": 2_u64
+        })
+    );
+}
+
+/// TypeScript and Zod already recurse into a nested tuple slot; pinned.
+#[test]
+fn test_nested_tuple_element_tuple_field_ts_and_zod() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct NestedTupleShape {
+        pub slot: (String, (u32, u32)),
+    }
+
+    let ts = NestedTupleShape::ts_definition();
+    assert!(
+        ts.contains("slot: [string, [number, number]]"),
+        "Expected the nested tuple's own TS rendering in the slot. Got: {ts}"
+    );
+
+    #[cfg(feature = "zod")]
+    {
+        let zod = NestedTupleShape::zod_schema();
+        assert!(
+            zod.contains(
+                "slot: z.tuple([z.string(), z.tuple([z.number().int(), z.number().int()])])"
+            ),
+            "Expected the nested tuple's own Zod rendering in the slot. Got: {zod}"
+        );
+    }
+}
+
+/// An opaque value in a tuple slot admits any value, as it does in field position. This is the
+/// sharp one: the slot serde fills with a string or a number must not fail its own schema.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn test_unknown_element_tuple_field_json_schema() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct UnknownSlotRow {
+        pub opaque: serde_json::Value,
+        pub slot: (String, serde_json::Value),
+    }
+
+    let properties = &UnknownSlotRow::json_schema()["properties"];
+    assert_eq!(
+        properties["slot"]["prefixItems"][1], properties["opaque"],
+        "An unknown slot must describe as the unknown field does. Got: {}",
+        properties["slot"]["prefixItems"][1]
+    );
+    assert_eq!(properties["slot"]["prefixItems"][1], serde_json::json!({}));
+}
+
+/// TypeScript and Zod already render the opaque slot permissively; pinned.
+#[test]
+fn test_unknown_element_tuple_field_ts_and_zod() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct UnknownSlotShape {
+        pub slot: (String, serde_json::Value),
+    }
+
+    let ts = UnknownSlotShape::ts_definition();
+    assert!(
+        ts.contains("slot: [string, unknown]"),
+        "Expected the opaque slot's TS rendering. Got: {ts}"
+    );
+
+    #[cfg(feature = "zod")]
+    {
+        let zod = UnknownSlotShape::zod_schema();
+        assert!(
+            zod.contains("slot: z.tuple([z.string(), z.unknown()])"),
+            "Expected the opaque slot's Zod rendering. Got: {zod}"
+        );
+    }
 }

--- a/tests/tuple_variant_tests/tests.rs
+++ b/tests/tuple_variant_tests/tests.rs
@@ -1,6 +1,21 @@
 use serde::{Deserialize, Serialize};
 use tixschema::model_schema;
 
+/// A generated schema module reaches its siblings through the enclosing module, and a function body
+/// is not one, so a type another type references is declared here rather than inside a test.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Inner {
+    pub field: String,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum Outer {
+    Paired(Inner, i64),
+    Wrapped(Inner),
+}
+
 /// Test 1: Single-element tuple variants.
 /// Each variant has exactly one tuple element.
 #[test]
@@ -471,19 +486,6 @@ fn test_optional_in_tuple() {
 /// Test 10: Tuple variant with nested custom type.
 #[test]
 fn test_tuple_with_custom_type() {
-    #[model_schema()]
-    #[derive(Serialize, Deserialize, Debug, Clone)]
-    pub struct Inner {
-        pub field: String,
-    }
-
-    #[model_schema()]
-    #[derive(Serialize, Deserialize, Debug, Clone)]
-    pub enum Outer {
-        Paired(Inner, i64),
-        Wrapped(Inner),
-    }
-
     let ts = Outer::ts_definition();
 
     // Should reference the inner type
@@ -494,6 +496,25 @@ fn test_tuple_with_custom_type() {
     assert!(
         ts.contains("value: [Inner, number]"),
         "Paired should have tuple with Inner"
+    );
+}
+
+/// And the JSON schema of that variant's tuple slot carries the same reference: the sibling's own
+/// schema, in the position the TypeScript above names it.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn test_tuple_variant_sibling_element_carries_the_sibling_schema() {
+    let schema = Outer::json_schema();
+    let variant = schema["oneOf"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|member| member["properties"]["type"]["const"] == "Paired")
+        .unwrap();
+
+    assert_eq!(
+        variant["properties"]["value"]["prefixItems"][0],
+        Inner::json_schema()
     );
 }
 


### PR DESCRIPTION
Stacked on #44 (stack: #33 → … → #44 → this).

`BTreeSet<u32>` (and BinaryHeap/VecDeque/LinkedList) failed json-schema expansion with E0433 on synthesized modules — the field-position dispatch carried its own `Vec|HashSet` literal while the TS/Zod renderers carried another.

- One `is_sequence_wrapper` predicate now answers for all three surfaces. Membership criterion recorded in the doc, README, and pinned by tests: serde writes the wrapper as a JSON array of its single element (`seq_impl!` family). `Box`/`Rc`/`Arc`/`Cow` out (inner value), maps out (own path).
- Twin fixtures for BTreeSet/BinaryHeap/VecDeque against the `Vec` twin over seven element types on all three surfaces; red-first (each wrapper produced its own E0433 before). LinkedList is name-covered at the dispatch and renderers but has no end-to-end fixture — `clippy::linkedlist` is denied and suppressions are forbidden, so the fixture-vs-lint-policy decision is filed for the maintainer rather than worked around.
- HashSet/Vec byte-identity by construction; pre-existing pins untouched.

Gates: `just check`, `just lint-all` (68/68), `just test` (full powerset) green.