### PR TITLE
fix: each Option renders its null at the array level it was written

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,15 +123,21 @@ just ci
 **FieldDef** (central type representation):
 ```rust
 pub struct FieldDef {
-    pub is_optional: bool,           // Option<T> → T | undefined
     pub name: String,                // Field name (respects Serde rename)
     pub docs: String,                // Rust doc comments → JSDoc
     pub field_type: FieldDefType,    // The actual type category
     pub array_depth: u8,             // Vec<T> → Array<T>, one level per Vec/slice/set written
+    pub nullable_levels: Vec<u8>,    // Which array levels were written as Option
     pub array_num: Option<u16>,      // Future: fixed-size arrays
     pub model_schema_prop_meta: ..., // Field-level overrides
 }
 ```
+
+Levels count from the innermost value outward, so `Vec<Option<T>>` records level 0 — a `null`
+among the array's items, rendered `Array<T | null>` — while `Option<Vec<T>>` records level 1, a
+`null` in place of the whole array, rendered `Array<T> | undefined` in a field and
+`Array<T> | null` in a slot. `is_optional()` asks the question of the outermost level, the only
+one whose rendering depends on where the field sits.
 
 **FieldDefType** (type categories):
 - Primitives: `Boolean`, `String`, `U8-U64`, `I8-I64`, `F32`, `F64`, `Usize`, `Isize`

--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -130,9 +130,14 @@ pub enum FieldDefType {
 /// `model_schema.rs` to build the full type definitions.
 ///
 /// Fields:
-/// - `is_optional`: In struct-field position, adds `| undefined` / `z.union([type, z.undefined()])`.
-///   In tuple-element and map-value position, adds `| null` / `z.nullable(type)` — neither slot can
-///   be dropped the way an object key can, so a `None` there serializes as `null`.
+/// - `nullable_levels`: which array levels the field was written with an `Option` at. Level 0 is
+///   what `field_type` names and level `array_depth` is the field as a whole, so `Vec<Option<T>>`
+///   records level 0 and `Option<Vec<T>>` records level 1 — two different values on the wire
+///   (`[null]` against `null`) that a single flag could not tell apart. `is_optional` asks it for
+///   the outermost level, the only one whose `None` is not written inside an array and so the only
+///   one whose flavor depends on where the field sits: `| undefined` /
+///   `z.union([type, z.undefined()])` in struct-field position, `| null` / `z.nullable(type)` in a
+///   tuple element or map value, neither of which can be dropped the way an object key can.
 /// - name: Safe field name (uses serde rename if feature enabled)
 /// - docs: Doc comments from Rust - included in generated TS as `JSDoc`
 /// - `field_type`: The core type classification (see `FieldDefType`)
@@ -145,7 +150,7 @@ pub enum FieldDefType {
 ///
 /// Usage notes:
 /// - Created recursively for nested types
-/// - Handles Option<T> by setting `is_optional=true` on inner type
+/// - Handles Option<T> by recording its array level in `nullable_levels`
 /// - For `HashMap`, only String keys allowed
 /// - Feature "serde" affects name (rename attributes)
 /// - Feature "zod" enables `zod_type()` method
@@ -155,9 +160,9 @@ pub struct FieldDef {
     pub array_num: Option<u16>,
     pub docs: String,
     pub field_type: FieldDefType,
-    pub is_optional: bool,
     pub model_schema_prop_meta: Option<ModelSchemaPropMeta>,
     pub name: String,
+    pub nullable_levels: Vec<u8>,
 }
 
 impl FieldDef {
@@ -170,14 +175,17 @@ impl FieldDef {
     ///
     /// Every array level survives the move: the element's own, the one this wrapper adds, and the
     /// ones the wrapper itself sits under. The result therefore stands for the whole field, and a
-    /// caller must not re-apply the field's own levels on top of it.
+    /// caller must not re-apply the field's own levels on top of it. Each level keeps the
+    /// nullability it was written with, renumbered where it moved: the element's levels are the
+    /// innermost and keep their numbers, while the wrapper's own sit above the array it adds.
     pub fn collection_element_field(&self, element: &Self) -> Self {
         let mut arrayed = element.clone();
         arrayed.name.clone_from(&self.name);
-        arrayed.array_depth = element
-            .array_depth
-            .saturating_add(1)
-            .saturating_add(self.array_depth);
+        arrayed.array_depth = element.array_depth.saturating_add(1);
+        for level in &self.nullable_levels {
+            arrayed.mark_nullable_at(level.saturating_add(arrayed.array_depth));
+        }
+        arrayed.array_depth = arrayed.array_depth.saturating_add(self.array_depth);
         arrayed
             .model_schema_prop_meta
             .clone_from(&self.model_schema_prop_meta);
@@ -308,7 +316,7 @@ impl FieldDef {
     }
 
     fn has_ts_optional(&self) -> bool {
-        self.is_optional
+        self.is_optional()
             && self
                 .model_schema_prop_meta
                 .as_ref()
@@ -320,6 +328,28 @@ impl FieldDef {
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
     pub const fn is_array(&self) -> bool {
         self.array_depth > 0
+    }
+
+    /// Whether the value sitting at array level `level` was written as an `Option`.
+    ///
+    /// Levels count from the innermost value outward: level 0 is what `field_type` names, level
+    /// `array_depth` is the field as a whole. Below the outermost, a `None` reaches the wire as a
+    /// `null` among the items of the array one level up — the array itself is always written.
+    pub fn is_nullable_at(&self, level: u8) -> bool {
+        self.nullable_levels.contains(&level)
+    }
+
+    /// Whether the field as a whole is an `Option` — the outermost level, and the only one whose
+    /// `None` is not written inside an array. What it costs is the position's to say: an absent key
+    /// in struct-field position, a `null` in a slot that cannot be dropped.
+    pub fn is_optional(&self) -> bool {
+        self.is_nullable_at(self.array_depth)
+    }
+
+    fn mark_nullable_at(&mut self, level: u8) {
+        if !self.nullable_levels.contains(&level) {
+            self.nullable_levels.push(level);
+        }
     }
 
     /// Rewrites any `Self` type reference to the concrete enclosing type name.
@@ -382,8 +412,10 @@ impl FieldDef {
         if self.has_ts_optional() { "?" } else { "" }
     }
 
-    /// Builds the TypeScript type before the struct-field optional wrap: the type match plus one
-    /// `Array<…>` per array level. The `| undefined` wrap lives in `typescript_typename`.
+    /// Builds the TypeScript type before the outermost optional wrap: the type match plus one
+    /// `Array<…>` per array level, each carrying the `| null` of the level it wraps. The outermost
+    /// level's wrap lives in `typescript_typename` and `typescript_slot_typename`, which is where
+    /// the position it sits in decides between `| undefined` and `| null`.
     fn typescript_base(&self) -> String {
         let result = match &self.field_type {
             FieldDefType::Unknown => "unknown".to_owned(),
@@ -467,7 +499,14 @@ impl FieldDef {
                 }
             }
         };
-        (0..self.array_depth).fold(result, |wrapped, _| format!("Array<{wrapped}>"))
+        (0..self.array_depth).fold(result, |wrapped, level| {
+            let item = if self.is_nullable_at(level) {
+                format!("{wrapped} | null")
+            } else {
+                wrapped
+            };
+            format!("Array<{item}>")
+        })
     }
 
     /// The TypeScript type for a value in a slot that cannot be dropped — a tuple element or a
@@ -476,7 +515,7 @@ impl FieldDef {
     /// in either position.
     fn typescript_slot_typename(&self) -> String {
         let base = self.typescript_base();
-        if self.is_optional {
+        if self.is_optional() {
             format!("{base} | null")
         } else {
             base
@@ -486,14 +525,15 @@ impl FieldDef {
     /// Generates the TypeScript type name for this field.
     ///
     /// This method is the core of TypeScript type generation. It recursively builds
-    /// the TS type string based on `field_type`, `array_depth`, and `is_optional`.
+    /// the TS type string based on `field_type`, `array_depth`, and `nullable_levels`.
     ///
     /// Process:
     /// 1. Match on `field_type` to get base type
-    /// 2. Wrap in Array<...> once per `array_depth` level
-    /// 3. If `is_optional`: struct-field position adds `| undefined`; tuple-element and map-value
-    ///    positions add `| null` (neither can be omitted like an object key, so a `None` there
-    ///    serializes as `null`)
+    /// 2. Wrap in Array<...> once per `array_depth` level, adding `| null` inside the wrap at each
+    ///    level written as an `Option` — the array is always written, so the `None` is an item
+    /// 3. If `is_optional`, which is that question asked of the outermost level: struct-field
+    ///    position adds `| undefined`; tuple-element and map-value positions add `| null` (neither
+    ///    can be omitted like an object key, so a `None` there serializes as `null`)
     ///
     /// Feature notes:
     /// - "`object_id"`: Uses special `ObjectId` type
@@ -505,7 +545,7 @@ impl FieldDef {
     /// Examples in README.md show generated output.
     pub fn typescript_typename(&self) -> String {
         let pre_result = self.typescript_base();
-        if self.is_optional {
+        if self.is_optional() {
             // `ts_optional` renders the key as `field?: T`, so the `| undefined` is redundant.
             if self.has_ts_optional() {
                 pre_result
@@ -517,7 +557,8 @@ impl FieldDef {
         }
     }
 
-    /// The type match plus one `z.array(…)` per array level, before the preprocess wrap.
+    /// The type match plus one `z.array(…)` per array level, each carrying the `z.nullable(…)` of
+    /// the level it wraps, before the preprocess wrap.
     ///
     /// A set's element re-enters the rendering here rather than at `zod_base`: it carries a copy of
     /// the field's own metadata, and the preprocess wrap belongs once, outside the array — where
@@ -591,7 +632,14 @@ impl FieldDef {
                 }
             }
         };
-        (0..self.array_depth).fold(result, |wrapped, _| format!("z.array({wrapped})"))
+        (0..self.array_depth).fold(result, |wrapped, level| {
+            let item = if self.is_nullable_at(level) {
+                format!("z.nullable({wrapped})")
+            } else {
+                wrapped
+            };
+            format!("z.array({item})")
+        })
     }
 
     /// Builds the Zod schema before the struct-field optional wrap: the type match, the
@@ -637,7 +685,7 @@ impl FieldDef {
     #[cfg(feature = "zod")]
     fn zod_slot_type(&self) -> String {
         let base = self.zod_base();
-        if self.is_optional {
+        if self.is_optional() {
             format!("z.nullable({base})")
         } else {
             base
@@ -679,16 +727,18 @@ impl FieldDef {
     /// - For String: Adds .`min(min_len)` if `model_schema_prop_meta` has `min_length`
     /// - For literals: Uses z.literal(...)
     /// - For `ObjectId`: Uses regex validation for hex string
-    /// - Wraps with `z.array()` once per `array_depth` level
-    /// - If `is_optional`: struct-field position wraps `z.union([type, z.undefined()])`;
-    ///   tuple-element and map-value positions wrap `z.nullable(type)` (neither can be omitted like
-    ///   an object key, so a `None` there serializes as `null`)
+    /// - Wraps with `z.array()` once per `array_depth` level, wrapping `z.nullable(…)` inside it
+    ///   at each level written as an `Option`
+    /// - If `is_optional`, which is that question asked of the outermost level: struct-field
+    ///   position wraps `z.union([type, z.undefined()])`; tuple-element and map-value positions wrap
+    ///   `z.nullable(type)` (neither can be omitted like an object key, so a `None` there
+    ///   serializes as `null`)
     ///
     /// Requires Zod v4 in frontend - generates v4-compatible syntax.
     /// See `notes/20250706_features.md` for Zod feature details.
     pub fn zod_type(&self) -> String {
         let pre_result = self.zod_base();
-        if self.is_optional {
+        if self.is_optional() {
             format!("z.union([{pre_result}, z.undefined()]).prefault(undefined)")
         } else {
             pre_result
@@ -724,19 +774,6 @@ pub fn is_sequence_wrapper(name: &str) -> bool {
 /// list than this defect was measured over, not a claim that they write anything else.
 pub fn is_transparent_wrapper(name: &str) -> bool {
     matches!(name, "Arc" | "Box" | "Cow" | "Rc")
-}
-
-/// Whether a generic type is optional on its element's behalf: true exactly when it is a covered
-/// sequence wrapper whose element is an `Option`.
-///
-/// A wrapper writes the JSON array its element decides, so a `None` the element holds reaches the
-/// wire as a `null` inside that array — and every reader that decides nullability, the field-
-/// position guard and the slot renderers alike, reads the field's own flag rather than descending
-/// into the wrapper. `Vec` never arrives here, the parser having collapsed it onto its element
-/// with the flag already carried up; this hands the other spellings that same flag, so what a
-/// `None` costs cannot depend on which covered wrapper was written around it.
-fn sequence_element_optionality(name: &str, args: &[FieldDef]) -> bool {
-    matches!(args, [element] if element.is_optional && is_sequence_wrapper(name))
 }
 
 /// Classifies a `syn::Variant` into its `VariantKind`.
@@ -777,7 +814,7 @@ pub fn classify_variant(variant: &Variant) -> VariantKind {
 /// Key behaviors:
 /// - Strips references (&T -> T)
 /// - Counts an `array_depth` level for each Vec, slice, array
-/// - Sets `is_optional` for Option
+/// - Records a nullable level for each Option, at the array level it was written at
 /// - Only supports `HashMap`<String, T> (panics or errors otherwise per rules)
 /// - Uses `safe_type_name()` to strip Json suffix
 ///
@@ -795,37 +832,37 @@ fn get_field_def_from_type_path(
     let Some(segment) = type_path.path.segments.last() else {
         return FieldDef {
             name: safe_name,
-            is_optional: false,
             field_type: FieldDefType::Unknown,
             array_depth: 0,
             array_num: None,
             docs: field_docs.to_owned(),
             model_schema_prop_meta: None,
+            nullable_levels: Vec::new(),
         };
     };
     let ident = segment.ident.to_string();
     match &segment.arguments {
         PathArguments::None => FieldDef {
-            is_optional: false,
             name: safe_name,
             field_type: get_field_def_type_or_sibling(&ident),
             array_depth: 0,
             array_num: None,
             docs: field_docs.to_owned(),
             model_schema_prop_meta: None,
+            nullable_levels: Vec::new(),
         },
         PathArguments::AngleBracketed(args) => {
             get_field_def_from_generic_type(&ident, args, safe_name, field_docs)
         }
         // Function pointer types are unsupported; fall back to `unknown`.
         PathArguments::Parenthesized(_) => FieldDef {
-            is_optional: false,
             name: safe_name,
             field_type: FieldDefType::Unknown,
             array_depth: 0,
             array_num: None,
             docs: field_docs.to_owned(),
             model_schema_prop_meta: None,
+            nullable_levels: Vec::new(),
         },
     }
 }
@@ -857,18 +894,18 @@ fn get_field_def_from_generic_type(
         .collect();
     if arg_types.is_empty() {
         FieldDef {
-            is_optional: false,
             name: safe_name,
             field_type: FieldDefType::SiblingType(ident.to_owned(), vec![]),
             array_depth: 0,
             array_num: None,
             docs: field_docs.to_owned(),
             model_schema_prop_meta: None,
+            nullable_levels: Vec::new(),
         }
     } else if arg_types.len() == 1 && ident == "Option" {
         let mut result = arg_types[0].clone();
         result.name = safe_name;
-        result.is_optional = true;
+        result.mark_nullable_at(result.array_depth);
         result
     } else if arg_types.len() == 1 && ident == "Vec" {
         let mut result = arg_types[0].clone();
@@ -894,7 +931,6 @@ fn get_field_def_from_generic_type(
         );
         FieldDef {
             array_depth: 0,
-            is_optional: false,
             array_num: None,
             name: safe_name,
             field_type: FieldDefType::Map(
@@ -903,6 +939,7 @@ fn get_field_def_from_generic_type(
             ),
             docs: field_docs.to_owned(),
             model_schema_prop_meta: None,
+            nullable_levels: Vec::new(),
         }
     } else if arg_types.len() == 1 && is_datetime_generic_type(ident) {
         // The timezone type parameter says nothing about what is written.
@@ -910,13 +947,13 @@ fn get_field_def_from_generic_type(
     } else {
         log::trace!("Creating SiblingType - name: {ident}, arg_types: {arg_types:?}");
         FieldDef {
-            is_optional: sequence_element_optionality(ident, &arg_types),
             name: safe_name,
             field_type: FieldDefType::SiblingType(ident.to_owned(), arg_types),
             array_depth: 0,
             array_num: None,
             docs: field_docs.to_owned(),
             model_schema_prop_meta: None,
+            nullable_levels: Vec::new(),
         }
     }
 }
@@ -951,23 +988,23 @@ pub fn get_field_def(name: &str, ty: &Type, field_docs: &str) -> FieldDef {
             .collect();
         FieldDef {
             name: safe_name,
-            is_optional: false,
             field_type: FieldDefType::Tuple(elements),
             array_depth: 0,
             array_num: None,
             docs: field_docs.to_owned(),
             model_schema_prop_meta: None,
+            nullable_levels: Vec::new(),
         }
     } else {
         // Fallback for BareFn, ImplTrait, etc.
         FieldDef {
             name: safe_name,
-            is_optional: false,
             field_type: FieldDefType::Unknown,
             array_depth: 0,
             array_num: None,
             docs: field_docs.to_owned(),
             model_schema_prop_meta: None,
+            nullable_levels: Vec::new(),
         }
     }
 }
@@ -1092,13 +1129,13 @@ const fn is_datetime_generic_type(_type_name: &str) -> bool {
 #[cfg(feature = "chrono")]
 fn handle_datetime_generic_type(safe_name: String, field_docs: &str) -> FieldDef {
     FieldDef {
-        is_optional: false,
         name: safe_name,
         field_type: FieldDefType::DateTime,
         array_depth: 0,
         array_num: None,
         docs: field_docs.to_owned(),
         model_schema_prop_meta: None,
+        nullable_levels: Vec::new(),
     }
 }
 
@@ -1106,13 +1143,13 @@ fn handle_datetime_generic_type(safe_name: String, field_docs: &str) -> FieldDef
 fn handle_datetime_generic_type(safe_name: String, field_docs: &str) -> FieldDef {
     // Fallback - should never be called since is_datetime_generic_type returns false
     FieldDef {
-        is_optional: false,
         name: safe_name,
         field_type: FieldDefType::SiblingType("DateTime".to_owned(), vec![]),
         array_depth: 0,
         array_num: None,
         docs: field_docs.to_owned(),
         model_schema_prop_meta: None,
+        nullable_levels: Vec::new(),
     }
 }
 

--- a/src/field_type/tests.rs
+++ b/src/field_type/tests.rs
@@ -16,8 +16,8 @@ fn field(field_type: FieldDefType) -> FieldDef {
         docs: String::new(),
         field_type,
         array_depth: 0,
-        is_optional: false,
         model_schema_prop_meta: None,
+        nullable_levels: Vec::new(),
         name: "items".to_owned(),
     }
 }
@@ -99,7 +99,7 @@ fn test_sequence_in_a_slot_renders_as_the_array_it_writes() {
         );
 
         let mut optional = sequence;
-        optional.is_optional = true;
+        optional.nullable_levels = vec![optional.array_depth];
         assert_eq!(
             optional.typescript_slot_typename(),
             "Array<string> | null",
@@ -140,7 +140,7 @@ fn test_sequence_within_an_array_field_nests_both_wraps() {
 #[test]
 fn test_optional_sequence_field_keeps_the_field_level_optionality() {
     let mut optional = sequence_of("HashSet", FieldDefType::String);
-    optional.is_optional = true;
+    optional.nullable_levels = vec![optional.array_depth];
     assert_eq!(optional.typescript_typename(), "Array<string> | undefined");
     #[cfg(feature = "zod")]
     assert_eq!(
@@ -219,7 +219,7 @@ fn test_a_transparent_wrapper_parses_as_the_field_it_wraps() {
         assert_eq!(parsed.name, "items", "for: {spelling}");
         assert_eq!(parsed.docs, " * items", "for: {spelling}");
         assert_eq!(parsed.array_depth, 0, "for: {spelling}");
-        assert!(!parsed.is_optional, "for: {spelling}");
+        assert!(!parsed.is_optional(), "for: {spelling}");
     }
 }
 
@@ -241,7 +241,7 @@ fn test_a_transparent_wrapper_carries_the_optionality_of_what_it_wraps() {
             matches!(parsed.field_type, FieldDefType::U32),
             "for: {spelling}"
         );
-        assert!(parsed.is_optional, "for: {spelling}");
+        assert!(parsed.is_optional(), "for: {spelling}");
         assert_eq!(parsed.array_depth, 0, "for: {spelling}");
     }
 }
@@ -280,5 +280,64 @@ fn test_a_borrowed_string_parses_as_a_string() {
             matches!(parsed.field_type, FieldDefType::String),
             "for: {spelling}"
         );
+    }
+}
+
+/// An `Option` written inside a sequence wrapper and one written around it are two different
+/// values on the wire — `[null]` against `null` — so the parse has to keep them apart. The level
+/// each is recorded at is the level it was written at: the element's below the array it sits in,
+/// the field's own at the top, where `is_optional` answers for it.
+#[test]
+fn test_the_parser_records_the_level_each_option_was_written_at() {
+    for (spelling, array_depth, nullable_levels) in [
+        ("u32", 0_u8, &[] as &[u8]),
+        ("Option<u32>", 0, &[0]),
+        ("Vec<u32>", 1, &[]),
+        ("Vec<Option<u32>>", 1, &[0]),
+        ("Option<Vec<u32>>", 1, &[1]),
+        ("[Option<u32>; 2]", 1, &[0]),
+        ("Vec<Vec<Option<u32>>>", 2, &[0]),
+        ("Vec<Option<Vec<u32>>>", 2, &[1]),
+        ("Option<Vec<Vec<u32>>>", 2, &[2]),
+        ("Option<Vec<Option<u32>>>", 1, &[0, 1]),
+        ("Vec<Option<Vec<Option<u32>>>>", 2, &[0, 1]),
+    ] {
+        let ty: syn::Type = syn::parse_str(spelling).unwrap();
+        let parsed = super::get_field_def("items", &ty, "");
+        assert_eq!(parsed.array_depth, array_depth, "for: {spelling}");
+        let mut recorded = parsed.nullable_levels.clone();
+        recorded.sort_unstable();
+        assert_eq!(recorded, nullable_levels, "for: {spelling}");
+    }
+}
+
+/// A covered wrapper writes the array its element decides, so the element's own `Option` is
+/// recorded at the level the wrapper puts it at — the same level the `Vec` spelling of the same
+/// field records it at, whichever wrapper name was written. Read off the surfaces, which is where
+/// the level shows.
+#[test]
+fn test_a_covered_wrapper_records_its_element_option_where_the_vec_spelling_does() {
+    let vec_spelling: syn::Type = syn::parse_str("Vec<Option<u32>>").unwrap();
+    let expected = super::get_field_def("items", &vec_spelling, "");
+    for wrapper in SEQUENCE_WRAPPERS {
+        let ty: syn::Type = syn::parse_str(&format!("{wrapper}<Option<u32>>")).unwrap();
+        let parsed = super::get_field_def("items", &ty, "");
+        assert_eq!(
+            parsed.typescript_typename(),
+            expected.typescript_typename(),
+            "for: {wrapper}"
+        );
+        assert_eq!(
+            parsed.typescript_slot_typename(),
+            expected.typescript_slot_typename(),
+            "for: {wrapper}"
+        );
+        assert_eq!(
+            parsed.is_optional(),
+            expected.is_optional(),
+            "for: {wrapper}"
+        );
+        #[cfg(feature = "zod")]
+        assert_eq!(parsed.zod_type(), expected.zod_type(), "for: {wrapper}");
     }
 }

--- a/src/generation/tests.rs
+++ b/src/generation/tests.rs
@@ -14,13 +14,13 @@ fn test_format_docs() {
 #[test]
 fn test_typescript_field_formatting() {
     let field = FieldDef {
-        is_optional: false,
         name: "test_field".to_owned(),
         docs: "Test documentation".to_owned(),
         field_type: FieldDefType::String,
         array_depth: 0,
         array_num: None,
         model_schema_prop_meta: None,
+        nullable_levels: Vec::new(),
     };
 
     let formatted = GenerationUtils::format_typescript_field(&field);

--- a/src/generation/typescript/tests.rs
+++ b/src/generation/typescript/tests.rs
@@ -13,22 +13,22 @@ fn test_generate_struct_type_empty() {
 fn test_generate_struct_type_with_fields() {
     let fields = vec![
         FieldDef {
-            is_optional: false,
             name: "id".to_owned(),
             docs: "ID field".to_owned(),
             field_type: FieldDefType::String,
             array_depth: 0,
             array_num: None,
             model_schema_prop_meta: None,
+            nullable_levels: Vec::new(),
         },
         FieldDef {
-            is_optional: true,
             name: "name".to_owned(),
             docs: "Name field".to_owned(),
             field_type: FieldDefType::String,
             array_depth: 0,
             array_num: None,
             model_schema_prop_meta: None,
+            nullable_levels: vec![0],
         },
     ];
 

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -767,7 +767,7 @@ fn branded_option_inner_error(
     inner_field: &Field,
 ) -> Option<proc_macro2::TokenStream> {
     get_field_def("_inner", &inner_field.ty, "")
-        .is_optional
+        .is_optional()
         .then(|| {
             syn::Error::new_spanned(
                 inner_field,
@@ -2670,7 +2670,7 @@ fn untagged_named_json_value(field_defs: &[FieldDef]) -> proc_macro2::TokenStrea
     let property_inserts = field_defs.iter().map(|fld| {
         let name_str = fld.name.clone();
         let value = field_json_schema_value(fld);
-        let required_insert = if fld.is_optional {
+        let required_insert = if fld.is_optional() {
             quote! {}
         } else {
             quote! {
@@ -2843,9 +2843,11 @@ fn collect_untagged_members(item_enum: &mut syn::ItemEnum) -> UntaggedMemberData
             let serde_field_meta = parse_serde_field_attributes(&field.attrs);
             if let Some(rejection) = serde_field_meta.cfg_attr_rejection.as_ref() {
                 guard_errors.push(cfg_attr_guard_error(rejection, &field_label(&field_name)));
-            } else if let Err(err) =
-                check_optional_field_serialization(field, field_def.is_optional, &serde_field_meta)
-            {
+            } else if let Err(err) = check_optional_field_serialization(
+                field,
+                field_def.is_optional(),
+                &serde_field_meta,
+            ) {
                 guard_errors.push(err.to_compile_error());
             } else {
                 // No guard violated by this field.
@@ -3161,7 +3163,7 @@ fn write_named_variant_fields(
         #[cfg(not(feature = "jsonschema"))]
         let _: &_ = &(tag_name, &json_schema_variant_fields);
 
-        if fld.is_optional {
+        if fld.is_optional() {
             optional_fields.push(fld.name.clone());
         }
     }
@@ -3243,7 +3245,7 @@ fn write_tuple_single_variant_fields(
     #[cfg(not(feature = "jsonschema"))]
     let _: &_ = &json_schema_variant_fields;
 
-    if fld.is_optional {
+    if fld.is_optional() {
         optional_fields.push(content_name.to_owned());
     }
 }
@@ -3346,6 +3348,10 @@ fn write_tuple_multiple_variant_fields(
 /// once instead of in each renderer. The levels are the ones the field was written at, so a
 /// `Vec<Vec<T>>` describes as the array of arrays serde writes for it.
 ///
+/// A level written as an `Option` admits `null` where it sits — inside the array that holds it,
+/// which is always written — rather than around the array, which is what the outermost level does
+/// and is the caller's to apply.
+///
 /// `item_schema` is a `serde_json::Value` expression, as is the result. Callers holding a literal
 /// fragment want [`arrayed_json_schema_fragment`].
 #[cfg(feature = "jsonschema")]
@@ -3353,7 +3359,12 @@ fn arrayed_json_schema_value(
     fld: &FieldDef,
     item_schema: proc_macro2::TokenStream,
 ) -> proc_macro2::TokenStream {
-    (0..fld.array_depth).fold(item_schema, |items, _| {
+    (0..fld.array_depth).fold(item_schema, |level_schema, level| {
+        let items = if fld.is_nullable_at(level) {
+            quote! { serde_json::json!({ "anyOf": [#level_schema, { "type": "null" }] }) }
+        } else {
+            level_schema
+        };
         quote! { serde_json::json!({ "type": "array", "items": #items }) }
     })
 }
@@ -3365,7 +3376,12 @@ fn arrayed_json_schema_fragment(
     fld: &FieldDef,
     item_schema: &proc_macro2::TokenStream,
 ) -> proc_macro2::TokenStream {
-    (0..fld.array_depth).fold(item_schema.clone(), |items, _| {
+    (0..fld.array_depth).fold(item_schema.clone(), |level_schema, level| {
+        let items = if fld.is_nullable_at(level) {
+            quote! { { "anyOf": [#level_schema, { "type": "null" }] } }
+        } else {
+            level_schema
+        };
         quote! { { "type": "array", "items": #items } }
     })
 }
@@ -3478,7 +3494,7 @@ fn nullable_slot_json_schema(
     fld: &FieldDef,
     base: &proc_macro2::TokenStream,
 ) -> Option<proc_macro2::TokenStream> {
-    fld.is_optional
+    fld.is_optional()
         .then(|| quote! { { "anyOf": [#base, { "type": "null" }] } })
 }
 
@@ -3677,9 +3693,10 @@ fn map_member_slot_value(
 /// the surfaces' one shared answer, so no name reaches a slot as an array on one surface and a
 /// schema module of its own on another.
 ///
-/// Nullability is carried across rather than taken from the element: a slot cannot be dropped the
-/// way an object key can, so a `None` on either side of the wrapper is written as `null` and the
-/// member schema has to admit it.
+/// An `Option` on either side of the wrapper survives the normalization at the level it was
+/// written at — inside, it is a `null` among the array's items; outside, it stands in place of the
+/// whole array, which a slot cannot drop the way an object key can. The two are different values on
+/// the wire, so the member schema keeps them apart.
 #[cfg(feature = "jsonschema")]
 fn normalized_slot_value(value: &FieldDef) -> FieldDef {
     let mut normalized = value.clone();
@@ -3687,9 +3704,7 @@ fn normalized_slot_value(value: &FieldDef) -> FieldDef {
         && is_sequence_wrapper(wrapper_name)
         && let [element] = wrapper_args.as_slice()
     {
-        let mut arrayed = normalized.collection_element_field(element);
-        arrayed.is_optional |= normalized.is_optional;
-        normalized = arrayed;
+        normalized = normalized.collection_element_field(element);
     }
     normalized
 }
@@ -4186,7 +4201,7 @@ fn build_field_schema(fld: &FieldDef) -> proc_macro2::TokenStream {
     let field_name_str = fld.name.clone();
     let schema_code = build_field_type_schema(fld, &field_name_str);
 
-    let required_code = if fld.is_optional {
+    let required_code = if fld.is_optional() {
         quote! {}
     } else {
         quote! {
@@ -4615,6 +4630,11 @@ fn validate_ts_optional_flag(field_optional: bool, flag_set: bool) -> Result<(),
 /// missing key but never `null`. `is_optional` is the same signal that drives that rendering,
 /// which keeps the guard and the contract from ever disagreeing. Positional fields are exempt: a
 /// tuple slot cannot be omitted, so there `None` correctly renders as nullable.
+///
+/// The subject is the outermost `Option` and only that one, `is_optional` being the question asked
+/// of that level. An `Option` written inside a sequence wrapper has no bare `null` to write: the
+/// array around it is always written, so the key is always present and the `None` is an item, which
+/// the field's own schema describes as nullable.
 #[cfg(feature = "serde")]
 fn check_optional_field_serialization(
     field: &Field,
@@ -4717,7 +4737,7 @@ fn process_field(
     #[cfg(feature = "serde")]
     let guard_error = serde_field_meta.cfg_attr_rejection.as_ref().map_or_else(
         || {
-            check_optional_field_serialization(field, field_def.is_optional, &serde_field_meta)
+            check_optional_field_serialization(field, field_def.is_optional(), &serde_field_meta)
                 .err()
                 .map(|err| err.to_compile_error())
         },
@@ -4752,7 +4772,7 @@ fn process_field(
         .is_some_and(|m| m.ts_optional);
     // A failed assert here surfaces as a compile error at macro-expansion time.
     assert!(
-        validate_ts_optional_flag(field_def.is_optional, ts_optional_flag).is_ok(),
+        validate_ts_optional_flag(field_def.is_optional(), ts_optional_flag).is_ok(),
         "#[model_schema_prop(ts_optional)] requires an Option<T> field on field `{final_name}`"
     );
 

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -78,7 +78,7 @@ fn guard_result(item: &syn::ItemStruct) -> Result<(), syn::Error> {
         .unwrap_or_default();
     let field_def = get_field_def(&field_name, &field.ty, "");
     let meta = parse_serde_field_attributes(&field.attrs);
-    check_optional_field_serialization(field, field_def.is_optional, &meta)
+    check_optional_field_serialization(field, field_def.is_optional(), &meta)
 }
 
 #[cfg(feature = "serde")]
@@ -100,40 +100,54 @@ fn report_with(spelling: &str) -> syn::ItemStruct {
     syn::parse_str(&format!("struct Report {{ notes: {spelling} }}")).unwrap()
 }
 
-/// A covered wrapper writes the JSON array its element decides, so a `None` the element holds
-/// reaches the wire as a `null` inside that array — which the absent-key form the field renders in
-/// cannot stand for. The guard therefore refuses it wherever it refuses the `Vec` spelling, `Vec`
-/// being the one wrapper the parser had always collapsed onto its element.
+/// The guard's subject is the `None` that reaches the wire as a bare `null` under the key, which is
+/// the one an `Option` around the whole field writes. A covered wrapper is such a field, so the
+/// wrapper spellings are refused exactly where the `Vec` spelling is.
 #[cfg(feature = "serde")]
 #[test]
-fn a_covered_wrapper_of_option_is_rejected_as_the_vec_spelling_is() {
-    for wrapper in SEQUENCE_WRAPPERS {
-        let message = guard_result(&report_with(&format!("{wrapper}<Option<String>>")))
+fn an_option_around_a_covered_wrapper_is_rejected_as_the_vec_spelling_is() {
+    for spelling in SEQUENCE_WRAPPERS
+        .iter()
+        .map(|wrapper| format!("Option<{wrapper}<String>>"))
+        .chain(["Option<Vec<String>>".to_owned()])
+    {
+        let message = guard_result(&report_with(&spelling))
             .unwrap_err()
             .to_string();
-        assert!(message.contains("notes"), "{wrapper}: {message}");
+        assert!(message.contains("notes"), "{spelling}: {message}");
         assert!(
             message.contains("skip_serializing_if"),
-            "{wrapper}: {message}"
+            "{spelling}: {message}"
         );
     }
 }
 
-/// Every level a wrapper is written at hands its element's optionality up, so a `None` is refused
-/// however deep the wrappers are stacked and whichever spelling each level takes.
+/// An `Option` the wrapper holds is a different `None`: the array around it is always written, so
+/// the key is always present and the `null` lands among the items, which is a value the field's
+/// schema describes rather than one it has no way to admit. The guard has no subject there and
+/// says nothing — at every depth, and whichever spelling each level takes.
 #[cfg(feature = "serde")]
 #[test]
-fn a_covered_wrapper_carries_its_element_optionality_at_every_depth() {
-    for spelling in [
-        "Vec<Vec<Option<String>>>",
-        "HashSet<Vec<Option<String>>>",
-        "Vec<HashSet<Option<String>>>",
-        "BTreeSet<VecDeque<Option<String>>>",
-    ] {
-        let message = guard_result(&report_with(spelling))
-            .unwrap_err()
-            .to_string();
-        assert!(message.contains("notes"), "{spelling}: {message}");
+fn an_option_inside_a_covered_wrapper_leaves_the_guard_nothing_to_refuse() {
+    for spelling in SEQUENCE_WRAPPERS
+        .iter()
+        .map(|wrapper| format!("{wrapper}<Option<String>>"))
+        .chain(
+            [
+                "Vec<Option<String>>",
+                "Vec<Vec<Option<String>>>",
+                "HashSet<Vec<Option<String>>>",
+                "Vec<HashSet<Option<String>>>",
+                "BTreeSet<VecDeque<Option<String>>>",
+                "Vec<Option<Vec<String>>>",
+            ]
+            .map(ToOwned::to_owned),
+        )
+    {
+        let refusal = guard_result(&report_with(&spelling))
+            .err()
+            .map(|err| err.to_string());
+        assert_eq!(refusal, None, "for: {spelling}");
     }
 }
 
@@ -1997,8 +2011,8 @@ fn wrapped_u32_value(wrapper: &str) -> super::FieldDef {
         docs: String::new(),
         field_type: FieldDefType::SiblingType(wrapper.to_owned(), vec![element]),
         array_depth: 0,
-        is_optional: false,
         model_schema_prop_meta: None,
+        nullable_levels: Vec::new(),
         name: "items".to_owned(),
     }
 }
@@ -2128,7 +2142,6 @@ fn a_sequence_wrapped_map_field_describes_as_the_array_of_the_map_it_holds() {
         ("HashMap<String, u64>", "Vec<HashMap<String, u64>>"),
         ("HashMap<String, u64>", "VecDeque<HashMap<String, u64>>"),
         ("HashMap<String, u64>", "Option<Vec<HashMap<String, u64>>>"),
-        ("HashMap<String, u64>", "Vec<Option<HashMap<String, u64>>>"),
         ("HashMap<Slot, u64>", "Vec<HashMap<Slot, u64>>"),
         (
             "HashMap<Slot, Vec<u64>>",
@@ -2147,6 +2160,21 @@ fn a_sequence_wrapped_map_field_describes_as_the_array_of_the_map_it_holds() {
             "for {wrapped_type}"
         );
     }
+}
+
+/// An `Option` the sequence holds is not the field's: the array is written either way, and the
+/// `None` lands among its items — so the map's own rendering is what admits the `null`, one level
+/// inside the array wrap rather than around it.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_sequence_of_optional_maps_admits_the_null_among_its_items() {
+    let item = inserted_field_value("HashMap<String, u64>");
+    assert_eq!(
+        inserted_field_value("Vec<Option<HashMap<String, u64>>>"),
+        format!(
+            r#"serde_json :: json ! ({{ "type" : "array" , "items" : serde_json :: json ! ({{ "anyOf" : [{item} , {{ "type" : "null" }}] }}) }})"#
+        )
+    );
 }
 
 /// A map named without a sequence wrapper describes exactly as it always has, on every key path.
@@ -2199,9 +2227,9 @@ fn an_object_id_tuple_element_keeps_the_field_position_oid_object() {
 #[test]
 fn an_optional_sequence_wrapper_member_stays_nullable() {
     let mut optional_set = wrapped_u32_value("HashSet");
-    optional_set.is_optional = true;
+    optional_set.nullable_levels = vec![optional_set.array_depth];
     let mut optional_vec = parsed_u32_vec_value();
-    optional_vec.is_optional = true;
+    optional_vec.nullable_levels = vec![optional_vec.array_depth];
     assert_eq!(
         super::build_map_member_schema(&optional_set)
             .unwrap()

--- a/tests/collection_tests/tests.rs
+++ b/tests/collection_tests/tests.rs
@@ -1977,16 +1977,20 @@ fn test_set_slots_describe_as_arrays_of_their_element() {
         properties["optional_ids"]["additionalProperties"],
         serde_json::json!({ "anyOf": [integer_array, { "type": "null" }] })
     );
-    // A `None` the wrapper itself holds is that same `null` to every reader of the slot: the
-    // element carries the wrapper's array-ness, so the optionality it carries is the slot's too —
-    // the one form the `Vec` spelling arrives in, and so the one a set has to describe as.
+    // A `None` the wrapper itself holds is a different `null`: the array is written either way, so
+    // it lands among the items rather than in place of the slot. The `Vec` spelling writes exactly
+    // that, and so describes as exactly this.
+    let nullable_integer_array = serde_json::json!({
+        "type": "array",
+        "items": { "anyOf": [{ "type": "integer" }, { "type": "null" }] }
+    });
     assert_eq!(
         properties["optional_element_ids"]["additionalProperties"],
-        serde_json::json!({ "anyOf": [integer_array, { "type": "null" }] })
+        nullable_integer_array
     );
     assert_eq!(
         properties["tuple_optional_ids"]["prefixItems"][1],
-        serde_json::json!({ "anyOf": [integer_array, { "type": "null" }] })
+        nullable_integer_array
     );
 }
 
@@ -2059,12 +2063,12 @@ fn test_set_slots_type_as_the_vec_slot_twin() {
     for spelling in [
         "aliased_tags: Partial<Record<string, Array<MetricTagRefType>>>;",
         "enum_keyed_ids: Partial<Record<MetricSlot, Array<number>>>;",
-        "optional_element_ids: Partial<Record<string, Array<number> | null>>;",
+        "optional_element_ids: Partial<Record<string, Array<number | null>>>;",
         "optional_ids: Partial<Record<string, Array<number> | null>>;",
         "sibling_tags: Partial<Record<string, Array<MetricTag>>>;",
         "tuple_ids: [string, Array<number>];",
         "tuple_labels: [number, Array<string>];",
-        "tuple_optional_ids: [string, Array<number> | null];",
+        "tuple_optional_ids: [string, Array<number | null>];",
     ] {
         assert!(ts_definition.contains(spelling), "Got: {ts_definition}");
     }
@@ -2082,11 +2086,11 @@ fn test_set_slots_validate_as_the_vec_slot_twin() {
     for spelling in [
         "aliased_tags: z.record(z.string(), z.array(MetricTagRefType$Schema)),",
         "enum_keyed_tags: z.record(MetricSlot$Schema, z.array(MetricTag$Schema)),",
-        "optional_element_ids: z.record(z.string(), z.nullable(z.array(z.number().int()))),",
+        "optional_element_ids: z.record(z.string(), z.array(z.nullable(z.number().int()))),",
         "optional_ids: z.record(z.string(), z.nullable(z.array(z.number().int()))),",
         "tuple_ids: z.tuple([z.string(), z.array(z.number().int())]),",
         "tuple_labels: z.tuple([z.number().int(), z.array(z.string())]),",
-        "tuple_optional_ids: z.tuple([z.string(), z.nullable(z.array(z.number().int()))]),",
+        "tuple_optional_ids: z.tuple([z.string(), z.array(z.nullable(z.number().int()))]),",
     ] {
         assert!(zod_schema.contains(spelling), "Got: {zod_schema}");
     }

--- a/tests/optional_nesting_tests.rs
+++ b/tests/optional_nesting_tests.rs
@@ -1,0 +1,5 @@
+extern crate alloc;
+
+#[cfg(test)]
+#[path = "optional_nesting_tests/tests.rs"]
+mod tests;

--- a/tests/optional_nesting_tests/tests.rs
+++ b/tests/optional_nesting_tests/tests.rs
@@ -1,0 +1,325 @@
+//! An `Option` inside a covered sequence wrapper and an `Option` around one are two different
+//! values on the wire, and each surface has to say which it describes.
+//!
+//! Every expectation here is read off what serde writes, asserted first in this file and then
+//! described by the three surfaces in the same order: a `None` the wrapper holds is a `null` among
+//! the array's items, so the items admit `null` and the array itself does not; a `None` around the
+//! wrapper replaces the whole array, so the array admits `null` and its items do not.
+
+use alloc::collections::BTreeSet;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use tixschema::model_schema;
+
+/// The `Option` inside the wrapper. Serde always writes the array, so the key is always present and
+/// the `None` reaches the wire as a `null` among the items.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct ElementNullFields {
+    set_items: BTreeSet<Option<u32>>,
+    vec_items: Vec<Option<u32>>,
+}
+
+/// The `Option` around the wrapper. In field position a `None` writes a bare `null` under the key,
+/// which the generated contract does not admit — so this shape carries the omission the guard
+/// demands, and the key is dropped instead.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct SlotNullFields {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    set_items: Option<BTreeSet<u32>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    vec_items: Option<Vec<u32>>,
+}
+
+/// The same four nestings in the two slots that cannot be dropped, plus the one holding both
+/// `Option`s at once — the levels are independent, and neither swallows the other.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct NullNestingSlots {
+    map_both: HashMap<String, Option<Vec<Option<u32>>>>,
+    map_set_element: HashMap<String, BTreeSet<Option<u32>>>,
+    map_set_slot: HashMap<String, Option<BTreeSet<u32>>>,
+    map_vec_element: HashMap<String, Vec<Option<u32>>>,
+    map_vec_slot: HashMap<String, Option<Vec<u32>>>,
+    map_wrapped: HashMap<String, Vec<Option<BTreeSet<Option<u32>>>>>,
+    tuple_both: (String, Option<Vec<Option<u32>>>),
+    tuple_set_element: (String, BTreeSet<Option<u32>>),
+    tuple_set_slot: (String, Option<BTreeSet<u32>>),
+    tuple_vec_element: (String, Vec<Option<u32>>),
+    tuple_vec_slot: (String, Option<Vec<u32>>),
+}
+
+fn element_null_fields() -> ElementNullFields {
+    ElementNullFields {
+        set_items: BTreeSet::from([None]),
+        vec_items: vec![None],
+    }
+}
+
+fn slot_null_fields() -> SlotNullFields {
+    SlotNullFields {
+        set_items: None,
+        vec_items: None,
+    }
+}
+
+fn null_nesting_slots() -> NullNestingSlots {
+    NullNestingSlots {
+        map_both: HashMap::from([("k".to_owned(), Some(vec![None]))]),
+        map_set_element: HashMap::from([("k".to_owned(), BTreeSet::from([None]))]),
+        map_set_slot: HashMap::from([("k".to_owned(), None)]),
+        map_vec_element: HashMap::from([("k".to_owned(), vec![None])]),
+        map_vec_slot: HashMap::from([("k".to_owned(), None)]),
+        map_wrapped: HashMap::from([("k".to_owned(), vec![Some(BTreeSet::from([None])), None])]),
+        tuple_both: ("t".to_owned(), Some(vec![None])),
+        tuple_set_element: ("t".to_owned(), BTreeSet::from([None])),
+        tuple_set_slot: ("t".to_owned(), None),
+        tuple_vec_element: ("t".to_owned(), vec![None]),
+        tuple_vec_slot: ("t".to_owned(), None),
+    }
+}
+
+/// A `None` the wrapper holds is a `null` inside the array, and the array is written either way.
+#[test]
+fn test_an_option_inside_a_wrapper_writes_a_null_among_the_items() {
+    let payload = serde_json::to_value(element_null_fields()).unwrap();
+    assert_eq!(payload["set_items"], serde_json::json!([null]));
+    assert_eq!(payload["vec_items"], serde_json::json!([null]));
+}
+
+/// A `None` around the wrapper stands in place of the whole array — and in field position, where
+/// the key can be dropped, the omission is what the schema is written against.
+#[test]
+fn test_an_option_around_a_wrapper_stands_for_the_whole_array() {
+    let payload = serde_json::to_value(slot_null_fields()).unwrap();
+    assert_eq!(payload, serde_json::json!({}));
+}
+
+/// In a slot the key cannot be dropped, so each nesting writes exactly what its own `Option` says:
+/// the items for the inner one, the slot itself for the outer, both when both are written.
+#[test]
+fn test_each_slot_writes_the_null_its_own_option_puts_there() {
+    let payload = serde_json::to_value(null_nesting_slots()).unwrap();
+    for field in ["map_set_element", "map_vec_element"] {
+        assert_eq!(payload[field]["k"], serde_json::json!([null]), "{field}");
+    }
+    for field in ["map_set_slot", "map_vec_slot"] {
+        assert_eq!(payload[field]["k"], serde_json::json!(null), "{field}");
+    }
+    assert_eq!(payload["map_both"]["k"], serde_json::json!([null]));
+    assert_eq!(
+        payload["map_wrapped"]["k"],
+        serde_json::json!([[null], null])
+    );
+    for field in ["tuple_set_element", "tuple_vec_element"] {
+        assert_eq!(payload[field][1], serde_json::json!([null]), "{field}");
+    }
+    for field in ["tuple_set_slot", "tuple_vec_slot"] {
+        assert_eq!(payload[field][1], serde_json::json!(null), "{field}");
+    }
+    assert_eq!(payload["tuple_both"][1], serde_json::json!([null]));
+}
+
+#[cfg(feature = "jsonschema")]
+fn integer_or_null() -> serde_json::Value {
+    serde_json::json!({ "anyOf": [{ "type": "integer" }, { "type": "null" }] })
+}
+
+#[cfg(feature = "jsonschema")]
+fn array_of(items: &serde_json::Value) -> serde_json::Value {
+    serde_json::json!({ "type": "array", "items": items })
+}
+
+#[cfg(feature = "jsonschema")]
+fn or_null(base: &serde_json::Value) -> serde_json::Value {
+    serde_json::json!({ "anyOf": [base, { "type": "null" }] })
+}
+
+/// The array is always written, so the field describes as an array whose items admit `null` —
+/// required, and never `null` itself.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_an_element_null_field_describes_as_an_array_of_nullable_items() {
+    let schema = ElementNullFields::json_schema();
+    let expected = array_of(&integer_or_null());
+    for field in ["set_items", "vec_items"] {
+        assert_eq!(schema["properties"][field], expected, "{field}");
+        assert!(
+            schema["required"]
+                .as_array()
+                .unwrap()
+                .contains(&serde_json::json!(field)),
+            "{field} must stay required: {schema}"
+        );
+    }
+}
+
+/// The key is dropped rather than written `null`, so the field describes as the plain array and
+/// says nothing about `null` at all — it is the absence that the schema admits, by not requiring it.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_a_slot_null_field_describes_as_the_array_it_writes_when_present() {
+    let schema = SlotNullFields::json_schema();
+    let expected = array_of(&serde_json::json!({ "type": "integer" }));
+    for field in ["set_items", "vec_items"] {
+        assert_eq!(schema["properties"][field], expected, "{field}");
+        assert!(
+            !schema["required"]
+                .as_array()
+                .unwrap()
+                .contains(&serde_json::json!(field)),
+            "{field} must not be required: {schema}"
+        );
+    }
+}
+
+/// Each slot describes the `null` its own `Option` writes, and no other: the items for the inner
+/// one, the member for the outer, both wraps when both were written.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_each_slot_describes_the_null_its_own_option_writes() {
+    let properties = NullNestingSlots::json_schema()["properties"].clone();
+    let plain_array = array_of(&serde_json::json!({ "type": "integer" }));
+    let nullable_items = array_of(&integer_or_null());
+
+    for field in ["map_set_element", "map_vec_element"] {
+        assert_eq!(
+            properties[field]["additionalProperties"], nullable_items,
+            "{field}"
+        );
+    }
+    for field in ["map_set_slot", "map_vec_slot"] {
+        assert_eq!(
+            properties[field]["additionalProperties"],
+            or_null(&plain_array),
+            "{field}"
+        );
+    }
+    assert_eq!(
+        properties["map_both"]["additionalProperties"],
+        or_null(&nullable_items)
+    );
+
+    for field in ["tuple_set_element", "tuple_vec_element"] {
+        assert_eq!(
+            properties[field]["prefixItems"][1], nullable_items,
+            "{field}"
+        );
+    }
+    for field in ["tuple_set_slot", "tuple_vec_slot"] {
+        assert_eq!(
+            properties[field]["prefixItems"][1],
+            or_null(&plain_array),
+            "{field}"
+        );
+    }
+    assert_eq!(
+        properties["tuple_both"]["prefixItems"][1],
+        or_null(&nullable_items)
+    );
+
+    // A wrapper under an array is two levels, and each one answers for the `Option` written at it:
+    // the inner array's items, then the inner array itself, both inside the outer array.
+    assert_eq!(
+        properties["map_wrapped"]["additionalProperties"],
+        array_of(&or_null(&nullable_items))
+    );
+}
+
+/// The TypeScript surface says the same thing in its own spelling: the `| null` sits inside the
+/// `Array<…>` for an element `Option` and outside it for a slot `Option`.
+#[test]
+#[cfg(feature = "typescript")]
+fn test_the_typescript_surface_puts_the_null_at_the_level_it_was_written() {
+    for spelling in [
+        "set_items: Array<number | null>;",
+        "vec_items: Array<number | null>;",
+    ] {
+        let definition = ElementNullFields::ts_definition();
+        assert!(definition.contains(spelling), "Got: {definition}");
+    }
+    for spelling in [
+        "set_items: Array<number> | undefined;",
+        "vec_items: Array<number> | undefined;",
+    ] {
+        let definition = SlotNullFields::ts_definition();
+        assert!(definition.contains(spelling), "Got: {definition}");
+    }
+    let definition = NullNestingSlots::ts_definition();
+    for spelling in [
+        "map_both: Partial<Record<string, Array<number | null> | null>>;",
+        "map_wrapped: Partial<Record<string, Array<Array<number | null> | null>>>;",
+        "map_set_element: Partial<Record<string, Array<number | null>>>;",
+        "map_set_slot: Partial<Record<string, Array<number> | null>>;",
+        "map_vec_element: Partial<Record<string, Array<number | null>>>;",
+        "map_vec_slot: Partial<Record<string, Array<number> | null>>;",
+        "tuple_both: [string, Array<number | null> | null];",
+        "tuple_set_element: [string, Array<number | null>];",
+        "tuple_set_slot: [string, Array<number> | null];",
+        "tuple_vec_element: [string, Array<number | null>];",
+        "tuple_vec_slot: [string, Array<number> | null];",
+    ] {
+        assert!(definition.contains(spelling), "Got: {definition}");
+    }
+}
+
+/// And the Zod surface: `z.nullable` inside the `z.array` for an element `Option`, around it for a
+/// slot `Option`.
+#[test]
+#[cfg(feature = "zod")]
+fn test_the_zod_surface_puts_the_nullable_at_the_level_it_was_written() {
+    let element_null = ElementNullFields::zod_schema();
+    for spelling in [
+        "set_items: z.array(z.nullable(z.number().int())),",
+        "vec_items: z.array(z.nullable(z.number().int())),",
+    ] {
+        assert!(element_null.contains(spelling), "Got: {element_null}");
+    }
+    let slot_null = SlotNullFields::zod_schema();
+    for spelling in [
+        "set_items: z.union([z.array(z.number().int()), z.undefined()]).prefault(undefined),",
+        "vec_items: z.union([z.array(z.number().int()), z.undefined()]).prefault(undefined),",
+    ] {
+        assert!(slot_null.contains(spelling), "Got: {slot_null}");
+    }
+    let schema = NullNestingSlots::zod_schema();
+    for spelling in [
+        "map_both: z.record(z.string(), z.nullable(z.array(z.nullable(z.number().int())))),",
+        "map_wrapped: z.record(z.string(), z.array(z.nullable(z.array(z.nullable(z.number().int()))))),",
+        "map_set_element: z.record(z.string(), z.array(z.nullable(z.number().int()))),",
+        "map_set_slot: z.record(z.string(), z.nullable(z.array(z.number().int()))),",
+        "map_vec_element: z.record(z.string(), z.array(z.nullable(z.number().int()))),",
+        "map_vec_slot: z.record(z.string(), z.nullable(z.array(z.number().int()))),",
+        "tuple_both: z.tuple([z.string(), z.nullable(z.array(z.nullable(z.number().int())))]),",
+        "tuple_set_element: z.tuple([z.string(), z.array(z.nullable(z.number().int()))]),",
+        "tuple_set_slot: z.tuple([z.string(), z.nullable(z.array(z.number().int()))]),",
+        "tuple_vec_element: z.tuple([z.string(), z.array(z.nullable(z.number().int()))]),",
+        "tuple_vec_slot: z.tuple([z.string(), z.nullable(z.array(z.number().int()))]),",
+    ] {
+        assert!(schema.contains(spelling), "Got: {schema}");
+    }
+}
+
+/// The set spelling and the `Vec` spelling of the same nesting write one value, so they describe as
+/// one — the parity the wrapper list exists to hold, now read at each level separately.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_a_set_nesting_describes_as_the_vec_nesting_it_writes() {
+    let properties = NullNestingSlots::json_schema()["properties"].clone();
+    for (set_field, vec_field) in [
+        ("map_set_element", "map_vec_element"),
+        ("map_set_slot", "map_vec_slot"),
+        ("tuple_set_element", "tuple_vec_element"),
+        ("tuple_set_slot", "tuple_vec_slot"),
+    ] {
+        assert_eq!(
+            properties[set_field], properties[vec_field],
+            "{set_field} against {vec_field}"
+        );
+    }
+    assert_eq!(
+        ElementNullFields::json_schema()["properties"]["set_items"],
+        ElementNullFields::json_schema()["properties"]["vec_items"]
+    );
+}


### PR DESCRIPTION
`Vec<Option<T>>` in a slot writes `[1, null]` but described as `anyOf[{array of T}, {null}]` — a nullable array, matching neither the wire nor the type.

- Phase 0: the serde wire matrix for all four Vec/Option nestings × three positions was measured from real output and recorded on the task before any change. Element-nulls live among the items and the array is always written; slot-nulls replace the array; sets are byte-identical to their Vec twins; both levels can be live at once.
- `is_optional` is deleted as stored state, replaced by `nullable_levels: Vec<u8>` — the complete set of array levels written as `Option`, renumbered through wrapper collapse so set spellings land exactly where Vec twins land. One source of truth; `is_optional()` becomes a question of it.
- Phase 1 landed the record with no reader — the untouched suite is the byte-identity proof. Phase 2 folds each level's null inside its own wrap on all four renderers, deleting the parity hack and the slot-normalization flag-OR.
- Field-position rule confirmed and unified: element-optionality is admitted everywhere (`Array<T | null>`, key required); `Option<Vec<T>>` named fields stay guarded exactly as before.

Gates: `just check` green during work; full powerset once at acceptance — green.
