### PR TITLE
fix: Path maps as String's borrowed form; OsString/OsStr rejected with a spanned guard

### DIFF
--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -352,6 +352,54 @@ impl FieldDef {
         }
     }
 
+    /// The name of the first `OsString`/`OsStr` this field reaches, at any depth.
+    ///
+    /// Neither has a primitive mapping and neither can get one: serde writes them as an externally
+    /// tagged enum whose variant is the target platform — `{"Unix":[u8, …]}` or
+    /// `{"Windows":[u16, …]}` — so the same Rust field has two wire forms and no schema can
+    /// describe both. Left unmapped they read as an ordinary `SiblingType`, and the generated code
+    /// would reference a schema module the user never wrote; the caller turns this into a guard
+    /// error naming the field instead.
+    ///
+    /// Recurses through `SiblingType` generics, `Map` keys/values, and `Tuple` elements.
+    pub fn os_string_name(&self) -> Option<&str> {
+        match &self.field_type {
+            FieldDefType::SiblingType(name, generics) => {
+                if matches!(name.as_str(), "OsString" | "OsStr") {
+                    return Some(name);
+                }
+                generics.iter().find_map(Self::os_string_name)
+            }
+            FieldDefType::Map(key, value) => {
+                key.os_string_name().or_else(|| value.os_string_name())
+            }
+            FieldDefType::Tuple(elements) => elements.iter().find_map(Self::os_string_name),
+            FieldDefType::Unknown
+            | FieldDefType::StringLiteral(_)
+            | FieldDefType::Boolean
+            | FieldDefType::String
+            | FieldDefType::U8
+            | FieldDefType::U16
+            | FieldDefType::U32
+            | FieldDefType::U64
+            | FieldDefType::I8
+            | FieldDefType::I16
+            | FieldDefType::I32
+            | FieldDefType::I64
+            | FieldDefType::Usize
+            | FieldDefType::Isize
+            | FieldDefType::F32
+            | FieldDefType::F64 => None,
+            #[cfg(feature = "object_id")]
+            FieldDefType::ObjectId => None,
+            #[cfg(feature = "chrono")]
+            FieldDefType::NaiveDate
+            | FieldDefType::NaiveTime
+            | FieldDefType::NaiveDateTime
+            | FieldDefType::DateTime => None,
+        }
+    }
+
     /// Rewrites any `Self` type reference to the concrete enclosing type name.
     ///
     /// A recursive type may refer to itself with the `Self` keyword
@@ -1028,9 +1076,12 @@ fn get_field_def_type_or_sibling(t_name: &str) -> FieldDefType {
     }
     match t_name {
         "bool" => FieldDefType::Boolean,
-        // `str` is `String`'s borrowed form and writes the same JSON string. It is reachable only
-        // behind a wrapper or a reference, both of which the parser reads through to land here.
-        "String" | "PathBuf" | "str" => FieldDefType::String,
+        // `str` and `Path` are the borrowed forms of `String` and `PathBuf`, and each writes the
+        // same JSON string its owned form does. Both are reachable only behind a wrapper or a
+        // reference, and the parser reads through either to land here. `OsString`/`OsStr` are
+        // deliberately absent: serde writes them as an externally tagged enum, not a string, so
+        // they fall through to `SiblingType` and are rejected by `os_string_name`.
+        "String" | "PathBuf" | "str" | "Path" => FieldDefType::String,
         "Value" => FieldDefType::Unknown,
         "u8" => FieldDefType::U8,
         "u16" => FieldDefType::U16,

--- a/src/field_type/tests.rs
+++ b/src/field_type/tests.rs
@@ -269,17 +269,82 @@ fn test_a_transparent_wrapper_keeps_the_array_levels_of_what_it_wraps() {
     }
 }
 
-/// The borrowed form of a mapped owned type writes what the owned form writes, and a wrapper is how
-/// a field reaches it at all.
+/// The borrowed form of a mapped owned type writes what the owned form writes, and a wrapper or a
+/// reference is how a field reaches it at all.
 #[test]
 fn test_a_borrowed_string_parses_as_a_string() {
-    for spelling in ["Arc<str>", "Box<str>", "Cow<'a, str>", "Rc<str>", "String"] {
+    for spelling in [
+        "Arc<str>",
+        "Box<str>",
+        "Cow<'a, str>",
+        "Rc<str>",
+        "String",
+        "&str",
+        "&'a str",
+        "Arc<Path>",
+        "Box<Path>",
+        "Cow<'a, Path>",
+        "Rc<Path>",
+        "PathBuf",
+        "&Path",
+        "&'a Path",
+    ] {
         let ty: syn::Type = syn::parse_str(spelling).unwrap();
         let parsed = super::get_field_def("label", &ty, "");
         assert!(
             matches!(parsed.field_type, FieldDefType::String),
             "for: {spelling}"
         );
+    }
+}
+
+/// `OsString`/`OsStr` are the owned/borrowed pair held out of the string mapping: serde writes
+/// them as an externally tagged enum naming the target platform, so no portable schema describes
+/// them. The parse leaves them as siblings and reports them from wherever they were written.
+#[test]
+fn test_an_os_string_is_reported_wherever_it_was_written() {
+    for spelling in [
+        "OsString",
+        "OsStr",
+        "&OsStr",
+        "Box<OsStr>",
+        "Cow<'a, OsStr>",
+        "Rc<OsStr>",
+        "Arc<OsStr>",
+        "Option<OsString>",
+        "Vec<OsString>",
+        "HashMap<String, OsString>",
+        "(String, OsString)",
+        "Wrapper<OsString>",
+    ] {
+        let ty: syn::Type = syn::parse_str(spelling).unwrap();
+        let parsed = super::get_field_def("location", &ty, "");
+        assert!(
+            parsed
+                .os_string_name()
+                .is_some_and(|name| name == "OsString" || name == "OsStr"),
+            "for: {spelling}"
+        );
+    }
+}
+
+/// The report is for those two names alone: a path, a string, and a user type that merely carries
+/// one of them inside its own name all describe a wire form and stay unreported.
+#[test]
+fn test_a_schematizable_field_is_not_reported_as_an_os_string() {
+    for spelling in [
+        "String",
+        "PathBuf",
+        "Box<Path>",
+        "Option<String>",
+        "Vec<PathBuf>",
+        "HashMap<String, String>",
+        "OsStringHolder",
+        "Wrapper<PathBuf>",
+    ] {
+        let ty: syn::Type = syn::parse_str(spelling).unwrap();
+        let parsed = super::get_field_def("location", &ty, "");
+        assert_eq!(parsed.os_string_name(), None, "for: {spelling}");
     }
 }
 

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -4792,6 +4792,22 @@ fn check_optional_field_serialization(
     ))
 }
 
+/// Every guard error the field violates: the `OsString` guard first — it reads the written type,
+/// which no attribute can hide — then the serde-side guard when one fired.
+fn collect_field_guard_errors(
+    field: &Field,
+    field_def: &FieldDef,
+    raw_field_ident: &str,
+    serde_guard_error: Option<proc_macro2::TokenStream>,
+) -> Vec<proc_macro2::TokenStream> {
+    check_os_string_field(field, field_def, &field_label(raw_field_ident))
+        .err()
+        .map(|err| err.to_compile_error())
+        .into_iter()
+        .chain(serde_guard_error)
+        .collect()
+}
+
 /// Rejects a field that reaches an `OsString`/`OsStr`, at any depth.
 ///
 /// serde writes both as an externally tagged enum naming the target platform — `{"Unix":[u8, …]}`
@@ -4912,13 +4928,8 @@ fn process_field(
     #[cfg(not(feature = "serde"))]
     let serde_guard_error: Option<proc_macro2::TokenStream> = None;
 
-    let guard_errors: Vec<proc_macro2::TokenStream> =
-        check_os_string_field(field, &field_def, &field_label(&raw_field_ident))
-            .err()
-            .map(|err| err.to_compile_error())
-            .into_iter()
-            .chain(serde_guard_error)
-            .collect();
+    let guard_errors =
+        collect_field_guard_errors(field, &field_def, &raw_field_ident, serde_guard_error);
 
     // Resolve `Self` references to the concrete type name so recursive fields
     // (e.g. `Vec<Self>`) are treated exactly like `Vec<EnclosingType>`.

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -724,7 +724,6 @@ fn cfg_attr_guard_error(rejection: &syn::Error, item: &str) -> proc_macro2::Toke
 }
 
 /// Names a field in a guard message; tuple slots have no ident to name.
-#[cfg(feature = "serde")]
 fn field_label(raw_field_ident: &str) -> String {
     if raw_field_ident.is_empty() {
         "tuple field".to_owned()
@@ -959,12 +958,10 @@ fn collect_struct_fields(
         #[cfg(not(feature = "serde"))]
         let is_flatten = false;
 
-        let (f_def, validation_fn, validate_body, guard_error) =
+        let (f_def, validation_fn, validate_body, field_guard_errors) =
             process_field(rename_all, field, module_name_opt, type_name);
 
-        if let Some(err) = guard_error {
-            guard_errors.push(err);
-        }
+        guard_errors.extend(field_guard_errors);
 
         if is_flatten {
             let _: (&_, &_) = (&validation_fn, &validate_body);
@@ -2340,14 +2337,12 @@ fn collect_discriminated_variants(
 
         let mut field_defs: Vec<FieldDef> = Vec::new();
         for field in &mut item.fields {
-            let (f_def, validation_fn, _validate_body, guard_error) =
+            let (f_def, validation_fn, _validate_body, field_guard_errors) =
                 process_field(rename_all, field, enum_module_name_opt, &enum_type_name);
             if let Some(vfn) = validation_fn {
                 enum_validation_fns.push(vfn);
             }
-            if let Some(err) = guard_error {
-                guard_errors.push(err);
-            }
+            guard_errors.extend(field_guard_errors);
             field_defs.push(f_def);
         }
 
@@ -2854,6 +2849,9 @@ fn collect_untagged_members(item_enum: &mut syn::ItemEnum) -> UntaggedMemberData
                 .map(ToString::to_string)
                 .unwrap_or_default();
             let mut field_def = get_field_def(&field_name, &field.ty, "");
+            if let Err(err) = check_os_string_field(field, &field_def, &field_label(&field_name)) {
+                guard_errors.push(err.to_compile_error());
+            }
             let serde_field_meta = parse_serde_field_attributes(&field.attrs);
             if let Some(rejection) = serde_field_meta.cfg_attr_rejection.as_ref() {
                 guard_errors.push(cfg_attr_guard_error(rejection, &field_label(&field_name)));
@@ -4768,9 +4766,33 @@ fn check_optional_field_serialization(
     ))
 }
 
+/// Rejects a field that reaches an `OsString`/`OsStr`, at any depth.
+///
+/// serde writes both as an externally tagged enum naming the target platform — `{"Unix":[u8, …]}`
+/// or `{"Windows":[u16, …]}` — so one Rust field has two wire forms and no schema describes both.
+/// Their owned string counterparts are what a portable field is written as instead.
+fn check_os_string_field(
+    field: &Field,
+    field_def: &FieldDef,
+    label: &str,
+) -> Result<(), syn::Error> {
+    let Some(name) = field_def.os_string_name() else {
+        return Ok(());
+    };
+    Err(syn::Error::new_spanned(
+        field,
+        format!(
+            "model_schema: {label} reaches `{name}`, which serde writes as an externally tagged \
+             enum naming the target platform (`{{\"Unix\":[u8, ...]}}` or \
+             `{{\"Windows\":[u16, ...]}}`), not a string, so no schema can describe it portably. \
+             Use `String`, or `PathBuf` for a filesystem path."
+        ),
+    ))
+}
+
 /// Processes a field and returns its definition, optional module items (validators/deserializers),
 /// optional `validate_body` (contribution to the type-level `validate()` method), and the
-/// `compile_error!` tokens for any guard the field violates.
+/// `compile_error!` tokens for every guard the field violates.
 fn process_field(
     rename_all: Option<&str>,
     field: &mut Field,
@@ -4780,7 +4802,7 @@ fn process_field(
     FieldDef,
     Option<proc_macro2::TokenStream>,
     Option<proc_macro2::TokenStream>,
-    Option<proc_macro2::TokenStream>,
+    Vec<proc_macro2::TokenStream>,
 ) {
     let mut new_attrs = Vec::new();
 
@@ -4843,9 +4865,10 @@ fn process_field(
     let mut field_def = get_field_def(&final_name, field_type, &field_docs);
 
     // A hidden serde attribute leaves every other field diagnostic unreliable — the Option-null
-    // guard included, since the wrapper is exactly what kept its evidence out of the meta.
+    // guard included, since the wrapper is exactly what kept its evidence out of the meta. The
+    // `OsString` guard reads the written type, which no attribute can hide, so it stands apart.
     #[cfg(feature = "serde")]
-    let guard_error = serde_field_meta.cfg_attr_rejection.as_ref().map_or_else(
+    let serde_guard_error = serde_field_meta.cfg_attr_rejection.as_ref().map_or_else(
         || {
             check_optional_field_serialization(field, field_def.is_optional(), &serde_field_meta)
                 .err()
@@ -4859,7 +4882,15 @@ fn process_field(
         },
     );
     #[cfg(not(feature = "serde"))]
-    let guard_error: Option<proc_macro2::TokenStream> = None;
+    let serde_guard_error: Option<proc_macro2::TokenStream> = None;
+
+    let guard_errors: Vec<proc_macro2::TokenStream> =
+        check_os_string_field(field, &field_def, &field_label(&raw_field_ident))
+            .err()
+            .map(|err| err.to_compile_error())
+            .into_iter()
+            .chain(serde_guard_error)
+            .collect();
 
     // Resolve `Self` references to the concrete type name so recursive fields
     // (e.g. `Vec<Self>`) are treated exactly like `Vec<EnclosingType>`.
@@ -4907,7 +4938,7 @@ fn process_field(
     // Update field docs to include length/range constraint information
     apply_constraint_docs(&mut field_def, &final_name);
 
-    (field_def, validation_fn, validate_body, guard_error)
+    (field_def, validation_fn, validate_body, guard_errors)
 }
 
 /// Whether the field needs a `#[serde(default)]` written for it alongside the `deserialize_with`.

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -1,15 +1,15 @@
 use super::{
-    FieldDefType, collect_discriminated_variants, render_discriminated_variants,
-    validate_as_number_flag, validate_ts_optional_flag,
+    FieldDefType, check_os_string_field, collect_discriminated_variants, field_label,
+    get_field_def, render_discriminated_variants, validate_as_number_flag,
+    validate_ts_optional_flag,
 };
 
 #[cfg(feature = "serde")]
 use super::{
     ModelSchemaPropMeta, build_field_validation, cfg_attr_guard_error,
     check_optional_field_serialization, collect_untagged_members, constrained_shape,
-    enum_cfg_attr_guard_errors, field_label, generate_numeric_validation_code,
-    generate_string_validation_code, get_field_def, needs_injected_default,
-    parse_serde_field_attributes, parse_serde_type_attributes,
+    enum_cfg_attr_guard_errors, generate_numeric_validation_code, generate_string_validation_code,
+    needs_injected_default, parse_serde_field_attributes, parse_serde_type_attributes,
 };
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
@@ -378,6 +378,65 @@ fn cfg_attr_wrapped_serde_on_a_field_is_rejected() {
     assert!(error.contains("compile_error"), "got: {error}");
     assert!(error.contains("field `note`"), "got: {error}");
     assert!(error.contains("#[serde(...)]"), "got: {error}");
+}
+
+/// Runs the field walk the way [`process_field`] does and renders the `OsString` guard failure.
+fn field_os_string_error(item: &syn::ItemStruct) -> Option<String> {
+    let field = item.fields.iter().next()?;
+    let name = field
+        .ident
+        .as_ref()
+        .map(ToString::to_string)
+        .unwrap_or_default();
+    let field_def = get_field_def(&name, &field.ty, "");
+    check_os_string_field(field, &field_def, &field_label(&name))
+        .err()
+        .map(|err| err.to_compile_error().to_string())
+}
+
+#[test]
+fn an_os_string_field_is_rejected_by_name() {
+    let error = field_os_string_error(&syn::parse_quote! {
+        struct Report {
+            location: OsString,
+        }
+    })
+    .unwrap();
+    assert!(error.contains("compile_error"), "got: {error}");
+    assert!(error.contains("field `location`"), "got: {error}");
+    assert!(error.contains("`OsString`"), "got: {error}");
+    assert!(error.contains("externally tagged enum"), "got: {error}");
+}
+
+/// The guard reads through the wrappers the parser reads through, so a borrowed `OsStr` is named
+/// as itself rather than as the wrapper it was written behind.
+#[test]
+fn a_wrapped_os_str_field_is_rejected_by_its_own_name() {
+    let error = field_os_string_error(&syn::parse_quote! {
+        struct Report {
+            location: Box<OsStr>,
+        }
+    })
+    .unwrap();
+    assert!(error.contains("`OsStr`"), "got: {error}");
+}
+
+/// The path types the borrowed-form rule takes in are the ones this guard must not catch.
+#[test]
+fn a_path_field_is_left_alone() {
+    for ty in [
+        quote::quote! { PathBuf },
+        quote::quote! { Box<Path> },
+        quote::quote! { Cow<'static, Path> },
+        quote::quote! { String },
+    ] {
+        let error = field_os_string_error(&syn::parse_quote! {
+            struct Report {
+                location: #ty,
+            }
+        });
+        assert!(error.is_none(), "for {ty}, got: {error:?}");
+    }
 }
 
 #[cfg(feature = "serde")]

--- a/tests/path_field_tests.rs
+++ b/tests/path_field_tests.rs
@@ -1,0 +1,5 @@
+extern crate alloc;
+
+#[cfg(test)]
+#[path = "path_field_tests/tests.rs"]
+mod tests;

--- a/tests/path_field_tests/tests.rs
+++ b/tests/path_field_tests/tests.rs
@@ -1,0 +1,134 @@
+use alloc::borrow::Cow;
+use alloc::rc::Rc;
+use alloc::sync::Arc;
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use tixschema::model_schema;
+
+/// `Path` is `PathBuf`'s borrowed form, reachable only behind a wrapper or a reference. Every
+/// spelling below writes the same JSON string the owned form writes.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct PathFields {
+    arced: Arc<Path>,
+    boxed: Box<Path>,
+    cowed: Cow<'static, Path>,
+    owned: PathBuf,
+    rced: Rc<Path>,
+}
+
+/// The spelling every field above is held against: the owned form written bare.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct PlainPathFields {
+    arced: PathBuf,
+    boxed: PathBuf,
+    cowed: PathBuf,
+    owned: PathBuf,
+    rced: PathBuf,
+}
+
+fn path_fields() -> PathFields {
+    PathFields {
+        arced: Arc::from(Path::new("/etc/hosts")),
+        boxed: PathBuf::from("/etc/hosts").into_boxed_path(),
+        cowed: Cow::Owned(PathBuf::from("/etc/hosts")),
+        owned: PathBuf::from("/etc/hosts"),
+        rced: Rc::from(Path::new("/etc/hosts")),
+    }
+}
+
+fn plain_path_fields() -> PlainPathFields {
+    PlainPathFields {
+        arced: PathBuf::from("/etc/hosts"),
+        boxed: PathBuf::from("/etc/hosts"),
+        cowed: PathBuf::from("/etc/hosts"),
+        owned: PathBuf::from("/etc/hosts"),
+        rced: PathBuf::from("/etc/hosts"),
+    }
+}
+
+/// The criterion the mapping rests on: serde writes a borrowed path exactly as it writes the owned
+/// one, so the two spellings owe the same schema.
+#[test]
+fn test_every_path_spelling_writes_the_owned_form_wire_value() {
+    assert_eq!(
+        serde_json::to_value(path_fields()).unwrap(),
+        serde_json::to_value(plain_path_fields()).unwrap()
+    );
+}
+
+#[test]
+fn test_a_borrowed_path_field_round_trips_through_the_owned_wire_form() {
+    let payload = serde_json::to_string(&path_fields()).unwrap();
+    assert_eq!(
+        serde_json::from_str::<PathFields>(&payload).unwrap(),
+        path_fields()
+    );
+}
+
+/// The field declarations of a generated `TypeScript` definition, without the `JSDoc` around them
+/// — the struct's own doc comment is the one thing the twins are not meant to share.
+#[cfg(feature = "typescript")]
+fn ts_field_declarations(definition: &str) -> Vec<String> {
+    definition
+        .lines()
+        .filter(|line| line.starts_with("  ") && line.ends_with(';'))
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+#[cfg(feature = "typescript")]
+#[test]
+fn test_path_fields_render_as_strings_in_typescript() {
+    let declarations = ts_field_declarations(&PathFields::ts_definition());
+    assert_eq!(
+        declarations,
+        ts_field_declarations(&PlainPathFields::ts_definition())
+    );
+    for field in ["arced", "boxed", "cowed", "owned", "rced"] {
+        assert!(
+            declarations.contains(&format!("  {field}: string;")),
+            "for {field}, got: {declarations:?}"
+        );
+    }
+}
+
+#[cfg(feature = "zod")]
+#[test]
+fn test_path_fields_render_as_strings_in_zod() {
+    let schema = PathFields::zod_schema();
+    assert_eq!(
+        schema.replace("PathFields", "PlainPathFields"),
+        PlainPathFields::zod_schema()
+    );
+    for field in ["arced", "boxed", "cowed", "owned", "rced"] {
+        assert!(
+            schema.contains(&format!("{field}: z.string()")),
+            "for {field}, got: {schema}"
+        );
+    }
+}
+
+#[cfg(feature = "jsonschema")]
+#[test]
+fn test_path_fields_render_as_strings_in_json_schema() {
+    let schema = PathFields::json_schema();
+    let properties = schema
+        .get("properties")
+        .and_then(serde_json::Value::as_object)
+        .unwrap();
+    for field in ["arced", "boxed", "cowed", "owned", "rced"] {
+        assert_eq!(
+            properties.get(field).unwrap().get("type").unwrap(),
+            &serde_json::json!("string"),
+            "for {field}, got: {schema}"
+        );
+    }
+    assert_eq!(
+        serde_json::to_string(&schema)
+            .unwrap()
+            .replace("PathFields", "PlainPathFields"),
+        serde_json::to_string(&PlainPathFields::json_schema()).unwrap()
+    );
+}


### PR DESCRIPTION
Path had no primitive mapping, so Box<Path>, &Path, Cow<Path>, Rc<Path>, Arc<Path> expanded to a reference to a nonexistent path_schema module (E0433). Path now joins str as a borrowed string form — serde writes it exactly as PathBuf, proven by a wire-equality fixture across all five spellings.

OsString/OsStr are deliberately NOT mapped: measured in-repo, serde writes them as an externally tagged enum naming the target platform ({"Unix":[104,...]}), so one Rust field has two wire forms and no portable schema exists. A spanned guard now rejects them from any nesting depth (SiblingType generics, map keys/values, tuple elements), naming the field and the wire form instead of the cryptic module error. process_field's guard slot widened Option->Vec so the OsString and serde guards can both report on one field.

Merge note: master's variant-scoped helper stems landed mid-flight; the union pushed process_field one line over clippy's too_many_lines, resolved by extracting collect_field_guard_errors (no suppressions).

Powerset green in the lane pre-merge; cheap gate re-run green on the merged state.
