### PR TITLE
fix: a flattened recursive base contributes its resolved body

### DIFF
--- a/src/features/jsonschema.rs
+++ b/src/features/jsonschema.rs
@@ -2,6 +2,9 @@
 //!
 //! This module handles JSON schema generation when the "jsonschema" feature is enabled.
 
+/// What every pointer the crate writes opens with; what follows it is the name being deferred.
+const DEFS_PREFIX: &str = "#/$defs/";
+
 /// Check if we should generate JSON schema methods.
 #[cfg(test)]
 pub const fn should_generate_json_schema() -> bool {
@@ -14,7 +17,7 @@ pub const fn should_generate_json_schema() -> bool {
 /// array, and the draft before it spells the same array with `items`/`additionalItems`), whose
 /// deferred schema is a `$ref` into the document's own `$defs`.
 fn defs_pointer(def_name: &str) -> String {
-    format!("#/$defs/{def_name}")
+    format!("{DEFS_PREFIX}{def_name}")
 }
 
 /// The pair of JSON-schema methods every schema module publishes.
@@ -123,6 +126,7 @@ fn flattened_object_body(
     json_schema_fields: &[proc_macro2::TokenStream],
     flatten_json_schemas: &[proc_macro2::TokenStream],
 ) -> proc_macro2::TokenStream {
+    let defs_prefix = DEFS_PREFIX;
     quote::quote! {
         {
             fn merge_object_schemas(
@@ -155,6 +159,21 @@ fn flattened_object_body(
                 out
             }
 
+            // A flattened base that names itself describes as a reference into the definitions
+            // being hoisted, and a reference is the one thing with no properties to merge. The
+            // body it points at is written by then — the frame that deferred the name fills the
+            // entry in before it returns — so the merge reads it back. The entry is still only
+            // reserved when the flatten is itself what came back around, and a base that holds
+            // itself has no closed object to contribute.
+            fn deferred_body<'doc>(
+                schema: &'doc serde_json::Value,
+                defs: &'doc serde_json::Map<String, serde_json::Value>,
+            ) -> Option<&'doc serde_json::Value> {
+                let pointer = schema.get("$ref")?.as_str()?;
+                let name = pointer.strip_prefix(#defs_prefix)?;
+                defs.get(name).filter(|body| body.is_object())
+            }
+
             fn branches_of(
                 schema: &serde_json::Value,
             ) -> Vec<serde_json::Map<String, serde_json::Value>> {
@@ -182,7 +201,8 @@ fn flattened_object_body(
 
             let mut branches: Vec<serde_json::Map<String, serde_json::Value>> = vec![schema_obj];
             for fs in &flattened {
-                let fs_branches = branches_of(fs);
+                let fs_body = deferred_body(fs, hoisted_defs).unwrap_or(fs);
+                let fs_branches = branches_of(fs_body);
                 if fs_branches.is_empty() {
                     continue;
                 }

--- a/tests/flatten_tests/tests.rs
+++ b/tests/flatten_tests/tests.rs
@@ -40,6 +40,25 @@ struct ExtraPart {
     priority: i64,
 }
 
+/// A base that names itself, written only where something asks what it describes as: what a
+/// flattened branch that is a reference rather than an object contributes to its container.
+#[cfg(feature = "jsonschema")]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct FlatHolder {
+    #[serde(flatten)]
+    base: FlatNode,
+    extra: String,
+}
+
+#[cfg(feature = "jsonschema")]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct FlatNode {
+    children: Vec<Self>,
+    val: String,
+}
+
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct FlattenOnly {
@@ -243,6 +262,65 @@ fn test_no_flatten_json_schema_closes_additional_properties() {
     assert!(schema.get("oneOf").is_none());
 }
 
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_flatten_recursive_base_contributes_its_fields() {
+    let schema = FlatHolder::json_schema();
+    assert!(schema.get("oneOf").is_none());
+    assert_eq!(
+        schema["additionalProperties"],
+        serde_json::Value::Bool(false)
+    );
+    let props = schema["properties"].as_object().unwrap();
+    assert!(props.contains_key("children"));
+    assert!(props.contains_key("val"));
+    assert!(props.contains_key("extra"));
+    let req = schema["required"].as_array().unwrap();
+    for name in ["children", "val", "extra"] {
+        assert!(
+            req.iter().any(|v| v.as_str() == Some(name)),
+            "{name} missing from {req:?}"
+        );
+    }
+}
+
+/// The base's own self-reference is written from the container's root, so it has to resolve there.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_flatten_recursive_base_self_reference_resolves_from_the_container() {
+    let schema = FlatHolder::json_schema();
+    let reference = schema["properties"]["children"]["items"]["$ref"]
+        .as_str()
+        .unwrap();
+    let pointer = reference.strip_prefix('#').unwrap();
+    let resolved = schema.pointer(pointer).unwrap();
+    let resolved_props = resolved["properties"].as_object().unwrap();
+    assert!(resolved_props.contains_key("children"));
+    assert!(resolved_props.contains_key("val"));
+}
+
+/// Flattening a base that does not name itself writes the document it wrote before, byte for byte.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_non_recursive_flatten_documents_are_byte_identical() {
+    assert_eq!(
+        serde_json::to_string(&DataElementSampleValueEntry::json_schema()).unwrap(),
+        r#"{"type":"object","oneOf":[{"type":"object","properties":{"dataElementId":{"type":"string"},"dataType":{"type":"string","const":"Alphanumeric"},"sampleValues":{"type":"array","items":{"type":"string"}}},"required":["dataElementId","dataType","sampleValues"],"additionalProperties":false},{"type":"object","properties":{"dataElementId":{"type":"string"},"dataType":{"type":"string","const":"Logical"},"sampleValues":{"type":"array","items":{"type":"boolean"}}},"required":["dataElementId","dataType","sampleValues"],"additionalProperties":false},{"type":"object","properties":{"dataElementId":{"type":"string"},"dataType":{"type":"string","const":"Numeric"},"sampleValues":{"type":"array","items":{"type":"integer"}}},"required":["dataElementId","dataType","sampleValues"],"additionalProperties":false}]}"#
+    );
+    assert_eq!(
+        serde_json::to_string(&MultiFlatten::json_schema()).unwrap(),
+        r#"{"type":"object","properties":{"id":{"type":"string"},"owner":{"type":"string"},"priority":{"type":"integer"}},"required":["id","owner","priority"],"additionalProperties":false}"#
+    );
+    assert_eq!(
+        serde_json::to_string(&FlattenOnly::json_schema()).unwrap(),
+        r#"{"type":"object","oneOf":[{"type":"object","properties":{"dataType":{"type":"string","const":"Alphanumeric"},"sampleValues":{"type":"array","items":{"type":"string"}}},"required":["dataType","sampleValues"],"additionalProperties":false},{"type":"object","properties":{"dataType":{"type":"string","const":"Logical"},"sampleValues":{"type":"array","items":{"type":"boolean"}}},"required":["dataType","sampleValues"],"additionalProperties":false},{"type":"object","properties":{"dataType":{"type":"string","const":"Numeric"},"sampleValues":{"type":"array","items":{"type":"integer"}}},"required":["dataType","sampleValues"],"additionalProperties":false}]}"#
+    );
+    assert_eq!(
+        serde_json::to_string(&NoFlatten::json_schema()).unwrap(),
+        r#"{"type":"object","additionalProperties":false,"properties":{"id":{"type":"string"},"name":{"type":"string"}},"required":["id","name"]}"#
+    );
+}
+
 // ========================================================================
 // Serialization round-trip
 // ========================================================================
@@ -266,4 +344,27 @@ fn test_flatten_serialization_is_flat() {
 
     let back: DataElementSampleValueEntry = serde_json::from_value(json).unwrap();
     assert_eq!(back, entry);
+}
+
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_flatten_recursive_base_serializes_flat() {
+    let holder = FlatHolder {
+        base: FlatNode {
+            children: vec![FlatNode {
+                children: Vec::new(),
+                val: "leaf".to_owned(),
+            }],
+            val: "root".to_owned(),
+        },
+        extra: "x".to_owned(),
+    };
+    let json = serde_json::to_value(&holder).unwrap();
+    assert_eq!(json["val"], "root");
+    assert_eq!(json["extra"], "x");
+    assert_eq!(json["children"][0]["val"], "leaf");
+    assert!(json.get("base").is_none());
+
+    let back: FlatHolder = serde_json::from_value(json).unwrap();
+    assert_eq!(back, holder);
 }


### PR DESCRIPTION
`#[serde(flatten)]` over a recursive base dropped every one of the base's fields: the base describes as `{"$ref": "#/$defs/<Name>"}` after #58, and `merge_object_schemas` reads only `properties`/`required` — which a reference lacks.

- The flatten loop resolves a ref-shaped branch with one pointer walk into the container's own `hoisted_defs` (the body is guaranteed written by the frame that deferred it) and merges the resolved body; inner self-refs resolve unchanged since the defs already root at the container.
- `DEFS_PREFIX` lifted so the pointer the crate writes and the one the merge reads are a single string.
- Red-first (fields absent + pointer walk unwrapping None on the unchanged tree); all four pre-existing non-recursive flatten documents pinned byte-identical.
- Discovered and filed, not fixed: a flatten *cycle* (A flattens B flattens Box<A>) still drops the second turn — no finite value inhabits that type anyway; raw dump on the task.

Gates: `just check` green during work; full powerset once at acceptance — green.
