### PR TITLE
fix: one runtime recursion guard serves cycles and inlined documents

### DIFF
--- a/src/features/jsonschema.rs
+++ b/src/features/jsonschema.rs
@@ -8,57 +8,69 @@ pub const fn should_generate_json_schema() -> bool {
     true // Always true when this module is compiled (feature is enabled)
 }
 
-/// Where a document holds the body of the type it describes, once that body names itself.
+/// Where a document holds the definition of `def_name`.
 ///
 /// The crate writes draft 2020-12 (`prefixItems` with `"items": false` is that draft's fixed-arity
 /// array, and the draft before it spells the same array with `items`/`additionalItems`), whose
-/// recursive schema is a `$ref` into the document's own `$defs`.
-fn self_reference_pointer(def_name: &str) -> String {
+/// deferred schema is a `$ref` into the document's own `$defs`.
+fn defs_pointer(def_name: &str) -> String {
     format!("#/$defs/{def_name}")
 }
 
-/// Roots a document whose body names itself: the body moves under `$defs`, and the document
-/// becomes the `$ref` into it.
+/// The pair of JSON-schema methods every schema module publishes.
 ///
-/// The body's own references are pointers from the document root, so this rooting is the only
-/// arrangement that resolves them — a body left at the root would point into a `$defs` that is not
-/// there.
-pub fn recursive_document(
+/// `json_schema` is the document a caller asks for. `json_schema_within` is that same description
+/// written into a document already being built, and carries the two things that have to travel
+/// with it: the names whose descriptions are still being written, and the definitions the
+/// document's root must hold.
+///
+/// A cycle is only knowable there. A type names another by inlining it, and no expansion can see
+/// the cycle it is part of — the other type may not have been expanded yet, and one that has been
+/// cannot be revisited. So the name is recognized while the description runs: a name re-entered
+/// while still in flight describes as a `$ref` into `$defs`, and the frame that put it in flight
+/// hoists its body to the root that pointer resolves against.
+pub fn json_schema_methods(
     def_name: &str,
     body: &proc_macro2::TokenStream,
 ) -> proc_macro2::TokenStream {
-    let pointer = self_reference_pointer(def_name);
-    quote::quote! {
-        {
-            let mut defs = serde_json::Map::new();
-            defs.insert(#def_name.to_string(), #body);
-            let mut document = serde_json::Map::new();
-            document.insert("$defs".to_string(), serde_json::Value::Object(defs));
-            document.insert(
-                "$ref".to_string(),
-                serde_json::Value::String(#pointer.to_string()),
-            );
-            serde_json::Value::Object(document)
-        }
-    }
-}
-
-/// The reference a self-naming type is described by wherever it appears inside its own document.
-pub fn self_reference_value(def_name: &str) -> proc_macro2::TokenStream {
-    let pointer = self_reference_pointer(def_name);
-    quote::quote! { serde_json::json!({ "$ref": #pointer }) }
-}
-
-/// Wraps a `json_schema()` body in the method, rooting it as a recursive document when the
-/// expansion emitted a reference back to the type being described.
-fn json_schema_method(
-    body: &proc_macro2::TokenStream,
-    self_reference: Option<&str>,
-) -> proc_macro2::TokenStream {
-    let value = self_reference.map_or_else(|| body.clone(), |name| recursive_document(name, body));
+    let pointer = defs_pointer(def_name);
     quote::quote! {
         pub fn json_schema() -> serde_json::Value {
-            #value
+            let mut in_flight: Vec<&'static str> = Vec::new();
+            let mut hoisted_defs = serde_json::Map::new();
+            let described = Self::json_schema_within(&mut in_flight, &mut hoisted_defs);
+            if hoisted_defs.is_empty() {
+                return described;
+            }
+            // The pointers into them are from the root, so the definitions join it — ahead of the
+            // description, which is the rest of the document. Every description the crate writes
+            // is an object, which is what can take them as a member.
+            let mut rooted = serde_json::Map::new();
+            rooted.insert("$defs".to_string(), serde_json::Value::Object(hoisted_defs));
+            if let serde_json::Value::Object(members) = described {
+                rooted.extend(members);
+            }
+            serde_json::Value::Object(rooted)
+        }
+
+        pub fn json_schema_within(
+            in_flight: &mut Vec<&'static str>,
+            hoisted_defs: &mut serde_json::Map<String, serde_json::Value>,
+        ) -> serde_json::Value {
+            if in_flight.contains(&#def_name) {
+                // Reserved rather than written: the frame that put this name in flight is still
+                // writing the body, and fills the entry in once it has one.
+                hoisted_defs.entry(#def_name).or_insert(serde_json::Value::Null);
+                return serde_json::json!({ "$ref": #pointer });
+            }
+            in_flight.push(#def_name);
+            let described = #body;
+            in_flight.pop();
+            if hoisted_defs.contains_key(#def_name) {
+                hoisted_defs.insert(#def_name.to_string(), described);
+                return serde_json::json!({ "$ref": #pointer });
+            }
+            described
         }
     }
 }
@@ -72,14 +84,14 @@ fn json_schema_method(
 pub fn generate_struct_json_schema_method(
     json_schema_fields: &[proc_macro2::TokenStream],
     flatten_json_schemas: &[proc_macro2::TokenStream],
-    self_reference: Option<&str>,
+    def_name: &str,
 ) -> proc_macro2::TokenStream {
     let body = if flatten_json_schemas.is_empty() {
         closed_object_body(json_schema_fields)
     } else {
         flattened_object_body(json_schema_fields, flatten_json_schemas)
     };
-    json_schema_method(&body, self_reference)
+    json_schema_methods(def_name, &body)
 }
 
 /// The struct's own fields as one closed object.
@@ -203,9 +215,10 @@ fn flattened_object_body(
 /// Generates the JSON schema method implementation for plain enums.
 pub fn generate_plain_enum_json_schema_method(
     enumerated: &[proc_macro2::TokenStream],
+    def_name: &str,
 ) -> proc_macro2::TokenStream {
-    quote::quote! {
-        pub fn json_schema() -> serde_json::Value {
+    let body = quote::quote! {
+        {
             let mut schema_obj = serde_json::Map::new();
             schema_obj.insert("type".to_string(), serde_json::Value::String("string".to_string()));
             schema_obj.insert("enum".to_string(), serde_json::Value::Array(
@@ -214,7 +227,8 @@ pub fn generate_plain_enum_json_schema_method(
 
             serde_json::Value::Object(schema_obj)
         }
-    }
+    };
+    json_schema_methods(def_name, &body)
 }
 
 #[cfg(test)]

--- a/src/features/jsonschema/tests.rs
+++ b/src/features/jsonschema/tests.rs
@@ -8,7 +8,7 @@ fn test_should_generate_json_schema() {
 #[test]
 fn test_json_schema_method_generation() {
     let fields = vec![];
-    let method = generate_struct_json_schema_method(&fields, &[], None);
+    let method = generate_struct_json_schema_method(&fields, &[], "Node");
     let method_str = method.to_string();
 
     assert!(method_str.contains("json_schema"));
@@ -20,11 +20,11 @@ fn test_json_schema_method_generation() {
 #[test]
 fn test_json_schema_method_flatten_emits_merge() {
     let fields = vec![];
-    let no_flatten = generate_struct_json_schema_method(&fields, &[], None).to_string();
+    let no_flatten = generate_struct_json_schema_method(&fields, &[], "Node").to_string();
     let with_flatten = generate_struct_json_schema_method(
         &fields,
         &[quote::quote! { serde_json::json!({ "type": "object" }) }],
-        None,
+        "Node",
     )
     .to_string();
 
@@ -33,29 +33,39 @@ fn test_json_schema_method_flatten_emits_merge() {
     assert!(with_flatten.contains("oneOf"));
 }
 
-/// A body that names itself is only reachable from under `$defs`, so the method must root the
-/// document there — in both the plain and the flattened shape, which spell their bodies apart.
+/// The two methods are one mechanism: the guarded one is what siblings call, and the entry point
+/// is what turns the definitions it collected into a document root.
 #[test]
-fn test_json_schema_method_roots_a_self_naming_body_under_defs() {
-    let fields = vec![];
-    let flattened = [quote::quote! { serde_json::json!({ "type": "object" }) }];
+fn test_json_schema_methods_pair_an_entry_point_with_a_guarded_body() {
+    let methods = json_schema_methods("Node", &quote::quote! { body }).to_string();
 
-    for flatten in [[].as_slice(), flattened.as_slice()] {
-        let method = generate_struct_json_schema_method(&fields, flatten, Some("Node")).to_string();
-
-        assert!(method.contains("\"$defs\""), "no $defs: {method}");
-        assert!(method.contains("\"#/$defs/Node\""), "no pointer: {method}");
-        assert!(method.contains("\"Node\""), "not keyed by name: {method}");
-    }
+    assert!(methods.contains("pub fn json_schema ()"), "{methods}");
+    assert!(methods.contains("pub fn json_schema_within"), "{methods}");
+    assert!(methods.contains("in_flight"), "{methods}");
+    assert!(methods.contains("\"$defs\""), "no $defs: {methods}");
 }
 
 /// The pointer and the `$defs` key are two spellings of one name; a document whose reference
-/// pointed anywhere but at its own entry would resolve to nothing.
+/// pointed anywhere but at the entry it hoists would resolve to nothing.
 #[test]
-fn test_self_reference_value_points_at_the_defs_entry() {
-    let reference = self_reference_value("Node").to_string();
-    let document = recursive_document("Node", &quote::quote! { body }).to_string();
+fn test_the_deferred_reference_points_at_the_hoisted_defs_entry() {
+    let methods = json_schema_methods("Node", &quote::quote! { body }).to_string();
 
-    assert!(reference.contains("\"#/$defs/Node\""), "{reference}");
-    assert!(document.contains("\"#/$defs/Node\""), "{document}");
+    assert!(
+        methods.contains("\"#/$defs/Node\""),
+        "no pointer: {methods}"
+    );
+    assert!(methods.contains("\"Node\""), "not keyed by name: {methods}");
+}
+
+/// A plain enum names nothing, but a type that names it reaches it through the guarded method
+/// like any other sibling.
+#[test]
+fn test_plain_enum_publishes_the_guarded_method_too() {
+    let method = generate_plain_enum_json_schema_method(&[quote::quote! { "a" }], "Flag");
+
+    assert!(
+        method.to_string().contains("pub fn json_schema_within"),
+        "{method}"
+    );
 }

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -53,11 +53,8 @@ use crate::features::model_schema_prop::ModelSchemaPropMeta;
 use crate::features::jsonschema::{
     generate_plain_enum_json_schema_method as generate_plain_enum_json_schema_method_impl,
     generate_struct_json_schema_method as generate_struct_json_schema_method_impl,
-    recursive_document, self_reference_value,
+    json_schema_methods,
 };
-
-#[cfg(feature = "jsonschema")]
-use crate::utils::{begin_expansion, emitted_self_reference, self_reference_def_name};
 
 #[cfg(any(feature = "typescript", feature = "zod"))]
 use crate::utils::{get_enum_docs, get_struct_docs, strip_examples_from_docs};
@@ -305,16 +302,10 @@ pub fn exec_model_schema(args: TokenStream, input: TokenStream) -> TokenStream {
     let parsed_args = parse_model_schema_args(args.into());
     let item = parse_macro_input!(input as Item);
     if let Item::Struct(item_struct) = item {
-        #[cfg(feature = "jsonschema")]
-        begin_expansion(&item_struct.ident.to_string());
         process_struct(item_struct, &parsed_args)
     } else if let Item::Enum(item_enum) = item {
-        #[cfg(feature = "jsonschema")]
-        begin_expansion(&item_enum.ident.to_string());
         process_enum(item_enum)
     } else if let Item::Type(item_type) = item {
-        #[cfg(feature = "jsonschema")]
-        begin_expansion(&item_type.ident.to_string());
         process_type_alias(item_type, &parsed_args)
     } else {
         syn::Error::new_spanned(item, "Unsupported target for model_schema")
@@ -1087,7 +1078,7 @@ fn process_struct(mut item_struct: syn::ItemStruct, args: &ModelSchemaArgs) -> T
         let flatten = compute_flatten_outputs(&collected.1);
         vec![
             #[cfg(feature = "jsonschema")]
-            generate_json_schema_method(&bodies.2, &flatten.2),
+            generate_json_schema_method(&bodies.2, &flatten.2, &item_name),
             #[cfg(feature = "typescript")]
             generate_ts_definition_method(&docs, &item_name, &bodies.0, bodies.3, &flatten.0),
             #[cfg(feature = "zod")]
@@ -1263,6 +1254,7 @@ fn build_branded_validation(
 fn build_branded_json_schema_method(
     args: &ModelSchemaArgs,
     json_inner_type: &str,
+    def_name: &str,
 ) -> proc_macro2::TokenStream {
     let mut constraint_inserts: Vec<proc_macro2::TokenStream> = Vec::new();
 
@@ -1282,14 +1274,15 @@ fn build_branded_json_schema_method(
         });
     }
 
-    quote! {
-        pub fn json_schema() -> serde_json::Value {
+    let body = quote! {
+        {
             let mut schema_obj = serde_json::Map::new();
             schema_obj.insert("type".to_string(), serde_json::Value::String(#json_inner_type.to_string()));
             #(#constraint_inserts)*
             serde_json::Value::Object(schema_obj)
         }
-    }
+    };
+    json_schema_methods(def_name, &body)
 }
 
 /// Extracts the generic type parameter names from a branded newtype's generics.
@@ -1875,7 +1868,7 @@ fn process_branded_newtype(item_struct: syn::ItemStruct, args: &ModelSchemaArgs)
 
     // --- Build schema module impl items ---
     #[cfg(feature = "jsonschema")]
-    let json_schema_method = build_branded_json_schema_method(args, &json_inner_type);
+    let json_schema_method = build_branded_json_schema_method(args, &json_inner_type, &item_name);
 
     let schema_impl_items: Vec<proc_macro2::TokenStream> = vec![
         #[cfg(feature = "jsonschema")]
@@ -2186,7 +2179,7 @@ fn process_plain_enum(
 
     // Generate schema module methods
     #[cfg(feature = "jsonschema")]
-    let json_schema_method = generate_plain_enum_json_schema_method(&enumerated);
+    let json_schema_method = generate_plain_enum_json_schema_method(&enumerated, item_name);
 
     #[cfg(feature = "typescript")]
     let ts_definition_method =
@@ -2456,7 +2449,8 @@ fn process_discriminated_enum(
 
     // Generate schema module methods
     #[cfg(feature = "jsonschema")]
-    let json_schema_method = generate_discriminated_enum_json_schema_method(&main_schema_code);
+    let json_schema_method =
+        generate_discriminated_enum_json_schema_method(&main_schema_code, item_name);
 
     #[cfg(feature = "typescript")]
     let ts_definition_method =
@@ -2905,7 +2899,8 @@ fn process_untagged_enum(
 
     // Generate schema module methods
     #[cfg(feature = "jsonschema")]
-    let json_schema_method = generate_discriminated_enum_json_schema_method(&main_schema_code);
+    let json_schema_method =
+        generate_discriminated_enum_json_schema_method(&main_schema_code, item_name);
 
     #[cfg(feature = "typescript")]
     let ts_definition_method =
@@ -3489,16 +3484,14 @@ fn sibling_schema_module_ident(name: &str) -> Ident {
 /// flattened base — emits this one call, so a type cannot describe as itself in one position and as
 /// an open object in another.
 ///
-/// The type being expanded is the one name that cannot be asked: its schema is what is being
-/// written, so inlining it would have nothing to stop it. It is described by reference instead,
-/// which is what makes a self-naming type describable at all.
+/// It is the guarded form that is asked for, not the standalone document: the sibling is being
+/// written into a document already in progress, and it is the run that knows whether asking has
+/// come back around to a name still being written. So the names in flight and the definitions the
+/// root will carry travel into the call.
 #[cfg(feature = "jsonschema")]
 fn sibling_json_schema_value(name: &str) -> proc_macro2::TokenStream {
-    if let Some(def_name) = self_reference_def_name(name) {
-        return self_reference_value(&def_name);
-    }
     let module_ident = sibling_schema_module_ident(name);
-    quote! { #module_ident::Schema::json_schema() }
+    quote! { #module_ident::Schema::json_schema_within(in_flight, hoisted_defs) }
 }
 
 /// Builds JSON schema for a tuple element (used for tuple fields and for tuple variants), or the
@@ -4769,12 +4762,9 @@ fn get_final_variant_name(
 fn generate_json_schema_method(
     json_schema_fields: &[proc_macro2::TokenStream],
     flatten_json_schemas: &[proc_macro2::TokenStream],
+    def_name: &str,
 ) -> proc_macro2::TokenStream {
-    generate_struct_json_schema_method_impl(
-        json_schema_fields,
-        flatten_json_schemas,
-        emitted_self_reference().as_deref(),
-    )
+    generate_struct_json_schema_method_impl(json_schema_fields, flatten_json_schemas, def_name)
 }
 
 #[cfg(feature = "jsonschema")]
@@ -4931,15 +4921,16 @@ fn generate_enum_json_docs_part(docs: &str) -> proc_macro2::TokenStream {
 /// Generates the JSON schema method for plain enums conditionally.
 fn generate_plain_enum_json_schema_method(
     enumerated: &[proc_macro2::TokenStream],
+    def_name: &str,
 ) -> proc_macro2::TokenStream {
     #[cfg(feature = "jsonschema")]
     {
-        generate_plain_enum_json_schema_method_impl(enumerated)
+        generate_plain_enum_json_schema_method_impl(enumerated, def_name)
     }
 
     #[cfg(not(feature = "jsonschema"))]
     {
-        let _: &_ = &enumerated; // Suppress unused variable warning
+        let _: &_ = &(enumerated, def_name); // Suppress unused variable warning
         quote::quote! {
             // JSON schema method not available - jsonschema feature disabled
             // To enable: add "jsonschema" to your features
@@ -5028,15 +5019,9 @@ fn generate_plain_enum_zod_schema_method(
 /// Generates the JSON schema method for discriminated enums conditionally.
 fn generate_discriminated_enum_json_schema_method(
     main_schema_code: &proc_macro2::TokenStream,
+    def_name: &str,
 ) -> proc_macro2::TokenStream {
-    let body = quote::quote! { { #main_schema_code } };
-    let value = emitted_self_reference()
-        .map_or_else(|| body.clone(), |name| recursive_document(&name, &body));
-    quote::quote! {
-        pub fn json_schema() -> serde_json::Value {
-            #value
-        }
-    }
+    json_schema_methods(def_name, &quote::quote! { { #main_schema_code } })
 }
 
 #[cfg(feature = "typescript")]
@@ -5235,11 +5220,7 @@ fn generate_alias_json_schema_method(
     {
         let body = build_tuple_element_json_schema(&alias_json_schema_field_def(alias, field_def))
             .unwrap_or_else(|rejection| alias_json_schema_rejection(export_name, &rejection));
-        quote! {
-            pub fn json_schema() -> serde_json::Value {
-                #body
-            }
-        }
+        json_schema_methods(export_name, &body)
     }
     #[cfg(not(feature = "jsonschema"))]
     {

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -450,7 +450,7 @@ fn struct_schema_example_carries_no_cfg_attribute() {
 #[test]
 fn branded_json_schema_method_carries_no_cfg_attribute() {
     let args = super::ModelSchemaArgs::default();
-    let tokens = super::build_branded_json_schema_method(&args, "string");
+    let tokens = super::build_branded_json_schema_method(&args, "string", "DocumentId");
     assert_no_cfg_attribute(&tokens, "build_branded_json_schema_method");
 }
 
@@ -519,8 +519,13 @@ fn an_alias_of_an_unrenderable_target_emits_only_the_compile_error() {
             "for {alias_source}, got: {tokens}"
         );
         assert!(
-            !tokens.contains("json !"),
-            "for {alias_source}, got: {tokens}"
+            tokens.contains("= compile_error !"),
+            "the description is the diagnostic, not a schema: for {alias_source}, got: {tokens}"
+        );
+        assert!(
+            !tokens.contains("\"type\""),
+            "no schema for the rejected target is left beside the diagnostic: \
+             for {alias_source}, got: {tokens}"
         );
     }
 }
@@ -544,7 +549,7 @@ fn an_alias_type_parameter_is_erased_at_every_depth() {
         let tokens =
             super::generate_alias_json_schema_method(&alias, "HolderType", &field_def).to_string();
         assert!(
-            !tokens.contains("Schema :: json_schema ()"),
+            !tokens.contains("_schema :: Schema ::"),
             "for {alias_source}, got: {tokens}"
         );
     }
@@ -1160,7 +1165,7 @@ fn a_nested_enum_keyed_map_value_renders_its_inner_members() {
         ),
         (
             "HashMap<Slot, HashMap<String, Inner>>",
-            r#"serde_json :: json ! ({ "type" : "object" , "additionalProperties" : inner_schema :: Schema :: json_schema () })"#,
+            r#"serde_json :: json ! ({ "type" : "object" , "additionalProperties" : inner_schema :: Schema :: json_schema_within (in_flight , hoisted_defs) })"#,
         ),
         (
             "HashMap<Slot, Vec<HashMap<String, String>>>",
@@ -1190,7 +1195,7 @@ fn a_nested_enum_keyed_map_value_renders_its_inner_members() {
 fn a_generic_sibling_enum_keyed_map_value_emits_the_sibling_schema() {
     let tokens = map_field_schema("HashMap<Slot, Wrapper<String>>").to_string();
     assert!(
-        tokens.contains("let value_schema = wrapper_schema :: Schema :: json_schema () ;"),
+        tokens.contains("let value_schema = wrapper_schema :: Schema :: json_schema_within (in_flight , hoisted_defs) ;"),
         "got: {tokens}"
     );
 }
@@ -1276,14 +1281,14 @@ fn a_vec_sibling_enum_keyed_map_value_arrays_the_sibling_schema() {
     let arrayed = map_field_schema("HashMap<Slot, Vec<Inner>>").to_string();
     assert!(
         arrayed.contains(
-            r#"let value_schema = serde_json :: json ! ({ "type" : "array" , "items" : inner_schema :: Schema :: json_schema () }) ;"#
+            r#"let value_schema = serde_json :: json ! ({ "type" : "array" , "items" : inner_schema :: Schema :: json_schema_within (in_flight , hoisted_defs) }) ;"#
         ),
         "got: {arrayed}"
     );
 
     let single = map_field_schema("HashMap<Slot, Inner>").to_string();
     assert!(
-        single.contains("let value_schema = inner_schema :: Schema :: json_schema () ;"),
+        single.contains("let value_schema = inner_schema :: Schema :: json_schema_within (in_flight , hoisted_defs) ;"),
         "got: {single}"
     );
 }
@@ -1545,7 +1550,7 @@ fn a_nested_string_keyed_map_value_renders_its_inner_members() {
         ),
         (
             "HashMap<String, HashMap<String, Inner>>",
-            r#"{ "type" : "object" , "additionalProperties" : inner_schema :: Schema :: json_schema () }"#,
+            r#"{ "type" : "object" , "additionalProperties" : inner_schema :: Schema :: json_schema_within (in_flight , hoisted_defs) }"#,
         ),
         (
             "HashMap<String, Option<HashMap<String, String>>>",
@@ -1580,7 +1585,7 @@ fn a_vec_of_maps_string_keyed_map_value_renders_its_inner_members() {
         ),
         (
             "HashMap<String, Vec<HashMap<String, Inner>>>",
-            r#"{ "type" : "array" , "items" : { "type" : "object" , "additionalProperties" : inner_schema :: Schema :: json_schema () } }"#,
+            r#"{ "type" : "array" , "items" : { "type" : "object" , "additionalProperties" : inner_schema :: Schema :: json_schema_within (in_flight , hoisted_defs) } }"#,
         ),
     ] {
         let tokens = map_field_schema(map_type).to_string();
@@ -1931,19 +1936,19 @@ fn a_sibling_string_keyed_map_value_emits_the_sibling_schema() {
     for (map_type, expected) in [
         (
             "HashMap<String, Inner>",
-            "inner_schema :: Schema :: json_schema ()",
+            "inner_schema :: Schema :: json_schema_within (in_flight , hoisted_defs)",
         ),
         (
             "HashMap<String, Vec<Inner>>",
-            r#"serde_json :: json ! ({ "type" : "array" , "items" : inner_schema :: Schema :: json_schema () })"#,
+            r#"serde_json :: json ! ({ "type" : "array" , "items" : inner_schema :: Schema :: json_schema_within (in_flight , hoisted_defs) })"#,
         ),
         (
             "HashMap<String, Option<Inner>>",
-            r#"serde_json :: json ! ({ "anyOf" : [inner_schema :: Schema :: json_schema () , { "type" : "null" }] })"#,
+            r#"serde_json :: json ! ({ "anyOf" : [inner_schema :: Schema :: json_schema_within (in_flight , hoisted_defs) , { "type" : "null" }] })"#,
         ),
         (
             "HashMap<String, Option<Vec<Inner>>>",
-            r#"serde_json :: json ! ({ "anyOf" : [serde_json :: json ! ({ "type" : "array" , "items" : inner_schema :: Schema :: json_schema () }) , { "type" : "null" }] })"#,
+            r#"serde_json :: json ! ({ "anyOf" : [serde_json :: json ! ({ "type" : "array" , "items" : inner_schema :: Schema :: json_schema_within (in_flight , hoisted_defs) }) , { "type" : "null" }] })"#,
         ),
     ] {
         let tokens = map_field_schema(map_type).to_string();
@@ -1973,7 +1978,9 @@ fn an_aliased_string_keyed_map_value_resolves_its_module_through_the_registry() 
     for map_type in ["HashMap<String, Inner>", "HashMap<String, Vec<Inner>>"] {
         let tokens = map_field_schema(map_type).to_string();
         assert!(
-            tokens.contains("inner_type_schema :: Schema :: json_schema ()"),
+            tokens.contains(
+                "inner_type_schema :: Schema :: json_schema_within (in_flight , hoisted_defs)"
+            ),
             "for {map_type}, got: {tokens}"
         );
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -32,27 +32,8 @@ pub struct AliasInfo {
     pub module_name: String,
 }
 
-/// The type the running expansion describes, and the `$defs` name a reference back to it was
-/// emitted under.
-///
-/// A JSON schema names a type by inlining it, which a type naming itself cannot be described by —
-/// the inlining has nothing to stop it. Recognizing that case belongs where references are
-/// emitted, which is far from the item being expanded, so the name travels here.
-#[cfg(feature = "jsonschema")]
-#[derive(Default)]
-struct ExpansionSelfReference {
-    def_name: Option<String>,
-    rust_ident: String,
-}
-
 thread_local! {
     static ALIAS_INFO: RefCell<HashMap<String, AliasInfo>> = RefCell::new(HashMap::new());
-}
-
-#[cfg(feature = "jsonschema")]
-thread_local! {
-    static SELF_REFERENCE: RefCell<ExpansionSelfReference> =
-        RefCell::new(ExpansionSelfReference::default());
 }
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
@@ -79,42 +60,6 @@ pub fn register_alias_info(
 
 pub fn lookup_alias_info(rust_ident: &str) -> Option<AliasInfo> {
     ALIAS_INFO.with(|map| map.borrow().get(rust_ident).cloned())
-}
-
-/// Names the type the expansion starting now describes.
-///
-/// Every expansion sets it. A name left behind by the previous one would make an unrelated type's
-/// reference read as a self reference and describe as a `$ref` into a `$defs` nobody wrote.
-#[cfg(feature = "jsonschema")]
-pub fn begin_expansion(rust_ident: &str) {
-    SELF_REFERENCE.with(|cell| {
-        *cell.borrow_mut() = ExpansionSelfReference {
-            rust_ident: rust_ident.to_owned(),
-            def_name: None,
-        };
-    });
-}
-
-/// The `$defs` name to describe `rust_ident` under when it is the type being expanded, recording
-/// that this document now needs the entry the reference points into.
-///
-/// `None` for every other name, which is described by inlining as before.
-#[cfg(feature = "jsonschema")]
-pub fn self_reference_def_name(rust_ident: &str) -> Option<String> {
-    if !SELF_REFERENCE.with(|cell| cell.borrow().rust_ident == rust_ident) {
-        return None;
-    }
-    let def_name = lookup_alias_info(rust_ident)
-        .map_or_else(|| safe_type_name(rust_ident), |info| info.export_name);
-    SELF_REFERENCE.with(|cell| cell.borrow_mut().def_name = Some(def_name.clone()));
-    Some(def_name)
-}
-
-/// The `$defs` name the expansion emitted a self reference under, or `None` when it named itself
-/// nowhere and describes fully inlined.
-#[cfg(feature = "jsonschema")]
-pub fn emitted_self_reference() -> Option<String> {
-    SELF_REFERENCE.with(|cell| cell.borrow().def_name.clone())
 }
 
 pub fn safe_type_name(key: &str) -> String {

--- a/tests/recursive_type_tests/tests.rs
+++ b/tests/recursive_type_tests/tests.rs
@@ -6,7 +6,10 @@
 /// status the parent asserts on, so a regression fails one test instead of killing the suite.
 #[cfg(feature = "jsonschema")]
 mod describes {
-    use super::{ChainNode, DynamicValueTest, RecursiveMapEnum, TreeNode};
+    use super::{
+        ChainNode, CycleA, DynamicValueTest, Holder, Nest, Ping, Pong, RecursiveMapEnum, Registry,
+        TreeNode,
+    };
     use serde_json::{Value, json};
     use std::env;
     use std::process::Command;
@@ -38,6 +41,42 @@ mod describes {
         }
     }
 
+    /// The pointer every `$ref` anywhere in a description carries, in document order.
+    fn references(value: &Value) -> Vec<String> {
+        match value {
+            Value::Object(members) => members
+                .iter()
+                .flat_map(|(key, member)| {
+                    if key == "$ref" {
+                        member.as_str().map(ToOwned::to_owned).into_iter().collect()
+                    } else {
+                        references(member)
+                    }
+                })
+                .collect(),
+            Value::Array(items) => items.iter().flat_map(references).collect(),
+            Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => Vec::new(),
+        }
+    }
+
+    /// Walks every reference in a description against the description itself, which is what a
+    /// validator reading it does. A pointer landing on nothing — or on the null a definition
+    /// reserved but never filled would leave — is the dangling reference.
+    fn every_reference_resolves(document: &Value) -> usize {
+        let found = references(document);
+        for reference in &found {
+            let resolved = reference
+                .strip_prefix('#')
+                .and_then(|path| document.pointer(path))
+                .filter(|target| !target.is_null());
+            assert!(
+                resolved.is_some(),
+                "`{reference}` resolves to nothing in {document}"
+            );
+        }
+        found.len()
+    }
+
     fn produce(description: &str) -> String {
         match description {
             "vec_self_json" => serde_json::to_string(&TreeNode::json_schema()).unwrap(),
@@ -47,6 +86,13 @@ mod describes {
             "map_self_json" => serde_json::to_string(&RecursiveMapEnum::json_schema()).unwrap(),
             "enum_self_json" => serde_json::to_string(&DynamicValueTest::json_schema()).unwrap(),
             "enum_self_ts" => DynamicValueTest::ts_definition(),
+            "mutual_ping_json" => serde_json::to_string(&Ping::json_schema()).unwrap(),
+            "mutual_pong_json" => serde_json::to_string(&Pong::json_schema()).unwrap(),
+            "mutual_ping_ts" => Ping::ts_definition(),
+            "cycle_json" => serde_json::to_string(&CycleA::json_schema()).unwrap(),
+            "held_json" => serde_json::to_string(&Holder::json_schema()).unwrap(),
+            "registry_json" => serde_json::to_string(&Registry::json_schema()).unwrap(),
+            "nested_json" => serde_json::to_string(&Nest::json_schema()).unwrap(),
             other => format!("no description named `{other}`"),
         }
     }
@@ -156,6 +202,108 @@ mod describes {
         );
     }
 
+    /// Neither expansion can see the cycle: each is written before the other exists, and a type
+    /// names the other by inlining it. Only the run knows it has come back around.
+    #[test]
+    fn two_types_naming_each_other_terminate_and_resolve() {
+        for (description, def_name) in [("mutual_ping_json", "Ping"), ("mutual_pong_json", "Pong")]
+        {
+            let document: Value = serde_json::from_str(&produced(description)).unwrap();
+
+            assert_eq!(document["$ref"], json!(format!("#/$defs/{def_name}")));
+            assert!(
+                every_reference_resolves(&document) >= 2,
+                "the pair should name each other by reference: {document}"
+            );
+            assert!(
+                depth(&document) <= 12,
+                "unrolled rather than named: {document}"
+            );
+        }
+    }
+
+    /// A cycle longer than a pair closes just the same, and closes on the one name the run
+    /// re-entered rather than on every name it passed through.
+    #[test]
+    fn a_three_type_cycle_terminates_and_resolves() {
+        let document: Value = serde_json::from_str(&produced("cycle_json")).unwrap();
+
+        assert_eq!(document["$ref"], json!("#/$defs/CycleA"));
+        assert_eq!(
+            document["$defs"].as_object().map(serde_json::Map::len),
+            Some(1),
+            "only the re-entered name needs a definition: {document}"
+        );
+        assert!(every_reference_resolves(&document) >= 1);
+        assert!(
+            depth(&document) <= 16,
+            "unrolled rather than named: {document}"
+        );
+    }
+
+    /// A recursive type carries references that are pointers from a document root. Held by another
+    /// type, the root is the holder's, so that is where its definition has to be.
+    #[test]
+    fn a_recursive_type_held_by_another_resolves_in_the_holders_document() {
+        let document: Value = serde_json::from_str(&produced("held_json")).unwrap();
+
+        assert_eq!(document["type"], json!("object"));
+        assert_eq!(
+            document["properties"]["root"],
+            json!({ "$ref": "#/$defs/Node" })
+        );
+        assert_eq!(document["required"], json!(["root"]));
+        assert_eq!(
+            document["$defs"]["Node"]["properties"]["children"],
+            json!({ "type": "array", "items": { "$ref": "#/$defs/Node" } })
+        );
+        assert!(every_reference_resolves(&document) >= 2);
+    }
+
+    /// The definition is hoisted once however many positions name the type, and every position
+    /// points at that one entry — a field, an array element, a map value.
+    #[test]
+    fn a_recursive_type_named_from_several_positions_is_hoisted_once() {
+        let document: Value = serde_json::from_str(&produced("registry_json")).unwrap();
+
+        let reference = json!({ "$ref": "#/$defs/Node" });
+        assert_eq!(document["properties"]["primary"], reference);
+        assert_eq!(document["properties"]["spares"]["items"], reference);
+        assert_eq!(
+            document["properties"]["by_name"]["additionalProperties"],
+            reference
+        );
+        assert_eq!(
+            document["$defs"].as_object().map(serde_json::Map::len),
+            Some(1),
+            "one name, one definition: {document}"
+        );
+        assert_eq!(
+            document["$defs"]["Node"]["properties"]["val"],
+            json!({ "type": "string" }),
+            "the hoisted entry is the body, not the place held for it: {document}"
+        );
+        assert!(every_reference_resolves(&document) >= 4);
+    }
+
+    /// A recursive type holding another one puts two definitions at the same root, and the
+    /// document is the reference into its own.
+    #[test]
+    fn a_recursive_type_holding_another_hoists_both_definitions() {
+        let document: Value = serde_json::from_str(&produced("nested_json")).unwrap();
+
+        assert_eq!(document["$ref"], json!("#/$defs/Nest"));
+        assert_eq!(
+            document["$defs"]["Nest"]["properties"]["inner"],
+            json!({ "$ref": "#/$defs/Node" })
+        );
+        assert_eq!(
+            document["$defs"]["Nest"]["properties"]["kids"],
+            json!({ "type": "array", "items": { "$ref": "#/$defs/Nest" } })
+        );
+        assert!(every_reference_resolves(&document) >= 3);
+    }
+
     #[test]
     fn typescript_names_the_type_it_is_defining() {
         let vec_self = produced("vec_self_ts");
@@ -174,6 +322,14 @@ mod describes {
         assert!(
             enum_self.contains("Array<DynamicValueTest>"),
             "a recursive variant names the enum: {enum_self}"
+        );
+
+        // The JSDoc embeds the JSON schema, so a pair that cannot be described takes the
+        // TypeScript surface down with it.
+        let mutual = produced("mutual_ping_ts");
+        assert!(
+            mutual.contains("pong: Array<Pong>;"),
+            "a mutually recursive field names the other type: {mutual}"
         );
     }
 }
@@ -199,6 +355,84 @@ pub struct ChainNode {
 pub struct Address {
     pub city: String,
     pub street: String,
+}
+
+// The types below exist to be described as JSON schema and nothing else — the Zod and TypeScript
+// surfaces they also carry are read off the types above. So they are written only where something
+// asks them what they describe as.
+
+/// One half of a pair that names the other half, written before that half exists.
+#[cfg(feature = "jsonschema")]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Ping {
+    pub pong: Vec<Pong>,
+}
+
+/// The other half, which names the first back.
+#[cfg(feature = "jsonschema")]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Pong {
+    pub ping: Vec<Ping>,
+}
+
+/// The head of a cycle three types long.
+#[cfg(feature = "jsonschema")]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CycleA {
+    pub b: CycleB,
+}
+
+#[cfg(feature = "jsonschema")]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CycleB {
+    pub c: CycleC,
+}
+
+#[cfg(feature = "jsonschema")]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CycleC {
+    pub a: Vec<CycleA>,
+}
+
+/// A type that names itself, held by types that are not recursive themselves.
+#[cfg(feature = "jsonschema")]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Node {
+    pub children: Vec<Self>,
+    pub val: String,
+}
+
+/// Holds one recursive type in one field.
+#[cfg(feature = "jsonschema")]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Holder {
+    pub root: Node,
+}
+
+/// Names the same recursive type from a field, an array element, and a map value.
+#[cfg(feature = "jsonschema")]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Registry {
+    pub by_name: HashMap<String, Node>,
+    pub primary: Node,
+    pub spares: Vec<Node>,
+}
+
+/// Names itself and another recursive type, so one document holds both definitions.
+#[cfg(feature = "jsonschema")]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Nest {
+    pub inner: Node,
+    pub kids: Vec<Self>,
 }
 
 /// Complex `DynamicValue`-like enum with multiple recursive variants.


### PR DESCRIPTION
Two composition holes left after #57, one mechanism for both:

- **Mutual recursion** (`Ping`/`Pong`, 3-cycles) still overflowed — an expansion-scoped marker can only know the one name it is describing.
- **Inlined recursive documents** carried a `$ref` pointing at a root that lacked the `$defs`.

Every generated schema module now publishes `json_schema_within(in_flight, hoisted_defs)` beside `json_schema()`: a re-entered name reserves its `$defs` entry and returns `{"$ref": "#/$defs/<name>"}`; the finishing call files its real body; the outermost call roots all hoisted defs at the document root. All sibling references flow through the one choke point, so field, array-element, and map-value positions inherit.

- Red-first through the abort-safe harness (SIGABRT → failed assertion): Ping/Pong, A→B→C→A, and the dangling-ref fixtures; resolution asserted by real pointer walks that fail on missing **or null**.
- Self-reference output proven byte-identical by pre-captured differential dump vs master (insertion-order-sensitive, matched).
- The #57 macro-time marker is replaced outright — recorded rationale: it produced whole nested documents at field positions, which is exactly what blocked hoisting.

Gates: `just check` green during work; full powerset once at acceptance — green.