### PR TITLE
fix: an untagged newtype variant's Option content renders slot-flavored on all three surfaces

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -2600,6 +2600,10 @@ fn render_untagged_variant(
 }
 
 /// Renders a `TupleSingle` (`S(T)`) untagged variant as a union member (`T` / `T$Schema` / value).
+///
+/// The inner value is a slot: untagged, the variant carries no key of its own, so the content *is*
+/// the whole serialized value and a `None` there reaches the wire as a bare `null` rather than
+/// going absent. All three surfaces read it through the slot spellings for that reason.
 #[cfg(feature = "serde")]
 fn render_untagged_tuple_single(
     variant_name: &str,
@@ -2612,15 +2616,15 @@ fn render_untagged_tuple_single(
     );
     let fld = &field_defs[0];
 
-    let ts = fld.typescript_typename();
+    let ts = fld.typescript_slot_typename();
 
     #[cfg(feature = "zod")]
-    let zod = fld.zod_type();
+    let zod = fld.zod_slot_type();
     #[cfg(not(feature = "zod"))]
     let zod = String::new();
 
     #[cfg(feature = "jsonschema")]
-    let json_val = field_json_schema_value(fld);
+    let json_val = nullable_slot_json_schema_value(fld, field_json_schema_value(fld));
     #[cfg(not(feature = "jsonschema"))]
     let json_val = quote! {};
 

--- a/tests/untagged_tests/tests.rs
+++ b/tests/untagged_tests/tests.rs
@@ -59,6 +59,16 @@ enum CompliantUnion {
     },
 }
 
+// An untagged newtype variant's content has no key to drop: it is the whole serialized value, so
+// a `None` there reaches the wire as a bare `null`. The non-`Option` member beside it carries none.
+#[model_schema()]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+enum SlotUnion {
+    Maybe(Option<i64>),
+    Plain(String),
+}
+
 #[test]
 fn test_untagged_entry_constructible() {
     let entry = DataElementSampleValueEntry {
@@ -282,4 +292,63 @@ fn test_serde_round_trip_number_member() {
     assert_eq!(json, "5");
     let back: DateValue = serde_json::from_str(&json).unwrap();
     assert_eq!(back, value);
+}
+
+// ========================================================================
+// Untagged newtype variant holding an `Option` — the slot the three surfaces read against
+// ========================================================================
+
+/// What serde writes for an untagged newtype variant whose content is `None` — the capture the
+/// three surface assertions below are read against.
+#[test]
+fn test_untagged_newtype_option_content_writes_bare_null() {
+    assert_eq!(
+        serde_json::to_value(SlotUnion::Maybe(None)).unwrap(),
+        serde_json::Value::Null,
+        "The content is the whole value, so a `None` writes a bare `null`"
+    );
+}
+
+/// TypeScript describes that content as the slot it is.
+#[test]
+#[cfg(feature = "typescript")]
+fn test_untagged_newtype_option_content_typescript_null_flavor() {
+    let ts = SlotUnion::ts_definition();
+
+    assert!(
+        ts.contains("export type SlotUnion = number | null | string;"),
+        "Maybe's content is the slot the `None` fills with `null`, Plain's carries no null. \
+         Got:\n{ts}"
+    );
+}
+
+/// The Zod schema admits the `null` serde writes. An untagged member cannot be omitted, so an
+/// undefined-flavored union there would leave the captured `null` unmatched.
+#[test]
+#[cfg(feature = "zod")]
+fn test_untagged_newtype_option_content_zod_null_flavor() {
+    let zod = SlotUnion::zod_schema();
+
+    assert!(
+        zod.contains("z.union([z.nullable(z.number().int()), z.string()])"),
+        "Got:\n{zod}"
+    );
+}
+
+/// The JSON schema admits it too: `field_json_schema_value` adds no null wrap on its own, so the
+/// member goes through the shared nullable-slot wrap.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_untagged_newtype_option_content_json_schema_null_flavor() {
+    let schema = SlotUnion::json_schema();
+    let any_of = schema["anyOf"].as_array().unwrap();
+
+    assert_eq!(any_of.len(), 2, "Got:\n{schema}");
+    assert_eq!(
+        any_of[0],
+        serde_json::json!({
+            "anyOf": [{ "type": "integer" }, { "type": "null" }]
+        })
+    );
+    assert_eq!(any_of[1], serde_json::json!({ "type": "string" }));
 }


### PR DESCRIPTION
Untagged, the newtype variant's content is the whole serialized value — no key exists to drop, so serde writes None as bare null. All three surfaces rendered the field-position flavor and rejected the only payload serde produces; unlike the two landed tuple fixes, the JSON arm was wrong here too (field_json_schema_value adds no null wrap).

render_untagged_tuple_single now reads TS through typescript_slot_typename, Zod through zod_slot_type, and JSON through nullable_slot_json_schema_value. Struct-variant members keep the field-position flavor — their keys are genuinely droppable. Capture-first tests; non-Option member pinned byte-identical.

Powerset green in the lane; master merged cleanly; cheap gate green on the merged state.
