### PR TITLE
fix: generated output is deterministic and in declaration order

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,5 @@ redundant_test_prefix = "allow"
 # Integer division is used safely for threshold calculations and tests.
 integer_division = "allow"
 integer_division_remainder_used = "allow"
-# HashSet iteration order is irrelevant for set-comparison operations.
-iter_over_hash_type = "allow"
 # HashSet parameters use the default hasher; generalization adds complexity for no benefit.
 implicit_hasher = "allow"

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -2,7 +2,6 @@ extern crate alloc;
 
 use alloc::borrow::ToOwned;
 use core::fmt::Write as _;
-use std::collections::HashMap;
 
 use proc_macro::TokenStream;
 use quote::quote;
@@ -73,13 +72,23 @@ use crate::utils::to_snake_case;
 
 use crate::rename_rule::resolve_rename_rule;
 
-/// Per-variant data collected from a discriminated enum: field defs, doc strings, and variant
-/// kinds (each keyed by serialized discriminator value), plus the collected serde validators and
+/// One variant of a discriminated enum, carrying everything its union member is rendered from.
+struct DiscriminatedVariant {
+    discriminator_value: String,
+    docs: String,
+    field_defs: Vec<FieldDef>,
+    kind: VariantKind,
+}
+
+/// Per-variant data collected from a discriminated enum, plus the collected serde validators and
 /// the `compile_error!` tokens for any field-level guard violations.
+///
+/// The variants are a sequence, not a map: their order is the enum's declaration order and it
+/// reaches the emitted output verbatim (JSON-schema `oneOf`, the TypeScript union, the Zod
+/// `discriminatedUnion`). Any hash-ordered container here would re-randomize that output per
+/// build.
 type DiscriminatedVariantData = (
-    HashMap<String, Vec<FieldDef>>,
-    HashMap<String, String>,
-    HashMap<String, VariantKind>,
+    Vec<DiscriminatedVariant>,
     Vec<proc_macro2::TokenStream>,
     Vec<proc_macro2::TokenStream>,
 );
@@ -2260,16 +2269,13 @@ fn process_plain_enum(
 }
 
 /// Processes each variant of a discriminated enum, returning per-variant field defs, doc strings,
-/// and variant kinds (keyed by serialized discriminator value), plus the collected serde
-/// validation functions.
+/// and variant kinds in declaration order, plus the collected serde validation functions.
 fn collect_discriminated_variants(
     item_enum: &mut syn::ItemEnum,
     rename_all: Option<&str>,
     enum_module_name_opt: Option<&str>,
 ) -> DiscriminatedVariantData {
-    let mut field_defs_by_variant: HashMap<String, Vec<FieldDef>> = HashMap::new();
-    let mut docs_by_variant: HashMap<String, String> = HashMap::new();
-    let mut kinds_by_variant: HashMap<String, VariantKind> = HashMap::new();
+    let mut variants: Vec<DiscriminatedVariant> = Vec::new();
     let mut enum_validation_fns: Vec<proc_macro2::TokenStream> = Vec::new();
     let mut guard_errors: Vec<proc_macro2::TokenStream> = Vec::new();
     let enum_type_name = item_enum.ident.to_string();
@@ -2297,8 +2303,6 @@ fn collect_discriminated_variants(
             field_defs.push(f_def);
         }
 
-        field_defs_by_variant.insert(final_name.clone(), field_defs);
-        kinds_by_variant.insert(final_name.clone(), variant_kind);
         let discriminator_docs = get_variant_docs(item).map_or_else(
             || {
                 [final_name.clone(), String::new()]
@@ -2317,16 +2321,15 @@ fn collect_discriminated_variants(
                     .join("\n")
             },
         );
-        docs_by_variant.insert(final_name, discriminator_docs);
+        variants.push(DiscriminatedVariant {
+            discriminator_value: final_name,
+            docs: discriminator_docs,
+            field_defs,
+            kind: variant_kind,
+        });
     }
 
-    (
-        field_defs_by_variant,
-        docs_by_variant,
-        kinds_by_variant,
-        enum_validation_fns,
-        guard_errors,
-    )
+    (variants, enum_validation_fns, guard_errors)
 }
 
 /// Renders the TypeScript type fragments, Zod schema fragments (with optional-field lists), and
@@ -2335,24 +2338,21 @@ fn render_discriminated_variants(
     tag_name: &str,
     content_name: &str,
     item_name: &str,
-    field_defs_by_variant: HashMap<String, Vec<FieldDef>>,
-    docs_by_variant: &HashMap<String, String>,
-    kinds_by_variant: &HashMap<String, VariantKind>,
+    variants: &[DiscriminatedVariant],
 ) -> RenderedVariants {
     let mut type_code_items = Vec::new();
     let mut schema_code_items = Vec::new();
     let mut json_schema_variants: Vec<proc_macro2::TokenStream> = Vec::new();
 
-    for (discriminator_value, field_defs) in field_defs_by_variant {
-        let variant_kind = &kinds_by_variant[&discriminator_value];
+    for variant in variants {
         let (variant_type_code, variant_schema_code, optional_fields, json_schema_variant) =
             generate_variant_code(
                 tag_name,
                 content_name,
-                &discriminator_value,
-                &field_defs,
-                variant_kind,
-                &docs_by_variant[&discriminator_value],
+                &variant.discriminator_value,
+                &variant.field_defs,
+                &variant.kind,
+                &variant.docs,
                 item_name,
             );
         type_code_items.push(variant_type_code);
@@ -2413,20 +2413,13 @@ fn process_discriminated_enum(
     let enum_module_name_opt = None;
 
     // Bind both result tuples whole so feature-gated field access marks them used (no per-element
-    // guards): `variants` = (field_defs, docs, kinds, validation_fns, guard_errors);
+    // guards): `variants` = (variants, validation_fns, guard_errors);
     // `rendered` = (ts, zod, json).
     let variants = collect_discriminated_variants(&mut item_enum, rename_all, enum_module_name_opt);
-    if let Some(output) = guard_failure_output(&item_enum, &variants.4) {
+    if let Some(output) = guard_failure_output(&item_enum, &variants.2) {
         return output;
     }
-    let rendered = render_discriminated_variants(
-        tag_name,
-        content_name,
-        item_name,
-        variants.0,
-        &variants.1,
-        &variants.2,
-    );
+    let rendered = render_discriminated_variants(tag_name, content_name, item_name, &variants.0);
     #[cfg(not(any(feature = "typescript", feature = "zod", feature = "jsonschema")))]
     let _: &_ = &(name, &rendered);
 
@@ -2501,7 +2494,7 @@ fn process_discriminated_enum(
             &module_ident,
             name,
             &schema_impl_items,
-            &variants.3,
+            &variants.1,
             &delegate_impl_items,
         )
     }

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -1,4 +1,7 @@
-use super::{FieldDefType, validate_as_number_flag, validate_ts_optional_flag};
+use super::{
+    FieldDefType, collect_discriminated_variants, render_discriminated_variants,
+    validate_as_number_flag, validate_ts_optional_flag,
+};
 
 #[cfg(feature = "serde")]
 use super::{
@@ -12,6 +15,9 @@ use super::{AliasKind, branded_guard_errors, register_alias_info};
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 use syn::spanned::Spanned as _;
+
+/// The variants of [`rendered_discriminated_union`]'s enum, in the order they are declared.
+const DECLARED_VARIANTS: [&str; 6] = ["Upload", "Generate", "Delete", "Rename", "Move", "Archive"];
 
 /// The covered wrappers, under the names a dispatch reads them by.
 #[cfg(feature = "jsonschema")]
@@ -2070,4 +2076,79 @@ fn an_optional_sequence_wrapper_member_stays_nullable() {
             .unwrap()
             .to_string()
     );
+}
+
+/// Runs a fixed discriminated enum through the real collect/render pipeline, returning its
+/// TypeScript member fragments, Zod member fragments, and JSON-schema member fragments.
+///
+/// Rebuilt from scratch on every call so repeated calls exercise whatever ordering the collection
+/// stage imposes, not a single cached traversal.
+fn rendered_discriminated_union() -> (Vec<String>, Vec<String>, Vec<String>) {
+    let mut item: syn::ItemEnum = syn::parse_quote! {
+        enum Action {
+            Upload { path: String },
+            Generate,
+            Delete(String),
+            Rename { from: String, to: String },
+            Move(String, String),
+            Archive,
+        }
+    };
+    let variants = collect_discriminated_variants(&mut item, None, Some("action_schema"));
+    let rendered = render_discriminated_variants("type", "value", "Action", &variants.0);
+    (
+        rendered.0,
+        rendered
+            .1
+            .into_iter()
+            .map(|(schema_code, _optional)| schema_code)
+            .collect(),
+        rendered.2.iter().map(ToString::to_string).collect(),
+    )
+}
+
+/// Union member order is semantic, not cosmetic: serde tries untagged members in declaration
+/// order, so the emitted union must carry that same order on every surface.
+#[test]
+fn discriminated_union_members_follow_declaration_order() {
+    let (ts_members, zod_members, json_members) = rendered_discriminated_union();
+    assert_eq!(ts_members.len(), DECLARED_VARIANTS.len());
+    assert_eq!(zod_members.len(), DECLARED_VARIANTS.len());
+    assert_eq!(json_members.len(), DECLARED_VARIANTS.len());
+
+    for (position, declared) in DECLARED_VARIANTS.iter().enumerate() {
+        assert!(
+            ts_members[position].contains(&format!("type: \"{declared}\";")),
+            "TypeScript member {position} is not `{declared}`: {}",
+            ts_members[position]
+        );
+        assert!(
+            zod_members[position].contains(&format!("type: z.literal(\"{declared}\")")),
+            "Zod member {position} is not `{declared}`: {}",
+            zod_members[position]
+        );
+        #[cfg(feature = "jsonschema")]
+        assert!(
+            json_members[position].contains(&format!("\"const\" : \"{declared}\"")),
+            "JSON-schema member {position} is not `{declared}`: {}",
+            json_members[position]
+        );
+    }
+}
+
+/// Every per-variant collection feeding emission must be order-preserving. A hash-ordered one
+/// reseeds per instance, so the same source expands to a different union on each build — which
+/// this catches by rendering the same enum repeatedly inside one process.
+#[test]
+fn discriminated_union_rendering_is_stable_across_runs() {
+    const RUNS: usize = 32;
+
+    let first = rendered_discriminated_union();
+    for run in 1..RUNS {
+        assert_eq!(
+            rendered_discriminated_union(),
+            first,
+            "run {run} rendered a different union than run 0"
+        );
+    }
 }


### PR DESCRIPTION
Stacked on #50 (stack: #33 → … → #50 → this).

Same input, different output every build: discriminated/untagged enum variants were emitted in `HashMap` iteration order (`RandomState` reseeds per map instance — 12 expansions of `tuple_variant_tests` gave 12 distinct outputs). Untagged try-order is **semantic** in serde, so this wasn't just cosmetic.

- The three parallel maps are replaced outright by a `Vec<DiscriminatedVariant>` built while walking `item_enum.variants` — the sequence IS declaration order. **No new dependency** (the keyed lookups only ever paired data with the variant being rendered).
- Audit table in the task covers every hash-iterated site: the alias registry never iterates; the untagged collector already walked variants; `serde_json::Map` is order-deterministic.
- The crate-wide `iter_over_hash_type = "allow"` is **removed** — it silenced exactly this bug class and now silences nothing; reintroduction is a hard clippy error. (A suppression removed, not added.)
- Full sweep: all 26 test targets, 6 expansions each → 1 distinct output. Declaration order asserted per-position on TS/Zod/JSON surfaces.

Gates: `just check`, `just lint-all` (68/68), `just test` (full powerset) green.
