### PR TITLE
fix: validate() reaches constrained values through wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -821,7 +821,26 @@ match reg.validate() {
 
 The macro also generates into the type's schema module:
 - `validate_{field}_value(&FieldType) -> Result<(), String>` -- pure static validator per field
-- `deserialize_{field}(D) -> Result<FieldType, E>` -- serde hook that calls the static validator
+- `deserialize_{field}(D) -> Result<FieldType, E>` -- serde hook that calls the static validator, emitted for a bare field only
+
+#### Constraints under `Option`, wrappers, and sequences
+
+A constraint describes the value the field puts on the wire, wherever it was written. `validate()` therefore reaches through everything the parser reads through -- an `Option`, a transparent wrapper (`Box`, `Rc`, `Arc`, `Cow`), and every sequence level (`Vec`, `VecDeque`, `HashSet`, `BTreeSet`, `LinkedList`, `BinaryHeap`, arrays and slices) -- and checks the innermost value, which is the same place the Zod, TypeScript and JSON Schema surfaces put it.
+
+```rust
+#[model_schema()]
+#[derive(Serialize, Deserialize)]
+pub struct Article {
+    #[model_schema_prop(minLength = 3)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subtitle: Option<String>,   // checked inside the Some; a None is nothing to check
+
+    #[model_schema_prop(minLength = 3)]
+    pub tags: Vec<String>,          // checked per element, once per failing tag
+}
+```
+
+Serde-side enforcement is narrower: the generated `deserialize_{field}` hook answers for the constrained value itself, so it is attached only when the field is written bare. A wrapped field is checked by `validate()`.
 
 ### Literal Values
 

--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -722,7 +722,7 @@ pub fn is_sequence_wrapper(name: &str) -> bool {
 /// not a type argument and never reaches the collected arguments, so a `Cow` arrives with the one
 /// argument a `Box` arrives with. The interior-mutability wrappers are absent — that is a wider
 /// list than this defect was measured over, not a claim that they write anything else.
-fn is_transparent_wrapper(name: &str) -> bool {
+pub fn is_transparent_wrapper(name: &str) -> bool {
     matches!(name, "Arc" | "Box" | "Cow" | "Rc")
 }
 

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -41,8 +41,11 @@ use crate::features::serde::{SerdeFieldMeta, SerdeTypeMeta};
 #[cfg(feature = "serde")]
 use crate::field_type::{parse_serde_field_attributes, parse_serde_type_attributes};
 
-#[cfg(feature = "jsonschema")]
+#[cfg(any(feature = "jsonschema", feature = "serde"))]
 use crate::field_type::is_sequence_wrapper;
+
+#[cfg(feature = "serde")]
+use crate::field_type::is_transparent_wrapper;
 
 use crate::features::model_schema_prop::parse_model_schema_prop_attributes;
 
@@ -138,6 +141,34 @@ struct BrandedNewtypeOutput<'parts> {
     schema_impl_items: &'parts [proc_macro2::TokenStream],
     validate_method: &'parts proc_macro2::TokenStream,
     validation_tokens: &'parts proc_macro2::TokenStream,
+}
+
+/// What a field bottoms out in, under the wrappers it was written beneath.
+#[cfg(feature = "serde")]
+struct ConstrainedShape {
+    leaf: ConstraintLeaf,
+    wraps: Vec<ConstraintWrap>,
+}
+
+/// The value a constrained field ultimately writes, and how it is spelled.
+#[cfg(feature = "serde")]
+enum ConstraintLeaf {
+    /// The bare Rust numeric type, which is the validator's parameter type.
+    Number(&'static str),
+    Str,
+}
+
+/// A wrapper a constrained field can be written under, outermost first.
+///
+/// Each one says how to reach one level further in, and nothing else: an `Option` yields what its
+/// `Some` holds, a sequence yields each element, and a transparent wrapper — being nothing on the
+/// wire — yields only what it derefs to.
+#[cfg(feature = "serde")]
+#[derive(Clone, Copy)]
+enum ConstraintWrap {
+    Optional,
+    Sequence,
+    Transparent,
 }
 
 /// Holds the generated validation code for a single field.
@@ -4215,13 +4246,93 @@ fn write_field_type_and_schema(
     }
 }
 
-/// Generates the static validator and serde deserializer for a String field with constraints.
+/// The binding a walk step introduces, numbered by depth so no two steps of one chain collide.
+#[cfg(feature = "serde")]
+fn wrap_binding(depth: usize) -> proc_macro2::Ident {
+    proc_macro2::Ident::new(&format!("value_{depth}"), proc_macro2::Span::call_site())
+}
+
+/// Builds the `validate()` contribution for a field, reaching through its wrappers to run the
+/// check on the value the constraint actually describes.
+///
+/// A bare field is checked in place, which is the whole of the body when there is nothing to reach
+/// through. Otherwise the chain is bound once and walked: the head binding keeps every later step
+/// dereferencing a binding rather than a fresh borrow, and the block keeps its names off the
+/// enclosing body, where the next field's chain reuses them.
+#[cfg(feature = "serde")]
+fn build_field_validation(
+    wraps: &[ConstraintWrap],
+    field_ident_tok: &proc_macro2::Ident,
+    validate_value_fn_ident: &proc_macro2::Ident,
+) -> proc_macro2::TokenStream {
+    if wraps.is_empty() {
+        return quote! {
+            if let Err(e) = #validate_value_fn_ident(&self.#field_ident_tok) {
+                errors.push(e);
+            }
+        };
+    }
+    let head = wrap_binding(0);
+    let walk = walk_wraps(wraps, &head, 1, validate_value_fn_ident);
+    quote! {
+        {
+            let #head = &self.#field_ident_tok;
+            #walk
+        }
+    }
+}
+
+/// Emits the reach-through for one wrapper and, at the end of the chain, the check itself.
+#[cfg(feature = "serde")]
+fn walk_wraps(
+    wraps: &[ConstraintWrap],
+    value: &proc_macro2::Ident,
+    depth: usize,
+    validate_value_fn_ident: &proc_macro2::Ident,
+) -> proc_macro2::TokenStream {
+    let Some((wrap, rest)) = wraps.split_first() else {
+        return quote! {
+            if let Err(e) = #validate_value_fn_ident(#value) {
+                errors.push(e);
+            }
+        };
+    };
+    let next = wrap_binding(depth);
+    let inner = walk_wraps(
+        rest,
+        &next,
+        depth.saturating_add(1),
+        validate_value_fn_ident,
+    );
+    match *wrap {
+        // A `None` writes nothing, so there is nothing for the constraint to describe.
+        ConstraintWrap::Optional => quote! {
+            if let Some(#next) = #value {
+                #inner
+            }
+        },
+        ConstraintWrap::Sequence => quote! {
+            for #next in #value {
+                #inner
+            }
+        },
+        ConstraintWrap::Transparent => quote! {
+            let #next = &**#value;
+            #inner
+        },
+    }
+}
+
+/// Generates the static validator for a String field with constraints, plus the serde deserializer
+/// when the field is bare — a wrapped field's declared type is not the validator's, so only the
+/// bare spelling can carry `deserialize_with`.
 ///
 /// Returns (`module_items`, `validate_body`) — both go into the schema module and `validate()` respectively.
 #[cfg(feature = "serde")]
 fn generate_string_validation_code(
     field_ident: &str,
     meta: &ModelSchemaPropMeta,
+    wraps: &[ConstraintWrap],
 ) -> FieldValidationCode {
     let validate_value_fn_name = format!("validate_{field_ident}_value");
     let validate_value_fn_ident =
@@ -4275,30 +4386,32 @@ fn generate_string_validation_code(
         });
     }
 
+    let deserializer = wraps.is_empty().then(|| {
+        quote! {
+            pub fn #deserialize_fn_ident<'de, D>(deserializer: D) -> Result<String, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                use serde::Deserialize;
+                let s = String::deserialize(deserializer)?;
+                #validate_value_fn_ident(&s).map_err(serde::de::Error::custom)?;
+                Ok(s)
+            }
+        }
+    });
+
     let module_items = quote! {
         pub fn #validate_value_fn_ident(value: &str) -> Result<(), String> {
             #(#checks)*
             Ok(())
         }
 
-        pub fn #deserialize_fn_ident<'de, D>(deserializer: D) -> Result<String, D::Error>
-        where
-            D: serde::Deserializer<'de>,
-        {
-            use serde::Deserialize;
-            let s = String::deserialize(deserializer)?;
-            #validate_value_fn_ident(&s).map_err(serde::de::Error::custom)?;
-            Ok(s)
-        }
+        #deserializer
     };
 
     let field_ident_tok = proc_macro2::Ident::new(field_ident, proc_macro2::Span::call_site());
 
-    let validate_body = quote! {
-        if let Err(e) = #validate_value_fn_ident(&self.#field_ident_tok) {
-            errors.push(e);
-        }
-    };
+    let validate_body = build_field_validation(wraps, &field_ident_tok, &validate_value_fn_ident);
 
     FieldValidationCode {
         module_items,
@@ -4306,12 +4419,14 @@ fn generate_string_validation_code(
     }
 }
 
-/// Generates the static validator and serde deserializer for a numeric field with constraints.
+/// Generates the static validator for a numeric field with constraints, plus the serde deserializer
+/// when the field is bare — see `generate_string_validation_code` for why only that spelling gets one.
 #[cfg(feature = "serde")]
 fn generate_numeric_validation_code(
     field_ident: &str,
     rust_type_str: &str,
     meta: &ModelSchemaPropMeta,
+    wraps: &[ConstraintWrap],
 ) -> FieldValidationCode {
     let validate_value_fn_name = format!("validate_{field_ident}_value");
     let validate_value_fn_ident =
@@ -4352,30 +4467,32 @@ fn generate_numeric_validation_code(
         });
     }
 
+    let deserializer = wraps.is_empty().then(|| {
+        quote! {
+            pub fn #deserialize_fn_ident<'de, D>(deserializer: D) -> Result<#rust_type_ident, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                use serde::Deserialize;
+                let v = #rust_type_ident::deserialize(deserializer)?;
+                #validate_value_fn_ident(&v).map_err(serde::de::Error::custom)?;
+                Ok(v)
+            }
+        }
+    });
+
     let module_items = quote! {
         pub fn #validate_value_fn_ident(value: &#rust_type_ident) -> Result<(), String> {
             #(#checks)*
             Ok(())
         }
 
-        pub fn #deserialize_fn_ident<'de, D>(deserializer: D) -> Result<#rust_type_ident, D::Error>
-        where
-            D: serde::Deserializer<'de>,
-        {
-            use serde::Deserialize;
-            let v = #rust_type_ident::deserialize(deserializer)?;
-            #validate_value_fn_ident(&v).map_err(serde::de::Error::custom)?;
-            Ok(v)
-        }
+        #deserializer
     };
 
     let field_ident_tok = proc_macro2::Ident::new(field_ident, proc_macro2::Span::call_site());
 
-    let validate_body = quote! {
-        if let Err(e) = #validate_value_fn_ident(&self.#field_ident_tok) {
-            errors.push(e);
-        }
-    };
+    let validate_body = build_field_validation(wraps, &field_ident_tok, &validate_value_fn_ident);
 
     FieldValidationCode {
         module_items,
@@ -4383,43 +4500,90 @@ fn generate_numeric_validation_code(
     }
 }
 
-/// Determines the concrete bare Rust numeric type for numeric validation, if any.
+/// Reads a field's type down to the value a constraint can land on, collecting the wrappers on the
+/// way.
 ///
-/// Only matches bare types (not wrapped in Vec, Option, etc.).
+/// The three generated surfaces read the same collapsed field, so the constraint they render sits
+/// on the innermost value however it was written; this is what lets the Rust validator land it in
+/// the same place. Anything else — a sibling type, a map, a tuple, a multi-argument generic — has no
+/// value for a length or a range to apply to and yields nothing.
 #[cfg(feature = "serde")]
-fn field_rust_type_str(field: &Field) -> Option<&'static str> {
-    if let syn::Type::Path(tp) = &field.ty
-        && let Some(seg) = tp.path.segments.last()
-        && matches!(seg.arguments, syn::PathArguments::None)
-    {
-        return match seg.ident.to_string().as_str() {
-            "u8" => Some("u8"),
-            "u16" => Some("u16"),
-            "u32" => Some("u32"),
-            "u64" => Some("u64"),
-            "i8" => Some("i8"),
-            "i16" => Some("i16"),
-            "i32" => Some("i32"),
-            "i64" => Some("i64"),
-            "usize" => Some("usize"),
-            "isize" => Some("isize"),
-            "f32" => Some("f32"),
-            "f64" => Some("f64"),
-            _ => None,
-        };
+fn constrained_shape(ty: &syn::Type) -> Option<ConstrainedShape> {
+    let mut wraps = Vec::new();
+    let mut current = ty;
+    loop {
+        if let syn::Type::Array(array) = current {
+            wraps.push(ConstraintWrap::Sequence);
+            current = &array.elem;
+        } else if let syn::Type::Slice(slice) = current {
+            wraps.push(ConstraintWrap::Sequence);
+            current = &slice.elem;
+        } else if let syn::Type::Path(path) = current {
+            let segment = path.path.segments.last()?;
+            if let syn::PathArguments::AngleBracketed(args) = &segment.arguments {
+                wraps.push(generic_wrap(&segment.ident.to_string())?);
+                current = sole_type_argument(args)?;
+            } else if matches!(segment.arguments, syn::PathArguments::None) {
+                let leaf = leaf_for_ident(&segment.ident.to_string())?;
+                return Some(ConstrainedShape { leaf, wraps });
+            } else {
+                return None;
+            }
+        } else {
+            return None;
+        }
     }
-    None
 }
 
-/// Checks if the field is a bare String type (not Vec<String>, Option<String>, etc.).
+/// The wrapper a generic type stands for, or `None` if it is not one the constraint reads through.
 #[cfg(feature = "serde")]
-fn field_is_bare_string(field: &Field) -> bool {
-    if let syn::Type::Path(tp) = &field.ty
-        && let Some(seg) = tp.path.segments.last()
-    {
-        return seg.ident == "String" && matches!(seg.arguments, syn::PathArguments::None);
+fn generic_wrap(ident: &str) -> Option<ConstraintWrap> {
+    if ident == "Option" {
+        Some(ConstraintWrap::Optional)
+    } else if is_sequence_wrapper(ident) {
+        Some(ConstraintWrap::Sequence)
+    } else if is_transparent_wrapper(ident) {
+        Some(ConstraintWrap::Transparent)
+    } else {
+        None
     }
-    false
+}
+
+/// The one type argument a wrapper holds. A lifetime writes nothing and is not one, which is what
+/// lets `Cow<'a, str>` answer here exactly as `Box<str>` does.
+#[cfg(feature = "serde")]
+fn sole_type_argument(args: &syn::AngleBracketedGenericArguments) -> Option<&syn::Type> {
+    let mut types = args.args.iter().filter_map(|arg| {
+        if let syn::GenericArgument::Type(ty) = arg {
+            Some(ty)
+        } else {
+            None
+        }
+    });
+    let only = types.next()?;
+    types.next().is_none().then_some(only)
+}
+
+/// The leaf a bare type name stands for. `str` is `String`'s borrowed form and answers as one; the
+/// numerics name themselves, since the validator's parameter is written from the name.
+#[cfg(feature = "serde")]
+fn leaf_for_ident(ident: &str) -> Option<ConstraintLeaf> {
+    match ident {
+        "String" | "str" => Some(ConstraintLeaf::Str),
+        "u8" => Some(ConstraintLeaf::Number("u8")),
+        "u16" => Some(ConstraintLeaf::Number("u16")),
+        "u32" => Some(ConstraintLeaf::Number("u32")),
+        "u64" => Some(ConstraintLeaf::Number("u64")),
+        "i8" => Some(ConstraintLeaf::Number("i8")),
+        "i16" => Some(ConstraintLeaf::Number("i16")),
+        "i32" => Some(ConstraintLeaf::Number("i32")),
+        "i64" => Some(ConstraintLeaf::Number("i64")),
+        "usize" => Some(ConstraintLeaf::Number("usize")),
+        "isize" => Some(ConstraintLeaf::Number("isize")),
+        "f32" => Some(ConstraintLeaf::Number("f32")),
+        "f64" => Some(ConstraintLeaf::Number("f64")),
+        _ => None,
+    }
 }
 
 fn validate_as_number_flag(field_type: &FieldDefType, flag_set: bool) -> Result<(), String> {
@@ -4629,57 +4793,48 @@ fn generate_field_validation(
     Option<proc_macro2::TokenStream>,
     Option<proc_macro2::TokenStream>,
 ) {
-    // String constraints (minLength, maxLength, pattern) only apply to bare String fields.
-    let has_string_constraints = (model_schema_prop_meta.min_length.is_some()
+    let has_string_constraints = model_schema_prop_meta.min_length.is_some()
         || model_schema_prop_meta.max_length.is_some()
-        || model_schema_prop_meta.pattern.is_some())
-        && field_is_bare_string(field);
+        || model_schema_prop_meta.pattern.is_some();
     let has_numeric_constraints =
         model_schema_prop_meta.minimum.is_some() || model_schema_prop_meta.maximum.is_some();
 
-    schema_module_name.map_or_else(
-        || (None, None),
-        |module_name| {
-            if has_string_constraints {
-                // String field with constraints: generate static validator + deserializer
-                let validation_code =
-                    generate_string_validation_code(raw_field_ident, model_schema_prop_meta);
-                let deserialize_with_path = format!("{module_name}::deserialize_{raw_field_ident}");
-                let path_lit =
-                    syn::LitStr::new(&deserialize_with_path, proc_macro2::Span::call_site());
-                let serde_attr: syn::Attribute = syn::parse_quote! {
-                    #[serde(deserialize_with = #path_lit)]
-                };
-                new_attrs.push(serde_attr);
-                (
-                    Some(validation_code.module_items),
-                    Some(validation_code.validate_body),
-                )
-            } else if has_numeric_constraints {
-                // Numeric field with constraints: generate static validator + deserializer
-                field_rust_type_str(field).map_or((None, None), |rust_type| {
-                    let validation_code = generate_numeric_validation_code(
-                        raw_field_ident,
-                        rust_type,
-                        model_schema_prop_meta,
-                    );
-                    let deserialize_with_path =
-                        format!("{module_name}::deserialize_{raw_field_ident}");
-                    let path_lit =
-                        syn::LitStr::new(&deserialize_with_path, proc_macro2::Span::call_site());
-                    let serde_attr: syn::Attribute = syn::parse_quote! {
-                        #[serde(deserialize_with = #path_lit)]
-                    };
-                    new_attrs.push(serde_attr);
-                    (
-                        Some(validation_code.module_items),
-                        Some(validation_code.validate_body),
-                    )
-                })
-            } else {
-                (None, None)
-            }
-        },
+    let (Some(module_name), Some(shape)) = (schema_module_name, constrained_shape(&field.ty))
+    else {
+        return (None, None);
+    };
+
+    let generated = match shape.leaf {
+        ConstraintLeaf::Str => has_string_constraints.then(|| {
+            generate_string_validation_code(raw_field_ident, model_schema_prop_meta, &shape.wraps)
+        }),
+        ConstraintLeaf::Number(rust_type) => has_numeric_constraints.then(|| {
+            generate_numeric_validation_code(
+                raw_field_ident,
+                rust_type,
+                model_schema_prop_meta,
+                &shape.wraps,
+            )
+        }),
+    };
+    let Some(validation_code) = generated else {
+        return (None, None);
+    };
+
+    // Only a bare field gets a `deserialize_with`: the generated deserializer answers for the
+    // constrained value itself, which is the field's own type only when nothing wraps it.
+    if shape.wraps.is_empty() {
+        let deserialize_with_path = format!("{module_name}::deserialize_{raw_field_ident}");
+        let path_lit = syn::LitStr::new(&deserialize_with_path, proc_macro2::Span::call_site());
+        let serde_attr: syn::Attribute = syn::parse_quote! {
+            #[serde(deserialize_with = #path_lit)]
+        };
+        new_attrs.push(serde_attr);
+    }
+
+    (
+        Some(validation_code.module_items),
+        Some(validation_code.validate_body),
     )
 }
 

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -5,9 +5,9 @@ use super::{
 
 #[cfg(feature = "serde")]
 use super::{
-    cfg_attr_guard_error, check_optional_field_serialization, collect_untagged_members,
-    enum_cfg_attr_guard_errors, field_label, get_field_def, parse_serde_field_attributes,
-    parse_serde_type_attributes,
+    build_field_validation, cfg_attr_guard_error, check_optional_field_serialization,
+    collect_untagged_members, constrained_shape, enum_cfg_attr_guard_errors, field_label,
+    get_field_def, parse_serde_field_attributes, parse_serde_type_attributes,
 };
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
@@ -2283,6 +2283,103 @@ fn discriminated_union_rendering_is_stable_across_runs() {
             rendered_discriminated_union(),
             first,
             "run {run} rendered a different union than run 0"
+        );
+    }
+}
+
+/// The `validate()` contribution for a field spelled `spelling`, as tokens.
+#[cfg(feature = "serde")]
+fn emitted_validation(spelling: &str) -> String {
+    let ty: syn::Type = syn::parse_str(spelling).unwrap();
+    let shape = constrained_shape(&ty).unwrap();
+    let field = proc_macro2::Ident::new("field", proc_macro2::Span::call_site());
+    let checker = proc_macro2::Ident::new("check", proc_macro2::Span::call_site());
+    build_field_validation(&shape.wraps, &field, &checker).to_string()
+}
+
+/// The one spelling whose emitted body predates the reach-through and must not move: anything else
+/// would change what every already-generated bare field validates.
+#[cfg(feature = "serde")]
+#[test]
+fn a_bare_field_is_checked_in_place() {
+    assert_eq!(
+        emitted_validation("String"),
+        "if let Err (e) = check (& self . field) { errors . push (e) ; }"
+    );
+    assert_eq!(emitted_validation("u32"), emitted_validation("String"));
+}
+
+/// A constraint describes the value on the wire, and a `None` puts none there.
+#[cfg(feature = "serde")]
+#[test]
+fn an_option_is_checked_inside_its_some() {
+    assert_eq!(
+        emitted_validation("Option<String>"),
+        "{ let value_0 = & self . field ; if let Some (value_1) = value_0 { if let Err (e) = check (value_1) { errors . push (e) ; } } }"
+    );
+}
+
+/// A transparent wrapper writes its inner value and nothing else, so reaching through it is a
+/// deref and no check of its own.
+#[cfg(feature = "serde")]
+#[test]
+fn a_transparent_wrapper_is_dereferenced_through() {
+    let expected = "{ let value_0 = & self . field ; let value_1 = & * * value_0 ; if let Err (e) = check (value_1) { errors . push (e) ; } }";
+    for spelling in ["Arc<str>", "Box<String>", "Cow<'a, str>", "Rc<str>"] {
+        assert_eq!(
+            emitted_validation(spelling),
+            expected,
+            "spelling {spelling}"
+        );
+    }
+}
+
+/// Every sequence spelling writes an array of its element, so each element answers for the
+/// constraint — one level per depth, the innermost being where it lands.
+#[cfg(feature = "serde")]
+#[test]
+fn a_sequence_is_checked_per_element() {
+    let expected = "{ let value_0 = & self . field ; for value_1 in value_0 { if let Err (e) = check (value_1) { errors . push (e) ; } } }";
+    for wrapper in SEQUENCE_WRAPPERS {
+        assert_eq!(
+            emitted_validation(&format!("{wrapper}<String>")),
+            expected,
+            "wrapper {wrapper}"
+        );
+    }
+    assert_eq!(emitted_validation("[String ; 2]"), expected);
+
+    assert_eq!(
+        emitted_validation("Vec<Vec<String>>"),
+        "{ let value_0 = & self . field ; for value_1 in value_0 { for value_2 in value_1 { if let Err (e) = check (value_2) { errors . push (e) ; } } } }"
+    );
+}
+
+/// The wrappers compose in the order they were written, each reaching exactly one level.
+#[cfg(feature = "serde")]
+#[test]
+fn mixed_wrappers_compose_in_written_order() {
+    assert_eq!(
+        emitted_validation("Option<Arc<[String]>>"),
+        "{ let value_0 = & self . field ; if let Some (value_1) = value_0 { let value_2 = & * * value_1 ; for value_3 in value_2 { if let Err (e) = check (value_3) { errors . push (e) ; } } } }"
+    );
+}
+
+/// A field with no value for a length or a range to describe emits nothing at all.
+#[cfg(feature = "serde")]
+#[test]
+fn a_field_without_a_constrainable_value_has_no_shape() {
+    for spelling in [
+        "Tag",
+        "Option<Tag>",
+        "HashMap<String, String>",
+        "(String, String)",
+        "PathBuf",
+    ] {
+        let ty: syn::Type = syn::parse_str(spelling).unwrap();
+        assert!(
+            constrained_shape(&ty).is_none(),
+            "spelling {spelling} should reach no constrainable value"
         );
     }
 }

--- a/tests/validation_tests.rs
+++ b/tests/validation_tests.rs
@@ -1,3 +1,5 @@
+extern crate alloc;
+
 #[cfg(test)]
 #[path = "validation_tests/tests.rs"]
 mod tests;

--- a/tests/validation_tests/tests.rs
+++ b/tests/validation_tests/tests.rs
@@ -2,6 +2,11 @@
     feature = "serde",
     any(feature = "typescript", feature = "zod", feature = "jsonschema")
 ))]
+use alloc::sync::Arc;
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
 use serde::{Deserialize, Serialize};
 #[cfg(all(
     feature = "serde",
@@ -1133,5 +1138,257 @@ fn test_pattern_empty_string_match() {
     assert!(
         errors[0].contains("does not match pattern"),
         "Error should mention 'does not match pattern': {errors:?}"
+    );
+}
+
+// ==================== Constraints under Option / wrappers / sequences ====================
+
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn test_validate_optional_string_some_too_short() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug)]
+    pub struct OptionalConstrained {
+        #[model_schema_prop(minLength = 3)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub nickname: Option<String>,
+    }
+
+    let instance = OptionalConstrained {
+        nickname: Some("a".to_owned()),
+    };
+    let result = instance.validate();
+    assert!(
+        result.is_err(),
+        "validate() should reject a Some holding a too-short string"
+    );
+    let errors = result.unwrap_err();
+    assert_eq!(
+        errors,
+        vec!["'nickname' is too short: minimum length is 3, got 1"],
+        "Unexpected errors: {errors:?}"
+    );
+}
+
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn test_validate_optional_string_none_is_ok() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug)]
+    pub struct OptionalAbsent {
+        #[model_schema_prop(minLength = 3)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub nickname: Option<String>,
+    }
+
+    let instance = OptionalAbsent { nickname: None };
+    let result = instance.validate();
+    assert!(
+        result.is_ok(),
+        "A None writes no string, so nothing constrains it: {:?}",
+        result.err()
+    );
+}
+
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn test_validate_boxed_string_too_short() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug)]
+    pub struct BoxedConstrained {
+        #[model_schema_prop(minLength = 3)]
+        pub label: Box<str>,
+    }
+
+    let instance = BoxedConstrained { label: "a".into() };
+    let result = instance.validate();
+    assert!(
+        result.is_err(),
+        "validate() should reject a too-short string under a Box"
+    );
+    let errors = result.unwrap_err();
+    assert_eq!(
+        errors,
+        vec!["'label' is too short: minimum length is 3, got 1"],
+        "Unexpected errors: {errors:?}"
+    );
+}
+
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn test_validate_vec_string_per_element() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug)]
+    pub struct VecConstrained {
+        #[model_schema_prop(minLength = 3)]
+        pub tags: Vec<String>,
+    }
+
+    let instance = VecConstrained {
+        tags: vec!["ok!".to_owned(), "a".to_owned(), "b".to_owned()],
+    };
+    let result = instance.validate();
+    let errors = result.unwrap_err();
+    assert_eq!(
+        errors,
+        vec![
+            "'tags' is too short: minimum length is 3, got 1",
+            "'tags' is too short: minimum length is 3, got 1",
+        ],
+        "Each failing element reports: {errors:?}"
+    );
+}
+
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn test_validate_optional_vec_string() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug)]
+    pub struct OptionalVecConstrained {
+        #[model_schema_prop(minLength = 3)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub tags: Option<Vec<String>>,
+    }
+
+    let present = OptionalVecConstrained {
+        tags: Some(vec!["a".to_owned()]),
+    };
+    let errors = present.validate().unwrap_err();
+    assert_eq!(
+        errors,
+        vec!["'tags' is too short: minimum length is 3, got 1"],
+        "Unexpected errors: {errors:?}"
+    );
+
+    let absent = OptionalVecConstrained { tags: None };
+    assert!(
+        absent.validate().is_ok(),
+        "A None holds no elements to constrain"
+    );
+}
+
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn test_validate_nested_vec_string() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug)]
+    pub struct NestedVecConstrained {
+        #[model_schema_prop(minLength = 3)]
+        pub rows: Vec<Vec<String>>,
+    }
+
+    let instance = NestedVecConstrained {
+        rows: vec![vec!["ok!".to_owned()], vec!["a".to_owned()]],
+    };
+    let errors = instance.validate().unwrap_err();
+    assert_eq!(
+        errors,
+        vec!["'rows' is too short: minimum length is 3, got 1"],
+        "The constraint lands on the innermost element: {errors:?}"
+    );
+}
+
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn test_validate_optional_numeric_minimum() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug)]
+    pub struct OptionalNumeric {
+        #[model_schema_prop(minimum = 18)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub age: Option<u32>,
+    }
+
+    let too_small = OptionalNumeric { age: Some(5) };
+    let errors = too_small.validate().unwrap_err();
+    assert_eq!(
+        errors,
+        vec!["'age' is too small: minimum is 18, got 5"],
+        "Unexpected errors: {errors:?}"
+    );
+
+    assert!(
+        OptionalNumeric { age: None }.validate().is_ok(),
+        "A None writes no number to constrain"
+    );
+}
+
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn test_validate_arc_slice_mixed_wrappers() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug)]
+    pub struct MixedWrappers {
+        #[model_schema_prop(maxLength = 2)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub codes: Option<Arc<[String]>>,
+    }
+
+    let instance = MixedWrappers {
+        codes: Some(Arc::from(["ok".to_owned(), "toolong".to_owned()])),
+    };
+    let errors = instance.validate().unwrap_err();
+    assert_eq!(
+        errors,
+        vec!["'codes' is too long: maximum length is 2, got 7"],
+        "Unexpected errors: {errors:?}"
+    );
+}
+
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn test_validate_boxed_option_string() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug)]
+    pub struct BoxedOption {
+        #[model_schema_prop(minLength = 3)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub nickname: Box<Option<String>>,
+    }
+
+    let instance = BoxedOption {
+        nickname: Box::new(Some("a".to_owned())),
+    };
+    let errors = instance.validate().unwrap_err();
+    assert_eq!(
+        errors,
+        vec!["'nickname' is too short: minimum length is 3, got 1"],
+        "Unexpected errors: {errors:?}"
+    );
+
+    assert!(
+        BoxedOption {
+            nickname: Box::new(None)
+        }
+        .validate()
+        .is_ok(),
+        "A None under a Box still writes nothing to constrain"
     );
 }


### PR DESCRIPTION
Three `minLength = 3` fields holding 1-char values; `validate()` reported only the bare `String` — `Option`/`Box`/`Vec`-wrapped constrained fields passed silently while all three schema surfaces constrain them.

- The validation emitter walks the field's syn type into a wrapper chain + leaf: inside `Option::Some` (a `None` writes nothing, so nothing constrains it), one deref through `Box`/`Rc`/`Arc`/`Cow`, per element at every sequence depth (all covered wrappers + arrays/slices); `str` leaves count with `String`.
- Red-first per shape; bare-field emission pinned byte-identical to the literal pre-change token stream via early return.
- Out of scope with evidence filed: the generated `deserialize_with` can only carry checks when the constrained value IS the declared field type — wrapped fields' deserialization gap is its own task; so is `PathBuf` rendering constraints no layer enforces.

Gates: `just check` green during work; full powerset once at acceptance — green.
