### PR TITLE
fix: a variant's constrained field names its validator helpers for its variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -823,6 +823,8 @@ The macro also generates into the type's schema module:
 - `validate_{field}_value(&FieldType) -> Result<(), String>` -- pure static validator per field
 - `deserialize_{field}(D) -> Result<FieldType, E>` -- serde hook that calls the static validator
 
+A constrained field of an enum variant is named for its variant too -- `validate_{variant}_{field}_value` and `deserialize_{variant}_{field}`, with `{variant}` in `snake_case`. One schema module holds every variant's helpers, and a field name is unique only within the variant that declares it, so two variants naming one field carry their own constraints.
+
 #### Constraints under `Option`, wrappers, and sequences
 
 A constraint describes the value the field puts on the wire, wherever it was written. `validate()` therefore reaches through everything the parser reads through -- an `Option`, a transparent wrapper (`Box`, `Rc`, `Arc`, `Cow`), and every sequence level (`Vec`, `VecDeque`, `HashSet`, `BTreeSet`, `LinkedList`, `BinaryHeap`, arrays and slices) -- and checks the innermost value, which is the same place the Zod, TypeScript and JSON Schema surfaces put it.

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -71,7 +71,12 @@ use crate::utils::{format_docs_for_ts, get_item_docs};
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 use crate::utils::register_alias_info;
 
-#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[cfg(any(
+    feature = "typescript",
+    feature = "zod",
+    feature = "jsonschema",
+    feature = "serde"
+))]
 use crate::utils::to_snake_case;
 
 use crate::rename_rule::resolve_rename_rule;
@@ -960,7 +965,7 @@ fn collect_struct_fields(
         let is_flatten = false;
 
         let (f_def, validation_fn, validate_body, guard_error) =
-            process_field(rename_all, field, module_name_opt, type_name);
+            process_field(rename_all, field, module_name_opt, None, type_name);
 
         if let Some(err) = guard_error {
             guard_errors.push(err);
@@ -2334,14 +2339,20 @@ fn collect_discriminated_variants(
         #[cfg(not(feature = "serde"))]
         let field_rename: Option<String> = None;
 
+        let variant_ident = item.ident.to_string();
         let final_name =
-            get_final_variant_name(&item.ident.to_string(), field_rename.as_deref(), rename_all);
+            get_final_variant_name(&variant_ident, field_rename.as_deref(), rename_all);
         let variant_kind = classify_variant(item);
 
         let mut field_defs: Vec<FieldDef> = Vec::new();
         for field in &mut item.fields {
-            let (f_def, validation_fn, _validate_body, guard_error) =
-                process_field(rename_all, field, enum_module_name_opt, &enum_type_name);
+            let (f_def, validation_fn, _validate_body, guard_error) = process_field(
+                rename_all,
+                field,
+                enum_module_name_opt,
+                Some(&variant_ident),
+                &enum_type_name,
+            );
             if let Some(vfn) = validation_fn {
                 enum_validation_fns.push(vfn);
             }
@@ -4405,6 +4416,20 @@ fn build_wrapped_deserializer(
     }
 }
 
+/// The stem the per-field helpers are named from: `validate_{stem}_value` and `deserialize_{stem}`.
+///
+/// A field name is unique only within the variant that declares it, while one schema module holds
+/// every variant's helpers — so a variant's field carries its variant into the stem, and two
+/// variants naming one field name two constraints instead of colliding. A struct field has no
+/// variant and keeps the bare field name its helpers have always been spelled with.
+#[cfg(feature = "serde")]
+fn helper_name_stem(field_ident: &str, variant_ident: Option<&str>) -> String {
+    variant_ident.map_or_else(
+        || field_ident.to_owned(),
+        |variant| format!("{}_{field_ident}", to_snake_case(variant)),
+    )
+}
+
 /// Generates the static validator for a String field with constraints, plus the serde deserializer
 /// — written against the constrained value itself when the field is bare, and against the field's
 /// declared type when it is wrapped.
@@ -4413,15 +4438,16 @@ fn build_wrapped_deserializer(
 #[cfg(feature = "serde")]
 fn generate_string_validation_code(
     field_ident: &str,
+    helper_stem: &str,
     meta: &ModelSchemaPropMeta,
     shape: &ConstrainedShape,
     field_ty: &syn::Type,
 ) -> FieldValidationCode {
     let wraps: &[ConstraintWrap] = &shape.wraps;
-    let validate_value_fn_name = format!("validate_{field_ident}_value");
+    let validate_value_fn_name = format!("validate_{helper_stem}_value");
     let validate_value_fn_ident =
         proc_macro2::Ident::new(&validate_value_fn_name, proc_macro2::Span::call_site());
-    let deserialize_fn_name = format!("deserialize_{field_ident}");
+    let deserialize_fn_name = format!("deserialize_{helper_stem}");
     let deserialize_fn_ident =
         proc_macro2::Ident::new(&deserialize_fn_name, proc_macro2::Span::call_site());
 
@@ -4516,16 +4542,17 @@ fn generate_string_validation_code(
 #[cfg(feature = "serde")]
 fn generate_numeric_validation_code(
     field_ident: &str,
+    helper_stem: &str,
     rust_type_str: &str,
     meta: &ModelSchemaPropMeta,
     shape: &ConstrainedShape,
     field_ty: &syn::Type,
 ) -> FieldValidationCode {
     let wraps: &[ConstraintWrap] = &shape.wraps;
-    let validate_value_fn_name = format!("validate_{field_ident}_value");
+    let validate_value_fn_name = format!("validate_{helper_stem}_value");
     let validate_value_fn_ident =
         proc_macro2::Ident::new(&validate_value_fn_name, proc_macro2::Span::call_site());
-    let deserialize_fn_name = format!("deserialize_{field_ident}");
+    let deserialize_fn_name = format!("deserialize_{helper_stem}");
     let deserialize_fn_ident =
         proc_macro2::Ident::new(&deserialize_fn_name, proc_macro2::Span::call_site());
 
@@ -4775,6 +4802,7 @@ fn process_field(
     rename_all: Option<&str>,
     field: &mut Field,
     schema_module_name: Option<&str>,
+    variant_ident: Option<&str>,
     type_name: &str,
 ) -> (
     FieldDef,
@@ -4820,6 +4848,7 @@ fn process_field(
         field,
         schema_module_name,
         &raw_field_ident,
+        variant_ident,
         &model_schema_prop_meta,
         &mut new_attrs,
     );
@@ -4830,7 +4859,7 @@ fn process_field(
         Option<proc_macro2::TokenStream>,
     ) = (None, None);
     #[cfg(not(feature = "serde"))]
-    let _: &_ = &schema_module_name;
+    let _: &_ = &(schema_module_name, variant_ident);
 
     field.attrs = new_attrs;
 
@@ -4938,6 +4967,7 @@ fn generate_field_validation(
     field: &Field,
     schema_module_name: Option<&str>,
     raw_field_ident: &str,
+    variant_ident: Option<&str>,
     model_schema_prop_meta: &ModelSchemaPropMeta,
     new_attrs: &mut Vec<syn::Attribute>,
 ) -> (
@@ -4955,10 +4985,12 @@ fn generate_field_validation(
         return (None, None);
     };
 
+    let helper_stem = helper_name_stem(raw_field_ident, variant_ident);
     let generated = match shape.leaf {
         ConstraintLeaf::Str => has_string_constraints.then(|| {
             generate_string_validation_code(
                 raw_field_ident,
+                &helper_stem,
                 model_schema_prop_meta,
                 &shape,
                 &field.ty,
@@ -4967,6 +4999,7 @@ fn generate_field_validation(
         ConstraintLeaf::Number(rust_type) => has_numeric_constraints.then(|| {
             generate_numeric_validation_code(
                 raw_field_ident,
+                &helper_stem,
                 rust_type,
                 model_schema_prop_meta,
                 &shape,
@@ -4978,7 +5011,7 @@ fn generate_field_validation(
         return (None, None);
     };
 
-    let deserialize_with_path = format!("{module_name}::deserialize_{raw_field_ident}");
+    let deserialize_with_path = format!("{module_name}::deserialize_{helper_stem}");
     let path_lit = syn::LitStr::new(&deserialize_with_path, proc_macro2::Span::call_site());
     new_attrs.push(syn::parse_quote! {
         #[serde(deserialize_with = #path_lit)]

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -8,7 +8,7 @@ use super::{
     ModelSchemaPropMeta, build_field_validation, cfg_attr_guard_error,
     check_optional_field_serialization, collect_untagged_members, constrained_shape,
     enum_cfg_attr_guard_errors, field_label, generate_numeric_validation_code,
-    generate_string_validation_code, get_field_def, needs_injected_default,
+    generate_string_validation_code, get_field_def, helper_name_stem, needs_injected_default,
     parse_serde_field_attributes, parse_serde_type_attributes,
 };
 
@@ -2404,9 +2404,15 @@ fn emitted_string_module(spelling: &str) -> String {
         min_length: Some(3),
         ..ModelSchemaPropMeta::default()
     };
-    generate_string_validation_code("field", &meta, &shape, &ty)
-        .module_items
-        .to_string()
+    generate_string_validation_code(
+        "field",
+        &helper_name_stem("field", None),
+        &meta,
+        &shape,
+        &ty,
+    )
+    .module_items
+    .to_string()
 }
 
 /// Just the deserializer of [`emitted_string_module`], which is everything after the validator.
@@ -2440,6 +2446,7 @@ fn a_bare_field_deserializes_the_constrained_value_itself() {
     };
     let numeric = generate_numeric_validation_code(
         "field",
+        &helper_name_stem("field", None),
         "u32",
         &numeric_meta,
         &constrained_shape(&numeric_ty).unwrap(),
@@ -2455,6 +2462,20 @@ fn a_bare_field_deserializes_the_constrained_value_itself() {
              validate_field_value (& v) . map_err (serde :: de :: Error :: custom) ? ; Ok (v) }"
         ),
         "bare numeric deserializer moved: {numeric}"
+    );
+}
+
+/// A struct field names its helpers for the field alone — the spelling every already-generated
+/// struct is gated by — while a variant's field names them for its variant too, which is what keeps
+/// two variants naming one field from colliding in the single schema module that holds both.
+#[cfg(feature = "serde")]
+#[test]
+fn a_variant_field_names_its_helpers_for_its_variant() {
+    assert_eq!(helper_name_stem("note", None), "note");
+    assert_eq!(helper_name_stem("note", Some("Upload")), "upload_note");
+    assert_eq!(
+        helper_name_stem("note", Some("DeleteForever")),
+        "delete_forever_note"
     );
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -155,7 +155,12 @@ fn collect_doc_lines(attrs: &[Attribute]) -> Option<Vec<String>> {
     }
 }
 
-#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[cfg(any(
+    feature = "typescript",
+    feature = "zod",
+    feature = "jsonschema",
+    feature = "serde"
+))]
 pub fn to_snake_case(name: &str) -> String {
     let mut result = String::new();
     let mut prev_lower = false;

--- a/tests/validation_tests/tests.rs
+++ b/tests/validation_tests/tests.rs
@@ -1710,3 +1710,52 @@ fn test_deserialize_and_validate_agree_on_every_wrapped_shape() {
         );
     }
 }
+
+/// A field name is unique only within the variant that declares it, so the helpers a variant's
+/// field generates are named for that variant: two variants naming one field carry two constraints.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn test_two_variants_naming_one_field_keep_their_own_constraints() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug)]
+    #[serde(tag = "kind")]
+    pub enum Action {
+        Delete {
+            #[model_schema_prop(minLength = 5)]
+            note: String,
+        },
+        Upload {
+            #[model_schema_prop(minLength = 3)]
+            note: String,
+        },
+    }
+
+    let too_short_for_delete =
+        serde_json::from_str::<Action>(r#"{"kind":"Delete","note":"abc"}"#).unwrap_err();
+    assert!(
+        too_short_for_delete
+            .to_string()
+            .contains("'note' is too short: minimum length is 5, got 3"),
+        "Unexpected error: {too_short_for_delete}"
+    );
+    assert!(
+        serde_json::from_str::<Action>(r#"{"kind":"Delete","note":"abcde"}"#).is_ok(),
+        "Delete admits its own minimum"
+    );
+
+    let too_short_for_upload =
+        serde_json::from_str::<Action>(r#"{"kind":"Upload","note":"ab"}"#).unwrap_err();
+    assert!(
+        too_short_for_upload
+            .to_string()
+            .contains("'note' is too short: minimum length is 3, got 2"),
+        "Unexpected error: {too_short_for_upload}"
+    );
+    assert!(
+        serde_json::from_str::<Action>(r#"{"kind":"Upload","note":"abc"}"#).is_ok(),
+        "A value Upload admits is not held to Delete's minimum"
+    );
+}


### PR DESCRIPTION
Two enum variants declaring a same-named constrained field redefined validate_{field}_value / deserialize_{field} in the single enum schema module (E0428). The helper stem is now computed once — helper_name_stem(field, variant) — and threaded into both generators and the injected deserialize_with path, so the three spellings cannot drift. Struct fields pass None and stay byte-identical, pinned by the pre-existing token assertions.

Red-first: the new fixture reproduced both E0428s before the change; after, each variant enforces its own minLength in both wire directions. to_snake_case's cfg widened to include serde (the validator path is serde-gated).

Powerset green in the lane; master merged in cleanly and the cheap gate re-run on the merged state.
