### PR TITLE
fix: deserialization rejects what the schemas reject, through wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -821,7 +821,7 @@ match reg.validate() {
 
 The macro also generates into the type's schema module:
 - `validate_{field}_value(&FieldType) -> Result<(), String>` -- pure static validator per field
-- `deserialize_{field}(D) -> Result<FieldType, E>` -- serde hook that calls the static validator, emitted for a bare field only
+- `deserialize_{field}(D) -> Result<FieldType, E>` -- serde hook that calls the static validator
 
 #### Constraints under `Option`, wrappers, and sequences
 
@@ -840,7 +840,9 @@ pub struct Article {
 }
 ```
 
-Serde-side enforcement is narrower: the generated `deserialize_{field}` hook answers for the constrained value itself, so it is attached only when the field is written bare. A wrapped field is checked by `validate()`.
+Deserialization applies the same reach. A bare field's hook answers for the constrained value itself; a wrapped field's hook deserializes the field's own declared type and then runs that same walk over it, so a payload carrying a value the constraint rejects is rejected as it is read, not only when `validate()` is called. The two differ in one thing: `validate()` answers with every violation in the instance, while a `Deserializer` answers with one error, so the read stops at the first.
+
+A field whose key may be left out keeps that reading: an `Option` written outermost (under any number of transparent wrappers) is given `#[serde(default)]` alongside the hook, since a `deserialize_with` otherwise turns a missing key into an error. A field that writes its own `default` keeps the one it wrote.
 
 ### Literal Values
 

--- a/src/features/serde.rs
+++ b/src/features/serde.rs
@@ -6,7 +6,8 @@
 #[cfg(test)]
 use crate::rename_rule::resolve_rename_rule;
 use proc_macro2::{Delimiter, TokenTree};
-use syn::{Attribute, Error, LitStr, Meta};
+use syn::meta::ParseNestedMeta;
+use syn::{Attribute, Error, LitStr, Meta, Token};
 
 /// Message of the rejection raised for a serde attribute hidden behind `cfg_attr`.
 const CFG_ATTR_SERDE_REJECTION: &str = "cfg_attr-wrapped serde attribute is invisible to \
@@ -145,6 +146,7 @@ pub fn parse_serde_field_attributes(attrs: &[Attribute]) -> SerdeFieldMeta {
                 } else {
                     // Ignore other serde attributes.
                 }
+                consume_unread_value(&nested)?;
                 Ok(())
             })
             .unwrap_or_else(|e| {
@@ -156,6 +158,42 @@ pub fn parse_serde_field_attributes(attrs: &[Attribute]) -> SerdeFieldMeta {
     }
 
     meta
+}
+
+/// Consumes the value of a `key = value` the walk had no use for.
+///
+/// An unread value ends the walk on the comma that follows it, taking every attribute written
+/// after it along — so which attributes a field is read by would otherwise depend on the order
+/// someone happened to write them in.
+fn consume_unread_value(nested: &ParseNestedMeta<'_>) -> syn::Result<()> {
+    if nested.input.peek(Token![=]) {
+        nested.value()?.parse::<syn::Expr>()?;
+    }
+    Ok(())
+}
+
+/// Whether the field writes a value for itself when its key is missing, in either spelling
+/// (`default` and `default = "path"`).
+///
+/// Asked of the attributes rather than carried on [`SerdeFieldMeta`]: nothing the generated
+/// surfaces describe turns on it — it is read where a serde hook is written, to decide whether
+/// that hook has a missing key to answer for.
+pub fn has_serde_default(attrs: &[Attribute]) -> bool {
+    let mut defaulted = false;
+    for attr in attrs {
+        if !attr.path().is_ident("serde") {
+            continue;
+        }
+        attr.parse_nested_meta(|nested| {
+            defaulted |= nested.path.is_ident("default");
+            consume_unread_value(&nested)?;
+            Ok(())
+        })
+        .unwrap_or_else(|e| {
+            log::trace!("Failed to parse serde field attribute: {e}");
+        });
+    }
+    defaulted
 }
 
 /// Applies serde `rename_all` transformation to a field name.

--- a/src/features/serde/tests.rs
+++ b/src/features/serde/tests.rs
@@ -98,7 +98,11 @@ fn test_flatten_default_is_false() {
 }
 
 fn field_meta(item: &syn::ItemStruct) -> SerdeFieldMeta {
-    parse_serde_field_attributes(&item.fields.iter().next().unwrap().attrs)
+    parse_serde_field_attributes(field_attrs(item))
+}
+
+fn field_attrs(item: &syn::ItemStruct) -> &[syn::Attribute] {
+    &item.fields.iter().next().unwrap().attrs
 }
 
 #[test]
@@ -229,4 +233,59 @@ fn test_parse_untagged_type_attribute() {
 fn test_untagged_default_is_false() {
     let meta = SerdeTypeMeta::default();
     assert!(!meta.untagged);
+}
+
+/// A field's default is read in either spelling, since either one answers for a missing key.
+#[test]
+fn test_has_serde_default_reads_either_spelling() {
+    let bare: syn::ItemStruct = syn::parse_quote! {
+        struct S {
+            #[serde(default)]
+            note: Option<String>,
+        }
+    };
+    let named: syn::ItemStruct = syn::parse_quote! {
+        struct S {
+            #[serde(default = "make_note")]
+            note: Option<String>,
+        }
+    };
+    let neither: syn::ItemStruct = syn::parse_quote! {
+        struct S {
+            #[serde(skip_serializing_if = "Option::is_none")]
+            note: Option<String>,
+        }
+    };
+    assert!(has_serde_default(field_attrs(&bare)));
+    assert!(has_serde_default(field_attrs(&named)));
+    assert!(!has_serde_default(field_attrs(&neither)));
+}
+
+/// The walk reads every attribute in the list, wherever it sits. A `key = value` this parser has
+/// no use for still has to be consumed: an unread value ends the walk on the comma after it, and
+/// everything written past that point would go unseen — which is a field diagnosed by the
+/// attributes someone happened to write first.
+#[test]
+fn test_attributes_after_an_unread_value_are_still_read() {
+    let item: syn::ItemStruct = syn::parse_quote! {
+        struct S {
+            #[serde(skip_serializing_if = "Option::is_none", default, flatten, rename = "renamed")]
+            note: Option<String>,
+        }
+    };
+    let meta = field_meta(&item);
+    assert!(
+        meta.omits_none,
+        "skip_serializing_if is the attribute read first"
+    );
+    assert!(
+        has_serde_default(field_attrs(&item)),
+        "default is written after an unread value"
+    );
+    assert!(meta.flatten, "flatten is written after an unread value");
+    assert_eq!(
+        meta.rename.as_deref(),
+        Some("renamed"),
+        "rename is written last of all"
+    );
 }

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -36,7 +36,7 @@ use crate::utils::extract_example_from_docs;
 use crate::utils::{AliasKind, lookup_alias_info};
 
 #[cfg(feature = "serde")]
-use crate::features::serde::{SerdeFieldMeta, SerdeTypeMeta};
+use crate::features::serde::{SerdeFieldMeta, SerdeTypeMeta, has_serde_default};
 
 #[cfg(feature = "serde")]
 use crate::field_type::{parse_serde_field_attributes, parse_serde_type_attributes};
@@ -147,6 +147,9 @@ struct BrandedNewtypeOutput<'parts> {
 #[cfg(feature = "serde")]
 struct ConstrainedShape {
     leaf: ConstraintLeaf,
+    /// Every non-`'static` lifetime the field's type spells, deduplicated. A free function that
+    /// returns that type has to declare them itself — nothing of the struct's is in scope there.
+    lifetimes: Vec<syn::Lifetime>,
     wraps: Vec<ConstraintWrap>,
 }
 
@@ -156,6 +159,17 @@ enum ConstraintLeaf {
     /// The bare Rust numeric type, which is the validator's parameter type.
     Number(&'static str),
     Str,
+}
+
+/// What the end of a walk does with a violation it found.
+///
+/// `validate()` answers with every violation in the instance, so its walk collects; a
+/// `Deserializer` answers with one error, so the wire walk stops at the first.
+#[cfg(feature = "serde")]
+#[derive(Clone, Copy)]
+enum CheckSink {
+    Collect,
+    Fail,
 }
 
 /// A wrapper a constrained field can be written under, outermost first.
@@ -4288,7 +4302,7 @@ fn build_field_validation(
         };
     }
     let head = wrap_binding(0);
-    let walk = walk_wraps(wraps, &head, 1, validate_value_fn_ident);
+    let walk = walk_wraps(wraps, &head, 1, validate_value_fn_ident, CheckSink::Collect);
     quote! {
         {
             let #head = &self.#field_ident_tok;
@@ -4304,12 +4318,18 @@ fn walk_wraps(
     value: &proc_macro2::Ident,
     depth: usize,
     validate_value_fn_ident: &proc_macro2::Ident,
+    sink: CheckSink,
 ) -> proc_macro2::TokenStream {
     let Some((wrap, rest)) = wraps.split_first() else {
-        return quote! {
-            if let Err(e) = #validate_value_fn_ident(#value) {
-                errors.push(e);
-            }
+        return match sink {
+            CheckSink::Collect => quote! {
+                if let Err(e) = #validate_value_fn_ident(#value) {
+                    errors.push(e);
+                }
+            },
+            CheckSink::Fail => quote! {
+                #validate_value_fn_ident(#value)?;
+            },
         };
     };
     let next = wrap_binding(depth);
@@ -4318,6 +4338,7 @@ fn walk_wraps(
         &next,
         depth.saturating_add(1),
         validate_value_fn_ident,
+        sink,
     );
     match *wrap {
         // A `None` writes nothing, so there is nothing for the constraint to describe.
@@ -4338,17 +4359,65 @@ fn walk_wraps(
     }
 }
 
+/// Builds the serde hook for a field written under wrappers: it deserializes the field's own
+/// declared type and then runs the same walk `validate()` runs, so the wire is gated where the
+/// constraint lands rather than where the field happens to be spelled.
+///
+/// The declared type is the field's own tokens, both where it is returned and where it is checked,
+/// so a type naming a lifetime needs that lifetime declared here — nothing of the struct's generics
+/// reaches a free function. The check's parameter is typed rather than inferred: inference reaches
+/// the walk before it reaches the return type, and the walk's own leaf call would otherwise settle
+/// the helper's `T` as the validator's parameter type instead of the field's.
+#[cfg(feature = "serde")]
+fn build_wrapped_deserializer(
+    deserialize_fn_ident: &proc_macro2::Ident,
+    validate_value_fn_ident: &proc_macro2::Ident,
+    field_ty: &syn::Type,
+    lifetimes: &[syn::Lifetime],
+    wraps: &[ConstraintWrap],
+) -> proc_macro2::TokenStream {
+    let head = wrap_binding(0);
+    let walk = walk_wraps(wraps, &head, 1, validate_value_fn_ident, CheckSink::Fail);
+    quote! {
+        pub fn #deserialize_fn_ident<'de, #(#lifetimes,)* D>(deserializer: D) -> Result<#field_ty, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            // Nested so that each hook carries its own: a schema module holds one hook per
+            // constrained field and a shared name would have to be emitted exactly once.
+            fn deserialize_validated<'de, D, T, F>(deserializer: D, check: F) -> Result<T, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+                T: serde::Deserialize<'de>,
+                F: FnOnce(&T) -> Result<(), String>,
+            {
+                use serde::Deserialize;
+                let value = T::deserialize(deserializer)?;
+                check(&value).map_err(serde::de::Error::custom)?;
+                Ok(value)
+            }
+
+            deserialize_validated(deserializer, |#head: &#field_ty| {
+                #walk
+                Ok(())
+            })
+        }
+    }
+}
+
 /// Generates the static validator for a String field with constraints, plus the serde deserializer
-/// when the field is bare — a wrapped field's declared type is not the validator's, so only the
-/// bare spelling can carry `deserialize_with`.
+/// — written against the constrained value itself when the field is bare, and against the field's
+/// declared type when it is wrapped.
 ///
 /// Returns (`module_items`, `validate_body`) — both go into the schema module and `validate()` respectively.
 #[cfg(feature = "serde")]
 fn generate_string_validation_code(
     field_ident: &str,
     meta: &ModelSchemaPropMeta,
-    wraps: &[ConstraintWrap],
+    shape: &ConstrainedShape,
+    field_ty: &syn::Type,
 ) -> FieldValidationCode {
+    let wraps: &[ConstraintWrap] = &shape.wraps;
     let validate_value_fn_name = format!("validate_{field_ident}_value");
     let validate_value_fn_ident =
         proc_macro2::Ident::new(&validate_value_fn_name, proc_macro2::Span::call_site());
@@ -4401,7 +4470,7 @@ fn generate_string_validation_code(
         });
     }
 
-    let deserializer = wraps.is_empty().then(|| {
+    let deserializer = if wraps.is_empty() {
         quote! {
             pub fn #deserialize_fn_ident<'de, D>(deserializer: D) -> Result<String, D::Error>
             where
@@ -4413,7 +4482,15 @@ fn generate_string_validation_code(
                 Ok(s)
             }
         }
-    });
+    } else {
+        build_wrapped_deserializer(
+            &deserialize_fn_ident,
+            &validate_value_fn_ident,
+            field_ty,
+            &shape.lifetimes,
+            wraps,
+        )
+    };
 
     let module_items = quote! {
         pub fn #validate_value_fn_ident(value: &str) -> Result<(), String> {
@@ -4435,14 +4512,16 @@ fn generate_string_validation_code(
 }
 
 /// Generates the static validator for a numeric field with constraints, plus the serde deserializer
-/// when the field is bare — see `generate_string_validation_code` for why only that spelling gets one.
+/// — see `generate_string_validation_code` for how the two spellings differ.
 #[cfg(feature = "serde")]
 fn generate_numeric_validation_code(
     field_ident: &str,
     rust_type_str: &str,
     meta: &ModelSchemaPropMeta,
-    wraps: &[ConstraintWrap],
+    shape: &ConstrainedShape,
+    field_ty: &syn::Type,
 ) -> FieldValidationCode {
+    let wraps: &[ConstraintWrap] = &shape.wraps;
     let validate_value_fn_name = format!("validate_{field_ident}_value");
     let validate_value_fn_ident =
         proc_macro2::Ident::new(&validate_value_fn_name, proc_macro2::Span::call_site());
@@ -4482,7 +4561,7 @@ fn generate_numeric_validation_code(
         });
     }
 
-    let deserializer = wraps.is_empty().then(|| {
+    let deserializer = if wraps.is_empty() {
         quote! {
             pub fn #deserialize_fn_ident<'de, D>(deserializer: D) -> Result<#rust_type_ident, D::Error>
             where
@@ -4494,7 +4573,15 @@ fn generate_numeric_validation_code(
                 Ok(v)
             }
         }
-    });
+    } else {
+        build_wrapped_deserializer(
+            &deserialize_fn_ident,
+            &validate_value_fn_ident,
+            field_ty,
+            &shape.lifetimes,
+            wraps,
+        )
+    };
 
     let module_items = quote! {
         pub fn #validate_value_fn_ident(value: &#rust_type_ident) -> Result<(), String> {
@@ -4525,6 +4612,7 @@ fn generate_numeric_validation_code(
 #[cfg(feature = "serde")]
 fn constrained_shape(ty: &syn::Type) -> Option<ConstrainedShape> {
     let mut wraps = Vec::new();
+    let mut lifetimes: Vec<syn::Lifetime> = Vec::new();
     let mut current = ty;
     loop {
         if let syn::Type::Array(array) = current {
@@ -4537,15 +4625,37 @@ fn constrained_shape(ty: &syn::Type) -> Option<ConstrainedShape> {
             let segment = path.path.segments.last()?;
             if let syn::PathArguments::AngleBracketed(args) = &segment.arguments {
                 wraps.push(generic_wrap(&segment.ident.to_string())?);
+                collect_lifetimes(args, &mut lifetimes);
                 current = sole_type_argument(args)?;
             } else if matches!(segment.arguments, syn::PathArguments::None) {
                 let leaf = leaf_for_ident(&segment.ident.to_string())?;
-                return Some(ConstrainedShape { leaf, wraps });
+                return Some(ConstrainedShape {
+                    leaf,
+                    lifetimes,
+                    wraps,
+                });
             } else {
                 return None;
             }
         } else {
             return None;
+        }
+    }
+}
+
+/// Adds the lifetimes a wrapper spells to the ones already collected, skipping `'static` — which
+/// needs no declaration — and any already there, since a lifetime can only be declared once.
+#[cfg(feature = "serde")]
+fn collect_lifetimes(
+    args: &syn::AngleBracketedGenericArguments,
+    lifetimes: &mut Vec<syn::Lifetime>,
+) {
+    for arg in &args.args {
+        if let syn::GenericArgument::Lifetime(lifetime) = arg
+            && lifetime.ident != "static"
+            && !lifetimes.iter().any(|seen| seen.ident == lifetime.ident)
+        {
+            lifetimes.push(lifetime.clone());
         }
     }
 }
@@ -4800,8 +4910,29 @@ fn process_field(
     (field_def, validation_fn, validate_body, guard_error)
 }
 
+/// Whether the field needs a `#[serde(default)]` written for it alongside the `deserialize_with`.
+///
+/// serde reads a missing key as a `None` for any field that deserializes as an option — but only
+/// while the field deserializes itself. A `deserialize_with` makes that same missing key a hard
+/// error, and the generated schemas say the key may be left out, so such a field is given the
+/// default that restores what its absence already meant: `None`, wrapped as it was written. A
+/// field that already carries a default keeps the one it was written with.
+///
+/// A transparent wrapper hands its inner type the deserializer it was given, so a run of them
+/// changes nothing about which key is optional; a sequence does not, and neither does a `None`
+/// found beneath one. So the question is asked of the first wrapper that is not transparent, and
+/// anything else is a field whose key was never optional — its absence stays the error it was.
+#[cfg(feature = "serde")]
+fn needs_injected_default(wraps: &[ConstraintWrap], has_default: bool) -> bool {
+    let first_opaque = wraps
+        .iter()
+        .find(|wrap| !matches!(**wrap, ConstraintWrap::Transparent));
+    matches!(first_opaque, Some(ConstraintWrap::Optional)) && !has_default
+}
+
 /// Generates per-field serde validation code (static validator + `deserialize_with`) and, when
-/// constraints apply, injects the corresponding `#[serde(deserialize_with = ...)]` attribute.
+/// constraints apply, injects the corresponding `#[serde(deserialize_with = ...)]` attribute — plus
+/// the `#[serde(default)]` that keeps an optional key optional under one.
 #[cfg(feature = "serde")]
 fn generate_field_validation(
     field: &Field,
@@ -4826,14 +4957,20 @@ fn generate_field_validation(
 
     let generated = match shape.leaf {
         ConstraintLeaf::Str => has_string_constraints.then(|| {
-            generate_string_validation_code(raw_field_ident, model_schema_prop_meta, &shape.wraps)
+            generate_string_validation_code(
+                raw_field_ident,
+                model_schema_prop_meta,
+                &shape,
+                &field.ty,
+            )
         }),
         ConstraintLeaf::Number(rust_type) => has_numeric_constraints.then(|| {
             generate_numeric_validation_code(
                 raw_field_ident,
                 rust_type,
                 model_schema_prop_meta,
-                &shape.wraps,
+                &shape,
+                &field.ty,
             )
         }),
     };
@@ -4841,15 +4978,15 @@ fn generate_field_validation(
         return (None, None);
     };
 
-    // Only a bare field gets a `deserialize_with`: the generated deserializer answers for the
-    // constrained value itself, which is the field's own type only when nothing wraps it.
-    if shape.wraps.is_empty() {
-        let deserialize_with_path = format!("{module_name}::deserialize_{raw_field_ident}");
-        let path_lit = syn::LitStr::new(&deserialize_with_path, proc_macro2::Span::call_site());
-        let serde_attr: syn::Attribute = syn::parse_quote! {
-            #[serde(deserialize_with = #path_lit)]
-        };
-        new_attrs.push(serde_attr);
+    let deserialize_with_path = format!("{module_name}::deserialize_{raw_field_ident}");
+    let path_lit = syn::LitStr::new(&deserialize_with_path, proc_macro2::Span::call_site());
+    new_attrs.push(syn::parse_quote! {
+        #[serde(deserialize_with = #path_lit)]
+    });
+    if needs_injected_default(&shape.wraps, has_serde_default(&field.attrs)) {
+        new_attrs.push(syn::parse_quote! {
+            #[serde(default)]
+        });
     }
 
     (

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -5,9 +5,11 @@ use super::{
 
 #[cfg(feature = "serde")]
 use super::{
-    build_field_validation, cfg_attr_guard_error, check_optional_field_serialization,
-    collect_untagged_members, constrained_shape, enum_cfg_attr_guard_errors, field_label,
-    get_field_def, parse_serde_field_attributes, parse_serde_type_attributes,
+    ModelSchemaPropMeta, build_field_validation, cfg_attr_guard_error,
+    check_optional_field_serialization, collect_untagged_members, constrained_shape,
+    enum_cfg_attr_guard_errors, field_label, generate_numeric_validation_code,
+    generate_string_validation_code, get_field_def, needs_injected_default,
+    parse_serde_field_attributes, parse_serde_type_attributes,
 };
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
@@ -2391,6 +2393,201 @@ fn mixed_wrappers_compose_in_written_order() {
         emitted_validation("Option<Arc<[String]>>"),
         "{ let value_0 = & self . field ; if let Some (value_1) = value_0 { let value_2 = & * * value_1 ; for value_3 in value_2 { if let Err (e) = check (value_3) { errors . push (e) ; } } } }"
     );
+}
+
+/// The schema-module items emitted for a `minLength` field spelled `spelling`, as tokens.
+#[cfg(feature = "serde")]
+fn emitted_string_module(spelling: &str) -> String {
+    let ty: syn::Type = syn::parse_str(spelling).unwrap();
+    let shape = constrained_shape(&ty).unwrap();
+    let meta = ModelSchemaPropMeta {
+        min_length: Some(3),
+        ..ModelSchemaPropMeta::default()
+    };
+    generate_string_validation_code("field", &meta, &shape, &ty)
+        .module_items
+        .to_string()
+}
+
+/// Just the deserializer of [`emitted_string_module`], which is everything after the validator.
+#[cfg(feature = "serde")]
+fn emitted_string_deserializer(spelling: &str) -> String {
+    let module = emitted_string_module(spelling);
+    assert!(
+        module.contains("pub fn deserialize_field"),
+        "no deserializer emitted for {spelling}: {module}"
+    );
+    module[module.find("pub fn deserialize_field").unwrap()..].to_owned()
+}
+
+/// The one deserializer whose body predates the reach-through and must not move: it is what every
+/// already-generated bare field is gated by.
+#[cfg(feature = "serde")]
+#[test]
+fn a_bare_field_deserializes_the_constrained_value_itself() {
+    assert_eq!(
+        emitted_string_deserializer("String"),
+        "pub fn deserialize_field < 'de , D > (deserializer : D) -> Result < String , D :: Error > \
+         where D : serde :: Deserializer < 'de > , { use serde :: Deserialize ; \
+         let s = String :: deserialize (deserializer) ? ; \
+         validate_field_value (& s) . map_err (serde :: de :: Error :: custom) ? ; Ok (s) }"
+    );
+
+    let numeric_ty: syn::Type = syn::parse_str("u32").unwrap();
+    let numeric_meta = ModelSchemaPropMeta {
+        minimum: Some(5.0_f64),
+        ..ModelSchemaPropMeta::default()
+    };
+    let numeric = generate_numeric_validation_code(
+        "field",
+        "u32",
+        &numeric_meta,
+        &constrained_shape(&numeric_ty).unwrap(),
+        &numeric_ty,
+    )
+    .module_items
+    .to_string();
+    assert!(
+        numeric.ends_with(
+            "pub fn deserialize_field < 'de , D > (deserializer : D) -> Result < u32 , D :: Error > \
+             where D : serde :: Deserializer < 'de > , { use serde :: Deserialize ; \
+             let v = u32 :: deserialize (deserializer) ? ; \
+             validate_field_value (& v) . map_err (serde :: de :: Error :: custom) ? ; Ok (v) }"
+        ),
+        "bare numeric deserializer moved: {numeric}"
+    );
+}
+
+/// A wrapped field is gated on the way in by the walk that gates it in `validate()`, run over the
+/// field's own declared type — the one thing a hook attached to that field can answer for.
+#[cfg(feature = "serde")]
+#[test]
+fn a_wrapped_field_deserializes_its_declared_type() {
+    assert_eq!(
+        emitted_string_deserializer("Option<String>"),
+        "pub fn deserialize_field < 'de , D > (deserializer : D) -> Result < Option < String > , D :: Error > \
+         where D : serde :: Deserializer < 'de > , \
+         { fn deserialize_validated < 'de , D , T , F > (deserializer : D , check : F) -> Result < T , D :: Error > \
+         where D : serde :: Deserializer < 'de > , T : serde :: Deserialize < 'de > , F : FnOnce (& T) -> Result < () , String > , \
+         { use serde :: Deserialize ; let value = T :: deserialize (deserializer) ? ; \
+         check (& value) . map_err (serde :: de :: Error :: custom) ? ; Ok (value) } \
+         deserialize_validated (deserializer , | value_0 : & Option < String > | \
+         { if let Some (value_1) = value_0 { validate_field_value (value_1) ? ; } Ok (()) }) }"
+    );
+}
+
+/// The `validate()` walk for `spelling` rewritten into the ending the wire needs: the collected
+/// violation becomes the answered one, and nothing else about the walk is touched.
+#[cfg(feature = "serde")]
+fn wire_walk_of(spelling: &str) -> String {
+    let ty: syn::Type = syn::parse_str(spelling).unwrap();
+    let shape = constrained_shape(&ty).unwrap();
+    let field = proc_macro2::Ident::new("field", proc_macro2::Span::call_site());
+    let checker = proc_macro2::Ident::new("validate_field_value", proc_macro2::Span::call_site());
+    build_field_validation(&shape.wraps, &field, &checker)
+        .to_string()
+        .replace(
+            "if let Err (e) = validate_field_value (",
+            "validate_field_value (",
+        )
+        .replace(") { errors . push (e) ; }", ") ? ;")
+        .trim_start_matches("{ let value_0 = & self . field ; ")
+        .trim_end_matches(" }")
+        .to_owned()
+}
+
+/// The walk inside the hook is the walk `validate()` runs — same reach, same bindings, same order,
+/// differing only where it ends: a `Deserializer` answers with one error, so the wire walk stops at
+/// the first violation instead of collecting every one.
+#[cfg(feature = "serde")]
+#[test]
+fn the_wire_walk_is_the_validate_walk_shape_for_shape() {
+    for spelling in [
+        "Box<String>",
+        "Vec<String>",
+        "Cow<'static, str>",
+        "Option<Vec<String>>",
+        "Option<Arc<[String]>>",
+        "Vec<Vec<String>>",
+    ] {
+        let walk = wire_walk_of(spelling);
+        let deserializer = emitted_string_deserializer(spelling);
+        assert!(
+            deserializer.contains(&walk),
+            "spelling {spelling} walks differently on the wire than in validate(): \
+             expected {walk} within {deserializer}"
+        );
+    }
+}
+
+/// A lifetime the field spells is declared by the hook that returns that type: a free function is
+/// handed none of the struct's generics. `'static` needs no declaration and gets none.
+#[cfg(feature = "serde")]
+#[test]
+fn a_borrowed_field_type_carries_its_lifetime_into_the_hook() {
+    assert!(
+        emitted_string_deserializer("Cow<'a, str>").starts_with(
+            "pub fn deserialize_field < 'de , 'a , D > (deserializer : D) -> Result < Cow < 'a , str > , D :: Error >"
+        ),
+        "{}",
+        emitted_string_deserializer("Cow<'a, str>")
+    );
+    assert!(
+        emitted_string_deserializer("Cow<'static, str>").starts_with(
+            "pub fn deserialize_field < 'de , D > (deserializer : D) -> Result < Cow < 'static , str > , D :: Error >"
+        ),
+        "{}",
+        emitted_string_deserializer("Cow<'static, str>")
+    );
+
+    let ty: syn::Type = syn::parse_str("Option<Cow<'a, Cow<'a, str>>>").unwrap();
+    let lifetimes = constrained_shape(&ty).unwrap().lifetimes;
+    assert_eq!(
+        lifetimes.len(),
+        1,
+        "a lifetime spelled twice must still be declared once"
+    );
+}
+
+/// serde reads a missing key for an `Option` as a `None` only while the field deserializes itself,
+/// so the hook that replaces that reading is given the default which restores it — and only there.
+#[cfg(feature = "serde")]
+#[test]
+fn only_an_outermost_option_without_a_default_gets_one_injected() {
+    let defaulted = true;
+    let plain = false;
+
+    for spelling in [
+        "Option<String>",
+        "Option<Vec<String>>",
+        "Box<Option<String>>",
+        "Arc<Rc<Option<String>>>",
+    ] {
+        let ty: syn::Type = syn::parse_str(spelling).unwrap();
+        let wraps = constrained_shape(&ty).unwrap().wraps;
+        assert!(
+            needs_injected_default(&wraps, plain),
+            "{spelling} would answer a missing key with an error"
+        );
+        assert!(
+            !needs_injected_default(&wraps, defaulted),
+            "{spelling} already has a default of its own"
+        );
+    }
+
+    for spelling in [
+        "String",
+        "Vec<Option<String>>",
+        "Box<String>",
+        "Box<Vec<Option<String>>>",
+    ] {
+        let ty: syn::Type = syn::parse_str(spelling).unwrap();
+        let wraps = constrained_shape(&ty).unwrap().wraps;
+        assert!(
+            !needs_injected_default(&wraps, plain),
+            "{spelling} has no optional key to restore"
+        );
+    }
 }
 
 /// A field with no value for a length or a range to describe emits nothing at all.

--- a/tests/validation_tests/tests.rs
+++ b/tests/validation_tests/tests.rs
@@ -2,6 +2,11 @@
     feature = "serde",
     any(feature = "typescript", feature = "zod", feature = "jsonschema")
 ))]
+use alloc::borrow::Cow;
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
 use alloc::sync::Arc;
 #[cfg(all(
     feature = "serde",
@@ -1391,4 +1396,317 @@ fn test_validate_boxed_option_string() {
         .is_ok(),
         "A None under a Box still writes nothing to constrain"
     );
+}
+
+// ==================== Constraints on the wire, under Option / wrappers / sequences ====================
+
+/// The gate every consumer reaches first. A constraint describes the value the field puts on the
+/// wire, so a payload carrying a value the constraint rejects is rejected as it is read — at the
+/// same place, and with the same message, that `validate()` would answer with.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn test_deserialize_optional_string_rejects_a_short_some() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug)]
+    pub struct WireOptional {
+        #[model_schema_prop(minLength = 3)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub nickname: Option<String>,
+    }
+
+    let error = serde_json::from_str::<WireOptional>(r#"{"nickname":"a"}"#).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("'nickname' is too short: minimum length is 3, got 1"),
+        "Unexpected error: {error}"
+    );
+
+    let accepted = serde_json::from_str::<WireOptional>(r#"{"nickname":"abc"}"#).unwrap();
+    assert_eq!(accepted.nickname.as_deref(), Some("abc"));
+}
+
+/// A `None` puts no string on the wire, so neither spelling of its absence has anything to reject.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn test_deserialize_optional_string_still_admits_an_absent_key() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug)]
+    pub struct WireAbsent {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[model_schema_prop(minLength = 3)]
+        pub nickname: Option<String>,
+    }
+
+    assert!(
+        serde_json::from_str::<WireAbsent>("{}")
+            .unwrap()
+            .nickname
+            .is_none(),
+        "A missing key is what the generated schemas describe as the absent form"
+    );
+    assert!(
+        serde_json::from_str::<WireAbsent>(r#"{"nickname":null}"#)
+            .unwrap()
+            .nickname
+            .is_none(),
+        "A null reads as the same None it always did"
+    );
+}
+
+/// A field that writes its own default keeps it: the hook is given no second one.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn test_deserialize_optional_string_keeps_a_written_default() {
+    fn preset() -> Option<String> {
+        Some("preset".to_owned()).filter(|preset| preset.len() >= 3)
+    }
+
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug)]
+    pub struct WirePreset {
+        #[serde(default = "preset", skip_serializing_if = "Option::is_none")]
+        #[model_schema_prop(minLength = 3)]
+        pub nickname: Option<String>,
+    }
+
+    assert_eq!(
+        serde_json::from_str::<WirePreset>("{}")
+            .unwrap()
+            .nickname
+            .as_deref(),
+        Some("preset"),
+        "The field's own default is what answers for its missing key"
+    );
+}
+
+/// A transparent wrapper writes its inner value and nothing else, so the wire the constraint
+/// describes is the same one a bare field writes.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn test_deserialize_boxed_string_rejects_a_short_value() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug)]
+    pub struct WireBoxed {
+        #[model_schema_prop(minLength = 3)]
+        pub label: Box<str>,
+    }
+
+    let error = serde_json::from_str::<WireBoxed>(r#"{"label":"a"}"#).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("'label' is too short: minimum length is 3, got 1"),
+        "Unexpected error: {error}"
+    );
+    assert_eq!(
+        &*serde_json::from_str::<WireBoxed>(r#"{"label":"abc"}"#)
+            .unwrap()
+            .label,
+        "abc"
+    );
+}
+
+/// A `Cow` arrives as the `Box` does, its lifetime being no part of what it writes.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn test_deserialize_cow_string_rejects_a_short_value() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug)]
+    pub struct WireCow {
+        #[model_schema_prop(minLength = 3)]
+        pub label: Cow<'static, str>,
+    }
+
+    let error = serde_json::from_str::<WireCow>(r#"{"label":"a"}"#).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("'label' is too short: minimum length is 3, got 1"),
+        "Unexpected error: {error}"
+    );
+    assert_eq!(
+        serde_json::from_str::<WireCow>(r#"{"label":"abc"}"#)
+            .unwrap()
+            .label,
+        "abc"
+    );
+}
+
+/// A sequence writes an array of the constrained value, so one failing element fails the read.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn test_deserialize_vec_string_rejects_a_short_element() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug)]
+    pub struct WireVec {
+        #[model_schema_prop(minLength = 3)]
+        pub tags: Vec<String>,
+    }
+
+    let error = serde_json::from_str::<WireVec>(r#"{"tags":["ok!","a"]}"#).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("'tags' is too short: minimum length is 3, got 1"),
+        "Unexpected error: {error}"
+    );
+    assert_eq!(
+        serde_json::from_str::<WireVec>(r#"{"tags":["ok!","two"]}"#)
+            .unwrap()
+            .tags,
+        vec!["ok!".to_owned(), "two".to_owned()]
+    );
+    assert!(
+        serde_json::from_str::<WireVec>(r#"{"tags":[]}"#)
+            .unwrap()
+            .tags
+            .is_empty(),
+        "An empty array writes no element to constrain"
+    );
+}
+
+/// The wrappers compose on the wire in the order they were written.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn test_deserialize_optional_vec_string_rejects_a_short_element() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug)]
+    pub struct WireOptionalVec {
+        #[model_schema_prop(minLength = 3)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub tags: Option<Vec<String>>,
+    }
+
+    let error = serde_json::from_str::<WireOptionalVec>(r#"{"tags":["ok!","a"]}"#).unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("'tags' is too short: minimum length is 3, got 1"),
+        "Unexpected error: {error}"
+    );
+    assert!(
+        serde_json::from_str::<WireOptionalVec>("{}")
+            .unwrap()
+            .tags
+            .is_none(),
+        "A missing key is still the absent form the schemas describe"
+    );
+}
+
+/// A range describes the number on the wire wherever the field wrote it, exactly as a length
+/// describes the string.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn test_deserialize_optional_numeric_rejects_an_out_of_range_some() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug)]
+    pub struct WireNumeric {
+        #[model_schema_prop(minimum = 18, maximum = 120)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub age: Option<u32>,
+        #[model_schema_prop(minimum = 1)]
+        pub counts: Vec<u32>,
+    }
+
+    let out_of_range =
+        serde_json::from_str::<WireNumeric>(r#"{"age":5,"counts":[1]}"#).unwrap_err();
+    assert!(
+        out_of_range
+            .to_string()
+            .contains("'age' is too small: minimum is 18, got 5"),
+        "Unexpected error: {out_of_range}"
+    );
+
+    let under_element =
+        serde_json::from_str::<WireNumeric>(r#"{"age":21,"counts":[1,0]}"#).unwrap_err();
+    assert!(
+        under_element
+            .to_string()
+            .contains("'counts' is too small: minimum is 1, got 0"),
+        "Unexpected error: {under_element}"
+    );
+
+    let accepted = serde_json::from_str::<WireNumeric>(r#"{"age":21,"counts":[1]}"#).unwrap();
+    assert_eq!(accepted.age, Some(21));
+}
+
+/// What the wire admits and what `validate()` admits are the same set — a value one accepts and the
+/// other rejects is the disagreement this covers.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn test_deserialize_and_validate_agree_on_every_wrapped_shape() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug)]
+    pub struct WireAgreement {
+        #[model_schema_prop(minLength = 3)]
+        pub boxed: Box<str>,
+        #[model_schema_prop(minLength = 3)]
+        pub cow: Cow<'static, str>,
+        #[model_schema_prop(minLength = 3)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub nested: Option<Vec<String>>,
+        #[model_schema_prop(minLength = 3)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub opt: Option<String>,
+        #[model_schema_prop(minLength = 3)]
+        pub plain: String,
+        #[model_schema_prop(minLength = 3)]
+        pub tags: Vec<String>,
+    }
+
+    const GOOD: &str =
+        r#"{"opt":"aaa","boxed":"bbb","tags":["ccc"],"cow":"ddd","nested":["eee"],"plain":"fff"}"#;
+
+    let accepted = serde_json::from_str::<WireAgreement>(GOOD).unwrap();
+    assert!(
+        accepted.validate().is_ok(),
+        "A payload the wire admits must be one validate() admits"
+    );
+
+    for (field, short) in [
+        ("opt", r#""a""#),
+        ("boxed", r#""b""#),
+        ("tags", r#"["c"]"#),
+        ("cow", r#""d""#),
+        ("nested", r#"["e"]"#),
+        ("plain", r#""f""#),
+    ] {
+        let mut payload: serde_json::Value = serde_json::from_str(GOOD).unwrap();
+        payload[field] = serde_json::from_str(short).unwrap();
+        let error = serde_json::from_str::<WireAgreement>(&payload.to_string()).unwrap_err();
+        assert!(
+            error.to_string().contains(&format!(
+                "'{field}' is too short: minimum length is 3, got 1"
+            )),
+            "field {field} was admitted by the wire but is rejected by validate(): {error}"
+        );
+    }
 }


### PR DESCRIPTION
Wrapped constrained fields (`Option<String>`, `Box<str>`, `Vec<String>`, …) were rejected by `validate()` and all three schema surfaces but **admitted at deserialization** — the wire gate consumers actually rely on.

- `deserialize_validated<'de, D, T, F>` deserializes the field's declared type and maps a failed check through `de::Error::custom`; the check closure body is PR 60's walker — one check source, two consumers split by `CheckSink` (validate collects all, the wire answers first).
- Three measured necessities recorded: the closure parameter must be typed (inference otherwise settles `T` wrong), non-static lifetimes are declared per hook, and `serde(default)` is injected for Option-outer shapes because `deserialize_with` otherwise turns an absent key into a hard error the schemas don't describe.
- In-scope parser fix: field-attr parsing left unread `key = value` values on the stream, ending syn's walk and silently hiding every following attribute — the injection decision reads exactly those.
- Red-first verified by stubbing each half; bare-field deserializer token-pinned. Scope limit recorded on the task: struct-lifetime `Cow` is unreachable under the macro today (filed).

Gates: `just check` green during work; full powerset once at acceptance — green.
