### PR TITLE
fix: a constraint on a positional field is refused with a spanned error, not a panic

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -964,12 +964,10 @@ fn collect_struct_fields(
         #[cfg(not(feature = "serde"))]
         let is_flatten = false;
 
-        let (f_def, validation_fn, validate_body, guard_error) =
+        let (f_def, validation_fn, validate_body, field_guard_errors) =
             process_field(rename_all, field, module_name_opt, None, type_name);
 
-        if let Some(err) = guard_error {
-            guard_errors.push(err);
-        }
+        guard_errors.extend(field_guard_errors);
 
         if is_flatten {
             let _: (&_, &_) = (&validation_fn, &validate_body);
@@ -2346,7 +2344,7 @@ fn collect_discriminated_variants(
 
         let mut field_defs: Vec<FieldDef> = Vec::new();
         for field in &mut item.fields {
-            let (f_def, validation_fn, _validate_body, guard_error) = process_field(
+            let (f_def, validation_fn, _validate_body, field_guard_errors) = process_field(
                 rename_all,
                 field,
                 enum_module_name_opt,
@@ -2356,9 +2354,7 @@ fn collect_discriminated_variants(
             if let Some(vfn) = validation_fn {
                 enum_validation_fns.push(vfn);
             }
-            if let Some(err) = guard_error {
-                guard_errors.push(err);
-            }
+            guard_errors.extend(field_guard_errors);
             field_defs.push(f_def);
         }
 
@@ -4794,9 +4790,40 @@ fn check_optional_field_serialization(
     ))
 }
 
+/// The `compile_error!` tokens for every guard the field violates.
+///
+/// A hidden serde attribute leaves every serde-read diagnostic unreliable — the `Option`-null guard
+/// included, since the wrapper is exactly what kept its evidence out of the meta. The
+/// positional-constraint guard reads no serde attribute, so it stands whatever the wrapper hid.
+#[cfg(feature = "serde")]
+fn field_guard_errors(
+    field: &Field,
+    raw_field_ident: &str,
+    is_optional: bool,
+    serde_field_meta: &SerdeFieldMeta,
+    positional_constraint_error: Option<proc_macro2::TokenStream>,
+) -> Vec<proc_macro2::TokenStream> {
+    positional_constraint_error
+        .into_iter()
+        .chain(serde_field_meta.cfg_attr_rejection.as_ref().map_or_else(
+            || {
+                check_optional_field_serialization(field, is_optional, serde_field_meta)
+                    .err()
+                    .map(|err| err.to_compile_error())
+            },
+            |rejection| {
+                Some(cfg_attr_guard_error(
+                    rejection,
+                    &field_label(raw_field_ident),
+                ))
+            },
+        ))
+        .collect()
+}
+
 /// Processes a field and returns its definition, optional module items (validators/deserializers),
 /// optional `validate_body` (contribution to the type-level `validate()` method), and the
-/// `compile_error!` tokens for any guard the field violates.
+/// `compile_error!` tokens for every guard the field violates.
 fn process_field(
     rename_all: Option<&str>,
     field: &mut Field,
@@ -4807,7 +4834,7 @@ fn process_field(
     FieldDef,
     Option<proc_macro2::TokenStream>,
     Option<proc_macro2::TokenStream>,
-    Option<proc_macro2::TokenStream>,
+    Vec<proc_macro2::TokenStream>,
 ) {
     let mut new_attrs = Vec::new();
 
@@ -4843,7 +4870,7 @@ fn process_field(
 
     // Generate validation code and inject serde attribute if serde feature is enabled
     #[cfg(feature = "serde")]
-    let (validation_fn, validate_body) = generate_field_validation(
+    let (validation_fn, validate_body, positional_constraint_error) = generate_field_validation(
         field,
         schema_module_name,
         &raw_field_ident,
@@ -4870,24 +4897,16 @@ fn process_field(
     // Create the field definition and apply any model_schema_prop overrides
     let mut field_def = get_field_def(&final_name, field_type, &field_docs);
 
-    // A hidden serde attribute leaves every other field diagnostic unreliable — the Option-null
-    // guard included, since the wrapper is exactly what kept its evidence out of the meta.
     #[cfg(feature = "serde")]
-    let guard_error = serde_field_meta.cfg_attr_rejection.as_ref().map_or_else(
-        || {
-            check_optional_field_serialization(field, field_def.is_optional(), &serde_field_meta)
-                .err()
-                .map(|err| err.to_compile_error())
-        },
-        |rejection| {
-            Some(cfg_attr_guard_error(
-                rejection,
-                &field_label(&raw_field_ident),
-            ))
-        },
+    let guard_errors = field_guard_errors(
+        field,
+        &raw_field_ident,
+        field_def.is_optional(),
+        &serde_field_meta,
+        positional_constraint_error,
     );
     #[cfg(not(feature = "serde"))]
-    let guard_error: Option<proc_macro2::TokenStream> = None;
+    let guard_errors: Vec<proc_macro2::TokenStream> = Vec::new();
 
     // Resolve `Self` references to the concrete type name so recursive fields
     // (e.g. `Vec<Self>`) are treated exactly like `Vec<EnclosingType>`.
@@ -4935,7 +4954,7 @@ fn process_field(
     // Update field docs to include length/range constraint information
     apply_constraint_docs(&mut field_def, &final_name);
 
-    (field_def, validation_fn, validate_body, guard_error)
+    (field_def, validation_fn, validate_body, guard_errors)
 }
 
 /// Whether the field needs a `#[serde(default)]` written for it alongside the `deserialize_with`.
@@ -4958,9 +4977,34 @@ fn needs_injected_default(wraps: &[ConstraintWrap], has_default: bool) -> bool {
     matches!(first_opaque, Some(ConstraintWrap::Optional)) && !has_default
 }
 
+/// The `compile_error!` tokens for a length or range constraint written on a positional field.
+///
+/// Both helpers such a constraint generates are named from the field ident, and `validate()` reaches
+/// the value through that same ident — a spelling a tuple slot has none of.
+#[cfg(feature = "serde")]
+fn positional_constraint_guard_error(
+    field: &Field,
+    raw_field_ident: &str,
+) -> proc_macro2::TokenStream {
+    syn::Error::new_spanned(
+        field,
+        format!(
+            "model_schema: {}: pattern, minLength, maxLength, minimum and maximum are unsupported \
+             on a positional field — the generated validator, the generated deserializer and the \
+             `validate()` accessor are all named from the field ident, which a tuple slot has \
+             none of. Move the element into a struct variant with a named field, or drop the \
+             constraint.",
+            field_label(raw_field_ident)
+        ),
+    )
+    .to_compile_error()
+}
+
 /// Generates per-field serde validation code (static validator + `deserialize_with`) and, when
 /// constraints apply, injects the corresponding `#[serde(deserialize_with = ...)]` attribute — plus
 /// the `#[serde(default)]` that keeps an optional key optional under one.
+///
+/// Returns (`module_items`, `validate_body`, `guard_error`).
 #[cfg(feature = "serde")]
 fn generate_field_validation(
     field: &Field,
@@ -4972,6 +5016,7 @@ fn generate_field_validation(
 ) -> (
     Option<proc_macro2::TokenStream>,
     Option<proc_macro2::TokenStream>,
+    Option<proc_macro2::TokenStream>,
 ) {
     let has_string_constraints = model_schema_prop_meta.min_length.is_some()
         || model_schema_prop_meta.max_length.is_some()
@@ -4979,9 +5024,17 @@ fn generate_field_validation(
     let has_numeric_constraints =
         model_schema_prop_meta.minimum.is_some() || model_schema_prop_meta.maximum.is_some();
 
+    if raw_field_ident.is_empty() && (has_string_constraints || has_numeric_constraints) {
+        return (
+            None,
+            None,
+            Some(positional_constraint_guard_error(field, raw_field_ident)),
+        );
+    }
+
     let (Some(module_name), Some(shape)) = (schema_module_name, constrained_shape(&field.ty))
     else {
-        return (None, None);
+        return (None, None, None);
     };
 
     let helper_stem = helper_name_stem(raw_field_ident, variant_ident);
@@ -5007,7 +5060,7 @@ fn generate_field_validation(
         }),
     };
     let Some(validation_code) = generated else {
-        return (None, None);
+        return (None, None, None);
     };
 
     let deserialize_with_path = format!("{module_name}::deserialize_{helper_stem}");
@@ -5024,6 +5077,7 @@ fn generate_field_validation(
     (
         Some(validation_code.module_items),
         Some(validation_code.validate_body),
+        None,
     )
 }
 

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -7,9 +7,10 @@ use super::{
 use super::{
     ModelSchemaPropMeta, build_field_validation, cfg_attr_guard_error,
     check_optional_field_serialization, collect_untagged_members, constrained_shape,
-    enum_cfg_attr_guard_errors, field_label, generate_numeric_validation_code,
-    generate_string_validation_code, get_field_def, helper_name_stem, needs_injected_default,
-    parse_serde_field_attributes, parse_serde_type_attributes,
+    enum_cfg_attr_guard_errors, field_label, generate_field_validation,
+    generate_numeric_validation_code, generate_string_validation_code, get_field_def,
+    helper_name_stem, needs_injected_default, parse_serde_field_attributes,
+    parse_serde_type_attributes,
 };
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
@@ -2477,6 +2478,106 @@ fn a_variant_field_names_its_helpers_for_its_variant() {
         helper_name_stem("note", Some("DeleteForever")),
         "delete_forever_note"
     );
+}
+
+/// The sole field of `item`, run through the constraint generator under `constraint` as the field
+/// of variant `One`, returning (`module_items`, `validate_body`, `guard_error`, injected attribute
+/// count).
+#[cfg(feature = "serde")]
+fn generated_field_validation(
+    item: &syn::ItemStruct,
+    constraint: &ModelSchemaPropMeta,
+) -> (bool, bool, Option<String>, usize) {
+    let field = item.fields.iter().next().unwrap();
+    let raw_field_ident = field
+        .ident
+        .as_ref()
+        .map(ToString::to_string)
+        .unwrap_or_default();
+    let mut new_attrs = Vec::new();
+    let (module_items, validate_body, guard_error) = generate_field_validation(
+        field,
+        Some("probe_schema"),
+        &raw_field_ident,
+        Some("One"),
+        constraint,
+        &mut new_attrs,
+    );
+    (
+        module_items.is_some(),
+        validate_body.is_some(),
+        guard_error.map(|tokens| tokens.to_string()),
+        new_attrs.len(),
+    )
+}
+
+/// A length or range constraint spells three names from the field ident — the validator, the
+/// deserializer, and the `validate()` accessor — so a slot that has no ident is refused before the
+/// first of them is built, where the `Ident` made from the empty name used to abort the expansion.
+/// A named field is reached by none of this and generates what it always has.
+#[cfg(feature = "serde")]
+#[test]
+fn a_constraint_on_a_positional_field_is_refused_before_a_name_is_spelled() {
+    let positional: syn::ItemStruct = syn::parse_quote! { struct Probe(String); };
+    let named: syn::ItemStruct = syn::parse_quote! { struct Probe { note: String } };
+
+    for constraint in [
+        ModelSchemaPropMeta {
+            min_length: Some(3),
+            ..ModelSchemaPropMeta::default()
+        },
+        ModelSchemaPropMeta {
+            maximum: Some(5.0_f64),
+            ..ModelSchemaPropMeta::default()
+        },
+    ] {
+        let (module_items, validate_body, guard_error, injected_attrs) =
+            generated_field_validation(&positional, &constraint);
+        let error = guard_error.unwrap();
+        assert!(error.contains("compile_error"), "got: {error}");
+        assert!(error.contains("tuple field"), "got: {error}");
+        assert!(!module_items, "a refused slot generated helpers: {error}");
+        assert!(!validate_body, "a refused slot reached validate(): {error}");
+        assert_eq!(injected_attrs, 0, "a refused slot was given a serde hook");
+    }
+
+    let named_string = generated_field_validation(
+        &named,
+        &ModelSchemaPropMeta {
+            min_length: Some(3),
+            ..ModelSchemaPropMeta::default()
+        },
+    );
+    assert_eq!(named_string, (true, true, None, 1));
+
+    let unconstrained = generated_field_validation(&positional, &ModelSchemaPropMeta::default());
+    assert_eq!(unconstrained, (false, false, None, 0));
+}
+
+/// The whole expansion is what a panicking `Ident` cost, so the enum the bug was found on must
+/// come back as diagnostics — one per offending slot, and none for the slot that carries no
+/// constraint.
+#[cfg(feature = "serde")]
+#[test]
+fn a_constrained_tuple_variant_yields_diagnostics_rather_than_helpers() {
+    let mut item: syn::ItemEnum = syn::parse_quote! {
+        enum Probe {
+            One(#[model_schema_prop(minLength = 3)] String),
+            Two(#[model_schema_prop(minLength = 5)] String),
+            Three(String),
+        }
+    };
+    let variants = collect_discriminated_variants(&mut item, None, Some("probe_schema"));
+
+    let validation_fns: Vec<String> = variants.1.iter().map(ToString::to_string).collect();
+    assert!(validation_fns.is_empty(), "got: {validation_fns:?}");
+
+    let errors: Vec<String> = variants.2.iter().map(ToString::to_string).collect();
+    assert_eq!(errors.len(), 2, "got: {errors:?}");
+    for error in &errors {
+        assert!(error.contains("compile_error"), "got: {error}");
+        assert!(error.contains("tuple field"), "got: {error}");
+    }
 }
 
 /// A wrapped field is gated on the way in by the walk that gates it in `validate()`, run over the


### PR DESCRIPTION
A pattern/minLength/maxLength/minimum/maximum on a tuple-variant (or tuple-struct) field aborted the whole expansion: the empty raw_field_ident reached proc_macro2::Ident::new and panicked. generate_field_validation now returns a third slot and refuses the constraint before any name is spelled, with a spanned error naming the position and the fix. The guard fires under any serde build (not only when a schema feature is on), keeping the diagnostic consistent across the powerset.

process_field's guard slot is a Vec so the positional, OsString and serde guards ride together; merge with master unified the two guard helpers into serde-side field_guard_errors feeding the ungated collect_field_guard_errors (OsString first).

Powerset green in the lane; cheap gate re-run green on the merged state.
