### PR TITLE
fix: multi-element tuple variant elements render slot-flavored on TS/Zod

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -3273,6 +3273,10 @@ fn write_tuple_single_variant_fields(
 }
 
 /// Writes the multi-element tuple portion of a discriminated enum variant.
+///
+/// Every element is a slot: serde writes each position of the tuple, so a `None` there reaches the
+/// wire as a `null` in place rather than shortening the tuple. All three surfaces read the elements
+/// through the slot spellings for that reason.
 fn write_tuple_multiple_variant_fields(
     field_defs: &[FieldDef],
     content_name: &str,
@@ -3285,7 +3289,7 @@ fn write_tuple_multiple_variant_fields(
     // Multi-element tuple: use TypeScript tuple type `value: [T1, T2, ...]`
     let ts_tuple_types: Vec<String> = field_defs
         .iter()
-        .map(super::field_type::FieldDef::typescript_typename)
+        .map(super::field_type::FieldDef::typescript_slot_typename)
         .collect();
     let ts_tuple = format!("[{}]", ts_tuple_types.join(", "));
 
@@ -3308,7 +3312,7 @@ fn write_tuple_multiple_variant_fields(
     {
         let zod_tuple_types: Vec<String> = field_defs
             .iter()
-            .map(super::field_type::FieldDef::zod_type)
+            .map(super::field_type::FieldDef::zod_slot_type)
             .collect();
         let zod_tuple = format!("z.tuple([{}])", zod_tuple_types.join(", "));
 

--- a/tests/tuple_variant_tests/tests.rs
+++ b/tests/tuple_variant_tests/tests.rs
@@ -29,6 +29,16 @@ pub enum SlotContent {
     Plain(String),
 }
 
+/// Every position of a multi-element tuple variant is a slot for the same reason: serde writes each
+/// one, so a `None` among them reaches the wire as a `null` in place rather than shortening the
+/// tuple. The non-`Option` element beside it carries no null.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(tag = "type", content = "value")]
+pub enum SlotElements {
+    Pair(String, Option<u32>),
+}
+
 /// Test 1: Single-element tuple variants.
 /// Each variant has exactly one tuple element.
 #[test]
@@ -489,9 +499,9 @@ fn test_optional_in_tuple() {
         "Maybe should have nullable string"
     );
 
-    // Multi tuple with optional element
+    // Multi tuple with optional element: each position is a slot too, so the same null flavor.
     assert!(
-        ts.contains("[string, number | undefined]"),
+        ts.contains("[string, number | null]"),
         "MaybePair should have tuple with optional element"
     );
 }
@@ -847,5 +857,65 @@ fn test_single_tuple_variant_option_content_json_schema_null_flavor() {
     assert_eq!(
         variant_of("Plain")["properties"]["value"],
         serde_json::json!({ "type": "string" })
+    );
+}
+
+/// Test 18: what serde writes for a multi-element tuple variant whose second element is an
+/// `Option` — the capture the three surfaces below are read against.
+#[test]
+fn test_multi_tuple_variant_option_element_writes_null_in_place() {
+    assert_eq!(
+        serde_json::to_value(SlotElements::Pair("a".to_owned(), None)).unwrap(),
+        serde_json::json!({ "type": "Pair", "value": ["a", null] }),
+        "A `None` element keeps its position and writes `null` there"
+    );
+}
+
+/// Test 18a: TypeScript describes those elements as the slots they are.
+#[test]
+fn test_multi_tuple_variant_option_element_typescript_null_flavor() {
+    let ts = SlotElements::ts_definition();
+
+    assert!(
+        ts.contains("value: [string, number | null]"),
+        "Pair's second element is the slot the `None` fills with `null`. Got: {ts}"
+    );
+}
+
+/// Test 18b: the Zod schema of that tuple admits the `null` serde writes. A `z.tuple` element
+/// cannot be omitted, so an undefined-flavored union there would leave `["a", null]` unmatched.
+#[cfg(feature = "zod")]
+#[test]
+fn test_multi_tuple_variant_option_element_zod_null_flavor() {
+    let zod = SlotElements::zod_schema();
+
+    assert!(
+        zod.contains("value: z.tuple([z.string(), z.nullable(z.number().int())])"),
+        "Pair's tuple admits the `null` in place. Got: {zod}"
+    );
+}
+
+/// Test 18c: the JSON schema already said so, and keeps saying it unchanged.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn test_multi_tuple_variant_option_element_json_schema_null_flavor() {
+    let schema = SlotElements::json_schema();
+    let variant = schema["oneOf"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|member| member["properties"]["type"]["const"] == "Pair")
+        .unwrap();
+
+    assert_eq!(
+        variant["properties"]["value"],
+        serde_json::json!({
+            "type": "array",
+            "prefixItems": [
+                { "type": "string" },
+                { "anyOf": [{ "type": "integer" }, { "type": "null" }] }
+            ],
+            "items": false
+        })
     );
 }


### PR DESCRIPTION
The multi-element mirror of the landed single-element fix: write_tuple_multiple_variant_fields rendered elements with the struct-field spellings, so an Option element said `| undefined` / z.union([T, z.undefined()]).prefault(undefined) — unreachable inside z.tuple, rejecting ["a",null], the only payload serde produces. Both render calls now use the slot spellings; the JSON arm was already slot-flavored and is byte-identical. Capture-first tests mirror the single-element suite; the one test codifying the bug corrected.

Powerset green in the lane; master merged in cleanly, cheap gate green on the merged state.
