### PR TITLE
fix: enum-keyed maps enumerate their members in every position

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,5 @@ redundant_test_prefix = "allow"
 # Integer division is used safely for threshold calculations and tests.
 integer_division = "allow"
 integer_division_remainder_used = "allow"
-# HashSet iteration order is irrelevant for set-comparison operations.
-iter_over_hash_type = "allow"
 # HashSet parameters use the default hasher; generalization adds complexity for no benefit.
 implicit_hasher = "allow"

--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -234,6 +234,64 @@ impl FieldDef {
         }
     }
 
+    /// Replaces every reference to one of the enclosing item's type parameters with the opaque
+    /// type.
+    ///
+    /// A parameter names no type at expansion — the instantiation names one, and the schema is
+    /// written once for every instantiation. So a parameter describes as an opaque value does,
+    /// which leaves the shape it sits in — a tuple's arity, an array, a map's keys — described.
+    ///
+    /// Recurses through `SiblingType` generics, `Map` keys/values, and `Tuple` elements.
+    #[cfg(feature = "jsonschema")]
+    pub fn erase_type_parameters(&mut self, parameters: &[String]) {
+        if let FieldDefType::SiblingType(name, _) = &self.field_type
+            && parameters.iter().any(|parameter| parameter == name)
+        {
+            self.field_type = FieldDefType::Unknown;
+            return;
+        }
+        match &mut self.field_type {
+            FieldDefType::SiblingType(_, generics) => {
+                for generic in generics.iter_mut() {
+                    generic.erase_type_parameters(parameters);
+                }
+            }
+            FieldDefType::Map(key, value) => {
+                key.erase_type_parameters(parameters);
+                value.erase_type_parameters(parameters);
+            }
+            FieldDefType::Tuple(elements) => {
+                for element in elements.iter_mut() {
+                    element.erase_type_parameters(parameters);
+                }
+            }
+            // Leaf types name no parameter.
+            FieldDefType::Unknown
+            | FieldDefType::StringLiteral(_)
+            | FieldDefType::Boolean
+            | FieldDefType::String
+            | FieldDefType::U8
+            | FieldDefType::U16
+            | FieldDefType::U32
+            | FieldDefType::U64
+            | FieldDefType::I8
+            | FieldDefType::I16
+            | FieldDefType::I32
+            | FieldDefType::I64
+            | FieldDefType::Usize
+            | FieldDefType::Isize
+            | FieldDefType::F32
+            | FieldDefType::F64 => {}
+            #[cfg(feature = "object_id")]
+            FieldDefType::ObjectId => {}
+            #[cfg(feature = "chrono")]
+            FieldDefType::NaiveDate
+            | FieldDefType::NaiveTime
+            | FieldDefType::NaiveDateTime
+            | FieldDefType::DateTime => {}
+        }
+    }
+
     #[cfg(feature = "chrono")]
     fn has_as_number(&self) -> bool {
         self.model_schema_prop_meta

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -152,6 +152,32 @@ enum MapMemberItem {
     Value(proc_macro2::TokenStream),
 }
 
+/// Why a value in a slot has no rendering. Each shape carries its own diagnostic, and the field
+/// name the message needs belongs to the caller rather than to the dispatch, so the reason travels
+/// out and the message is formatted once at the top.
+#[cfg(feature = "jsonschema")]
+#[derive(Debug)]
+enum MapMemberRejection {
+    /// A map key the registry proves carries no `enum_members()`, named so the author can act on it.
+    NonEnumKey(String),
+    Tuple,
+}
+
+/// What a map key opens: one open member set, the members it enumerates, or nothing this expansion
+/// can narrow.
+///
+/// Every position a map is written in reads its key through this one classification, so a key
+/// cannot enumerate its members in field position and stay open in a slot.
+#[cfg(feature = "jsonschema")]
+enum MapKeyPath<'key> {
+    /// A key named by a type path, whose `enum_members()` become the object's keys.
+    Enumerated(&'key str),
+    /// A `String` key, which enumerates nothing — one schema stands for every member.
+    Open,
+    /// A key this expansion cannot narrow, leaving the members unconstrained.
+    Unnarrowed,
+}
+
 #[derive(Default, Clone)]
 struct ModelSchemaArgs {
     max_length: Option<usize>,
@@ -3145,9 +3171,12 @@ fn push_single_tuple_json_field(
     fld: &FieldDef,
 ) {
     let content_name_str = content_name.to_owned();
-    let Some(field_schema) = build_tuple_element_json_schema(fld) else {
-        json_schema_variant_fields.push(unsupported_map_value_error(content_name));
-        return;
+    let field_schema = match build_tuple_element_json_schema(fld) {
+        Ok(field_schema) => field_schema,
+        Err(rejection) => {
+            json_schema_variant_fields.push(map_member_rejection_error(content_name, &rejection));
+            return;
+        }
     };
     json_schema_variant_fields.push(quote! {
         properties.insert(#content_name_str.to_string(), #field_schema);
@@ -3283,9 +3312,9 @@ fn write_tuple_multiple_variant_fields(
         match field_defs
             .iter()
             .map(build_tuple_element_json_schema)
-            .collect::<Option<Vec<_>>>()
+            .collect::<Result<Vec<_>, _>>()
         {
-            Some(tuple_schemas) => json_schema_variant_fields.push(quote! {
+            Ok(tuple_schemas) => json_schema_variant_fields.push(quote! {
                 properties.insert(#content_name_str.to_string(), {
                     serde_json::json!({
                         "type": "array",
@@ -3295,7 +3324,10 @@ fn write_tuple_multiple_variant_fields(
                 });
                 required.push(serde_json::Value::String(#content_name_str.to_string()));
             }),
-            None => json_schema_variant_fields.push(unsupported_map_value_error(content_name)),
+            Err(rejection) => {
+                json_schema_variant_fields
+                    .push(map_member_rejection_error(content_name, &rejection));
+            }
         }
     }
     #[cfg(not(feature = "jsonschema"))]
@@ -3385,15 +3417,13 @@ fn scalar_field_json_schema_item(fld: &FieldDef) -> Option<proc_macro2::TokenStr
 /// Every other value is the member the map path renders, at every depth, so a type describes the
 /// same in either slot.
 #[cfg(feature = "jsonschema")]
-fn build_tuple_element_item(value: &FieldDef) -> Option<MapMemberItem> {
+fn build_tuple_element_item(value: &FieldDef) -> Result<MapMemberItem, MapMemberRejection> {
     #[cfg(feature = "object_id")]
     if matches!(value.field_type, FieldDefType::ObjectId) {
-        return Some(MapMemberItem::Fragment(scalar_field_json_schema_item(
-            value,
-        )?));
+        return Ok(MapMemberItem::Fragment(scalar_slot_item(value)?));
     }
     if let FieldDefType::Tuple(elements) = &value.field_type {
-        return Some(MapMemberItem::Value(tuple_json_schema_value(elements)?));
+        return Ok(MapMemberItem::Value(tuple_json_schema_value(elements)?));
     }
     build_map_member_item(value)
 }
@@ -3409,10 +3439,12 @@ fn build_tuple_element_item(value: &FieldDef) -> Option<MapMemberItem> {
 /// it is named. The nullable wrap is applied by `build_tuple_element_json_schema`, off the element
 /// as it was written.
 #[cfg(feature = "jsonschema")]
-fn build_tuple_element_base_json_schema(fld: &FieldDef) -> Option<proc_macro2::TokenStream> {
+fn build_tuple_element_base_json_schema(
+    fld: &FieldDef,
+) -> Result<proc_macro2::TokenStream, MapMemberRejection> {
     let value = normalized_slot_value(fld);
     let item = build_tuple_element_item(&value)?;
-    Some(arrayed_json_schema_value(&value, item.into_value()))
+    Ok(arrayed_json_schema_value(&value, item.into_value()))
 }
 
 /// The `anyOf [<base>, null]` form for a value in a slot that cannot be dropped — a tuple element
@@ -3469,30 +3501,34 @@ fn sibling_json_schema_value(name: &str) -> proc_macro2::TokenStream {
     quote! { #module_ident::Schema::json_schema() }
 }
 
-/// Builds JSON schema for a tuple element (used for tuple fields and for tuple variants), or
-/// `None` when the element holds a value the dispatch cannot render — which the callers turn into
-/// the single diagnostic naming the field.
+/// Builds JSON schema for a tuple element (used for tuple fields and for tuple variants), or the
+/// rejection when the element holds a value the dispatch cannot render — which the callers turn
+/// into the single diagnostic naming the field.
 #[cfg(feature = "jsonschema")]
-fn build_tuple_element_json_schema(fld: &FieldDef) -> Option<proc_macro2::TokenStream> {
-    Some(nullable_slot_json_schema_value(
+fn build_tuple_element_json_schema(
+    fld: &FieldDef,
+) -> Result<proc_macro2::TokenStream, MapMemberRejection> {
+    Ok(nullable_slot_json_schema_value(
         fld,
         build_tuple_element_base_json_schema(fld)?,
     ))
 }
 
-/// The fixed-arity array a tuple describes as — the form serde writes it in — or `None` when any
-/// element holds a value the dispatch cannot render.
+/// The fixed-arity array a tuple describes as — the form serde writes it in — or the rejection when
+/// any element holds a value the dispatch cannot render.
 ///
 /// A tuple field and a tuple nested in a slot are the same array, so both are built here rather
 /// than each spelling the bounds itself.
 #[cfg(feature = "jsonschema")]
-fn tuple_json_schema_value(elements: &[FieldDef]) -> Option<proc_macro2::TokenStream> {
+fn tuple_json_schema_value(
+    elements: &[FieldDef],
+) -> Result<proc_macro2::TokenStream, MapMemberRejection> {
     let arity = elements.len();
     let element_schemas = elements
         .iter()
         .map(build_tuple_element_json_schema)
-        .collect::<Option<Vec<_>>>()?;
-    Some(quote! {
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(quote! {
         serde_json::json!({
             "type": "array",
             "prefixItems": [#(#element_schemas),*],
@@ -3503,41 +3539,87 @@ fn tuple_json_schema_value(elements: &[FieldDef]) -> Option<proc_macro2::TokenSt
     })
 }
 
+/// The classification every position reads a map key through.
+///
+/// Only a bare type path can name an enum: a generic spelling is a type this expansion has no
+/// `enum_members()` for, and every other type names keys the schema cannot enumerate.
+#[cfg(feature = "jsonschema")]
+const fn map_key_path(key: &FieldDef) -> MapKeyPath<'_> {
+    match &key.field_type {
+        FieldDefType::String => MapKeyPath::Open,
+        FieldDefType::SiblingType(key_type_name, args) if args.is_empty() => {
+            MapKeyPath::Enumerated(key_type_name.as_str())
+        }
+        FieldDefType::SiblingType(..)
+        | FieldDefType::Unknown
+        | FieldDefType::Map(..)
+        | FieldDefType::Tuple(..)
+        | FieldDefType::Boolean
+        | FieldDefType::StringLiteral(_)
+        | FieldDefType::U8
+        | FieldDefType::U16
+        | FieldDefType::U32
+        | FieldDefType::U64
+        | FieldDefType::I8
+        | FieldDefType::I16
+        | FieldDefType::I32
+        | FieldDefType::I64
+        | FieldDefType::Usize
+        | FieldDefType::Isize
+        | FieldDefType::F32
+        | FieldDefType::F64 => MapKeyPath::Unnarrowed,
+        #[cfg(feature = "object_id")]
+        FieldDefType::ObjectId => MapKeyPath::Unnarrowed,
+        #[cfg(feature = "chrono")]
+        FieldDefType::DateTime
+        | FieldDefType::NaiveDate
+        | FieldDefType::NaiveDateTime
+        | FieldDefType::NaiveTime => MapKeyPath::Unnarrowed,
+    }
+}
+
+/// The `json!` literal a map whose keys cannot be narrowed describes as: an object, with nothing
+/// said about its members. Written once so field and slot positions state the same thing.
+#[cfg(feature = "jsonschema")]
+fn unnarrowed_key_map_json_schema_item() -> proc_macro2::TokenStream {
+    quote! { { "type": "object", "additionalProperties": true } }
+}
+
 /// Fallback JSON schema for map fields whose key type is not specially handled.
 #[cfg(feature = "jsonschema")]
 fn map_key_fallback_schema(field_name_str: &str, key: &FieldDef) -> proc_macro2::TokenStream {
     log::trace!("Map Key Type {:?}", key.field_type);
+    let item = unnarrowed_key_map_json_schema_item();
     quote! {
         properties.insert(#field_name_str.to_string(), {
-            serde_json::json!({
-                "type": "object",
-                "additionalProperties": true
-            })
+            serde_json::json!(#item)
         });
     }
 }
 
-/// The member schema for a `String`-keyed map whose value is itself a map: an object whose own
-/// members carry the inner value's rendering, or `None` when that value has no rendering here.
-///
-/// Only a `String` inner key opens a member set this dispatcher describes; an inner key of any
-/// other type names members this branch does not enumerate, so those members stay unconstrained —
-/// the value is still known to be an object, which is what the map guarantees.
+/// The rendering a map whose value is itself a map carries, dispatched on the inner key exactly as
+/// the field position dispatches on the outer one.
 #[cfg(feature = "jsonschema")]
-fn build_map_nested_map_member_schema(
+fn build_nested_map_member_item(
     inner_key: &FieldDef,
     inner_value: &FieldDef,
-) -> Option<proc_macro2::TokenStream> {
+) -> Result<MapMemberItem, MapMemberRejection> {
     log::trace!(
         "Map Value is another Map => inner_key: {inner_key:?}, inner_value: {inner_value:?}"
     );
 
-    let inner_member = if matches!(inner_key.field_type, FieldDefType::String) {
-        build_map_member_schema(inner_value)?
-    } else {
-        quote! { true }
-    };
-    Some(quote! { { "type": "object", "additionalProperties": #inner_member } })
+    Ok(match map_key_path(inner_key) {
+        MapKeyPath::Enumerated(key_type_name) => {
+            MapMemberItem::Value(enum_key_map_json_schema_value(key_type_name, inner_value)?)
+        }
+        MapKeyPath::Open => {
+            let inner_member = build_map_member_schema(inner_value)?;
+            MapMemberItem::Fragment(
+                quote! { { "type": "object", "additionalProperties": #inner_member } },
+            )
+        }
+        MapKeyPath::Unnarrowed => MapMemberItem::Fragment(unnarrowed_key_map_json_schema_item()),
+    })
 }
 
 /// Wraps a member's base schema for the slot it sits in — arrayed when the value is a `Vec`,
@@ -3596,22 +3678,23 @@ fn normalized_slot_value(value: &FieldDef) -> FieldDef {
     normalized
 }
 
-/// The rendering a value in a slot carries, with the slot wraps left to the caller, or `None` when
-/// the value type has no rendering here.
+/// The rendering a value in a slot carries, with the slot wraps left to the caller, or the
+/// rejection when the value type has no rendering here.
 ///
-/// A map value is dispatched through this same function, so the members of a nested map carry the
-/// inner value type's own rendering at every depth rather than an open object. A tuple element is
+/// A map value is dispatched through this same function, so a nested map carries the rendering its
+/// own key and value types give it at every depth rather than an open object. A tuple element is
 /// dispatched through it too (via [`build_tuple_element_item`]), so the two slot positions cannot
 /// disagree about what a type describes as.
 ///
-/// A tuple is the only value the mapping cannot render, at any depth — a tuple element overrides
-/// that arm with the array its own field position renders, a map member has no such renderer — and
-/// the callers turn that `None` into the single diagnostic naming the field.
+/// A tuple is the one value type the mapping cannot render — a tuple element overrides that arm
+/// with the array its own field position renders, a map member has no such renderer — and a nested
+/// map can be turned away for its key. Either way the callers turn the rejection into the single
+/// diagnostic naming the field.
 #[cfg(feature = "jsonschema")]
-fn build_map_member_item(value: &FieldDef) -> Option<MapMemberItem> {
-    Some(match &value.field_type {
+fn build_map_member_item(value: &FieldDef) -> Result<MapMemberItem, MapMemberRejection> {
+    Ok(match &value.field_type {
         FieldDefType::Map(inner_key, inner_value) => {
-            MapMemberItem::Fragment(build_map_nested_map_member_schema(inner_key, inner_value)?)
+            build_nested_map_member_item(inner_key, inner_value)?
         }
         // The member is the sibling's own schema, as it is in field position — an expression, not a
         // literal, so it is already the value form.
@@ -3651,35 +3734,52 @@ fn build_map_member_item(value: &FieldDef) -> Option<MapMemberItem> {
         | FieldDefType::U16
         | FieldDefType::U32
         | FieldDefType::U64
-        | FieldDefType::Usize => MapMemberItem::Fragment(scalar_field_json_schema_item(value)?),
+        | FieldDefType::Usize => MapMemberItem::Fragment(scalar_slot_item(value)?),
         #[cfg(feature = "chrono")]
         FieldDefType::DateTime
         | FieldDefType::NaiveDate
         | FieldDefType::NaiveDateTime
-        | FieldDefType::NaiveTime => MapMemberItem::Fragment(scalar_field_json_schema_item(value)?),
+        | FieldDefType::NaiveTime => MapMemberItem::Fragment(scalar_slot_item(value)?),
     })
 }
 
-/// The `additionalProperties` schema every member of a `String`-keyed map carries, or `None` when
-/// the value type has no rendering here.
+/// [`scalar_field_json_schema_item`] for a slot, where a tuple is the one type reaching it with no
+/// inline rendering — every other type the scalar mapping names renders there.
 #[cfg(feature = "jsonschema")]
-fn build_map_member_schema(value: &FieldDef) -> Option<proc_macro2::TokenStream> {
-    let normalized = normalized_slot_value(value);
-    Some(build_map_member_item(&normalized)?.into_member_schema(&normalized))
+fn scalar_slot_item(fld: &FieldDef) -> Result<proc_macro2::TokenStream, MapMemberRejection> {
+    scalar_field_json_schema_item(fld).ok_or(MapMemberRejection::Tuple)
 }
 
-/// The one diagnostic a map value the mapping cannot render produces — on either key path, and in
-/// a tuple slot the map is reached through.
+/// The `additionalProperties` schema every member of a `String`-keyed map carries, or the rejection
+/// when the value type has no rendering here.
+#[cfg(feature = "jsonschema")]
+fn build_map_member_schema(
+    value: &FieldDef,
+) -> Result<proc_macro2::TokenStream, MapMemberRejection> {
+    let normalized = normalized_slot_value(value);
+    Ok(build_map_member_item(&normalized)?.into_member_schema(&normalized))
+}
+
+/// The one diagnostic a slot the mapping cannot render produces — on either key path, at any depth,
+/// and in a tuple slot the value is reached through.
 ///
 /// It replaces the branch's whole output rather than joining it: an emission left in place hands
 /// the author a schema the expansion has already rejected, and on the enum-key path a second error
 /// on the `value_schema` the failed binding never bound — macro-internal state the author cannot
-/// act on. The field and the type are what the author can act on, so the message names both.
+/// act on. The field and the type are what the author can act on, so each message names both.
 #[cfg(feature = "jsonschema")]
-fn unsupported_map_value_error(field_name_str: &str) -> proc_macro2::TokenStream {
-    let message = format!(
-        "field `{field_name_str}`: a tuple is not supported as a map value — give the value a `#[model_schema()]` struct instead"
-    );
+fn map_member_rejection_error(
+    field_name_str: &str,
+    rejection: &MapMemberRejection,
+) -> proc_macro2::TokenStream {
+    let message = match rejection {
+        MapMemberRejection::NonEnumKey(key_type_name) => format!(
+            "field `{field_name_str}`: a map key must be a plain `#[model_schema()]` enum, whose members become the object's keys — `{key_type_name}` resolves to a type with no `enum_members()`"
+        ),
+        MapMemberRejection::Tuple => format!(
+            "field `{field_name_str}`: a tuple is not supported as a map value — give the value a `#[model_schema()]` struct instead"
+        ),
+    };
     quote! { compile_error!(#message); }
 }
 
@@ -3692,8 +3792,9 @@ fn build_string_key_map_value_schema(
     value: &FieldDef,
     field_name_str: &str,
 ) -> proc_macro2::TokenStream {
-    let Some(value_schema) = build_map_member_schema(value) else {
-        return unsupported_map_value_error(field_name_str);
+    let value_schema = match build_map_member_schema(value) {
+        Ok(value_schema) => value_schema,
+        Err(rejection) => return map_member_rejection_error(field_name_str, &rejection),
     };
     quote! {
         properties.insert(#field_name_str.to_string(), {
@@ -3710,27 +3811,58 @@ fn build_string_key_map_value_schema(
 /// where a `String`-keyed member carries the closed, unpatterned one. Which of the two a map member
 /// should carry is unsettled, so each key path keeps the rendering it has.
 #[cfg(feature = "jsonschema")]
-fn build_enum_key_map_member_item(value: &FieldDef) -> Option<MapMemberItem> {
+fn build_enum_key_map_member_item(value: &FieldDef) -> Result<MapMemberItem, MapMemberRejection> {
     #[cfg(feature = "object_id")]
     if matches!(value.field_type, FieldDefType::ObjectId) {
-        return Some(MapMemberItem::Fragment(scalar_field_json_schema_item(
-            value,
-        )?));
+        return Ok(MapMemberItem::Fragment(scalar_slot_item(value)?));
     }
     build_map_member_item(value)
 }
 
-/// Binds `value_schema` — the JSON schema every member of an enum-keyed map carries — or `None`
-/// when the value type has no rendering here.
+/// The object an enum-keyed map describes as, as a standalone `serde_json::Value` expression: one
+/// property per member the key enumerates, each carrying the value type's own rendering, and closed
+/// to every other key. `Err` when the value has no rendering here, or when the registry proves the
+/// key carries no members.
 ///
-/// The member is the one the `String`-key path renders, materialized as a `serde_json::Value` for
-/// the insertion loop to clone per key, so which values a map may hold is the value type's answer
-/// rather than the key path's.
+/// The members are built by a block rather than spelled into a literal — only the expansion's own
+/// runtime knows them — and the block is bound inside a `serde_json::json!`, which makes the whole
+/// emission an expression. That is what lets one rendering serve every position a map is written
+/// in: a field's insertion, a member of an enclosing map, a tuple's `prefixItems` slot. A key that
+/// enumerates its members therefore enumerates them at any depth.
+///
+/// The key is written as a *type path*, which resolves through any alias, so an alias of a non-enum
+/// lands on a type with no `enum_members()` and rustc blames `#[model_schema()]` for a method the
+/// author never wrote. Only a target the registry positively rules out is turned away here: an
+/// unregistered name — a foreign type, or one expanded after this struct — stays on the emitting
+/// path, where it behaves as it always has.
 #[cfg(feature = "jsonschema")]
-fn build_enum_key_map_value_binding(value: &FieldDef) -> Option<proc_macro2::TokenStream> {
+fn enum_key_map_json_schema_value(
+    key_type_name: &str,
+    value: &FieldDef,
+) -> Result<proc_macro2::TokenStream, MapMemberRejection> {
+    if lookup_alias_info(key_type_name)
+        .is_some_and(|key_alias| key_alias.kind == AliasKind::NoEnumMembers)
+    {
+        return Err(MapMemberRejection::NonEnumKey(key_type_name.to_owned()));
+    }
+
     let normalized = normalized_slot_value(value);
-    let value_schema = build_enum_key_map_member_item(&normalized)?.into_member_value(&normalized);
-    Some(quote! { let value_schema = #value_schema; })
+    let member_value = build_enum_key_map_member_item(&normalized)?.into_member_value(&normalized);
+    let key_type_name_ident = Ident::new(key_type_name, proc_macro2::Span::call_site());
+    Ok(quote! {
+        serde_json::json!({
+            "type": "object",
+            "properties": ({
+                let value_schema = #member_value;
+                let mut map_properties = serde_json::Map::new();
+                for enum_key in #key_type_name_ident::enum_members() {
+                    map_properties.insert(enum_key.to_string(), value_schema.clone());
+                }
+                map_properties
+            }),
+            "additionalProperties": false
+        })
+    })
 }
 
 #[cfg(feature = "jsonschema")]
@@ -3741,78 +3873,17 @@ fn build_map_field_schema(
 ) -> proc_macro2::TokenStream {
     log::trace!("Map => field_name: {field_name_str}, key: {key:?}, value: {value:?}");
 
-    match &key.field_type {
-        FieldDefType::String => build_string_key_map_value_schema(value, field_name_str),
-        FieldDefType::SiblingType(key_type_name, lst) if lst.is_empty() => {
-            // The loop below writes the key as a *type path*, which resolves through any alias, so
-            // an alias of a non-enum lands on a type with no `enum_members()` and rustc blames
-            // `#[model_schema()]` for a missing method the author never wrote. Only a target the
-            // registry positively rules out is rejected here: an unregistered name (a foreign type,
-            // or one expanded after this struct) stays on the emitting path, where it behaves as it
-            // always has.
-            if let Some(key_alias) = lookup_alias_info(key_type_name)
-                && key_alias.kind == AliasKind::NoEnumMembers
-            {
-                let message = format!(
-                    "field `{field_name_str}`: a map key must be a plain `#[model_schema()]` enum, whose members become the object's keys — `{key_type_name}` resolves to a type with no `enum_members()`"
-                );
-                return quote! { compile_error!(#message); };
-            }
-
-            // For enum_members(), we call the type directly (delegation works)
-            let key_type_name_ident =
-                proc_macro2::Ident::new(key_type_name.as_str(), proc_macro2::Span::call_site());
-
-            let Some(value_schema_code) = build_enum_key_map_value_binding(value) else {
-                return unsupported_map_value_error(field_name_str);
-            };
-
-            quote! {
-                let mut map_properties = serde_json::Map::new();
-
-                #value_schema_code
-
-                for enum_key in #key_type_name_ident::enum_members() {
-                    map_properties.insert(enum_key.to_string(), value_schema.clone());
-                }
-
-                let mut json_schema_def = serde_json::json!({
-                    "type": "object",
-                    "properties": map_properties,
-                    "additionalProperties": false
-                });
-
-                properties.insert(#field_name_str.to_string(), {
-                    json_schema_def
-                });
+    match map_key_path(key) {
+        MapKeyPath::Enumerated(key_type_name) => {
+            match enum_key_map_json_schema_value(key_type_name, value) {
+                Ok(map_schema) => quote! {
+                    properties.insert(#field_name_str.to_string(), #map_schema);
+                },
+                Err(rejection) => map_member_rejection_error(field_name_str, &rejection),
             }
         }
-
-        FieldDefType::SiblingType(..)
-        | FieldDefType::Unknown
-        | FieldDefType::Map(..)
-        | FieldDefType::Tuple(..)
-        | FieldDefType::Boolean
-        | FieldDefType::StringLiteral(_)
-        | FieldDefType::U8
-        | FieldDefType::U16
-        | FieldDefType::U32
-        | FieldDefType::U64
-        | FieldDefType::I8
-        | FieldDefType::I16
-        | FieldDefType::I32
-        | FieldDefType::I64
-        | FieldDefType::Usize
-        | FieldDefType::Isize
-        | FieldDefType::F32
-        | FieldDefType::F64 => map_key_fallback_schema(field_name_str, key),
-        #[cfg(feature = "object_id")]
-        FieldDefType::ObjectId => map_key_fallback_schema(field_name_str, key),
-        #[cfg(feature = "chrono")]
-        FieldDefType::NaiveDate
-        | FieldDefType::NaiveTime
-        | FieldDefType::NaiveDateTime
-        | FieldDefType::DateTime => map_key_fallback_schema(field_name_str, key),
+        MapKeyPath::Open => build_string_key_map_value_schema(value, field_name_str),
+        MapKeyPath::Unnarrowed => map_key_fallback_schema(field_name_str, key),
     }
 }
 
@@ -4082,8 +4153,9 @@ fn build_tuple_field_schema(
     field_name_str: &str,
     lst: &[FieldDef],
 ) -> proc_macro2::TokenStream {
-    let Some(tuple_schema) = tuple_json_schema_value(lst) else {
-        return unsupported_map_value_error(field_name_str);
+    let tuple_schema = match tuple_json_schema_value(lst) {
+        Ok(tuple_schema) => tuple_schema,
+        Err(rejection) => return map_member_rejection_error(field_name_str, &rejection),
     };
 
     if fld.is_array {

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -2,7 +2,6 @@ extern crate alloc;
 
 use alloc::borrow::ToOwned;
 use core::fmt::Write as _;
-use std::collections::HashMap;
 
 use proc_macro::TokenStream;
 use quote::quote;
@@ -73,13 +72,23 @@ use crate::utils::to_snake_case;
 
 use crate::rename_rule::resolve_rename_rule;
 
-/// Per-variant data collected from a discriminated enum: field defs, doc strings, and variant
-/// kinds (each keyed by serialized discriminator value), plus the collected serde validators and
+/// One variant of a discriminated enum, carrying everything its union member is rendered from.
+struct DiscriminatedVariant {
+    discriminator_value: String,
+    docs: String,
+    field_defs: Vec<FieldDef>,
+    kind: VariantKind,
+}
+
+/// Per-variant data collected from a discriminated enum, plus the collected serde validators and
 /// the `compile_error!` tokens for any field-level guard violations.
+///
+/// The variants are a sequence, not a map: their order is the enum's declaration order and it
+/// reaches the emitted output verbatim (JSON-schema `oneOf`, the TypeScript union, the Zod
+/// `discriminatedUnion`). Any hash-ordered container here would re-randomize that output per
+/// build.
 type DiscriminatedVariantData = (
-    HashMap<String, Vec<FieldDef>>,
-    HashMap<String, String>,
-    HashMap<String, VariantKind>,
+    Vec<DiscriminatedVariant>,
     Vec<proc_macro2::TokenStream>,
     Vec<proc_macro2::TokenStream>,
 );
@@ -347,7 +356,8 @@ fn process_type_alias(item_type: ItemType, args: &ModelSchemaArgs) -> TokenStrea
     register_alias_info(&rust_ident_str, &export_name, &module_name, kind);
 
     let ts_method = generate_alias_ts_definition_method(&alias, &export_name, &alias_field_def);
-    let json_schema_method = generate_alias_json_schema_stub();
+    let json_schema_method =
+        generate_alias_json_schema_method(&alias, &export_name, &alias_field_def);
     let zod_method = generate_alias_zod_method(&export_name, &alias_field_def);
 
     let output = quote! {
@@ -2259,16 +2269,13 @@ fn process_plain_enum(
 }
 
 /// Processes each variant of a discriminated enum, returning per-variant field defs, doc strings,
-/// and variant kinds (keyed by serialized discriminator value), plus the collected serde
-/// validation functions.
+/// and variant kinds in declaration order, plus the collected serde validation functions.
 fn collect_discriminated_variants(
     item_enum: &mut syn::ItemEnum,
     rename_all: Option<&str>,
     enum_module_name_opt: Option<&str>,
 ) -> DiscriminatedVariantData {
-    let mut field_defs_by_variant: HashMap<String, Vec<FieldDef>> = HashMap::new();
-    let mut docs_by_variant: HashMap<String, String> = HashMap::new();
-    let mut kinds_by_variant: HashMap<String, VariantKind> = HashMap::new();
+    let mut variants: Vec<DiscriminatedVariant> = Vec::new();
     let mut enum_validation_fns: Vec<proc_macro2::TokenStream> = Vec::new();
     let mut guard_errors: Vec<proc_macro2::TokenStream> = Vec::new();
     let enum_type_name = item_enum.ident.to_string();
@@ -2296,8 +2303,6 @@ fn collect_discriminated_variants(
             field_defs.push(f_def);
         }
 
-        field_defs_by_variant.insert(final_name.clone(), field_defs);
-        kinds_by_variant.insert(final_name.clone(), variant_kind);
         let discriminator_docs = get_variant_docs(item).map_or_else(
             || {
                 [final_name.clone(), String::new()]
@@ -2316,16 +2321,15 @@ fn collect_discriminated_variants(
                     .join("\n")
             },
         );
-        docs_by_variant.insert(final_name, discriminator_docs);
+        variants.push(DiscriminatedVariant {
+            discriminator_value: final_name,
+            docs: discriminator_docs,
+            field_defs,
+            kind: variant_kind,
+        });
     }
 
-    (
-        field_defs_by_variant,
-        docs_by_variant,
-        kinds_by_variant,
-        enum_validation_fns,
-        guard_errors,
-    )
+    (variants, enum_validation_fns, guard_errors)
 }
 
 /// Renders the TypeScript type fragments, Zod schema fragments (with optional-field lists), and
@@ -2334,24 +2338,21 @@ fn render_discriminated_variants(
     tag_name: &str,
     content_name: &str,
     item_name: &str,
-    field_defs_by_variant: HashMap<String, Vec<FieldDef>>,
-    docs_by_variant: &HashMap<String, String>,
-    kinds_by_variant: &HashMap<String, VariantKind>,
+    variants: &[DiscriminatedVariant],
 ) -> RenderedVariants {
     let mut type_code_items = Vec::new();
     let mut schema_code_items = Vec::new();
     let mut json_schema_variants: Vec<proc_macro2::TokenStream> = Vec::new();
 
-    for (discriminator_value, field_defs) in field_defs_by_variant {
-        let variant_kind = &kinds_by_variant[&discriminator_value];
+    for variant in variants {
         let (variant_type_code, variant_schema_code, optional_fields, json_schema_variant) =
             generate_variant_code(
                 tag_name,
                 content_name,
-                &discriminator_value,
-                &field_defs,
-                variant_kind,
-                &docs_by_variant[&discriminator_value],
+                &variant.discriminator_value,
+                &variant.field_defs,
+                &variant.kind,
+                &variant.docs,
                 item_name,
             );
         type_code_items.push(variant_type_code);
@@ -2412,20 +2413,13 @@ fn process_discriminated_enum(
     let enum_module_name_opt = None;
 
     // Bind both result tuples whole so feature-gated field access marks them used (no per-element
-    // guards): `variants` = (field_defs, docs, kinds, validation_fns, guard_errors);
+    // guards): `variants` = (variants, validation_fns, guard_errors);
     // `rendered` = (ts, zod, json).
     let variants = collect_discriminated_variants(&mut item_enum, rename_all, enum_module_name_opt);
-    if let Some(output) = guard_failure_output(&item_enum, &variants.4) {
+    if let Some(output) = guard_failure_output(&item_enum, &variants.2) {
         return output;
     }
-    let rendered = render_discriminated_variants(
-        tag_name,
-        content_name,
-        item_name,
-        variants.0,
-        &variants.1,
-        &variants.2,
-    );
+    let rendered = render_discriminated_variants(tag_name, content_name, item_name, &variants.0);
     #[cfg(not(any(feature = "typescript", feature = "zod", feature = "jsonschema")))]
     let _: &_ = &(name, &rendered);
 
@@ -2500,7 +2494,7 @@ fn process_discriminated_enum(
             &module_ident,
             name,
             &schema_impl_items,
-            &variants.3,
+            &variants.1,
             &delegate_impl_items,
         )
     }
@@ -3504,6 +3498,10 @@ fn sibling_json_schema_value(name: &str) -> proc_macro2::TokenStream {
 /// Builds JSON schema for a tuple element (used for tuple fields and for tuple variants), or the
 /// rejection when the element holds a value the dispatch cannot render — which the callers turn
 /// into the single diagnostic naming the field.
+///
+/// An alias's target is rendered through here too: an alias names a type, and this is the dispatch
+/// total over the types the crate renders, so what the alias publishes is what a field written as
+/// the target would carry.
 #[cfg(feature = "jsonschema")]
 fn build_tuple_element_json_schema(
     fld: &FieldDef,
@@ -3760,6 +3758,21 @@ fn build_map_member_schema(
     Ok(build_map_member_item(&normalized)?.into_member_schema(&normalized))
 }
 
+/// What a value the mapping cannot render is reported as. The `subject` names where the value was
+/// written — a field, an alias — which is what the author can act on and all that differs between
+/// those positions, so the reasons are worded once.
+#[cfg(feature = "jsonschema")]
+fn map_member_rejection_message(subject: &str, rejection: &MapMemberRejection) -> String {
+    match rejection {
+        MapMemberRejection::NonEnumKey(key_type_name) => format!(
+            "{subject}: a map key must be a plain `#[model_schema()]` enum, whose members become the object's keys — `{key_type_name}` resolves to a type with no `enum_members()`"
+        ),
+        MapMemberRejection::Tuple => format!(
+            "{subject}: a tuple is not supported as a map value — give the value a `#[model_schema()]` struct instead"
+        ),
+    }
+}
+
 /// The one diagnostic a slot the mapping cannot render produces — on either key path, at any depth,
 /// and in a tuple slot the value is reached through.
 ///
@@ -3772,14 +3785,7 @@ fn map_member_rejection_error(
     field_name_str: &str,
     rejection: &MapMemberRejection,
 ) -> proc_macro2::TokenStream {
-    let message = match rejection {
-        MapMemberRejection::NonEnumKey(key_type_name) => format!(
-            "field `{field_name_str}`: a map key must be a plain `#[model_schema()]` enum, whose members become the object's keys — `{key_type_name}` resolves to a type with no `enum_members()`"
-        ),
-        MapMemberRejection::Tuple => format!(
-            "field `{field_name_str}`: a tuple is not supported as a map value — give the value a `#[model_schema()]` struct instead"
-        ),
-    };
+    let message = map_member_rejection_message(&format!("field `{field_name_str}`"), rejection);
     quote! { compile_error!(#message); }
 }
 
@@ -5264,15 +5270,67 @@ fn generate_ts_alias_method(
     }
 }
 
+/// The alias target as the JSON mapping reads it: every reference to one of the alias's own type
+/// parameters replaced by the opaque type.
+///
+/// A parameter names no type until the alias is instantiated, and every position that references an
+/// alias references it uninstantiated — a field written as `Pair<A, B>` carries the alias module's
+/// one schema. So a parameter admits any value, as an opaque field does, while the shape around it
+/// — arity, array-ness, a map's keys — is still described.
+#[cfg(feature = "jsonschema")]
+fn alias_json_schema_field_def(alias: &ItemType, field_def: &FieldDef) -> FieldDef {
+    let parameters: Vec<String> = alias
+        .generics
+        .params
+        .iter()
+        .filter_map(|param| match param {
+            syn::GenericParam::Type(tp) => Some(tp.ident.to_string()),
+            syn::GenericParam::Const(_) | syn::GenericParam::Lifetime(_) => None,
+        })
+        .collect();
+    let mut erased = field_def.clone();
+    erased.erase_type_parameters(&parameters);
+    erased
+}
+
+/// The diagnostic an alias whose target the dispatch cannot render emits, in place of the whole
+/// `json_schema()` body.
+///
+/// It replaces the body rather than joining it: a schema left there would describe a type the
+/// expansion has already rejected, and every slot naming the alias would carry it. The tokens are
+/// the body's tail expression — no trailing semicolon, so the method's return type raises no second
+/// error on top of the one the author can act on.
+#[cfg(feature = "jsonschema")]
+fn alias_json_schema_rejection(
+    export_name: &str,
+    rejection: &MapMemberRejection,
+) -> proc_macro2::TokenStream {
+    let message = map_member_rejection_message(&format!("type alias `{export_name}`"), rejection);
+    quote! { compile_error!(#message) }
+}
+
+/// Builds the alias module's `json_schema()`, or nothing when `jsonschema` is off.
+///
+/// An alias names a type, so it publishes that type's own schema: the target `FieldDef` — the one
+/// the TypeScript and Zod methods render from — through the dispatch a positional slot uses, that
+/// being the dispatch total over the types the crate renders and the one whose `ObjectId` is the
+/// field-position object. So the alias describes what a field written as the target describes. A
+/// sibling target is carried by the shared reference, which resolves through the registry: an alias
+/// of an alias lands on the type at the end of the chain, and an alias of a type that never
+/// expanded fails on the module it names, exactly as a field of that type does.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-fn generate_alias_json_schema_stub() -> proc_macro2::TokenStream {
+fn generate_alias_json_schema_method(
+    alias: &ItemType,
+    export_name: &str,
+    field_def: &FieldDef,
+) -> proc_macro2::TokenStream {
     #[cfg(feature = "jsonschema")]
     {
+        let body = build_tuple_element_json_schema(&alias_json_schema_field_def(alias, field_def))
+            .unwrap_or_else(|rejection| alias_json_schema_rejection(export_name, &rejection));
         quote! {
             pub fn json_schema() -> serde_json::Value {
-                serde_json::json!({
-                    "warning": "JSON schema generation for aliases is not yet supported"
-                })
+                #body
             }
         }
     }
@@ -5280,6 +5338,7 @@ fn generate_alias_json_schema_stub() -> proc_macro2::TokenStream {
     {
         // Nothing in this build references an alias module's `json_schema()`; the sibling
         // reference that would (`flatten_field_json_schema_ref`) is itself jsonschema-gated.
+        let _: &_ = &(alias, export_name, field_def);
         quote! {}
     }
 }

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -980,14 +980,14 @@ fn an_unsupported_enum_keyed_map_value_emits_only_the_compile_error() {
     }
 }
 
-/// The enum-key branch's binding for a map value built by hand, for the value types no source type
+/// The enum-key branch's rendering for a map value built by hand, for the value types no source type
 /// produces.
 #[cfg(feature = "jsonschema")]
 fn enum_key_map_value_binding(field_type: FieldDefType) -> String {
     let ty: syn::Type = syn::parse_str("String").unwrap();
     let mut value = super::get_field_def("m", &ty, "");
     value.field_type = field_type;
-    super::build_enum_key_map_value_binding(&value)
+    super::enum_key_map_json_schema_value("Slot", &value)
         .unwrap()
         .to_string()
 }
@@ -1054,7 +1054,10 @@ fn a_generic_sibling_enum_keyed_map_value_emits_the_sibling_schema() {
 #[test]
 fn an_opaque_enum_keyed_map_value_stays_permissive() {
     let tokens = enum_key_map_value_binding(FieldDefType::Unknown);
-    assert_eq!(tokens, "let value_schema = serde_json :: json ! ({ }) ;");
+    assert!(
+        tokens.contains("let value_schema = serde_json :: json ! ({ }) ;"),
+        "got: {tokens}"
+    );
 }
 
 /// A string literal keeps the `const` it carries on the `String`-key path.
@@ -1062,9 +1065,11 @@ fn an_opaque_enum_keyed_map_value_stays_permissive() {
 #[test]
 fn a_string_literal_enum_keyed_map_value_keeps_its_const() {
     let tokens = enum_key_map_value_binding(FieldDefType::StringLiteral("Tixena".to_owned()));
-    assert_eq!(
-        tokens,
-        r#"let value_schema = serde_json :: json ! ({ "type" : "string" , "const" : "Tixena" }) ;"#
+    assert!(
+        tokens.contains(
+            r#"let value_schema = serde_json :: json ! ({ "type" : "string" , "const" : "Tixena" }) ;"#
+        ),
+        "got: {tokens}"
     );
 }
 
@@ -1095,9 +1100,11 @@ fn a_chrono_enum_keyed_map_value_keeps_its_format() {
 #[test]
 fn an_object_id_enum_keyed_map_value_keeps_the_field_position_oid_object() {
     let tokens = enum_key_map_value_binding(FieldDefType::ObjectId);
-    assert_eq!(
-        tokens,
-        r#"let value_schema = serde_json :: json ! ({ "type" : "object" , "properties" : { "$oid" : { "type" : "string" , "pattern" : "^[a-f\\d]{24}$" } } , "required" : ["$oid"] }) ;"#
+    assert!(
+        tokens.contains(
+            r#"let value_schema = serde_json :: json ! ({ "type" : "object" , "properties" : { "$oid" : { "type" : "string" , "pattern" : "^[a-f\\d]{24}$" } } , "required" : ["$oid"] }) ;"#
+        ),
+        "got: {tokens}"
     );
 }
 
@@ -1511,18 +1518,198 @@ fn a_nested_object_id_map_value_keeps_its_oid_object() {
     );
 }
 
-/// An inner key type this branch does not enumerate leaves the inner members open — but the member
-/// is still known to be an object, which is more than an unconstrained value says.
+/// The rendering an enum-keyed map carries in every position, spelled out for a key of the given
+/// name and a member of the given tokens.
+#[cfg(feature = "jsonschema")]
+fn enum_key_map_rendering(key_type_name: &str, member: &str) -> String {
+    format!(
+        r#"serde_json :: json ! ({{ "type" : "object" , "properties" : ({{ let value_schema = {member} ; let mut map_properties = serde_json :: Map :: new () ; for enum_key in {key_type_name} :: enum_members () {{ map_properties . insert (enum_key . to_string () , value_schema . clone ()) ; }} map_properties }}) , "additionalProperties" : false }})"#
+    )
+}
+
+/// Which keys a map has is the key type's answer wherever the map is written, so an inner key that
+/// enumerates its members enumerates them under an outer `String` key too — the position the map
+/// sits in cannot decide whether its keys are known.
 #[cfg(feature = "jsonschema")]
 #[test]
-fn a_nested_map_under_an_unenumerated_key_still_renders_as_an_object() {
+fn a_nested_map_under_an_enumerating_key_expands_its_members() {
     let tokens = map_field_schema("HashMap<String, HashMap<Slot, String>>").to_string();
+    let inner = enum_key_map_rendering("Slot", r#"serde_json :: json ! ({ "type" : "string" })"#);
     assert!(
-        tokens.contains(
-            r#""additionalProperties" : { "type" : "object" , "additionalProperties" : true }"#
-        ),
+        tokens.contains(&format!(r#""additionalProperties" : {inner}"#)),
         "got: {tokens}"
     );
+    assert!(
+        !tokens.contains(r#""additionalProperties" : true"#),
+        "got: {tokens}"
+    );
+}
+
+/// And under an outer key that enumerates too: each level asks its own key type, so a two-level map
+/// spells both member sets out rather than stopping at the first.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_nested_map_under_two_enumerating_keys_expands_both_member_sets() {
+    let tokens = map_field_schema("HashMap<Slot, HashMap<Bucket, u64>>").to_string();
+    let inner =
+        enum_key_map_rendering("Bucket", r#"serde_json :: json ! ({ "type" : "integer" })"#);
+    assert!(
+        tokens.contains(&enum_key_map_rendering("Slot", &inner)),
+        "got: {tokens}"
+    );
+    assert!(
+        !tokens.contains(r#""additionalProperties" : true"#),
+        "got: {tokens}"
+    );
+}
+
+/// The slot wraps sit outside the map's own rendering, as they do for every other member: a `Vec` of
+/// enum-keyed maps is an array of the object each one describes as, and an `Option` admits `null`
+/// beside it.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_wrapped_nested_enum_keyed_map_keeps_its_members_inside_the_slot_wrap() {
+    let inner = enum_key_map_rendering("Slot", r#"serde_json :: json ! ({ "type" : "string" })"#);
+    for (map_type, expected) in [
+        (
+            "HashMap<String, Vec<HashMap<Slot, String>>>",
+            format!(r#"serde_json :: json ! ({{ "type" : "array" , "items" : {inner} }})"#),
+        ),
+        (
+            "HashMap<String, Option<HashMap<Slot, String>>>",
+            format!(r#"serde_json :: json ! ({{ "anyOf" : [{inner} , {{ "type" : "null" }}] }})"#),
+        ),
+    ] {
+        let tokens = map_field_schema(map_type).to_string();
+        assert!(
+            tokens.contains(&format!(r#""additionalProperties" : {expected}"#)),
+            "for {map_type}, got: {tokens}"
+        );
+    }
+}
+
+/// An enum-keyed map in a tuple slot is the same map, so it carries the same rendering: the slot
+/// dispatch reaches the one emission rather than falling back to the open object.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn an_enum_keyed_map_tuple_element_expands_its_members() {
+    let expected =
+        enum_key_map_rendering("Slot", r#"serde_json :: json ! ({ "type" : "integer" })"#);
+    for field_type in [
+        "(String, HashMap<Slot, u32>)",
+        "(String, HashMap<String, HashMap<Slot, u32>>)",
+    ] {
+        let tokens = tuple_field_schema(field_type);
+        assert!(
+            tokens.contains(&expected),
+            "for {field_type}, got: {tokens}"
+        );
+        assert!(
+            !tokens.contains(r#""additionalProperties" : true"#),
+            "for {field_type}, got: {tokens}"
+        );
+    }
+}
+
+/// An inner key the registry positively rules out is rejected where the outer one is: reaching the
+/// emitting path at depth resolves `enum_members()` through the alias onto a type that has no such
+/// method, and rustc blames the attribute for a method the author never wrote.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_nested_map_key_known_to_lack_enum_members_names_the_requirement() {
+    register_alias_info(
+        "KeyAlias",
+        "KeyAliasType",
+        "key_alias_type_schema",
+        AliasKind::NoEnumMembers,
+    );
+    for map_type in [
+        "HashMap<String, HashMap<KeyAlias, String>>",
+        "HashMap<Slot, HashMap<KeyAlias, String>>",
+        "HashMap<String, Vec<HashMap<KeyAlias, String>>>",
+    ] {
+        let tokens = map_field_schema(map_type).to_string();
+        assert!(
+            !tokens.contains("KeyAlias :: enum_members"),
+            "for {map_type}, got: {tokens}"
+        );
+        assert!(
+            tokens.starts_with("compile_error !"),
+            "for {map_type}, got: {tokens}"
+        );
+        assert!(
+            !tokens.contains("properties . insert"),
+            "for {map_type}, got: {tokens}"
+        );
+        assert!(
+            tokens.contains("a map key must be a plain"),
+            "for {map_type}, got: {tokens}"
+        );
+        assert!(tokens.contains("KeyAlias"), "for {map_type}, got: {tokens}");
+    }
+}
+
+/// The guard reaches a tuple slot too, that being another position the map is dispatched through.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_tuple_element_map_key_known_to_lack_enum_members_names_the_requirement() {
+    register_alias_info(
+        "KeyAlias",
+        "KeyAliasType",
+        "key_alias_type_schema",
+        AliasKind::NoEnumMembers,
+    );
+    let tokens = tuple_field_schema("(String, HashMap<KeyAlias, String>)");
+    assert!(tokens.starts_with("compile_error !"), "got: {tokens}");
+    assert!(
+        tokens.contains("a map key must be a plain"),
+        "got: {tokens}"
+    );
+    assert!(tokens.contains("field `t`"), "got: {tokens}");
+}
+
+/// The one emission answers for every position a map can sit in, so the object `HashMap<Slot, T>`
+/// describes as in field position is the object it describes as nested under either key flavor and
+/// in a tuple slot. Held against the field-position rendering, which is the one that has always
+/// enumerated — depth cannot widen what the key already settled.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn an_enum_keyed_map_renders_the_same_in_every_position() {
+    let expected =
+        enum_key_map_rendering("Slot", r#"serde_json :: json ! ({ "type" : "string" })"#);
+    assert!(
+        map_field_schema("HashMap<Slot, String>")
+            .to_string()
+            .contains(&expected),
+        "field position lost its enumeration"
+    );
+    for position in [
+        map_field_schema("HashMap<String, HashMap<Slot, String>>").to_string(),
+        map_field_schema("HashMap<Slot, HashMap<Slot, String>>").to_string(),
+        tuple_field_schema("(String, HashMap<Slot, String>)"),
+    ] {
+        assert!(position.contains(&expected), "got: {position}");
+    }
+}
+
+/// An inner key this expansion cannot narrow leaves the inner members open — the member is still
+/// known to be an object, which is what the map guarantees, and it is what the same key states in
+/// field position.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_nested_map_under_an_unenumerable_key_still_renders_as_an_object() {
+    for map_type in [
+        "HashMap<String, HashMap<u32, String>>",
+        "HashMap<String, HashMap<Wrapper<Slot>, String>>",
+    ] {
+        let tokens = map_field_schema(map_type).to_string();
+        assert!(
+            tokens.contains(
+                r#""additionalProperties" : { "type" : "object" , "additionalProperties" : true }"#
+            ),
+            "for {map_type}, got: {tokens}"
+        );
+    }
 }
 
 /// A value the mapping cannot render fails wherever it sits: nested behind a map, the tuple is

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -1,4 +1,7 @@
-use super::{FieldDefType, validate_as_number_flag, validate_ts_optional_flag};
+use super::{
+    FieldDefType, collect_discriminated_variants, render_discriminated_variants,
+    validate_as_number_flag, validate_ts_optional_flag,
+};
 
 #[cfg(feature = "serde")]
 use super::{
@@ -12,6 +15,9 @@ use super::{AliasKind, branded_guard_errors, register_alias_info};
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 use syn::spanned::Spanned as _;
+
+/// The variants of [`rendered_discriminated_union`]'s enum, in the order they are declared.
+const DECLARED_VARIANTS: [&str; 6] = ["Upload", "Generate", "Delete", "Rename", "Move", "Archive"];
 
 /// The covered wrappers, under the names a dispatch reads them by.
 #[cfg(feature = "jsonschema")]
@@ -423,9 +429,88 @@ fn discriminated_enum_ts_definition_carries_no_cfg_attribute() {
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
-fn alias_json_schema_stub_carries_no_cfg_attribute() {
-    let tokens = super::generate_alias_json_schema_stub();
-    assert_no_cfg_attribute(&tokens, "generate_alias_json_schema_stub");
+fn alias_json_schema_method_carries_no_cfg_attribute() {
+    let alias: syn::ItemType = syn::parse_quote!(
+        pub type AliasIdent = String;
+    );
+    let field_def = super::get_field_def("AliasType", &alias.ty, "");
+    let tokens = super::generate_alias_json_schema_method(&alias, "AliasType", &field_def);
+    assert_no_cfg_attribute(&tokens, "generate_alias_json_schema_method");
+}
+
+/// An alias whose target the dispatch cannot render fails the way a field of that target does: one
+/// diagnostic, naming the alias and the reason, in place of the whole body. A schema left there
+/// would be carried by every slot the alias fills.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn an_alias_of_an_unrenderable_target_emits_only_the_compile_error() {
+    for alias_source in [
+        "pub type Rows = HashMap<String, (u32, u32)>;",
+        "pub type Rows = Vec<HashMap<String, (u32, u32)>>;",
+        "pub type Rows = (String, HashMap<String, (u32, u32)>);",
+    ] {
+        let alias: syn::ItemType = syn::parse_str(alias_source).unwrap();
+        let field_def = super::get_field_def("RowsType", &alias.ty, "");
+        let tokens =
+            super::generate_alias_json_schema_method(&alias, "RowsType", &field_def).to_string();
+        assert!(
+            tokens.contains("compile_error !"),
+            "for {alias_source}, got: {tokens}"
+        );
+        assert!(
+            tokens.contains("type alias `RowsType`"),
+            "for {alias_source}, got: {tokens}"
+        );
+        assert!(
+            tokens.contains("a tuple is not supported as a map value"),
+            "for {alias_source}, got: {tokens}"
+        );
+        assert!(
+            !tokens.contains("json !"),
+            "for {alias_source}, got: {tokens}"
+        );
+    }
+}
+
+/// A type parameter reaches the mapping as a named type, and a name is carried by a reference to
+/// the schema module it registered — a module no expansion emits for a parameter. So the parameter
+/// is erased wherever it can be written, or the alias names a module that does not exist.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn an_alias_type_parameter_is_erased_at_every_depth() {
+    for alias_source in [
+        "pub type Holder<V> = V;",
+        "pub type Holder<V> = Vec<V>;",
+        "pub type Holder<V> = Option<V>;",
+        "pub type Holder<V> = (String, V);",
+        "pub type Holder<V> = HashMap<String, V>;",
+        "pub type Holder<V> = HashMap<String, Vec<V>>;",
+    ] {
+        let alias: syn::ItemType = syn::parse_str(alias_source).unwrap();
+        let field_def = super::get_field_def("HolderType", &alias.ty, "");
+        let tokens =
+            super::generate_alias_json_schema_method(&alias, "HolderType", &field_def).to_string();
+        assert!(
+            !tokens.contains("Schema :: json_schema ()"),
+            "for {alias_source}, got: {tokens}"
+        );
+    }
+}
+
+/// The stub this replaced answered every alias with an object carrying a lone `warning` key, which
+/// under JSON Schema constrains nothing — every slot naming an alias accepted every payload. No
+/// emission may carry one again.
+#[test]
+fn no_json_schema_emission_carries_a_warning_key() {
+    for (file, source) in [
+        ("model_schema.rs", include_str!("../model_schema.rs")),
+        (
+            "features/jsonschema.rs",
+            include_str!("../features/jsonschema.rs"),
+        ),
+    ] {
+        assert!(!source.contains("\"warning\""), "in: {file}");
+    }
 }
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
@@ -1991,4 +2076,79 @@ fn an_optional_sequence_wrapper_member_stays_nullable() {
             .unwrap()
             .to_string()
     );
+}
+
+/// Runs a fixed discriminated enum through the real collect/render pipeline, returning its
+/// TypeScript member fragments, Zod member fragments, and JSON-schema member fragments.
+///
+/// Rebuilt from scratch on every call so repeated calls exercise whatever ordering the collection
+/// stage imposes, not a single cached traversal.
+fn rendered_discriminated_union() -> (Vec<String>, Vec<String>, Vec<String>) {
+    let mut item: syn::ItemEnum = syn::parse_quote! {
+        enum Action {
+            Upload { path: String },
+            Generate,
+            Delete(String),
+            Rename { from: String, to: String },
+            Move(String, String),
+            Archive,
+        }
+    };
+    let variants = collect_discriminated_variants(&mut item, None, Some("action_schema"));
+    let rendered = render_discriminated_variants("type", "value", "Action", &variants.0);
+    (
+        rendered.0,
+        rendered
+            .1
+            .into_iter()
+            .map(|(schema_code, _optional)| schema_code)
+            .collect(),
+        rendered.2.iter().map(ToString::to_string).collect(),
+    )
+}
+
+/// Union member order is semantic, not cosmetic: serde tries untagged members in declaration
+/// order, so the emitted union must carry that same order on every surface.
+#[test]
+fn discriminated_union_members_follow_declaration_order() {
+    let (ts_members, zod_members, json_members) = rendered_discriminated_union();
+    assert_eq!(ts_members.len(), DECLARED_VARIANTS.len());
+    assert_eq!(zod_members.len(), DECLARED_VARIANTS.len());
+    assert_eq!(json_members.len(), DECLARED_VARIANTS.len());
+
+    for (position, declared) in DECLARED_VARIANTS.iter().enumerate() {
+        assert!(
+            ts_members[position].contains(&format!("type: \"{declared}\";")),
+            "TypeScript member {position} is not `{declared}`: {}",
+            ts_members[position]
+        );
+        assert!(
+            zod_members[position].contains(&format!("type: z.literal(\"{declared}\")")),
+            "Zod member {position} is not `{declared}`: {}",
+            zod_members[position]
+        );
+        #[cfg(feature = "jsonschema")]
+        assert!(
+            json_members[position].contains(&format!("\"const\" : \"{declared}\"")),
+            "JSON-schema member {position} is not `{declared}`: {}",
+            json_members[position]
+        );
+    }
+}
+
+/// Every per-variant collection feeding emission must be order-preserving. A hash-ordered one
+/// reseeds per instance, so the same source expands to a different union on each build — which
+/// this catches by rendering the same enum repeatedly inside one process.
+#[test]
+fn discriminated_union_rendering_is_stable_across_runs() {
+    const RUNS: usize = 32;
+
+    let first = rendered_discriminated_union();
+    for run in 1..RUNS {
+        assert_eq!(
+            rendered_discriminated_union(),
+            first,
+            "run {run} rendered a different union than run 0"
+        );
+    }
 }

--- a/tests/alias_reference_tests/tests.rs
+++ b/tests/alias_reference_tests/tests.rs
@@ -48,6 +48,15 @@ pub struct UsesAliasAsMapKey {
     pub by_slot: HashMap<DocumentSlotAlias, ReferencedDocumentId>,
 }
 
+#[model_schema()]
+pub type ReferencedDocumentIds = Vec<ReferencedDocumentId>;
+
+#[model_schema()]
+pub type DocumentIdsByName = HashMap<String, ReferencedDocumentId>;
+
+#[model_schema()]
+pub type DocumentIdsBySlot = HashMap<DocumentSlot, ReferencedDocumentId>;
+
 #[test]
 fn struct_referencing_an_alias_expands_in_this_feature_combination() {
     let value = UsesAliasByValue {
@@ -68,6 +77,21 @@ fn struct_referencing_an_alias_expands_in_this_feature_combination() {
     assert_eq!(
         map.by_slot.get(&DocumentSlot::Primary),
         Some(&"doc-3".to_owned())
+    );
+}
+
+#[test]
+fn collection_aliases_expand_in_this_feature_combination() {
+    let ids: ReferencedDocumentIds = vec!["doc-5".to_owned()];
+    assert_eq!(ids, vec!["doc-5".to_owned()]);
+
+    let by_name: DocumentIdsByName = HashMap::from([("n".to_owned(), "doc-6".to_owned())]);
+    assert_eq!(by_name.get("n"), Some(&"doc-6".to_owned()));
+
+    let by_slot: DocumentIdsBySlot = HashMap::from([(DocumentSlot::Primary, "doc-7".to_owned())]);
+    assert_eq!(
+        by_slot.get(&DocumentSlot::Primary),
+        Some(&"doc-7".to_owned())
     );
 }
 
@@ -130,6 +154,93 @@ fn alias_keyed_map_enumerates_the_members_of_the_aliased_enum() {
             DocumentSlot::enum_members().len(),
             "{field}: {keyed}"
         );
+    }
+}
+
+/// An alias names a type, so the schema it publishes is that type's own — the same one the scalar
+/// mapping gives a field written as the target directly.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn an_aliased_scalar_publishes_the_targets_schema() {
+    assert_eq!(
+        referenced_document_id_type_schema::Schema::json_schema(),
+        serde_json::json!({ "type": "string" })
+    );
+}
+
+/// A sibling target is carried by the one reference every position that names it carries, so the
+/// alias and the type it names describe the same values.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn an_aliased_sibling_publishes_the_siblings_own_schema() {
+    assert_eq!(
+        document_slot_alias_type_schema::Schema::json_schema(),
+        document_slot_schema::Schema::json_schema()
+    );
+}
+
+/// The reference resolves through the registry, which answers with whatever the named alias
+/// registered — so a chain of aliases lands on the enum at the end of it rather than on a link.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn an_alias_of_an_alias_resolves_to_the_type_at_the_end_of_the_chain() {
+    assert_eq!(
+        document_slot_alias_chain_type_schema::Schema::json_schema(),
+        document_slot_schema::Schema::json_schema()
+    );
+}
+
+#[cfg(feature = "jsonschema")]
+#[test]
+fn an_aliased_sequence_publishes_the_array_of_its_element() {
+    assert_eq!(
+        referenced_document_ids_type_schema::Schema::json_schema(),
+        serde_json::json!({
+            "type": "array",
+            "items": referenced_document_id_type_schema::Schema::json_schema()
+        })
+    );
+}
+
+/// A map target describes as its own key and value do, at the alias exactly as in field position:
+/// a `String` key leaves the members open under one value schema, an enum key enumerates them.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn an_aliased_map_publishes_the_object_its_key_and_value_describe() {
+    let member = referenced_document_id_type_schema::Schema::json_schema();
+    assert_eq!(
+        document_ids_by_name_type_schema::Schema::json_schema(),
+        serde_json::json!({ "type": "object", "additionalProperties": member })
+    );
+
+    let by_slot = document_ids_by_slot_type_schema::Schema::json_schema();
+    let properties = by_slot.get("properties").unwrap();
+    for slot in DocumentSlot::enum_members() {
+        assert_eq!(properties.get(&slot).unwrap(), &member, "in: {by_slot}");
+    }
+    assert_eq!(
+        properties.as_object().unwrap().len(),
+        DocumentSlot::enum_members().len(),
+        "in: {by_slot}"
+    );
+    assert_eq!(by_slot["additionalProperties"], false, "in: {by_slot}");
+}
+
+/// The stub this replaced answered every alias with an object carrying a lone `warning` key, which
+/// under JSON Schema constrains nothing and so accepts every payload a slot could hold.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn no_alias_publishes_a_schema_that_validates_nothing() {
+    for schema in [
+        referenced_document_id_type_schema::Schema::json_schema(),
+        referenced_document_ids_type_schema::Schema::json_schema(),
+        document_slot_alias_type_schema::Schema::json_schema(),
+        document_slot_alias_chain_type_schema::Schema::json_schema(),
+        document_ids_by_name_type_schema::Schema::json_schema(),
+        document_ids_by_slot_type_schema::Schema::json_schema(),
+    ] {
+        assert!(schema.get("warning").is_none(), "got: {schema}");
+        assert!(schema.get("type").is_some(), "got: {schema}");
     }
 }
 

--- a/tests/collection_tests/tests.rs
+++ b/tests/collection_tests/tests.rs
@@ -97,6 +97,35 @@ struct StringKeyedNestedMapValues {
     samples: HashMap<String, HashMap<String, MetricSample>>,
 }
 
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum MetricBucket {
+    High,
+    Low,
+}
+
+/// The enum-keyed map every position below is held against: the field-position rendering, which is
+/// the one that has always enumerated its key.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct BucketKeyedMap {
+    counts: HashMap<MetricBucket, u64>,
+    samples: HashMap<MetricBucket, MetricSample>,
+}
+
+// Which keys a map has is its key type's answer wherever the map is written, so an enum-keyed map
+// enumerates its members nested under either outer key flavor and behind either slot wrap — the
+// depth a map sits at cannot decide whether its keys are known.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct NestedEnumKeyedMapValues {
+    arrayed: HashMap<String, Vec<HashMap<MetricBucket, u64>>>,
+    enum_keyed_outer: HashMap<MetricSlot, HashMap<MetricBucket, u64>>,
+    optional: HashMap<String, Option<HashMap<MetricBucket, u64>>>,
+    siblings: HashMap<MetricSlot, HashMap<MetricBucket, MetricSample>>,
+    string_keyed_outer: HashMap<String, HashMap<MetricBucket, u64>>,
+}
+
 // A String key enumerates nothing, so one `additionalProperties` schema stands for every member —
 // and it is the value type's own, which is what the enum-keyed twin above spells out per key.
 #[model_schema()]
@@ -903,6 +932,153 @@ fn test_enum_keyed_nested_map_values_typescript_generation() {
         "labels: z.record(MetricSlot$Schema, z.record(z.string(), z.string())),",
         "rows: z.record(MetricSlot$Schema, z.array(z.record(z.string(), z.string()))),",
         "samples: z.record(MetricSlot$Schema, z.record(z.string(), MetricSample$Schema)),",
+    ] {
+        assert!(
+            zod_schema.contains(expected),
+            "missing {expected}, got: {zod_schema}"
+        );
+    }
+}
+
+/// The rendering `HashMap<MetricBucket, u64>` carries in field position — the one every nested
+/// position is held against, because field position is where an enum key has always enumerated.
+#[cfg(feature = "jsonschema")]
+fn bucket_keyed_count_map() -> serde_json::Value {
+    BucketKeyedMap::json_schema()["properties"]["counts"].clone()
+}
+
+#[test]
+fn test_nested_enum_keyed_map_values_constructible() {
+    let nested = NestedEnumKeyedMapValues {
+        arrayed: HashMap::new(),
+        enum_keyed_outer: HashMap::from([(
+            MetricSlot::Daily,
+            HashMap::from([(MetricBucket::Low, 3_u64)]),
+        )]),
+        optional: HashMap::from([("a".to_owned(), None)]),
+        siblings: HashMap::new(),
+        string_keyed_outer: HashMap::from([(
+            "a".to_owned(),
+            HashMap::from([(MetricBucket::High, 7_u64)]),
+        )]),
+    };
+    assert_eq!(
+        nested.enum_keyed_outer[&MetricSlot::Daily][&MetricBucket::Low],
+        3
+    );
+    assert_eq!(nested.string_keyed_outer["a"][&MetricBucket::High], 7);
+    assert_eq!(nested.optional["a"], None);
+
+    let field_position = BucketKeyedMap {
+        counts: HashMap::from([(MetricBucket::High, 7_u64)]),
+        samples: HashMap::new(),
+    };
+    assert_eq!(field_position.counts[&MetricBucket::High], 7);
+}
+
+/// An enum-keyed map is the same object wherever it is written: nested under a `String` key, under
+/// an enum key, and behind either slot wrap, it carries the members its own key enumerates rather
+/// than the open object a position that could not reach the key would leave.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_nested_enum_keyed_map_values_enumerate_their_inner_key() {
+    let expected = bucket_keyed_count_map();
+    assert_eq!(expected["additionalProperties"], false, "in: {expected}");
+    assert_eq!(
+        expected["properties"].as_object().unwrap().len(),
+        MetricBucket::enum_members().len(),
+        "in: {expected}"
+    );
+
+    let schema = NestedEnumKeyedMapValues::json_schema();
+    let properties = &schema["properties"];
+
+    assert_eq!(
+        properties["string_keyed_outer"]["additionalProperties"], expected,
+        "in: {}",
+        properties["string_keyed_outer"]
+    );
+    assert_eq!(
+        properties["arrayed"]["additionalProperties"]["items"], expected,
+        "in: {}",
+        properties["arrayed"]
+    );
+    assert_eq!(
+        properties["optional"]["additionalProperties"],
+        serde_json::json!({ "anyOf": [expected, { "type": "null" }] }),
+        "in: {}",
+        properties["optional"]
+    );
+    for member in MetricSlot::enum_members() {
+        assert_eq!(
+            properties["enum_keyed_outer"]["properties"][&member], expected,
+            "member {member} in: {}",
+            properties["enum_keyed_outer"]
+        );
+        assert_eq!(
+            properties["siblings"]["properties"][&member],
+            BucketKeyedMap::json_schema()["properties"]["samples"],
+            "member {member} in: {}",
+            properties["siblings"]
+        );
+    }
+}
+
+/// The enumerated members are the keys serde actually writes, so a payload's inner keys are named
+/// by the schema rather than admitted by an open member set.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_nested_enum_keyed_map_members_match_the_serialized_keys() {
+    let nested = NestedEnumKeyedMapValues {
+        arrayed: HashMap::new(),
+        enum_keyed_outer: HashMap::new(),
+        optional: HashMap::new(),
+        siblings: HashMap::new(),
+        string_keyed_outer: HashMap::from([(
+            "a".to_owned(),
+            HashMap::from([(MetricBucket::High, 7_u64)]),
+        )]),
+    };
+    let payload = serde_json::to_value(&nested).unwrap();
+    let written = payload["string_keyed_outer"]["a"].as_object().unwrap();
+    let member = &NestedEnumKeyedMapValues::json_schema()["properties"]["string_keyed_outer"]["additionalProperties"];
+
+    for key in written.keys() {
+        assert_eq!(
+            member["properties"][key],
+            serde_json::json!({ "type": "integer" }),
+            "key {key} in: {member}"
+        );
+    }
+}
+
+/// TypeScript and Zod recurse through a map value whatever the key is, at whatever depth, so the
+/// members the JSON schema now spells out under a nested enum key are the ones those two surfaces
+/// have always named — pinned so the three stay in step.
+#[test]
+#[cfg(all(feature = "typescript", feature = "zod"))]
+fn test_nested_enum_keyed_map_values_typescript_generation() {
+    let ts_definition = NestedEnumKeyedMapValues::ts_definition();
+    for expected in [
+        "arrayed: Partial<Record<string, Array<Partial<Record<MetricBucket, number>>>>>;",
+        "enum_keyed_outer: Partial<Record<MetricSlot, Partial<Record<MetricBucket, number>>>>;",
+        "optional: Partial<Record<string, Partial<Record<MetricBucket, number>> | null>>;",
+        "siblings: Partial<Record<MetricSlot, Partial<Record<MetricBucket, MetricSample>>>>;",
+        "string_keyed_outer: Partial<Record<string, Partial<Record<MetricBucket, number>>>>;",
+    ] {
+        assert!(
+            ts_definition.contains(expected),
+            "missing {expected}, got: {ts_definition}"
+        );
+    }
+
+    let zod_schema = NestedEnumKeyedMapValues::zod_schema();
+    for expected in [
+        "arrayed: z.record(z.string(), z.array(z.record(MetricBucket$Schema, z.number().int()))),",
+        "enum_keyed_outer: z.record(MetricSlot$Schema, z.record(MetricBucket$Schema, z.number().int())),",
+        "optional: z.record(z.string(), z.nullable(z.record(MetricBucket$Schema, z.number().int()))),",
+        "siblings: z.record(MetricSlot$Schema, z.record(MetricBucket$Schema, MetricSample$Schema)),",
+        "string_keyed_outer: z.record(z.string(), z.record(MetricBucket$Schema, z.number().int())),",
     ] {
         assert!(
             zod_schema.contains(expected),

--- a/tests/semantic_types_tests/tests.rs
+++ b/tests/semantic_types_tests/tests.rs
@@ -454,16 +454,113 @@ fn test_struct_with_alias_zod_schema() {
 // JSON Schema Tests
 // ========================================================================
 
+/// An alias publishes the schema of the type it names, so a slot filled by the alias validates
+/// exactly what the aliased type validates — the scalar mapping being the same one a field written
+/// as the target reads.
 #[test]
 #[cfg(all(feature = "jsonschema", feature = "typescript"))]
-fn test_alias_json_schema_exists() {
-    // JSON schema generation for aliases currently returns a stub
-    let json_schema = document_id_schema::Schema::json_schema();
+fn test_scalar_alias_json_schema() {
+    for (alias, schema, expected) in [
+        (
+            "DocumentId",
+            document_id_schema::Schema::json_schema(),
+            serde_json::json!({ "type": "string" }),
+        ),
+        (
+            "Revision",
+            revision_schema::Schema::json_schema(),
+            serde_json::json!({ "type": "integer" }),
+        ),
+        (
+            "Score",
+            score_schema::Schema::json_schema(),
+            serde_json::json!({ "type": "number" }),
+        ),
+        (
+            "IsActive",
+            is_active_schema::Schema::json_schema(),
+            serde_json::json!({ "type": "boolean" }),
+        ),
+    ] {
+        assert_eq!(schema, expected, "for {alias}");
+    }
+}
 
-    // Verify the method exists and returns a JSON value
-    assert!(
-        json_schema.is_object(),
-        "JSON schema should return an object"
+/// An alias cannot be dropped the way an optional object key can — a slot written as the alias is
+/// filled with the `null` serde writes for a `None`, so the schema has to admit it.
+#[test]
+#[cfg(all(feature = "jsonschema", feature = "typescript"))]
+fn test_optional_alias_json_schema() {
+    assert_eq!(
+        optional_note_schema::Schema::json_schema(),
+        serde_json::json!({ "anyOf": [{ "type": "string" }, { "type": "null" }] })
+    );
+}
+
+#[test]
+#[cfg(all(feature = "jsonschema", feature = "typescript"))]
+fn test_sequence_alias_json_schema() {
+    assert_eq!(
+        tags_schema::Schema::json_schema(),
+        serde_json::json!({ "type": "array", "items": { "type": "string" } })
+    );
+}
+
+/// A tuple is the fixed-arity array serde writes it as, at the alias exactly as in field position.
+#[test]
+#[cfg(all(feature = "jsonschema", feature = "typescript"))]
+fn test_tuple_alias_json_schema() {
+    assert_eq!(
+        compact_link_row_schema::Schema::json_schema(),
+        serde_json::json!({
+            "type": "array",
+            "prefixItems": [
+                { "anyOf": [{ "type": "string" }, { "type": "null" }] },
+                { "type": "array", "items": { "type": "integer" } },
+                { "type": "string" },
+                { "anyOf": [{ "type": "string" }, { "type": "null" }] }
+            ],
+            "items": false,
+            "minItems": 4_u64,
+            "maxItems": 4_u64
+        })
+    );
+}
+
+/// An alias of an alias carries the target's reference, which resolves through the registry — so
+/// the chain lands on the type at the end of it rather than on a link.
+#[test]
+#[cfg(all(feature = "jsonschema", feature = "typescript"))]
+fn test_nested_alias_json_schema() {
+    assert_eq!(
+        audit_id_schema::Schema::json_schema(),
+        order_id_schema::Schema::json_schema()
+    );
+    assert_eq!(
+        audit_id_schema::Schema::json_schema(),
+        serde_json::json!({ "type": "string" })
+    );
+}
+
+/// A type parameter names no type until the alias is instantiated, and every position that
+/// references an alias references it uninstantiated — so the parameter admits any value, while the
+/// shape around it is still described.
+#[test]
+#[cfg(all(feature = "jsonschema", feature = "typescript"))]
+fn test_generic_alias_json_schema() {
+    assert_eq!(
+        pair_schema::Schema::json_schema(),
+        serde_json::json!({
+            "type": "array",
+            "prefixItems": [{}, {}],
+            "items": false,
+            "minItems": 2_u64,
+            "maxItems": 2_u64
+        })
+    );
+    assert_eq!(
+        wrapper_schema::Schema::json_schema(),
+        serde_json::json!({ "anyOf": [{}, { "type": "null" }] })
     );
 }
 
@@ -481,6 +578,21 @@ fn test_struct_with_alias_json_schema() {
         schema["properties"].is_object(),
         "Should have properties. Got: {schema:?}"
     );
+
+    // A field written as an alias carries the alias module's schema, so what the field validates
+    // is what the alias publishes — every slot naming the alias agrees with every other.
+    for (field, alias_schema) in [
+        ("document_id", document_id_schema::Schema::json_schema()),
+        ("is_active", is_active_schema::Schema::json_schema()),
+        ("note", optional_note_schema::Schema::json_schema()),
+        ("revision", revision_schema::Schema::json_schema()),
+        ("score", score_schema::Schema::json_schema()),
+    ] {
+        assert_eq!(
+            schema["properties"][field], alias_schema,
+            "for {field} in: {schema}"
+        );
+    }
 }
 
 // ========================================================================

--- a/tests/tuple_field_tests/tests.rs
+++ b/tests/tuple_field_tests/tests.rs
@@ -17,6 +17,24 @@ pub struct WithSibling {
     pub pair: (DocumentId, String),
 }
 
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SlotKind {
+    Primary,
+    Secondary,
+}
+
+/// A map whose key enumerates its members, written in field position and in a tuple slot: the two
+/// hold the same type, so they must describe it the same way.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct EnumKeyedMapSlotRow {
+    pub field: HashMap<SlotKind, u32>,
+    pub nested_field: HashMap<String, HashMap<SlotKind, u32>>,
+    pub nested_slot: (String, HashMap<String, HashMap<SlotKind, u32>>),
+    pub slot: (String, HashMap<SlotKind, u32>),
+}
+
 /// Test 1 + 2 + 3: A `(String, String)` struct field renders as a tuple in
 /// TypeScript, Zod, and JSON Schema.
 #[test]
@@ -429,6 +447,73 @@ fn test_map_element_tuple_field_json_schema() {
         properties["slot"]["prefixItems"][0],
         serde_json::json!({ "type": "string" })
     );
+}
+
+/// A key that enumerates its members enumerates them in a tuple slot too: the slot dispatch reaches
+/// the map's own rendering, so a slot cannot describe as an open object what the same type in field
+/// position describes as a fixed set of keys.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn test_enum_keyed_map_element_tuple_field_json_schema() {
+    let schema = EnumKeyedMapSlotRow::json_schema();
+    let properties = &schema["properties"];
+
+    let members = SlotKind::enum_members();
+    assert_eq!(properties["field"]["additionalProperties"], false);
+    assert_eq!(
+        properties["field"]["properties"].as_object().unwrap().len(),
+        members.len(),
+        "in: {}",
+        properties["field"]
+    );
+    for member in members {
+        assert_eq!(
+            properties["field"]["properties"][&member],
+            serde_json::json!({ "type": "integer" }),
+            "member {member} in: {}",
+            properties["field"]
+        );
+    }
+
+    assert_eq!(
+        properties["slot"]["prefixItems"][1], properties["field"],
+        "An enum-keyed map slot must describe as the map field does. Got: {}",
+        properties["slot"]["prefixItems"][1]
+    );
+    assert_eq!(
+        properties["nested_slot"]["prefixItems"][1], properties["nested_field"],
+        "A nested enum-keyed map slot must recurse as the nested map field does. Got: {}",
+        properties["nested_slot"]["prefixItems"][1]
+    );
+    assert_eq!(
+        properties["nested_field"]["additionalProperties"], properties["field"],
+        "Got: {}",
+        properties["nested_field"]
+    );
+}
+
+/// TypeScript and Zod already carry the key into a slot; pinned so the json-schema fix cannot be
+/// read as the only surface that owes the enum-keyed map its keys.
+#[test]
+fn test_enum_keyed_map_element_tuple_field_ts_and_zod() {
+    let ts = EnumKeyedMapSlotRow::ts_definition();
+    for expected in [
+        "slot: [string, Partial<Record<SlotKind, number>>]",
+        "nested_slot: [string, Partial<Record<string, Partial<Record<SlotKind, number>>>>]",
+    ] {
+        assert!(ts.contains(expected), "missing {expected}, got: {ts}");
+    }
+
+    #[cfg(feature = "zod")]
+    {
+        let zod = EnumKeyedMapSlotRow::zod_schema();
+        for expected in [
+            "slot: z.tuple([z.string(), z.record(SlotKind$Schema, z.number().int())])",
+            "nested_slot: z.tuple([z.string(), z.record(z.string(), z.record(SlotKind$Schema, z.number().int()))])",
+        ] {
+            assert!(zod.contains(expected), "missing {expected}, got: {zod}");
+        }
+    }
 }
 
 /// The sibling reference survives the map wrap inside a slot: a map of siblings in a tuple element


### PR DESCRIPTION
Stacked on #48 (stack: #33 → … → #48 → this).

An enum-keyed map only enumerated its key's members in **field** position — nested under a String key, under another enum key, or in a tuple slot, the same map described as `additionalProperties: true`.

- `enum_key_map_json_schema_value` is position-independent: a `json!` whose properties bind the member once and clone per `enum_members()` key; the macro-call form is what inlines into `additionalProperties`/member/`prefixItems` without parse ambiguity.
- One `map_key_path` classification (Enumerated/Open/Unnarrowed) read by both field and member positions — the positions structurally cannot disagree, which was the bug class.
- The kind-registry guard moved inside the emission, so a provably-non-enum inner key fails at depth with the named diagnostic (probe-verified through the real macro). Slot dispatch returns `Result` so the reason reaches the caller that knows the field name.
- TS/Zod already recursed; pinned. Depth-one byte-identical (zero removed fixture lines).

Gates: `just check`, `just lint-all` (68/68), `just test` (full powerset) green.