### PR TITLE
fix: self-references defer in json_schema like they already do in Zod

### DIFF
--- a/src/features/jsonschema.rs
+++ b/src/features/jsonschema.rs
@@ -8,6 +8,61 @@ pub const fn should_generate_json_schema() -> bool {
     true // Always true when this module is compiled (feature is enabled)
 }
 
+/// Where a document holds the body of the type it describes, once that body names itself.
+///
+/// The crate writes draft 2020-12 (`prefixItems` with `"items": false` is that draft's fixed-arity
+/// array, and the draft before it spells the same array with `items`/`additionalItems`), whose
+/// recursive schema is a `$ref` into the document's own `$defs`.
+fn self_reference_pointer(def_name: &str) -> String {
+    format!("#/$defs/{def_name}")
+}
+
+/// Roots a document whose body names itself: the body moves under `$defs`, and the document
+/// becomes the `$ref` into it.
+///
+/// The body's own references are pointers from the document root, so this rooting is the only
+/// arrangement that resolves them — a body left at the root would point into a `$defs` that is not
+/// there.
+pub fn recursive_document(
+    def_name: &str,
+    body: &proc_macro2::TokenStream,
+) -> proc_macro2::TokenStream {
+    let pointer = self_reference_pointer(def_name);
+    quote::quote! {
+        {
+            let mut defs = serde_json::Map::new();
+            defs.insert(#def_name.to_string(), #body);
+            let mut document = serde_json::Map::new();
+            document.insert("$defs".to_string(), serde_json::Value::Object(defs));
+            document.insert(
+                "$ref".to_string(),
+                serde_json::Value::String(#pointer.to_string()),
+            );
+            serde_json::Value::Object(document)
+        }
+    }
+}
+
+/// The reference a self-naming type is described by wherever it appears inside its own document.
+pub fn self_reference_value(def_name: &str) -> proc_macro2::TokenStream {
+    let pointer = self_reference_pointer(def_name);
+    quote::quote! { serde_json::json!({ "$ref": #pointer }) }
+}
+
+/// Wraps a `json_schema()` body in the method, rooting it as a recursive document when the
+/// expansion emitted a reference back to the type being described.
+fn json_schema_method(
+    body: &proc_macro2::TokenStream,
+    self_reference: Option<&str>,
+) -> proc_macro2::TokenStream {
+    let value = self_reference.map_or_else(|| body.clone(), |name| recursive_document(name, body));
+    quote::quote! {
+        pub fn json_schema() -> serde_json::Value {
+            #value
+        }
+    }
+}
+
 /// Generates the JSON schema method implementation for structs.
 ///
 /// When the struct has `#[serde(flatten)]` fields, the base properties are
@@ -17,32 +72,47 @@ pub const fn should_generate_json_schema() -> bool {
 pub fn generate_struct_json_schema_method(
     json_schema_fields: &[proc_macro2::TokenStream],
     flatten_json_schemas: &[proc_macro2::TokenStream],
+    self_reference: Option<&str>,
 ) -> proc_macro2::TokenStream {
-    if flatten_json_schemas.is_empty() {
-        return quote::quote! {
-            pub fn json_schema() -> serde_json::Value {
-                let mut schema_obj = serde_json::Map::new();
-                schema_obj.insert("type".to_string(), serde_json::Value::String("object".to_string()));
-                schema_obj.insert("additionalProperties".to_string(), serde_json::Value::Bool(false));
-                let mut properties = serde_json::Map::new();
-                let mut required = Vec::new();
+    let body = if flatten_json_schemas.is_empty() {
+        closed_object_body(json_schema_fields)
+    } else {
+        flattened_object_body(json_schema_fields, flatten_json_schemas)
+    };
+    json_schema_method(&body, self_reference)
+}
 
-                #(#json_schema_fields)*
-
-                schema_obj.insert(
-                    "properties".to_string(),
-                    serde_json::Value::Object(properties),
-                );
-
-                schema_obj.insert("required".to_string(), serde_json::Value::Array(required));
-
-                serde_json::Value::Object(schema_obj)
-            }
-        };
-    }
-
+/// The struct's own fields as one closed object.
+fn closed_object_body(json_schema_fields: &[proc_macro2::TokenStream]) -> proc_macro2::TokenStream {
     quote::quote! {
-        pub fn json_schema() -> serde_json::Value {
+        {
+            let mut schema_obj = serde_json::Map::new();
+            schema_obj.insert("type".to_string(), serde_json::Value::String("object".to_string()));
+            schema_obj.insert("additionalProperties".to_string(), serde_json::Value::Bool(false));
+            let mut properties = serde_json::Map::new();
+            let mut required = Vec::new();
+
+            #(#json_schema_fields)*
+
+            schema_obj.insert(
+                "properties".to_string(),
+                serde_json::Value::Object(properties),
+            );
+
+            schema_obj.insert("required".to_string(), serde_json::Value::Array(required));
+
+            serde_json::Value::Object(schema_obj)
+        }
+    }
+}
+
+/// The struct's own fields distributed into each branch of the flattened types' schemas.
+fn flattened_object_body(
+    json_schema_fields: &[proc_macro2::TokenStream],
+    flatten_json_schemas: &[proc_macro2::TokenStream],
+) -> proc_macro2::TokenStream {
+    quote::quote! {
+        {
             fn merge_object_schemas(
                 a: &serde_json::Map<String, serde_json::Value>,
                 b: &serde_json::Map<String, serde_json::Value>,

--- a/src/features/jsonschema/tests.rs
+++ b/src/features/jsonschema/tests.rs
@@ -8,7 +8,7 @@ fn test_should_generate_json_schema() {
 #[test]
 fn test_json_schema_method_generation() {
     let fields = vec![];
-    let method = generate_struct_json_schema_method(&fields, &[]);
+    let method = generate_struct_json_schema_method(&fields, &[], None);
     let method_str = method.to_string();
 
     assert!(method_str.contains("json_schema"));
@@ -20,14 +20,42 @@ fn test_json_schema_method_generation() {
 #[test]
 fn test_json_schema_method_flatten_emits_merge() {
     let fields = vec![];
-    let no_flatten = generate_struct_json_schema_method(&fields, &[]).to_string();
+    let no_flatten = generate_struct_json_schema_method(&fields, &[], None).to_string();
     let with_flatten = generate_struct_json_schema_method(
         &fields,
         &[quote::quote! { serde_json::json!({ "type": "object" }) }],
+        None,
     )
     .to_string();
 
     assert!(!no_flatten.contains("merge_object_schemas"));
     assert!(with_flatten.contains("merge_object_schemas"));
     assert!(with_flatten.contains("oneOf"));
+}
+
+/// A body that names itself is only reachable from under `$defs`, so the method must root the
+/// document there — in both the plain and the flattened shape, which spell their bodies apart.
+#[test]
+fn test_json_schema_method_roots_a_self_naming_body_under_defs() {
+    let fields = vec![];
+    let flattened = [quote::quote! { serde_json::json!({ "type": "object" }) }];
+
+    for flatten in [[].as_slice(), flattened.as_slice()] {
+        let method = generate_struct_json_schema_method(&fields, flatten, Some("Node")).to_string();
+
+        assert!(method.contains("\"$defs\""), "no $defs: {method}");
+        assert!(method.contains("\"#/$defs/Node\""), "no pointer: {method}");
+        assert!(method.contains("\"Node\""), "not keyed by name: {method}");
+    }
+}
+
+/// The pointer and the `$defs` key are two spellings of one name; a document whose reference
+/// pointed anywhere but at its own entry would resolve to nothing.
+#[test]
+fn test_self_reference_value_points_at_the_defs_entry() {
+    let reference = self_reference_value("Node").to_string();
+    let document = recursive_document("Node", &quote::quote! { body }).to_string();
+
+    assert!(reference.contains("\"#/$defs/Node\""), "{reference}");
+    assert!(document.contains("\"#/$defs/Node\""), "{document}");
 }

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -53,7 +53,11 @@ use crate::features::model_schema_prop::ModelSchemaPropMeta;
 use crate::features::jsonschema::{
     generate_plain_enum_json_schema_method as generate_plain_enum_json_schema_method_impl,
     generate_struct_json_schema_method as generate_struct_json_schema_method_impl,
+    recursive_document, self_reference_value,
 };
+
+#[cfg(feature = "jsonschema")]
+use crate::utils::{begin_expansion, emitted_self_reference, self_reference_def_name};
 
 #[cfg(any(feature = "typescript", feature = "zod"))]
 use crate::utils::{get_enum_docs, get_struct_docs, strip_examples_from_docs};
@@ -301,10 +305,16 @@ pub fn exec_model_schema(args: TokenStream, input: TokenStream) -> TokenStream {
     let parsed_args = parse_model_schema_args(args.into());
     let item = parse_macro_input!(input as Item);
     if let Item::Struct(item_struct) = item {
+        #[cfg(feature = "jsonschema")]
+        begin_expansion(&item_struct.ident.to_string());
         process_struct(item_struct, &parsed_args)
     } else if let Item::Enum(item_enum) = item {
+        #[cfg(feature = "jsonschema")]
+        begin_expansion(&item_enum.ident.to_string());
         process_enum(item_enum)
     } else if let Item::Type(item_type) = item {
+        #[cfg(feature = "jsonschema")]
+        begin_expansion(&item_type.ident.to_string());
         process_type_alias(item_type, &parsed_args)
     } else {
         syn::Error::new_spanned(item, "Unsupported target for model_schema")
@@ -2726,14 +2736,7 @@ fn string_field_json_schema_value(fld: &FieldDef) -> proc_macro2::TokenStream {
 #[cfg(all(feature = "serde", feature = "jsonschema"))]
 fn field_json_schema_value(fld: &FieldDef) -> proc_macro2::TokenStream {
     let inner = match &fld.field_type {
-        FieldDefType::SiblingType(name, _) => {
-            let module_name = match lookup_alias_info(name) {
-                Some(alias) => alias.module_name,
-                None => format!("{}_schema", to_snake_case(&safe_type_name(name))),
-            };
-            let module_ident = Ident::new(&module_name, proc_macro2::Span::call_site());
-            quote! { #module_ident::Schema::json_schema() }
-        }
+        FieldDefType::SiblingType(name, _) => sibling_json_schema_value(name),
         FieldDefType::String => string_field_json_schema_value(fld),
         FieldDefType::StringLiteral(literal) => {
             quote! { serde_json::json!({ "type": "string", "const": #literal }) }
@@ -3485,8 +3488,15 @@ fn sibling_schema_module_ident(name: &str) -> Ident {
 /// Every position that carries a sibling by reference — a field, a map member, a tuple element, a
 /// flattened base — emits this one call, so a type cannot describe as itself in one position and as
 /// an open object in another.
+///
+/// The type being expanded is the one name that cannot be asked: its schema is what is being
+/// written, so inlining it would have nothing to stop it. It is described by reference instead,
+/// which is what makes a self-naming type describable at all.
 #[cfg(feature = "jsonschema")]
 fn sibling_json_schema_value(name: &str) -> proc_macro2::TokenStream {
+    if let Some(def_name) = self_reference_def_name(name) {
+        return self_reference_value(&def_name);
+    }
     let module_ident = sibling_schema_module_ident(name);
     quote! { #module_ident::Schema::json_schema() }
 }
@@ -4760,7 +4770,11 @@ fn generate_json_schema_method(
     json_schema_fields: &[proc_macro2::TokenStream],
     flatten_json_schemas: &[proc_macro2::TokenStream],
 ) -> proc_macro2::TokenStream {
-    generate_struct_json_schema_method_impl(json_schema_fields, flatten_json_schemas)
+    generate_struct_json_schema_method_impl(
+        json_schema_fields,
+        flatten_json_schemas,
+        emitted_self_reference().as_deref(),
+    )
 }
 
 #[cfg(feature = "jsonschema")]
@@ -5015,9 +5029,12 @@ fn generate_plain_enum_zod_schema_method(
 fn generate_discriminated_enum_json_schema_method(
     main_schema_code: &proc_macro2::TokenStream,
 ) -> proc_macro2::TokenStream {
+    let body = quote::quote! { { #main_schema_code } };
+    let value = emitted_self_reference()
+        .map_or_else(|| body.clone(), |name| recursive_document(&name, &body));
     quote::quote! {
         pub fn json_schema() -> serde_json::Value {
-            #main_schema_code
+            #value
         }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -32,8 +32,27 @@ pub struct AliasInfo {
     pub module_name: String,
 }
 
+/// The type the running expansion describes, and the `$defs` name a reference back to it was
+/// emitted under.
+///
+/// A JSON schema names a type by inlining it, which a type naming itself cannot be described by —
+/// the inlining has nothing to stop it. Recognizing that case belongs where references are
+/// emitted, which is far from the item being expanded, so the name travels here.
+#[cfg(feature = "jsonschema")]
+#[derive(Default)]
+struct ExpansionSelfReference {
+    def_name: Option<String>,
+    rust_ident: String,
+}
+
 thread_local! {
     static ALIAS_INFO: RefCell<HashMap<String, AliasInfo>> = RefCell::new(HashMap::new());
+}
+
+#[cfg(feature = "jsonschema")]
+thread_local! {
+    static SELF_REFERENCE: RefCell<ExpansionSelfReference> =
+        RefCell::new(ExpansionSelfReference::default());
 }
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
@@ -60,6 +79,42 @@ pub fn register_alias_info(
 
 pub fn lookup_alias_info(rust_ident: &str) -> Option<AliasInfo> {
     ALIAS_INFO.with(|map| map.borrow().get(rust_ident).cloned())
+}
+
+/// Names the type the expansion starting now describes.
+///
+/// Every expansion sets it. A name left behind by the previous one would make an unrelated type's
+/// reference read as a self reference and describe as a `$ref` into a `$defs` nobody wrote.
+#[cfg(feature = "jsonschema")]
+pub fn begin_expansion(rust_ident: &str) {
+    SELF_REFERENCE.with(|cell| {
+        *cell.borrow_mut() = ExpansionSelfReference {
+            rust_ident: rust_ident.to_owned(),
+            def_name: None,
+        };
+    });
+}
+
+/// The `$defs` name to describe `rust_ident` under when it is the type being expanded, recording
+/// that this document now needs the entry the reference points into.
+///
+/// `None` for every other name, which is described by inlining as before.
+#[cfg(feature = "jsonschema")]
+pub fn self_reference_def_name(rust_ident: &str) -> Option<String> {
+    if !SELF_REFERENCE.with(|cell| cell.borrow().rust_ident == rust_ident) {
+        return None;
+    }
+    let def_name = lookup_alias_info(rust_ident)
+        .map_or_else(|| safe_type_name(rust_ident), |info| info.export_name);
+    SELF_REFERENCE.with(|cell| cell.borrow_mut().def_name = Some(def_name.clone()));
+    Some(def_name)
+}
+
+/// The `$defs` name the expansion emitted a self reference under, or `None` when it named itself
+/// nowhere and describes fully inlined.
+#[cfg(feature = "jsonschema")]
+pub fn emitted_self_reference() -> Option<String> {
+    SELF_REFERENCE.with(|cell| cell.borrow().def_name.clone())
 }
 
 pub fn safe_type_name(key: &str) -> String {

--- a/tests/recursive_type_tests/tests.rs
+++ b/tests/recursive_type_tests/tests.rs
@@ -1,8 +1,197 @@
+/// What a self-referential type describes as on the JSON-schema and TypeScript surfaces.
+///
+/// Each description is produced in a child copy of this test binary. A description that does not
+/// terminate overflows the stack, and a stack overflow aborts the process rather than unwinding —
+/// there is nothing to catch where it happens. Running it in a child turns that abort into an exit
+/// status the parent asserts on, so a regression fails one test instead of killing the suite.
+#[cfg(feature = "jsonschema")]
+mod describes {
+    use super::{ChainNode, DynamicValueTest, RecursiveMapEnum, TreeNode};
+    use serde_json::{Value, json};
+    use std::env;
+    use std::process::Command;
+    use std::thread;
+
+    /// Selects the description a child run produces.
+    const DESCRIPTION_VAR: &str = "TIXSCHEMA_RECURSIVE_DESCRIPTION";
+
+    /// Opens the child's stderr report; everything after it is the description, newlines and all.
+    const PRODUCED_MARKER: &str = "--- produced ---\n";
+
+    /// The stack a description is produced on. Small enough that one that does not terminate dies
+    /// at once instead of working its way through the default stack.
+    const PRODUCTION_STACK_BYTES: usize = 256 * 1024;
+
+    /// The libtest path of [`production`], which the parent names to run only it in the child.
+    const CHILD_TEST: &str = "tests::describes::production";
+
+    /// The deepest object or array nesting anywhere in a description.
+    ///
+    /// A type that names itself has a description whose depth is set by its own fields. One that
+    /// terminated by unrolling itself a fixed number of times instead would be far deeper, which
+    /// is the difference this measures.
+    fn depth(value: &Value) -> usize {
+        match value {
+            Value::Object(members) => 1 + members.values().map(depth).max().unwrap_or_default(),
+            Value::Array(items) => 1 + items.iter().map(depth).max().unwrap_or_default(),
+            Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => 0,
+        }
+    }
+
+    fn produce(description: &str) -> String {
+        match description {
+            "vec_self_json" => serde_json::to_string(&TreeNode::json_schema()).unwrap(),
+            "vec_self_ts" => TreeNode::ts_definition(),
+            "boxed_self_json" => serde_json::to_string(&ChainNode::json_schema()).unwrap(),
+            "boxed_self_ts" => ChainNode::ts_definition(),
+            "map_self_json" => serde_json::to_string(&RecursiveMapEnum::json_schema()).unwrap(),
+            "enum_self_json" => serde_json::to_string(&DynamicValueTest::json_schema()).unwrap(),
+            "enum_self_ts" => DynamicValueTest::ts_definition(),
+            other => format!("no description named `{other}`"),
+        }
+    }
+
+    /// Produces the one description a parent run asked for. Without [`DESCRIPTION_VAR`] this is
+    /// not a child run and there is nothing to produce.
+    #[test]
+    fn production() {
+        let Ok(description) = env::var(DESCRIPTION_VAR) else {
+            return;
+        };
+        let produced = thread::Builder::new()
+            .stack_size(PRODUCTION_STACK_BYTES)
+            .spawn(move || produce(&description))
+            .unwrap()
+            .join()
+            .unwrap();
+        eprint!("{PRODUCED_MARKER}{produced}");
+    }
+
+    fn produced(description: &str) -> String {
+        let child = Command::new(env::current_exe().unwrap())
+            .args([CHILD_TEST, "--exact", "--nocapture", "--test-threads=1"])
+            .env(DESCRIPTION_VAR, description)
+            .output()
+            .unwrap();
+        let reported = String::from_utf8_lossy(&child.stderr).into_owned();
+        assert!(
+            child.status.success(),
+            "describing `{description}` did not terminate ({status}):\n{reported}",
+            status = child.status
+        );
+        assert!(
+            reported.contains(PRODUCED_MARKER),
+            "describing `{description}` produced nothing:\n{reported}"
+        );
+        reported.split_once(PRODUCED_MARKER).unwrap().1.to_owned()
+    }
+
+    #[test]
+    fn vec_of_self_is_a_reference_into_the_documents_own_defs() {
+        let document: Value = serde_json::from_str(&produced("vec_self_json")).unwrap();
+
+        assert_eq!(document["$ref"], json!("#/$defs/TreeNode"));
+        let body = &document["$defs"]["TreeNode"];
+        assert_eq!(
+            body["properties"]["children"],
+            json!({ "type": "array", "items": { "$ref": "#/$defs/TreeNode" } })
+        );
+        assert_eq!(body["properties"]["val"], json!({ "type": "string" }));
+        assert_eq!(body["required"], json!(["children", "val"]));
+        assert!(
+            depth(&document) <= 8,
+            "unrolled rather than named: {document}"
+        );
+    }
+
+    #[test]
+    fn boxed_option_of_self_is_a_reference_into_the_documents_own_defs() {
+        let document: Value = serde_json::from_str(&produced("boxed_self_json")).unwrap();
+
+        assert_eq!(document["$ref"], json!("#/$defs/ChainNode"));
+        let body = &document["$defs"]["ChainNode"];
+        assert_eq!(
+            body["properties"]["next"],
+            json!({ "$ref": "#/$defs/ChainNode" })
+        );
+        assert_eq!(body["properties"]["label"], json!({ "type": "string" }));
+        assert_eq!(body["required"], json!(["label"]));
+        assert!(
+            depth(&document) <= 8,
+            "unrolled rather than named: {document}"
+        );
+    }
+
+    #[test]
+    fn a_self_holding_map_value_is_a_reference() {
+        let document: Value = serde_json::from_str(&produced("map_self_json")).unwrap();
+
+        assert_eq!(document["$ref"], json!("#/$defs/RecursiveMapEnum"));
+        let variants = document["$defs"]["RecursiveMapEnum"]["oneOf"]
+            .as_array()
+            .unwrap();
+        let described = serde_json::to_string(variants).unwrap();
+        assert!(
+            described.contains(r##""additionalProperties":{"$ref":"#/$defs/RecursiveMapEnum"}"##),
+            "the map's values should be described by reference: {described}"
+        );
+    }
+
+    #[test]
+    fn an_enum_naming_itself_from_several_variants_is_described_once() {
+        let document: Value = serde_json::from_str(&produced("enum_self_json")).unwrap();
+
+        assert_eq!(document["$ref"], json!("#/$defs/DynamicValueTest"));
+        let described = serde_json::to_string(&document).unwrap();
+        assert_eq!(
+            described
+                .matches(r##"{"$ref":"#/$defs/DynamicValueTest"}"##)
+                .count(),
+            2,
+            "the array element and the map value each name the enum: {described}"
+        );
+        assert!(
+            depth(&document) <= 10,
+            "unrolled rather than named: {document}"
+        );
+    }
+
+    #[test]
+    fn typescript_names_the_type_it_is_defining() {
+        let vec_self = produced("vec_self_ts");
+        assert!(
+            vec_self.contains("children: Array<TreeNode>;"),
+            "a Vec of self is an array of the type's own name: {vec_self}"
+        );
+
+        let boxed_self = produced("boxed_self_ts");
+        assert!(
+            boxed_self.contains("next: ChainNode | undefined;"),
+            "an optional box of self is the type's own name: {boxed_self}"
+        );
+
+        let enum_self = produced("enum_self_ts");
+        assert!(
+            enum_self.contains("Array<DynamicValueTest>"),
+            "a recursive variant names the enum: {enum_self}"
+        );
+    }
+}
+
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use tixschema::model_schema;
 
 // ========== Type definitions at module level ==========
+
+/// Recursive struct holding at most one of itself.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ChainNode {
+    pub label: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next: Option<Box<Self>>,
+}
 
 /// Address struct for sibling reference test.
 #[model_schema()]
@@ -227,5 +416,20 @@ fn test_recursive_named_struct_variant() {
     assert!(
         zod.contains("text: z.string()"),
         "Non-recursive text field should use normal syntax. Got: {zod}"
+    );
+}
+
+/// Test 9: Struct holding at most one of itself.
+#[test]
+fn test_recursive_boxed_option_struct() {
+    let zod = ChainNode::zod_schema();
+
+    assert!(
+        zod.contains("get next()"),
+        "Recursive next field should use getter syntax. Got: {zod}"
+    );
+    assert!(
+        zod.contains("label: z.string()"),
+        "Non-recursive label field should use normal property syntax. Got: {zod}"
     );
 }


### PR DESCRIPTION
`Vec<Self>` / `Option<Box<Self>>` overflowed the stack at runtime in the generated `json_schema()` — the reference emitter called `Module::Schema::json_schema()` for every named type including the one being expanded. `ts_definition()` aborted through the same hole (its JSDoc enrichment embeds `Self::json_schema()`); the TS *type* was already natively recursive.

- Mirrors Zod's macro-time deferral at the single reference choke point: a self reference emits `{"$ref": "#/$defs/<Name>"}` and the emitting method roots its document as `$defs` + `$ref`. Structs, discriminated and untagged enums covered.
- Draft verified from the crate's own keyword set (2020-12 — `prefixItems` with `items:false`), recorded rather than assumed.
- Red-first with an abort-safe harness (256 KiB child stack turns non-termination into a failed assertion): 5 red on pristine master, green after. Zod + all non-recursive output proven byte-identical by differential dump over 10 shapes.
- Cross-document composition (inlined recursive types, mutual recursion) measured, filed separately with raw evidence.

Gates: `just check` green during work; full powerset once at acceptance — green.