### PR TITLE
fix: a tuple variant's value array carries the arity bounds via the shared builder

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -3288,7 +3288,9 @@ fn write_tuple_single_variant_fields(
 ///
 /// Every element is a slot: serde writes each position of the tuple, so a `None` there reaches the
 /// wire as a `null` in place rather than shortening the tuple. All three surfaces read the elements
-/// through the slot spellings for that reason.
+/// through the slot spellings for that reason, and the content array is the one
+/// [`tuple_json_schema_value`] renders for a tuple field — serde writes the same array in both
+/// positions.
 fn write_tuple_multiple_variant_fields(
     field_defs: &[FieldDef],
     content_name: &str,
@@ -3353,19 +3355,9 @@ fn write_tuple_multiple_variant_fields(
     #[cfg(feature = "jsonschema")]
     {
         let content_name_str = content_name.to_owned();
-        match field_defs
-            .iter()
-            .map(build_tuple_element_json_schema)
-            .collect::<Result<Vec<_>, _>>()
-        {
-            Ok(tuple_schemas) => json_schema_variant_fields.push(quote! {
-                properties.insert(#content_name_str.to_string(), {
-                    serde_json::json!({
-                        "type": "array",
-                        "prefixItems": [#(#tuple_schemas),*],
-                        "items": false
-                    })
-                });
+        match tuple_json_schema_value(field_defs) {
+            Ok(tuple_schema) => json_schema_variant_fields.push(quote! {
+                properties.insert(#content_name_str.to_string(), #tuple_schema);
                 required.push(serde_json::Value::String(#content_name_str.to_string()));
             }),
             Err(rejection) => {
@@ -3599,8 +3591,11 @@ fn build_tuple_element_json_schema(
 /// The fixed-arity array a tuple describes as — the form serde writes it in — or the rejection when
 /// any element holds a value the dispatch cannot render.
 ///
-/// A tuple field and a tuple nested in a slot are the same array, so both are built here rather
-/// than each spelling the bounds itself.
+/// A tuple field, a tuple nested in a slot, and a multi-element tuple variant's content are the
+/// same array, so all three are built here rather than each spelling the bounds itself. The bounds
+/// are what pins the minimum an array of `prefixItems` leaves open: draft 2020-12's `"items": false`
+/// closes the tail, so without `minItems` a shorter array — one serde can neither write nor read
+/// back — still validates.
 #[cfg(feature = "jsonschema")]
 fn tuple_json_schema_value(
     elements: &[FieldDef],
@@ -4142,10 +4137,8 @@ fn build_string_format_field_schema(
 /// Builds JSON schema for a tuple struct field.
 ///
 /// A Rust tuple field `(A, B, ...)` serializes (via serde) as a fixed-length JSON array, which is
-/// what [`tuple_json_schema_value`] renders — the same array a tuple nested in a slot renders, so
-/// the two positions cannot drift apart. The tuple **variant** path
-/// (`write_tuple_multiple_variant_fields`) shares the per-element builder but spells its own array,
-/// without the arity bounds.
+/// what [`tuple_json_schema_value`] renders — the same array a tuple nested in a slot and a
+/// multi-element tuple variant's content render, so the positions cannot drift apart.
 ///
 /// An element the dispatch cannot render replaces the whole insertion with the lone diagnostic,
 /// as an unrenderable map value does: a schema left in place would describe a field the expansion

--- a/tests/tuple_variant_tests/tests.rs
+++ b/tests/tuple_variant_tests/tests.rs
@@ -895,7 +895,8 @@ fn test_multi_tuple_variant_option_element_zod_null_flavor() {
     );
 }
 
-/// Test 18c: the JSON schema already said so, and keeps saying it unchanged.
+/// Test 18c: the JSON schema already said so, and keeps saying it — now over the fixed-arity array
+/// every other tuple position writes, bounds included.
 #[cfg(feature = "jsonschema")]
 #[test]
 fn test_multi_tuple_variant_option_element_json_schema_null_flavor() {
@@ -915,7 +916,92 @@ fn test_multi_tuple_variant_option_element_json_schema_null_flavor() {
                 { "type": "string" },
                 { "anyOf": [{ "type": "integer" }, { "type": "null" }] }
             ],
-            "items": false
+            "items": false,
+            "minItems": 2_u64,
+            "maxItems": 2_u64
         })
     );
+}
+
+/// The two-element tuple a variant carries and the two-element tuple a field carries are the same
+/// JSON array, so they describe as the same schema — bounds included.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn test_multi_tuple_variant_json_schema_matches_tuple_field() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct ArityField {
+        pub pair: (u32, u32),
+    }
+
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub enum ArityVariant {
+        Pair(u32, u32),
+    }
+
+    let schema = ArityVariant::json_schema();
+    let variant_value = &schema["oneOf"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|member| member["properties"]["type"]["const"] == "Pair")
+        .unwrap()["properties"]["value"];
+
+    assert_eq!(
+        *variant_value,
+        ArityField::json_schema()["properties"]["pair"],
+        "A variant's tuple array must describe as the tuple field does. Got: {variant_value}"
+    );
+    assert_eq!(
+        *variant_value,
+        serde_json::json!({
+            "type": "array",
+            "prefixItems": [{ "type": "integer" }, { "type": "integer" }],
+            "items": false,
+            "minItems": 2_u64,
+            "maxItems": 2_u64
+        })
+    );
+}
+
+/// The bounds are read against real payloads: the array serde writes for the variant sits inside
+/// them, and the short and long arrays serde can neither write nor read back sit outside.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn test_multi_tuple_variant_arity_bounds_reject_wrong_length_arrays() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    #[serde(tag = "type", content = "value")]
+    pub enum ArityProbe {
+        Pair(u32, u32),
+    }
+
+    let schema = ArityProbe::json_schema();
+    let value = &schema["oneOf"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|member| member["properties"]["type"]["const"] == "Pair")
+        .unwrap()["properties"]["value"];
+    let admitted = value["minItems"].as_u64().unwrap()..=value["maxItems"].as_u64().unwrap();
+
+    let written = serde_json::to_value(ArityProbe::Pair(1, 2)).unwrap();
+    let written_len = u64::try_from(written["value"].as_array().unwrap().len()).unwrap();
+    assert!(
+        admitted.contains(&written_len),
+        "What serde writes must validate. Got length {written_len} against {admitted:?}"
+    );
+
+    for rejected in [
+        serde_json::json!([]),
+        serde_json::json!([1_u32]),
+        serde_json::json!([1_u32, 2_u32, 3_u32]),
+    ] {
+        let len = u64::try_from(rejected.as_array().unwrap().len()).unwrap();
+        assert!(
+            !admitted.contains(&len),
+            "An array of {len} elements is not the tuple. Got {admitted:?}"
+        );
+    }
 }


### PR DESCRIPTION
write_tuple_multiple_variant_fields spelled its own fixed-arity array (prefixItems + items:false, no bounds), so a short array — one serde can neither write nor read back — validated: items:false closes the tail but leaves the minimum open. The variant now routes through tuple_json_schema_value, converging field, nested-slot, and variant positions on one spelling with minItems/maxItems.

Red-first: three tests failed before. A convergence test pins the variant's value schema byte-equal to the same tuple in field position; a payload test reads real serde output against the bounds window.

Powerset green in the lane; master merged cleanly; cheap gate green on the merged state.
