### PR TITLE
fix: covered sets carry their element's optionality like Vec

### DIFF
--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -710,6 +710,19 @@ pub fn is_sequence_wrapper(name: &str) -> bool {
     )
 }
 
+/// Whether a generic type is optional on its element's behalf: true exactly when it is a covered
+/// sequence wrapper whose element is an `Option`.
+///
+/// A wrapper writes the JSON array its element decides, so a `None` the element holds reaches the
+/// wire as a `null` inside that array — and every reader that decides nullability, the field-
+/// position guard and the slot renderers alike, reads the field's own flag rather than descending
+/// into the wrapper. `Vec` never arrives here, the parser having collapsed it onto its element
+/// with the flag already carried up; this hands the other spellings that same flag, so what a
+/// `None` costs cannot depend on which covered wrapper was written around it.
+fn sequence_element_optionality(name: &str, args: &[FieldDef]) -> bool {
+    matches!(args, [element] if element.is_optional && is_sequence_wrapper(name))
+}
+
 /// Classifies a `syn::Variant` into its `VariantKind`.
 ///
 /// This determines how the variant should be rendered in TypeScript/Zod:
@@ -846,7 +859,7 @@ fn get_field_def_from_type_path(
                 // Debug print to see what's happening with SiblingType
                 log::trace!("Creating SiblingType - name: {ident}, arg_types: {arg_types:?}");
                 FieldDef {
-                    is_optional: false,
+                    is_optional: sequence_element_optionality(&ident, &arg_types),
                     name: safe_name,
                     field_type: FieldDefType::SiblingType(ident, arg_types),
                     array_depth: 0,

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -20,7 +20,7 @@ use syn::spanned::Spanned as _;
 const DECLARED_VARIANTS: [&str; 6] = ["Upload", "Generate", "Delete", "Rename", "Move", "Archive"];
 
 /// The covered wrappers, under the names a dispatch reads them by.
-#[cfg(feature = "jsonschema")]
+#[cfg(any(feature = "jsonschema", feature = "serde"))]
 const SEQUENCE_WRAPPERS: [&str; 6] = [
     "BTreeSet",
     "BinaryHeap",
@@ -92,6 +92,59 @@ fn bare_option_field_is_rejected() {
     let message = guard_result(&item).unwrap_err().to_string();
     assert!(message.contains("note"));
     assert!(message.contains("skip_serializing_if = \"Option::is_none\""));
+}
+
+/// The single-field `Report` written with `notes` at the given spelling.
+#[cfg(feature = "serde")]
+fn report_with(spelling: &str) -> syn::ItemStruct {
+    syn::parse_str(&format!("struct Report {{ notes: {spelling} }}")).unwrap()
+}
+
+/// A covered wrapper writes the JSON array its element decides, so a `None` the element holds
+/// reaches the wire as a `null` inside that array — which the absent-key form the field renders in
+/// cannot stand for. The guard therefore refuses it wherever it refuses the `Vec` spelling, `Vec`
+/// being the one wrapper the parser had always collapsed onto its element.
+#[cfg(feature = "serde")]
+#[test]
+fn a_covered_wrapper_of_option_is_rejected_as_the_vec_spelling_is() {
+    for wrapper in SEQUENCE_WRAPPERS {
+        let message = guard_result(&report_with(&format!("{wrapper}<Option<String>>")))
+            .unwrap_err()
+            .to_string();
+        assert!(message.contains("notes"), "{wrapper}: {message}");
+        assert!(
+            message.contains("skip_serializing_if"),
+            "{wrapper}: {message}"
+        );
+    }
+}
+
+/// Every level a wrapper is written at hands its element's optionality up, so a `None` is refused
+/// however deep the wrappers are stacked and whichever spelling each level takes.
+#[cfg(feature = "serde")]
+#[test]
+fn a_covered_wrapper_carries_its_element_optionality_at_every_depth() {
+    for spelling in [
+        "Vec<Vec<Option<String>>>",
+        "HashSet<Vec<Option<String>>>",
+        "Vec<HashSet<Option<String>>>",
+        "BTreeSet<VecDeque<Option<String>>>",
+    ] {
+        let message = guard_result(&report_with(spelling))
+            .unwrap_err()
+            .to_string();
+        assert!(message.contains("notes"), "{spelling}: {message}");
+    }
+}
+
+/// The optionality read through a wrapper is the element's own and nothing else: a plain element
+/// leaves the field non-optional, so no wrapper name alone can trip the guard.
+#[cfg(feature = "serde")]
+#[test]
+fn a_covered_wrapper_of_a_plain_element_satisfies_the_guard() {
+    for wrapper in SEQUENCE_WRAPPERS {
+        guard_result(&report_with(&format!("{wrapper}<String>"))).unwrap();
+    }
 }
 
 #[cfg(feature = "serde")]

--- a/tests/collection_tests/tests.rs
+++ b/tests/collection_tests/tests.rs
@@ -284,11 +284,13 @@ struct SetSlotValues {
     enum_keyed_ids: HashMap<MetricSlot, HashSet<u32>>,
     enum_keyed_tags: HashMap<MetricSlot, BTreeSet<MetricTag>>,
     labels: HashMap<String, BTreeSet<String>>,
+    optional_element_ids: HashMap<String, HashSet<Option<u32>>>,
     optional_ids: HashMap<String, Option<HashSet<u32>>>,
     sibling_tags: HashMap<String, HashSet<MetricTag>>,
     small_ids: HashMap<String, HashSet<u32>>,
     tuple_ids: (String, HashSet<u32>),
     tuple_labels: (u32, BTreeSet<String>),
+    tuple_optional_ids: (String, BTreeSet<Option<u32>>),
 }
 
 #[model_schema()]
@@ -298,11 +300,13 @@ struct VecSlotValues {
     enum_keyed_ids: HashMap<MetricSlot, Vec<u32>>,
     enum_keyed_tags: HashMap<MetricSlot, Vec<MetricTag>>,
     labels: HashMap<String, Vec<String>>,
+    optional_element_ids: HashMap<String, Vec<Option<u32>>>,
     optional_ids: HashMap<String, Option<Vec<u32>>>,
     sibling_tags: HashMap<String, Vec<MetricTag>>,
     small_ids: HashMap<String, Vec<u32>>,
     tuple_ids: (String, Vec<u32>),
     tuple_labels: (u32, Vec<String>),
+    tuple_optional_ids: (String, Vec<Option<u32>>),
 }
 
 // A sibling is carried by reference wherever it sits, so a tuple element names the schema module a
@@ -378,11 +382,13 @@ fn set_slot_values() -> SetSlotValues {
         enum_keyed_ids: HashMap::from([(MetricSlot::Daily, one(7_u32))]),
         enum_keyed_tags: HashMap::from([(MetricSlot::Daily, one(metric_tag()))]),
         labels: HashMap::from([("k".to_owned(), one("t".to_owned()))]),
+        optional_element_ids: HashMap::from([("k".to_owned(), one(None))]),
         optional_ids: HashMap::from([("k".to_owned(), Some(one(7_u32)))]),
         sibling_tags: HashMap::from([("k".to_owned(), one(metric_tag()))]),
         small_ids: HashMap::from([("k".to_owned(), one(7_u32))]),
         tuple_ids: ("t".to_owned(), one(7_u32)),
         tuple_labels: (7, one("t".to_owned())),
+        tuple_optional_ids: ("t".to_owned(), one(None)),
     }
 }
 
@@ -393,11 +399,13 @@ fn vec_slot_values() -> VecSlotValues {
         enum_keyed_ids: HashMap::from([(MetricSlot::Daily, one(7_u32))]),
         enum_keyed_tags: HashMap::from([(MetricSlot::Daily, one(metric_tag()))]),
         labels: HashMap::from([("k".to_owned(), one("t".to_owned()))]),
+        optional_element_ids: HashMap::from([("k".to_owned(), one(None))]),
         optional_ids: HashMap::from([("k".to_owned(), Some(one(7_u32)))]),
         sibling_tags: HashMap::from([("k".to_owned(), one(metric_tag()))]),
         small_ids: HashMap::from([("k".to_owned(), one(7_u32))]),
         tuple_ids: ("t".to_owned(), one(7_u32)),
         tuple_labels: (7, one("t".to_owned())),
+        tuple_optional_ids: ("t".to_owned(), one(None)),
     }
 }
 
@@ -1904,6 +1912,7 @@ fn test_a_set_slot_writes_what_the_vec_slot_writes() {
         "enum_keyed_ids",
         "enum_keyed_tags",
         "labels",
+        "optional_element_ids",
         "optional_ids",
         "sibling_tags",
         "small_ids",
@@ -1912,7 +1921,7 @@ fn test_a_set_slot_writes_what_the_vec_slot_writes() {
             assert!(member.is_array(), "{field}[{key}] wrote: {member}");
         }
     }
-    for field in ["tuple_ids", "tuple_labels"] {
+    for field in ["tuple_ids", "tuple_labels", "tuple_optional_ids"] {
         let slots = payload[field].as_array().unwrap();
         assert!(
             slots.last().unwrap().is_array(),
@@ -1966,6 +1975,17 @@ fn test_set_slots_describe_as_arrays_of_their_element() {
     // A slot cannot be dropped, so a `None` there is `null` rather than an absent key.
     assert_eq!(
         properties["optional_ids"]["additionalProperties"],
+        serde_json::json!({ "anyOf": [integer_array, { "type": "null" }] })
+    );
+    // A `None` the wrapper itself holds is that same `null` to every reader of the slot: the
+    // element carries the wrapper's array-ness, so the optionality it carries is the slot's too —
+    // the one form the `Vec` spelling arrives in, and so the one a set has to describe as.
+    assert_eq!(
+        properties["optional_element_ids"]["additionalProperties"],
+        serde_json::json!({ "anyOf": [integer_array, { "type": "null" }] })
+    );
+    assert_eq!(
+        properties["tuple_optional_ids"]["prefixItems"][1],
         serde_json::json!({ "anyOf": [integer_array, { "type": "null" }] })
     );
 }
@@ -2039,10 +2059,12 @@ fn test_set_slots_type_as_the_vec_slot_twin() {
     for spelling in [
         "aliased_tags: Partial<Record<string, Array<MetricTagRefType>>>;",
         "enum_keyed_ids: Partial<Record<MetricSlot, Array<number>>>;",
+        "optional_element_ids: Partial<Record<string, Array<number> | null>>;",
         "optional_ids: Partial<Record<string, Array<number> | null>>;",
         "sibling_tags: Partial<Record<string, Array<MetricTag>>>;",
         "tuple_ids: [string, Array<number>];",
         "tuple_labels: [number, Array<string>];",
+        "tuple_optional_ids: [string, Array<number> | null];",
     ] {
         assert!(ts_definition.contains(spelling), "Got: {ts_definition}");
     }
@@ -2060,9 +2082,11 @@ fn test_set_slots_validate_as_the_vec_slot_twin() {
     for spelling in [
         "aliased_tags: z.record(z.string(), z.array(MetricTagRefType$Schema)),",
         "enum_keyed_tags: z.record(MetricSlot$Schema, z.array(MetricTag$Schema)),",
+        "optional_element_ids: z.record(z.string(), z.nullable(z.array(z.number().int()))),",
         "optional_ids: z.record(z.string(), z.nullable(z.array(z.number().int()))),",
         "tuple_ids: z.tuple([z.string(), z.array(z.number().int())]),",
         "tuple_labels: z.tuple([z.number().int(), z.array(z.string())]),",
+        "tuple_optional_ids: z.tuple([z.string(), z.nullable(z.array(z.number().int()))]),",
     ] {
         assert!(zod_schema.contains(spelling), "Got: {zod_schema}");
     }


### PR DESCRIPTION
`HashSet<Option<u32>>` compiled clean, wrote `[null]`, and every surface described plain integers — while `Vec<Option<T>>` is guard-rejected in field position and nullable-rendered in slots. The parser lifts `is_optional` when collapsing `Vec`; covered sets kept their own flag false, so all four readers saw nothing.

- One parser-level flag lift (`sequence_element_optionality`) repairs field-guard, map-member, and tuple positions at once; whole-schema parity with the Vec spellings pinned (including the `skip_serializing_if` escape hatch and a negative control).
- Re-verify verdict recorded on the task: the defect was live on master, not resolved by the depth/normalization series.

Gates: `just check` green during work; full powerset once at acceptance — green.
