### PR TITLE
fix: transparent wrappers collapse onto what they hold

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,9 @@ regex = ">=1.10"
 
 [dev-dependencies]
 mongodb = ">=3.7"
-serde = { version = "1", features = ["derive"] }
+# Test-only: `rc` supplies serde's `Rc`/`Arc` impls, without which the wire criterion the
+# transparent-wrapper coverage rests on cannot be read off an `Rc`/`Arc` field at all.
+serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 chrono = { version = ">=0.4.40", features = ["serde"] }
 regex = ">=1.10"

--- a/README.md
+++ b/README.md
@@ -119,6 +119,26 @@ pub struct UserWithCollections {
 }
 ```
 
+### Pointers and Borrowed Values
+
+`Box<T>`, `Rc<T>`, `Arc<T>` and `Cow<'_, T>` describe as `T`. serde writes each of them as the value it holds, with nothing of its own around it, so a field written under one is the field its inner type is — on every surface, and wherever the wrapper was written: `Box<Option<T>>` is the `Option<T>` field, optional; `Vec<Rc<T>>` is the `Vec<T>` field; `Box<str>`, `Rc<str>` and `Cow<'_, str>` are `String` fields, `str` being what a `String` writes.
+
+This is what lets a type hold itself: `Option<Box<Self>>` is the self-reference, deferred in the generated schema the way any self-reference is. An `Rc` or `Arc` field needs serde's `rc` feature, which is where serde's impls for those two live.
+
+```rust
+use std::borrow::Cow;
+use std::sync::Arc;
+
+#[model_schema()]
+#[derive(Serialize, Deserialize)]
+pub struct TreeNode {
+    pub label: Cow<'static, str>,
+    pub shared_tags: Arc<[String]>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next: Option<Box<TreeNode>>,
+}
+```
+
 ### Enums
 
 #### Plain Enums

--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -710,6 +710,22 @@ pub fn is_sequence_wrapper(name: &str) -> bool {
     )
 }
 
+/// The one list of std wrappers the crate reads straight through to what they hold.
+///
+/// Membership is decided on the wire and nothing else: serde writes each of these as its inner
+/// value, with nothing of its own around it, so a field written under one is the very field its
+/// inner type is. The parser therefore collapses them onto that inner field and no surface ever
+/// learns a wrapper was written — which is what keeps a wrapper name out of the generated output,
+/// where none of the three surfaces has any meaning for it.
+///
+/// `Cow` is covered on the same terms despite carrying a lifetime beside its type: the lifetime is
+/// not a type argument and never reaches the collected arguments, so a `Cow` arrives with the one
+/// argument a `Box` arrives with. The interior-mutability wrappers are absent — that is a wider
+/// list than this defect was measured over, not a claim that they write anything else.
+fn is_transparent_wrapper(name: &str) -> bool {
+    matches!(name, "Arc" | "Box" | "Cow" | "Rc")
+}
+
 /// Whether a generic type is optional on its element's behalf: true exactly when it is a covered
 /// sequence wrapper whose element is an `Option`.
 ///
@@ -799,75 +815,7 @@ fn get_field_def_from_type_path(
             model_schema_prop_meta: None,
         },
         PathArguments::AngleBracketed(args) => {
-            let arg_types: Vec<FieldDef> = args
-                .args
-                .iter()
-                .filter_map(|arg| {
-                    // Ignore lifetimes, const generics, etc.
-                    if let GenericArgument::Type(inner_ty) = arg {
-                        Some(get_field_def("", inner_ty, ""))
-                    } else {
-                        None
-                    }
-                })
-                .collect();
-            if arg_types.is_empty() {
-                FieldDef {
-                    is_optional: false,
-                    name: safe_name,
-                    field_type: FieldDefType::SiblingType(ident, vec![]),
-                    array_depth: 0,
-                    array_num: None,
-                    docs: field_docs.to_owned(),
-                    model_schema_prop_meta: None,
-                }
-            } else if arg_types.len() == 1 && &ident == "Option" {
-                let mut result = arg_types[0].clone();
-                result.name = safe_name;
-                result.is_optional = true;
-                result
-            } else if arg_types.len() == 1 && &ident == "Vec" {
-                let mut result = arg_types[0].clone();
-                result.name = safe_name;
-                result.array_depth = result.array_depth.saturating_add(1);
-                result
-            } else if arg_types.len() == 2 && (ident == "HashMap" || ident == "BTreeMap") {
-                // Debug print to see what's happening
-                log::trace!(
-                    "Creating HashMap Map type - key: {:?}, value: {:?}",
-                    arg_types[0],
-                    arg_types[1]
-                );
-                FieldDef {
-                    array_depth: 0,
-                    is_optional: false,
-                    array_num: None,
-                    name: safe_name,
-                    field_type: FieldDefType::Map(
-                        Box::new(arg_types[0].clone()),
-                        Box::new(arg_types[1].clone()),
-                    ),
-                    docs: field_docs.to_owned(),
-                    model_schema_prop_meta: None,
-                }
-            } else if arg_types.len() == 1 && is_datetime_generic_type(&ident) {
-                // Handle DateTime<Tz> - the timezone type parameter is ignored
-                handle_datetime_generic_type(safe_name, field_docs)
-            }
-            // Fall through to SiblingType for other generic types
-            else {
-                // Debug print to see what's happening with SiblingType
-                log::trace!("Creating SiblingType - name: {ident}, arg_types: {arg_types:?}");
-                FieldDef {
-                    is_optional: sequence_element_optionality(&ident, &arg_types),
-                    name: safe_name,
-                    field_type: FieldDefType::SiblingType(ident, arg_types),
-                    array_depth: 0,
-                    array_num: None,
-                    docs: field_docs.to_owned(),
-                    model_schema_prop_meta: None,
-                }
-            }
+            get_field_def_from_generic_type(&ident, args, safe_name, field_docs)
         }
         // Function pointer types are unsupported; fall back to `unknown`.
         PathArguments::Parenthesized(_) => FieldDef {
@@ -879,6 +827,97 @@ fn get_field_def_from_type_path(
             docs: field_docs.to_owned(),
             model_schema_prop_meta: None,
         },
+    }
+}
+
+/// Builds a `FieldDef` for a named type written with generic arguments.
+///
+/// Handles `Option<T>`, `Vec<T>`, the transparent wrappers, `HashMap`/`BTreeMap` and
+/// `DateTime<Tz>`, and falls back to `SiblingType` for everything else.
+///
+/// Only the type arguments are read. A lifetime writes nothing, so a type carrying one arrives here
+/// with the arguments it would have without it — which is what lets `Cow<'a, T>` be answered for by
+/// the same single-argument arms as `Box<T>`.
+fn get_field_def_from_generic_type(
+    ident: &str,
+    args: &syn::AngleBracketedGenericArguments,
+    safe_name: String,
+    field_docs: &str,
+) -> FieldDef {
+    let arg_types: Vec<FieldDef> = args
+        .args
+        .iter()
+        .filter_map(|arg| {
+            if let GenericArgument::Type(inner_ty) = arg {
+                Some(get_field_def("", inner_ty, ""))
+            } else {
+                None
+            }
+        })
+        .collect();
+    if arg_types.is_empty() {
+        FieldDef {
+            is_optional: false,
+            name: safe_name,
+            field_type: FieldDefType::SiblingType(ident.to_owned(), vec![]),
+            array_depth: 0,
+            array_num: None,
+            docs: field_docs.to_owned(),
+            model_schema_prop_meta: None,
+        }
+    } else if arg_types.len() == 1 && ident == "Option" {
+        let mut result = arg_types[0].clone();
+        result.name = safe_name;
+        result.is_optional = true;
+        result
+    } else if arg_types.len() == 1 && ident == "Vec" {
+        let mut result = arg_types[0].clone();
+        result.name = safe_name;
+        result.array_depth = result.array_depth.saturating_add(1);
+        result
+    }
+    // A wrapper that is not on the wire adds nothing for the field to carry: the inner field stands
+    // in whole, under the wrapped field's own name and its own docs, which belong to where the
+    // field was written rather than to what it was written under. Everything a wrapper could sit
+    // around or inside — the optionality an `Option` lifts, the levels a sequence counts — is
+    // already on that field and rides along untouched.
+    else if arg_types.len() == 1 && is_transparent_wrapper(ident) {
+        let mut result = arg_types[0].clone();
+        result.name = safe_name;
+        field_docs.clone_into(&mut result.docs);
+        result
+    } else if arg_types.len() == 2 && (ident == "HashMap" || ident == "BTreeMap") {
+        log::trace!(
+            "Creating HashMap Map type - key: {:?}, value: {:?}",
+            arg_types[0],
+            arg_types[1]
+        );
+        FieldDef {
+            array_depth: 0,
+            is_optional: false,
+            array_num: None,
+            name: safe_name,
+            field_type: FieldDefType::Map(
+                Box::new(arg_types[0].clone()),
+                Box::new(arg_types[1].clone()),
+            ),
+            docs: field_docs.to_owned(),
+            model_schema_prop_meta: None,
+        }
+    } else if arg_types.len() == 1 && is_datetime_generic_type(ident) {
+        // The timezone type parameter says nothing about what is written.
+        handle_datetime_generic_type(safe_name, field_docs)
+    } else {
+        log::trace!("Creating SiblingType - name: {ident}, arg_types: {arg_types:?}");
+        FieldDef {
+            is_optional: sequence_element_optionality(ident, &arg_types),
+            name: safe_name,
+            field_type: FieldDefType::SiblingType(ident.to_owned(), arg_types),
+            array_depth: 0,
+            array_num: None,
+            docs: field_docs.to_owned(),
+            model_schema_prop_meta: None,
+        }
     }
 }
 
@@ -952,7 +991,9 @@ fn get_field_def_type_or_sibling(t_name: &str) -> FieldDefType {
     }
     match t_name {
         "bool" => FieldDefType::Boolean,
-        "String" | "PathBuf" => FieldDefType::String,
+        // `str` is `String`'s borrowed form and writes the same JSON string. It is reachable only
+        // behind a wrapper or a reference, both of which the parser reads through to land here.
+        "String" | "PathBuf" | "str" => FieldDefType::String,
         "Value" => FieldDefType::Unknown,
         "u8" => FieldDefType::U8,
         "u16" => FieldDefType::U16,

--- a/src/field_type/tests.rs
+++ b/src/field_type/tests.rs
@@ -191,3 +191,94 @@ fn test_the_parser_counts_one_array_level_per_wrapper_written() {
         );
     }
 }
+
+/// The covered list, stated once so it is a decision rather than a spelling that happened to work.
+/// The names on the false side are not uncovered by omission: each is a type the parser answers for
+/// in a way of its own.
+#[test]
+fn test_the_covered_transparent_wrappers_are_exactly_the_recorded_list() {
+    for name in ["Arc", "Box", "Cow", "Rc"] {
+        assert!(super::is_transparent_wrapper(name), "for: {name}");
+    }
+    for name in ["BTreeMap", "HashMap", "Option", "Vec"] {
+        assert!(!super::is_transparent_wrapper(name), "for: {name}");
+    }
+}
+
+/// A covered wrapper writes nothing of its own, so the field it wraps is the field the parser
+/// produces — name and docs included, both of which belong to where the field was written.
+#[test]
+fn test_a_transparent_wrapper_parses_as_the_field_it_wraps() {
+    for spelling in ["Arc<u32>", "Box<u32>", "Cow<'a, u32>", "Rc<u32>", "u32"] {
+        let ty: syn::Type = syn::parse_str(spelling).unwrap();
+        let parsed = super::get_field_def("items", &ty, " * items");
+        assert!(
+            matches!(parsed.field_type, FieldDefType::U32),
+            "for: {spelling}"
+        );
+        assert_eq!(parsed.name, "items", "for: {spelling}");
+        assert_eq!(parsed.docs, " * items", "for: {spelling}");
+        assert_eq!(parsed.array_depth, 0, "for: {spelling}");
+        assert!(!parsed.is_optional, "for: {spelling}");
+    }
+}
+
+/// What a `None` costs is the `Option`'s answer at either side of a wrapper that is not on the
+/// wire: the flag is lifted onto the field exactly as the bare spelling lifts it.
+#[test]
+fn test_a_transparent_wrapper_carries_the_optionality_of_what_it_wraps() {
+    for spelling in [
+        "Arc<Option<u32>>",
+        "Box<Option<u32>>",
+        "Cow<'a, Option<u32>>",
+        "Option<Box<u32>>",
+        "Option<u32>",
+        "Rc<Option<u32>>",
+    ] {
+        let ty: syn::Type = syn::parse_str(spelling).unwrap();
+        let parsed = super::get_field_def("items", &ty, "");
+        assert!(
+            matches!(parsed.field_type, FieldDefType::U32),
+            "for: {spelling}"
+        );
+        assert!(parsed.is_optional, "for: {spelling}");
+        assert_eq!(parsed.array_depth, 0, "for: {spelling}");
+    }
+}
+
+/// The array levels a field was written at are counted the same through a wrapper, whichever side
+/// of it the sequence was written on — a boxed slice included, being the sequence a `Box` holds.
+#[test]
+fn test_a_transparent_wrapper_keeps_the_array_levels_of_what_it_wraps() {
+    for spelling in [
+        "Arc<[u32]>",
+        "Box<Vec<u32>>",
+        "Box<[u32]>",
+        "Cow<'a, [u32]>",
+        "Rc<Vec<u32>>",
+        "Vec<Box<u32>>",
+        "Vec<u32>",
+    ] {
+        let ty: syn::Type = syn::parse_str(spelling).unwrap();
+        let parsed = super::get_field_def("items", &ty, "");
+        assert!(
+            matches!(parsed.field_type, FieldDefType::U32),
+            "for: {spelling}"
+        );
+        assert_eq!(parsed.array_depth, 1, "for: {spelling}");
+    }
+}
+
+/// The borrowed form of a mapped owned type writes what the owned form writes, and a wrapper is how
+/// a field reaches it at all.
+#[test]
+fn test_a_borrowed_string_parses_as_a_string() {
+    for spelling in ["Arc<str>", "Box<str>", "Cow<'a, str>", "Rc<str>", "String"] {
+        let ty: syn::Type = syn::parse_str(spelling).unwrap();
+        let parsed = super::get_field_def("label", &ty, "");
+        assert!(
+            matches!(parsed.field_type, FieldDefType::String),
+            "for: {spelling}"
+        );
+    }
+}

--- a/tests/transparent_wrapper_tests.rs
+++ b/tests/transparent_wrapper_tests.rs
@@ -1,0 +1,5 @@
+extern crate alloc;
+
+#[cfg(test)]
+#[path = "transparent_wrapper_tests/tests.rs"]
+mod tests;

--- a/tests/transparent_wrapper_tests/tests.rs
+++ b/tests/transparent_wrapper_tests/tests.rs
@@ -1,0 +1,469 @@
+use alloc::borrow::Cow;
+use alloc::rc::Rc;
+use alloc::sync::Arc;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use tixschema::model_schema;
+
+/// The covered wrappers by the name a generated surface could leak.
+#[cfg(any(feature = "typescript", feature = "zod"))]
+const TRANSPARENT_WRAPPERS: [&str; 4] = ["Arc", "Box", "Cow", "Rc"];
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct Tag {
+    label: String,
+}
+
+// The spelling every wrapper twin below is held against: the inner types written bare.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct PlainFields {
+    count: u64,
+    labels: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    maybe_count: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    maybe_tag: Option<Tag>,
+    tag: Tag,
+    text: String,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct BoxedFields {
+    count: Box<u64>,
+    labels: Box<[String]>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    maybe_count: Box<Option<u64>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    maybe_tag: Box<Option<Tag>>,
+    tag: Box<Tag>,
+    text: Box<str>,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct RcFields {
+    count: Rc<u64>,
+    labels: Rc<[String]>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    maybe_count: Rc<Option<u64>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    maybe_tag: Rc<Option<Tag>>,
+    tag: Rc<Tag>,
+    text: Rc<str>,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct ArcFields {
+    count: Arc<u64>,
+    labels: Arc<[String]>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    maybe_count: Arc<Option<u64>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    maybe_tag: Arc<Option<Tag>>,
+    tag: Arc<Tag>,
+    text: Arc<str>,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct CowFields {
+    count: Cow<'static, u64>,
+    labels: Cow<'static, [String]>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    maybe_count: Cow<'static, Option<u64>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    maybe_tag: Cow<'static, Option<Tag>>,
+    tag: Cow<'static, Tag>,
+    text: Cow<'static, str>,
+}
+
+// A wrapper written under something else: inside an `Option`, inside a sequence, in a map's value
+// slot. Each position reads the collapsed field, so none of them sees a wrapper at all.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct WrappedInsideFields {
+    counts: HashMap<String, Rc<u64>>,
+    elements: Vec<Rc<Tag>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    maybe_tag: Option<Box<Tag>>,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct PlainInsideFields {
+    counts: HashMap<String, u64>,
+    elements: Vec<Tag>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    maybe_tag: Option<Tag>,
+}
+
+// One boxed field among unboxed ones: the collapse is the field's own, so its siblings are
+// untouched by it.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct MixedBoxedFields {
+    boxed_tag: Box<Tag>,
+    count: u64,
+    plain_tag: Tag,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct MixedPlainFields {
+    boxed_tag: Tag,
+    count: u64,
+    plain_tag: Tag,
+}
+
+// The reason `Box` exists in a schema type at all: a struct that holds itself.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct TreeNode {
+    label: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    next: Option<Box<Self>>,
+}
+
+fn tag() -> Tag {
+    Tag {
+        label: "a".to_owned(),
+    }
+}
+
+fn plain_fields() -> PlainFields {
+    PlainFields {
+        count: 7,
+        labels: vec!["x".to_owned()],
+        maybe_count: Some(3),
+        maybe_tag: Some(tag()),
+        tag: tag(),
+        text: "t".to_owned(),
+    }
+}
+
+fn boxed_fields() -> BoxedFields {
+    BoxedFields {
+        count: Box::new(7),
+        labels: vec!["x".to_owned()].into_boxed_slice(),
+        maybe_count: Box::new(Some(3)),
+        maybe_tag: Box::new(Some(tag())),
+        tag: Box::new(tag()),
+        text: "t".into(),
+    }
+}
+
+fn rc_fields() -> RcFields {
+    RcFields {
+        count: Rc::new(7),
+        labels: Rc::from(vec!["x".to_owned()]),
+        maybe_count: Rc::new(Some(3)),
+        maybe_tag: Rc::new(Some(tag())),
+        tag: Rc::new(tag()),
+        text: Rc::from("t"),
+    }
+}
+
+fn arc_fields() -> ArcFields {
+    ArcFields {
+        count: Arc::new(7),
+        labels: Arc::from(vec!["x".to_owned()]),
+        maybe_count: Arc::new(Some(3)),
+        maybe_tag: Arc::new(Some(tag())),
+        tag: Arc::new(tag()),
+        text: Arc::from("t"),
+    }
+}
+
+fn cow_fields() -> CowFields {
+    CowFields {
+        count: Cow::Owned(7),
+        labels: Cow::Owned(vec!["x".to_owned()]),
+        maybe_count: Cow::Owned(Some(3)),
+        maybe_tag: Cow::Owned(Some(tag())),
+        tag: Cow::Owned(tag()),
+        text: Cow::Borrowed("t"),
+    }
+}
+
+/// The field declarations of a generated `TypeScript` definition, without the `JSDoc` around them.
+#[cfg(feature = "typescript")]
+fn ts_field_declarations(definition: &str) -> Vec<String> {
+    definition
+        .lines()
+        .filter(|line| line.starts_with("  ") && line.ends_with(';'))
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+/// One populated instance of every wrapper twin, serialized, beside the bare spelling's.
+fn covered_wrapper_payloads() -> [(&'static str, serde_json::Value); 4] {
+    [
+        ("Box", serde_json::to_value(boxed_fields()).unwrap()),
+        ("Rc", serde_json::to_value(rc_fields()).unwrap()),
+        ("Arc", serde_json::to_value(arc_fields()).unwrap()),
+        ("Cow", serde_json::to_value(cow_fields()).unwrap()),
+    ]
+}
+
+/// Every wrapper twin's generated `TypeScript`, under the bare spelling's type name.
+#[cfg(feature = "typescript")]
+fn covered_wrapper_ts_definitions() -> [(&'static str, String); 4] {
+    [
+        (
+            "Box",
+            BoxedFields::ts_definition().replace("BoxedFields", "PlainFields"),
+        ),
+        (
+            "Rc",
+            RcFields::ts_definition().replace("RcFields", "PlainFields"),
+        ),
+        (
+            "Arc",
+            ArcFields::ts_definition().replace("ArcFields", "PlainFields"),
+        ),
+        (
+            "Cow",
+            CowFields::ts_definition().replace("CowFields", "PlainFields"),
+        ),
+    ]
+}
+
+/// The same for Zod.
+#[cfg(feature = "zod")]
+fn covered_wrapper_zod_schemas() -> [(&'static str, String); 4] {
+    [
+        (
+            "Box",
+            BoxedFields::zod_schema().replace("BoxedFields", "PlainFields"),
+        ),
+        (
+            "Rc",
+            RcFields::zod_schema().replace("RcFields", "PlainFields"),
+        ),
+        (
+            "Arc",
+            ArcFields::zod_schema().replace("ArcFields", "PlainFields"),
+        ),
+        (
+            "Cow",
+            CowFields::zod_schema().replace("CowFields", "PlainFields"),
+        ),
+    ]
+}
+
+#[cfg(feature = "jsonschema")]
+fn covered_wrapper_json_schemas() -> [(&'static str, serde_json::Value); 4] {
+    [
+        ("Box", BoxedFields::json_schema()),
+        ("Rc", RcFields::json_schema()),
+        ("Arc", ArcFields::json_schema()),
+        ("Cow", CowFields::json_schema()),
+    ]
+}
+
+#[test]
+fn test_transparent_wrapper_structs_constructible() {
+    assert_eq!(*boxed_fields().count, plain_fields().count);
+    assert_eq!(*rc_fields().count, plain_fields().count);
+    assert_eq!(*arc_fields().count, plain_fields().count);
+    assert_eq!(*cow_fields().count, plain_fields().count);
+
+    let node = TreeNode {
+        label: "root".to_owned(),
+        next: Some(Box::new(TreeNode {
+            label: "leaf".to_owned(),
+            next: None,
+        })),
+    };
+    assert_eq!(node.next.unwrap().label, "leaf");
+}
+
+/// A wrapper is covered when serde writes it as its inner value — the whole criterion, and the
+/// reason the twins may be held against the bare spelling at all. Read off what serde actually
+/// produces, so the covered list answers to the wire rather than to a name.
+#[test]
+fn test_every_covered_wrapper_writes_its_inner_value() {
+    let plain = serde_json::to_value(plain_fields()).unwrap();
+    for (wrapper, payload) in covered_wrapper_payloads() {
+        assert_eq!(payload, plain, "for: {wrapper}");
+    }
+}
+
+/// The criterion holds wherever the wrapper was written, not only in field position: inside an
+/// `Option`, inside a sequence, in a map's value slot, and beside fields wrapped in nothing.
+#[test]
+fn test_a_wrapper_written_inside_another_type_writes_the_inner_value() {
+    let inside = WrappedInsideFields {
+        counts: HashMap::from([("k".to_owned(), Rc::new(1_u64))]),
+        elements: vec![Rc::new(tag())],
+        maybe_tag: Some(Box::new(tag())),
+    };
+    let plain_inside = PlainInsideFields {
+        counts: HashMap::from([("k".to_owned(), 1_u64)]),
+        elements: vec![tag()],
+        maybe_tag: Some(tag()),
+    };
+    assert_eq!(
+        serde_json::to_value(inside).unwrap(),
+        serde_json::to_value(plain_inside).unwrap()
+    );
+
+    let mixed = MixedBoxedFields {
+        boxed_tag: Box::new(tag()),
+        count: 7,
+        plain_tag: tag(),
+    };
+    let mixed_plain = MixedPlainFields {
+        boxed_tag: tag(),
+        count: 7,
+        plain_tag: tag(),
+    };
+    assert_eq!(
+        serde_json::to_value(mixed).unwrap(),
+        serde_json::to_value(mixed_plain).unwrap()
+    );
+}
+
+/// Writing the same value as the bare spelling, every covered wrapper describes as it does — whole
+/// schema against whole schema, not one field at a time.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_every_covered_wrapper_describes_as_the_inner_spelling() {
+    let plain_schema = PlainFields::json_schema();
+    for (wrapper, schema) in covered_wrapper_json_schemas() {
+        assert_eq!(
+            schema["properties"], plain_schema["properties"],
+            "for: {wrapper}"
+        );
+        assert_eq!(
+            schema["required"], plain_schema["required"],
+            "for: {wrapper}"
+        );
+    }
+}
+
+/// The same holding on the `TypeScript` surface, with the fixture's own name set aside.
+/// Declarations rather than whole definitions, because the surrounding `JSDoc` differs for a reason
+/// of its own: a field written under an `Option` or a `Vec` has its doc comment dropped, so the
+/// twins' `Option`- and `Vec`-inner fields carry a doc comment the bare spelling has lost.
+#[test]
+#[cfg(feature = "typescript")]
+fn test_every_covered_wrapper_types_as_the_inner_spelling() {
+    let plain_declarations = ts_field_declarations(&PlainFields::ts_definition());
+    for (wrapper, definition) in covered_wrapper_ts_definitions() {
+        assert_eq!(
+            ts_field_declarations(&definition),
+            plain_declarations,
+            "for: {wrapper}"
+        );
+    }
+}
+
+/// And on the Zod surface.
+#[test]
+#[cfg(feature = "zod")]
+fn test_every_covered_wrapper_validates_as_the_inner_spelling() {
+    let plain_schema = PlainFields::zod_schema();
+    for (wrapper, schema) in covered_wrapper_zod_schemas() {
+        assert_eq!(schema, plain_schema, "for: {wrapper}");
+    }
+}
+
+/// Whatever a wrapped field renders as, it is not the Rust wrapper's name: neither surface has any
+/// meaning for it, so the name surviving anywhere into the output is a syntax error in the output.
+#[test]
+#[cfg(any(feature = "typescript", feature = "zod"))]
+fn test_no_transparent_wrapper_name_survives_into_generated_output() {
+    let mut generated: Vec<(&str, String)> = Vec::new();
+    #[cfg(feature = "typescript")]
+    generated.extend(covered_wrapper_ts_definitions());
+    #[cfg(feature = "zod")]
+    generated.extend(covered_wrapper_zod_schemas());
+
+    for (wrapper, output) in generated {
+        for name in TRANSPARENT_WRAPPERS {
+            assert!(!output.contains(name), "{wrapper} generated: {output}");
+        }
+    }
+}
+
+/// A wrapper holding an `Option` is optional on the field's behalf: the wrapper is not on the wire,
+/// so what a `None` costs is decided by the `Option` alone, at either side of the wrapper.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_wrapped_option_is_required_exactly_as_the_bare_option() {
+    let expected = serde_json::json!(["count", "labels", "tag", "text"]);
+    assert_eq!(PlainFields::json_schema()["required"], expected);
+    for (wrapper, schema) in covered_wrapper_json_schemas() {
+        assert_eq!(schema["required"], expected, "for: {wrapper}");
+    }
+}
+
+/// A wrapper written inside an `Option`, a sequence or a map's value slot describes as the bare
+/// element does in that same position.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_wrapper_inside_another_type_describes_as_the_inner_spelling() {
+    let wrapped = WrappedInsideFields::json_schema();
+    let plain = PlainInsideFields::json_schema();
+    assert_eq!(wrapped["properties"], plain["properties"]);
+    assert_eq!(wrapped["required"], plain["required"]);
+}
+
+#[test]
+#[cfg(feature = "typescript")]
+fn test_wrapper_inside_another_type_types_as_the_inner_spelling() {
+    assert_eq!(
+        WrappedInsideFields::ts_definition().replace("WrappedInsideFields", "PlainInsideFields"),
+        PlainInsideFields::ts_definition()
+    );
+}
+
+#[test]
+#[cfg(feature = "zod")]
+fn test_wrapper_inside_another_type_validates_as_the_inner_spelling() {
+    assert_eq!(
+        WrappedInsideFields::zod_schema().replace("WrappedInsideFields", "PlainInsideFields"),
+        PlainInsideFields::zod_schema()
+    );
+}
+
+/// The collapse is one field's, so the fields written beside it render as they always did.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_boxed_field_leaves_its_unboxed_siblings_alone() {
+    let mixed = MixedBoxedFields::json_schema();
+    let plain = MixedPlainFields::json_schema();
+    assert_eq!(mixed["properties"], plain["properties"]);
+    assert_eq!(mixed["required"], plain["required"]);
+}
+
+/// Whole definitions here, `JSDoc` and all: no field is written under an `Option` or a `Vec`, so
+/// the boxed field's documentation is the unboxed field's, down to the comment above it. What a
+/// field documents as is decided by where it was written, not by what it was written under.
+#[test]
+#[cfg(feature = "typescript")]
+fn test_boxed_field_types_beside_its_unboxed_siblings() {
+    assert_eq!(
+        MixedBoxedFields::ts_definition().replace("MixedBoxedFields", "MixedPlainFields"),
+        MixedPlainFields::ts_definition()
+    );
+}
+
+/// A `Box` is what makes a self-holding struct a type at all, and it is still not on the wire: the
+/// field is the self-reference it wraps, so the recursion is seen through it and gets the deferred
+/// spelling a self-reference needs.
+#[test]
+#[cfg(feature = "zod")]
+fn test_boxed_self_reference_validates_as_the_self_reference() {
+    let schema = TreeNode::zod_schema();
+    assert!(schema.contains("get next()"), "Got: {schema}");
+    assert!(schema.contains("label: z.string()"), "Got: {schema}");
+    for name in TRANSPARENT_WRAPPERS {
+        assert!(!schema.contains(name), "Got: {schema}");
+    }
+}


### PR DESCRIPTION
`Box<Option<T>>` (and any `Box`/`Rc`/`Arc`/`Cow` field) expanded to a reference to a nonexistent `box_schema` module — a hard compile error.

- The parser collapses transparent single-generic wrappers onto their inner `FieldDef`, so no surface ever learns a wrapper was written. Covered list recorded with its criterion (serde writes the wrapper as its inner value): `Box`, `Rc`, `Arc`, `Cow` — `Cow` needs no special shape handling since lifetimes never reach the collected type arguments (pinned).
- Composes with the optionality lift and array depth: `Box<Option<T>>` is the optional field, `Vec<Rc<T>>` the array, `Box<[u32]>`/`Arc<[String]>` the boxed-slice forms.
- `str` joins the primitive map as `String`'s borrowed form — required for `Box<str>`/`Cow<'_, str>` and fixing bare `&str` fields broken the same way.
- Dev-only serde `rc` feature so the wire criterion is testable on `Rc`/`Arc`. Interior-mutability wrappers deliberately left off the list and filed.
- 14 red-first integration tests + parser unit tests; README section added.

Gates: `just check` green during work; full powerset once at acceptance — green.