### PR TITLE
fix: single-element tuple variant Option content renders null-flavored on TS/Zod

### DIFF
--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -509,11 +509,12 @@ impl FieldDef {
         })
     }
 
-    /// The TypeScript type for a value in a slot that cannot be dropped — a tuple element or a
-    /// map entry. An `Option` there is null-flavored (`{base} | null`) rather than
-    /// undefined-flavored: only an object key can be omitted, so serde emits `null` for a `None`
-    /// in either position.
-    fn typescript_slot_typename(&self) -> String {
+    /// The TypeScript type for a value in a slot that cannot be dropped — a tuple element, a map
+    /// entry, or the content key of a single-element tuple variant, which serde always writes. An
+    /// `Option` there is null-flavored (`{base} | null`) rather than undefined-flavored: none of
+    /// those positions can be omitted the way an object key can, so serde emits `null` for a
+    /// `None` in each of them.
+    pub fn typescript_slot_typename(&self) -> String {
         let base = self.typescript_base();
         if self.is_optional() {
             format!("{base} | null")
@@ -678,12 +679,13 @@ impl FieldDef {
         result
     }
 
-    /// The Zod schema for a value in a slot that cannot be dropped — a tuple element or a map
-    /// entry. An `Option` there is null-flavored (`z.nullable({base})`) rather than
-    /// undefined-flavored: only an object key can be omitted, so serde emits `null` for a `None`
-    /// in either position.
+    /// The Zod schema for a value in a slot that cannot be dropped — a tuple element, a map entry,
+    /// or the content key of a single-element tuple variant, which serde always writes. An
+    /// `Option` there is null-flavored (`z.nullable({base})`) rather than undefined-flavored: none
+    /// of those positions can be omitted the way an object key can, so serde emits `null` for a
+    /// `None` in each of them.
     #[cfg(feature = "zod")]
-    fn zod_slot_type(&self) -> String {
+    pub fn zod_slot_type(&self) -> String {
         let base = self.zod_base();
         if self.is_optional() {
             format!("z.nullable({base})")

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -3205,6 +3205,10 @@ fn push_single_tuple_json_field(
 }
 
 /// Writes the single-element tuple portion of a discriminated enum variant.
+///
+/// The content key is a slot: serde writes it for every variant that has one, so a `None` there
+/// reaches the wire as a `null` under the key rather than dropping it. All three surfaces read the
+/// element through the slot spellings for that reason.
 fn write_tuple_single_variant_fields(
     field_defs: &[FieldDef],
     content_name: &str,
@@ -3213,7 +3217,6 @@ fn write_tuple_single_variant_fields(
 ) {
     let variant_type_code = &mut parts.type_code;
     let variant_schema_code = &mut parts.schema_code;
-    let optional_fields = &mut parts.optional_fields;
     let json_schema_variant_fields = &mut parts.json_fields;
     let Some(fld) = field_defs.first() else {
         let _: (&_, &_, &_) = (
@@ -3228,13 +3231,13 @@ fn write_tuple_single_variant_fields(
         variant_type_code,
         "  /** Tuple value */\n  {}: {};",
         content_name,
-        fld.typescript_typename()
+        fld.typescript_slot_typename()
     );
 
     // Add Zod schema definition
     #[cfg(feature = "zod")]
     {
-        let zod_field_type = fld.zod_type();
+        let zod_field_type = fld.zod_slot_type();
         let is_recursive = fld.contains_type_reference(self_type_name);
 
         if is_recursive {
@@ -3258,10 +3261,6 @@ fn write_tuple_single_variant_fields(
     push_single_tuple_json_field(json_schema_variant_fields, content_name, fld);
     #[cfg(not(feature = "jsonschema"))]
     let _: &_ = &json_schema_variant_fields;
-
-    if fld.is_optional() {
-        optional_fields.push(content_name.to_owned());
-    }
 }
 
 /// Writes the multi-element tuple portion of a discriminated enum variant.

--- a/tests/tuple_variant_tests/tests.rs
+++ b/tests/tuple_variant_tests/tests.rs
@@ -16,6 +16,19 @@ pub enum Outer {
     Wrapped(Inner),
 }
 
+/// The content key of a single-element tuple variant is a slot: serde always writes the key, so a
+/// `None` at the outermost level reaches the wire as a `null` under it rather than dropping the
+/// key. The three variants below are the three answers the surfaces owe — the `Option` around the
+/// array, the `Option` among its items, and no `Option` at all.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(tag = "type", content = "value")]
+pub enum SlotContent {
+    Covered(Option<Vec<u32>>),
+    Element(Vec<Option<u32>>),
+    Plain(String),
+}
+
 /// Test 1: Single-element tuple variants.
 /// Each variant has exactly one tuple element.
 #[test]
@@ -470,10 +483,10 @@ fn test_optional_in_tuple() {
 
     let ts = OptionalTuple::ts_definition();
 
-    // Single optional tuple
+    // Single optional tuple: the content key is a slot, so the `None` is a `null` under it.
     assert!(
-        ts.contains("value: string | undefined"),
-        "Maybe should have optional string"
+        ts.contains("value: string | null"),
+        "Maybe should have nullable string"
     );
 
     // Multi tuple with optional element
@@ -732,5 +745,107 @@ fn test_jsdoc_comments() {
     assert!(
         ts.contains("Tuple:") || ts.contains("Tuple value"),
         "Multi-tuple should have tuple documentation"
+    );
+}
+
+/// Test 17: what serde writes for a single-element tuple variant whose content is an `Option` —
+/// the capture the three surfaces below are read against.
+#[test]
+fn test_single_tuple_variant_option_content_writes_null_under_the_key() {
+    assert_eq!(
+        serde_json::to_value(SlotContent::Covered(None)).unwrap(),
+        serde_json::json!({ "type": "Covered", "value": null }),
+        "A `None` content keeps the key and writes `null` under it"
+    );
+    assert_eq!(
+        serde_json::to_value(SlotContent::Element(vec![None])).unwrap(),
+        serde_json::json!({ "type": "Element", "value": [null] }),
+        "A `None` among the items is a `null` among them"
+    );
+}
+
+/// Test 17a: TypeScript describes that content key as the slot it is.
+#[test]
+fn test_single_tuple_variant_option_content_typescript_null_flavor() {
+    let ts = SlotContent::ts_definition();
+
+    assert!(
+        ts.contains("value: Array<number> | null"),
+        "Covered's content is the slot the `None` fills with `null`. Got: {ts}"
+    );
+    assert!(
+        ts.contains("value: Array<number | null>"),
+        "Element's `None` stays among the items. Got: {ts}"
+    );
+    assert!(
+        ts.contains("value: string;"),
+        "Plain's content carries no null. Got: {ts}"
+    );
+}
+
+/// Test 17b: the Zod schema of that content key admits the `null` serde writes.
+#[cfg(feature = "zod")]
+#[test]
+fn test_single_tuple_variant_option_content_zod_null_flavor() {
+    let zod = SlotContent::zod_schema();
+
+    assert!(
+        zod.contains("value: z.nullable(z.array(z.number().int()))"),
+        "Covered's content admits the `null`. Got: {zod}"
+    );
+    assert!(
+        zod.contains("value: z.array(z.nullable(z.number().int()))"),
+        "Element's `null` stays among the items. Got: {zod}"
+    );
+    assert!(
+        zod.contains("value: z.string()"),
+        "Plain's content carries no null. Got: {zod}"
+    );
+}
+
+/// Test 17c: the JSON schema already said so, and keeps saying it unchanged.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn test_single_tuple_variant_option_content_json_schema_null_flavor() {
+    let schema = SlotContent::json_schema();
+    let variant_of = |discriminator: &str| {
+        schema["oneOf"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|member| member["properties"]["type"]["const"] == discriminator)
+            .unwrap()
+            .clone()
+    };
+
+    let covered = variant_of("Covered");
+    assert_eq!(
+        covered["properties"]["value"],
+        serde_json::json!({
+            "anyOf": [
+                { "type": "array", "items": { "type": "integer" } },
+                { "type": "null" }
+            ]
+        })
+    );
+    assert!(
+        covered["required"]
+            .as_array()
+            .unwrap()
+            .contains(&serde_json::Value::String("value".to_owned())),
+        "The key a `None` cannot drop stays required. Got: {}",
+        covered["required"]
+    );
+
+    assert_eq!(
+        variant_of("Element")["properties"]["value"],
+        serde_json::json!({
+            "type": "array",
+            "items": { "anyOf": [{ "type": "integer" }, { "type": "null" }] }
+        })
+    );
+    assert_eq!(
+        variant_of("Plain")["properties"]["value"],
+        serde_json::json!({ "type": "string" })
     );
 }


### PR DESCRIPTION
The content key of a single-element tuple variant is a slot serde always writes — a None reaches the wire as null under the key. JSON already said anyOf[T,null]; TS and Zod spelled the field-position absent form and rejected the only payload serde can produce.

write_tuple_single_variant_fields now renders TS/Zod through the FieldDef slot spellings (typescript_slot_typename / zod_slot_type, promoted to pub); the JSON arm is untouched. The dead optional_fields push for the content key is removed (consumed nowhere — the only consumer discards it). Red-first: live serde capture {"type":"Covered","value":null} asserted first, three surface tests read against it; one test that codified the bug corrected.

Full feature powerset green in the lane.
