### PR TITLE
fix: PathBuf constraints are enforced through the path's lossy rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -776,6 +776,8 @@ Generated JSON Schema for `username`: `{ "type": "string", "minLength": 3, "maxL
 
 The TypeScript type is unchanged -- still just `string`.
 
+A `PathBuf` field carries the same three constraints, as does the `Path` borrow behind a wrapper (`Box<Path>`, `Cow<'_, Path>`, `Arc<Path>`, `Rc<Path>`): serde writes a path as a JSON string, which is what the three surfaces render a constrained string for. The checks measure that string -- the path's `to_string_lossy` rendering, which is the exact wire value for every path serde can write, a path that is not UTF-8 being one serde refuses to serialize at all.
+
 ### Numeric Constraints (minimum, maximum)
 
 ```rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,6 +243,10 @@ pub fn model_schema(args: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// Generated JSON Schema: `{ "type": "string", "minLength": 3, "maxLength": 50, "pattern": "^[a-z0-9_]+$" }`.
 ///
+/// A `PathBuf` field carries these too, as does the `Path` borrow behind a wrapper: serde writes a
+/// path as a JSON string, and the checks measure that string — the path's `to_string_lossy`
+/// rendering, which is the exact wire value for every path serde can write.
+///
 /// ### Numeric Constraints
 ///
 /// - `minimum = N` — minimum value (integers and floats)

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -163,6 +163,14 @@ struct ConstrainedShape {
 enum ConstraintLeaf {
     /// The bare Rust numeric type, which is the validator's parameter type.
     Number(&'static str),
+    /// A filesystem path, whose checks read its `to_string_lossy` rendering.
+    ///
+    /// serde writes a path as the string its `to_str` yields and refuses to write one that has
+    /// none, so that rendering is the exact wire value for every path a payload can carry, and the
+    /// paths where it substitutes replacement characters are the ones no payload holds. That is
+    /// what lets a length or a pattern land on a path at all: it measures what the three surfaces
+    /// render a constrained string for.
+    Path,
     Str,
 }
 
@@ -4427,9 +4435,13 @@ fn helper_name_stem(field_ident: &str, variant_ident: Option<&str>) -> String {
     )
 }
 
-/// Generates the static validator for a String field with constraints, plus the serde deserializer
-/// — written against the constrained value itself when the field is bare, and against the field's
-/// declared type when it is wrapped.
+/// Generates the static validator for a string-shaped field with constraints, plus the serde
+/// deserializer — written against the constrained value itself when the field is bare, and against
+/// the field's declared type when it is wrapped.
+///
+/// A path leaf differs only in how the checked value is reached: the validator takes the borrowed
+/// path — which every wrap of the walk already ends at — and renders it once, so the checks below
+/// are the very ones a `String` field is held to, over the string serde writes for that path.
 ///
 /// Returns (`module_items`, `validate_body`) — both go into the schema module and `validate()` respectively.
 #[cfg(feature = "serde")]
@@ -4447,6 +4459,19 @@ fn generate_string_validation_code(
     let deserialize_fn_name = format!("deserialize_{helper_stem}");
     let deserialize_fn_ident =
         proc_macro2::Ident::new(&deserialize_fn_name, proc_macro2::Span::call_site());
+
+    let measures_path = matches!(shape.leaf, ConstraintLeaf::Path);
+    let (checked_param, rendering) = if measures_path {
+        (
+            quote! { path: &std::path::Path },
+            quote! {
+                let rendered = path.to_string_lossy();
+                let value: &str = &rendered;
+            },
+        )
+    } else {
+        (quote! { value: &str }, quote! {})
+    };
 
     let field_name_lit = field_ident.to_owned();
 
@@ -4494,13 +4519,20 @@ fn generate_string_validation_code(
     }
 
     let deserializer = if wraps.is_empty() {
+        // The owned form of the leaf, which is what a bare field of it is declared as: the
+        // borrowed form is unsized and cannot be a field by value.
+        let owned = if measures_path {
+            quote! { std::path::PathBuf }
+        } else {
+            quote! { String }
+        };
         quote! {
-            pub fn #deserialize_fn_ident<'de, D>(deserializer: D) -> Result<String, D::Error>
+            pub fn #deserialize_fn_ident<'de, D>(deserializer: D) -> Result<#owned, D::Error>
             where
                 D: serde::Deserializer<'de>,
             {
                 use serde::Deserialize;
-                let s = String::deserialize(deserializer)?;
+                let s = #owned::deserialize(deserializer)?;
                 #validate_value_fn_ident(&s).map_err(serde::de::Error::custom)?;
                 Ok(s)
             }
@@ -4516,7 +4548,8 @@ fn generate_string_validation_code(
     };
 
     let module_items = quote! {
-        pub fn #validate_value_fn_ident(value: &str) -> Result<(), String> {
+        pub fn #validate_value_fn_ident(#checked_param) -> Result<(), String> {
+            #rendering
             #(#checks)*
             Ok(())
         }
@@ -4713,12 +4746,14 @@ fn sole_type_argument(args: &syn::AngleBracketedGenericArguments) -> Option<&syn
     types.next().is_none().then_some(only)
 }
 
-/// The leaf a bare type name stands for. `str` is `String`'s borrowed form and answers as one; the
-/// numerics name themselves, since the validator's parameter is written from the name.
+/// The leaf a bare type name stands for. `str` is `String`'s borrowed form and answers as one, as
+/// `Path` does for `PathBuf`; the numerics name themselves, since the validator's parameter is
+/// written from the name.
 #[cfg(feature = "serde")]
 fn leaf_for_ident(ident: &str) -> Option<ConstraintLeaf> {
     match ident {
         "String" | "str" => Some(ConstraintLeaf::Str),
+        "PathBuf" | "Path" => Some(ConstraintLeaf::Path),
         "u8" => Some(ConstraintLeaf::Number("u8")),
         "u16" => Some(ConstraintLeaf::Number("u16")),
         "u32" => Some(ConstraintLeaf::Number("u32")),
@@ -5028,7 +5063,7 @@ fn generate_field_validation(
 
     let helper_stem = helper_name_stem(raw_field_ident, variant_ident);
     let generated = match shape.leaf {
-        ConstraintLeaf::Str => has_string_constraints.then(|| {
+        ConstraintLeaf::Path | ConstraintLeaf::Str => has_string_constraints.then(|| {
             generate_string_validation_code(
                 raw_field_ident,
                 &helper_stem,

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -6,7 +6,7 @@ use super::{
 
 #[cfg(feature = "serde")]
 use super::{
-    ModelSchemaPropMeta, build_field_validation, cfg_attr_guard_error,
+    ConstraintLeaf, ModelSchemaPropMeta, build_field_validation, cfg_attr_guard_error,
     check_optional_field_serialization, collect_untagged_members, constrained_shape,
     enum_cfg_attr_guard_errors, generate_numeric_validation_code, generate_string_validation_code,
     helper_name_stem, needs_injected_default, parse_serde_field_attributes,
@@ -2680,7 +2680,6 @@ fn a_field_without_a_constrainable_value_has_no_shape() {
         "Option<Tag>",
         "HashMap<String, String>",
         "(String, String)",
-        "PathBuf",
     ] {
         let ty: syn::Type = syn::parse_str(spelling).unwrap();
         assert!(
@@ -2688,4 +2687,70 @@ fn a_field_without_a_constrainable_value_has_no_shape() {
             "spelling {spelling} should reach no constrainable value"
         );
     }
+}
+
+/// A path writes a string on the wire, which is the value the rendered constraint describes, so
+/// every spelling of one reaches a leaf the checks can land on — the borrowed form included.
+#[cfg(feature = "serde")]
+#[test]
+fn every_path_spelling_reaches_a_constrainable_value() {
+    for spelling in [
+        "PathBuf",
+        "std::path::PathBuf",
+        "Box<Path>",
+        "Cow<'a, Path>",
+        "Option<PathBuf>",
+        "Vec<PathBuf>",
+    ] {
+        let ty: syn::Type = syn::parse_str(spelling).unwrap();
+        let shape = constrained_shape(&ty).unwrap();
+        assert!(
+            matches!(shape.leaf, ConstraintLeaf::Path),
+            "spelling {spelling} should reach the path leaf"
+        );
+    }
+}
+
+/// The path leaf changes what the validator is handed and nothing else: it takes the borrowed path
+/// every wrap of the walk already ends at, and the checks read the string serde writes for it.
+#[cfg(feature = "serde")]
+#[test]
+fn a_path_is_checked_through_its_lossy_rendering() {
+    let module = emitted_string_module("PathBuf");
+    assert!(
+        module.starts_with(
+            "pub fn validate_field_value (path : & std :: path :: Path) -> Result < () , String > \
+             { let rendered = path . to_string_lossy () ; let value : & str = & rendered ;"
+        ),
+        "got: {module}"
+    );
+    assert!(
+        module.contains("if value . len () < 3usize"),
+        "the checks are the ones a string field is held to: {module}"
+    );
+}
+
+/// A bare path field is declared as the owned form — the borrowed one is unsized — so that is what
+/// its deserializer reads before the check runs.
+#[cfg(feature = "serde")]
+#[test]
+fn a_bare_path_field_deserializes_the_owned_path() {
+    assert_eq!(
+        emitted_string_deserializer("PathBuf"),
+        "pub fn deserialize_field < 'de , D > (deserializer : D) -> Result < std :: path :: PathBuf , D :: Error > \
+         where D : serde :: Deserializer < 'de > , { use serde :: Deserialize ; \
+         let s = std :: path :: PathBuf :: deserialize (deserializer) ? ; \
+         validate_field_value (& s) . map_err (serde :: de :: Error :: custom) ? ; Ok (s) }"
+    );
+}
+
+/// A wrapped path is read as its declared type and checked by the same walk a wrapped string is,
+/// the deref of each wrapper landing on the borrowed path the validator takes.
+#[cfg(feature = "serde")]
+#[test]
+fn a_wrapped_path_field_deserializes_its_declared_type() {
+    assert_eq!(
+        emitted_string_deserializer("Box<Path>"),
+        emitted_string_deserializer("Box<str>").replace("Box < str >", "Box < Path >")
+    );
 }

--- a/tests/path_field_tests/tests.rs
+++ b/tests/path_field_tests/tests.rs
@@ -132,3 +132,182 @@ fn test_path_fields_render_as_strings_in_json_schema() {
         serde_json::to_string(&PlainPathFields::json_schema()).unwrap()
     );
 }
+
+/// A constrained path is measured by the string serde writes for it, so the bound the three
+/// surfaces render is the bound both the wire and `validate()` hold the field to.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn test_a_constrained_path_is_rejected_on_the_wire_and_by_validate() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug)]
+    struct ConstrainedPath {
+        #[model_schema_prop(minLength = 3, pattern = "^/[a-z]+$")]
+        owned: PathBuf,
+    }
+
+    let too_short = serde_json::from_str::<ConstrainedPath>(r#"{"owned":"/a"}"#).unwrap_err();
+    assert!(
+        too_short
+            .to_string()
+            .contains("'owned' is too short: minimum length is 3, got 2"),
+        "Unexpected error: {too_short}"
+    );
+
+    let unmatched = serde_json::from_str::<ConstrainedPath>(r#"{"owned":"etc"}"#).unwrap_err();
+    assert!(
+        unmatched
+            .to_string()
+            .contains("'owned' does not match pattern '^/[a-z]+$'"),
+        "Unexpected error: {unmatched}"
+    );
+
+    let accepted = serde_json::from_str::<ConstrainedPath>(r#"{"owned":"/etc"}"#).unwrap();
+    assert_eq!(accepted.owned, PathBuf::from("/etc"));
+    assert!(
+        accepted.validate().is_ok(),
+        "A payload the wire admits must be one validate() admits: {:?}",
+        accepted.validate().err()
+    );
+
+    let short = ConstrainedPath {
+        owned: PathBuf::from("/a"),
+    };
+    assert_eq!(
+        short.validate().unwrap_err(),
+        vec!["'owned' is too short: minimum length is 3, got 2"]
+    );
+}
+
+/// Every spelling of a path field writes the same wire string, so each carries its constraint to
+/// the same place — the borrowed forms through the wrapper they are reachable behind.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn test_every_constrained_path_spelling_is_held_to_its_bound() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug)]
+    struct ConstrainedPaths {
+        #[model_schema_prop(minLength = 3)]
+        arced: Arc<Path>,
+        #[model_schema_prop(minLength = 3)]
+        boxed: Box<Path>,
+        #[model_schema_prop(minLength = 3)]
+        cowed: Cow<'static, Path>,
+        #[model_schema_prop(minLength = 3)]
+        listed: Vec<PathBuf>,
+        #[model_schema_prop(minLength = 3)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        maybe: Option<PathBuf>,
+        #[model_schema_prop(minLength = 3)]
+        owned: PathBuf,
+        #[model_schema_prop(minLength = 3)]
+        rced: Rc<Path>,
+    }
+
+    const GOOD: &str = r#"{"arced":"/aaa","boxed":"/bbb","cowed":"/ccc","listed":["/ddd"],"maybe":"/eee","owned":"/fff","rced":"/ggg"}"#;
+    const SPELLINGS: [(&str, &str); 7] = [
+        ("arced", r#""a""#),
+        ("boxed", r#""b""#),
+        ("cowed", r#""c""#),
+        ("listed", r#"["d"]"#),
+        ("maybe", r#""e""#),
+        ("owned", r#""f""#),
+        ("rced", r#""g""#),
+    ];
+
+    let accepted = serde_json::from_str::<ConstrainedPaths>(GOOD).unwrap();
+    assert!(
+        accepted.validate().is_ok(),
+        "A payload the wire admits must be one validate() admits: {:?}",
+        accepted.validate().err()
+    );
+
+    for (field, short) in SPELLINGS {
+        let mut payload: serde_json::Value = serde_json::from_str(GOOD).unwrap();
+        payload[field] = serde_json::from_str(short).unwrap();
+        let error = serde_json::from_str::<ConstrainedPaths>(&payload.to_string()).unwrap_err();
+        assert!(
+            error.to_string().contains(&format!(
+                "'{field}' is too short: minimum length is 3, got 1"
+            )),
+            "spelling {field} was admitted by the wire: {error}"
+        );
+    }
+
+    let short = ConstrainedPaths {
+        arced: Arc::from(Path::new("a")),
+        boxed: PathBuf::from("b").into_boxed_path(),
+        cowed: Cow::Owned(PathBuf::from("c")),
+        listed: vec![PathBuf::from("d")],
+        maybe: Some(PathBuf::from("e")),
+        owned: PathBuf::from("f"),
+        rced: Rc::from(Path::new("g")),
+    };
+    assert_eq!(
+        short.validate().unwrap_err(),
+        SPELLINGS
+            .iter()
+            .map(|(field, _)| format!("'{field}' is too short: minimum length is 3, got 1"))
+            .collect::<Vec<_>>(),
+        "every spelling must report for itself"
+    );
+}
+
+/// The bound rendered for a path field and the bound enforced for it are one bound — the
+/// disagreement this covers is a schema that constrains what nothing checks.
+#[cfg(all(feature = "serde", feature = "zod"))]
+#[test]
+fn test_the_zod_bound_on_a_path_is_the_bound_the_wire_enforces() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug)]
+    struct RenderedBound {
+        #[model_schema_prop(minLength = 3)]
+        owned: PathBuf,
+    }
+
+    let schema = RenderedBound::zod_schema();
+    assert!(schema.contains("owned: z.string().min(3)"), "got: {schema}");
+    assert!(
+        serde_json::from_str::<RenderedBound>(r#"{"owned":"/a"}"#).is_err(),
+        "the rendered minimum admits no shorter value on the wire"
+    );
+}
+
+/// The rendering the checks measure, where it and the raw path part ways: serde refuses to write a
+/// path that is not UTF-8 at all, so the lossy form is the wire value wherever there is one, and
+/// the paths it renders differently are the ones no payload carries.
+#[cfg(all(
+    unix,
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn test_a_path_that_is_not_utf8_is_measured_by_its_lossy_rendering() {
+    use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStrExt as _;
+
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug)]
+    struct LossilyMeasured {
+        #[model_schema_prop(minLength = 3)]
+        owned: PathBuf,
+    }
+
+    let instance = LossilyMeasured {
+        owned: PathBuf::from(OsStr::from_bytes(&[0xff])),
+    };
+    assert!(
+        instance.validate().is_ok(),
+        "one invalid byte renders as the three-byte replacement character: {:?}",
+        instance.validate().err()
+    );
+    assert!(
+        serde_json::to_string(&instance).is_err(),
+        "serde writes no wire value for a path that is not UTF-8"
+    );
+}


### PR DESCRIPTION
String constraints on a PathBuf field were rendered by all three surfaces and enforced by nothing. Decision: enforce (the spec's recommendation). ConstraintLeaf gains Path; leaf_for_ident maps PathBuf/Path to it mirroring the borrowed-form rule; generate_string_validation_code runs the same three checks over the path's to_string_lossy rendering — the exact wire value for every path serde can write, since serde refuses to serialize a path with no to_str (pinned by a cfg(unix) non-UTF-8 test).

Wire/validate parity proven across all seven spellings (Arc/Box/Cow/Rc/Vec/Option/bare); unconstrained PathBuf byte-identical; the String branch's tokens untouched (frozen token tests pass unchanged). Decision recorded in README and the macro docs.

Powerset green in the lane; master merged cleanly; cheap gate green on the merged state.
