### PR TITLE
fix: a tuple struct describes as the wire form serde writes, not an empty-keyed object

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -1046,6 +1046,23 @@ fn struct_docs_and_example(item_struct: &syn::ItemStruct) -> (Option<Vec<String>
     (docs_vec, example_code)
 }
 
+/// The output a struct carrying a `cfg_attr`-wrapped serde attribute on the type is refused with,
+/// or `None` when it carries none.
+///
+/// A hidden `rename_all` reshapes every field name, so the item is refused before a single field
+/// is processed.
+#[cfg(feature = "serde")]
+fn struct_cfg_attr_guard_output(
+    item_struct: &syn::ItemStruct,
+    rejection: Option<&syn::Error>,
+) -> Option<TokenStream> {
+    let ident = &item_struct.ident;
+    guard_failure_output(
+        item_struct,
+        &[cfg_attr_guard_error(rejection?, &format!("type `{ident}`"))],
+    )
+}
+
 fn process_struct(mut item_struct: syn::ItemStruct, args: &ModelSchemaArgs) -> TokenStream {
     // Check if this is a branded newtype (transparent single-field tuple struct)
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
@@ -1056,19 +1073,14 @@ fn process_struct(mut item_struct: syn::ItemStruct, args: &ModelSchemaArgs) -> T
     // String constraints (pattern, minLength, maxLength) are only valid on branded newtypes
     assert_no_struct_string_constraints(args);
 
-    let name = &item_struct.ident;
+    let name = item_struct.ident.clone();
 
     #[cfg(feature = "serde")]
     let serde_type_meta = parse_serde_type_attributes(&item_struct.attrs);
 
-    // A hidden `rename_all` reshapes every field name, so the item is rejected before a single
-    // field is processed.
     #[cfg(feature = "serde")]
-    if let Some(rejection) = serde_type_meta.cfg_attr_rejection.as_ref()
-        && let Some(output) = guard_failure_output(
-            &item_struct,
-            &[cfg_attr_guard_error(rejection, &format!("type `{name}`"))],
-        )
+    if let Some(output) =
+        struct_cfg_attr_guard_output(&item_struct, serde_type_meta.cfg_attr_rejection.as_ref())
     {
         return output;
     }
@@ -1078,9 +1090,16 @@ fn process_struct(mut item_struct: syn::ItemStruct, args: &ModelSchemaArgs) -> T
     #[cfg(not(feature = "serde"))]
     let rename_all: Option<String> = None;
 
+    // A tuple struct's slots have no keys, so the named-field emitters below would render every
+    // one of them under the empty ident it carries.
+    #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+    if is_tuple_struct(&item_struct) {
+        return process_tuple_struct(item_struct, rename_all.as_deref());
+    }
+
     // Compute schema-module identifiers and register the struct in the alias registry.
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-    let (item_name, module_name, module_ident) = struct_module_idents(name);
+    let (item_name, module_name, module_ident) = struct_module_idents(&name);
 
     // Extract docs early for example extraction
     #[cfg(any(feature = "typescript", feature = "zod"))]
@@ -1113,7 +1132,7 @@ fn process_struct(mut item_struct: syn::ItemStruct, args: &ModelSchemaArgs) -> T
     }
 
     #[cfg(feature = "typescript")]
-    let docs = build_item_jsdoc(docs_and_example.0.as_deref(), name);
+    let docs = build_item_jsdoc(docs_and_example.0.as_deref(), &name);
 
     // Generate the schema module methods. The schema module emits zod_schema without examples;
     // example injection happens in the delegating method on the type to avoid `super::` issues.
@@ -1136,7 +1155,7 @@ fn process_struct(mut item_struct: syn::ItemStruct, args: &ModelSchemaArgs) -> T
     // schema_example must be directly on the type (not in the module) because the example code
     // uses type names that may not be accessible from the nested module.
     #[cfg(feature = "zod")]
-    let schema_example_method = build_struct_schema_example(docs_and_example.1.as_ref(), name);
+    let schema_example_method = build_struct_schema_example(docs_and_example.1.as_ref(), &name);
     #[cfg(all(
         not(feature = "zod"),
         any(feature = "typescript", feature = "jsonschema")
@@ -1168,7 +1187,7 @@ fn process_struct(mut item_struct: syn::ItemStruct, args: &ModelSchemaArgs) -> T
         assemble_schema_output(
             &item_struct,
             &module_ident,
-            name,
+            &name,
             &schema_impl_items,
             &collected.2,
             &delegate_impl_items,
@@ -1183,6 +1202,190 @@ fn process_struct(mut item_struct: syn::ItemStruct, args: &ModelSchemaArgs) -> T
         log::trace!("{output}");
         TokenStream::from(output)
     }
+}
+
+/// Returns whether a struct's slots are positional. A branded newtype is one too, and is
+/// dispatched ahead of this question.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+const fn is_tuple_struct(item_struct: &syn::ItemStruct) -> bool {
+    matches!(item_struct.fields, syn::Fields::Unnamed(_))
+}
+
+/// Walks a tuple struct's slots, returning their field defs in declaration order and the
+/// `compile_error!` tokens of every guard a slot violates.
+///
+/// Unlike [`collect_struct_fields`] the walk does not split on `#[serde(flatten)]`: a positional
+/// slot has no key for a flattened member to merge into, and dropping one here would silently
+/// change the arity the surfaces describe. The per-slot validators are dropped because a
+/// positional slot cannot carry a constraint — the guard that says so is what comes back instead.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn collect_tuple_slots(
+    fields: &mut syn::Fields,
+    rename_all: Option<&str>,
+    module_name: &str,
+    type_name: &str,
+) -> (Vec<FieldDef>, Vec<proc_macro2::TokenStream>) {
+    let mut slots: Vec<FieldDef> = Vec::new();
+    let mut guard_errors: Vec<proc_macro2::TokenStream> = Vec::new();
+    for field in fields.iter_mut() {
+        let (slot, _, _, slot_guard_errors) =
+            process_field(rename_all, field, Some(module_name), None, type_name);
+        guard_errors.extend(slot_guard_errors);
+        slots.push(slot);
+    }
+    (slots, guard_errors)
+}
+
+/// The TypeScript type a tuple struct describes as.
+///
+/// A single slot is the slot's own type: serde writes a newtype struct as that value alone, with
+/// nothing around it. Every other arity — the empty one included, which writes `[]` — is the fixed
+/// tuple the same slots describe as when they are written as a tuple field.
+#[cfg(feature = "typescript")]
+fn tuple_struct_ts_body(slots: &[FieldDef]) -> String {
+    if let [slot] = slots {
+        return slot.typescript_slot_typename();
+    }
+    format!(
+        "[{}]",
+        slots
+            .iter()
+            .map(FieldDef::typescript_slot_typename)
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
+}
+
+/// [`tuple_struct_ts_body`] for the Zod surface.
+#[cfg(feature = "zod")]
+fn tuple_struct_zod_body(slots: &[FieldDef]) -> String {
+    if let [slot] = slots {
+        return slot.zod_slot_type();
+    }
+    format!(
+        "z.tuple([{}])",
+        slots
+            .iter()
+            .map(FieldDef::zod_slot_type)
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
+}
+
+/// [`tuple_struct_ts_body`] for the JSON-schema surface, as a standalone `serde_json::Value`
+/// expression, or the diagnostic naming the type when a slot holds a value the dispatch cannot
+/// render.
+#[cfg(feature = "jsonschema")]
+fn tuple_struct_json_body(item_name: &str, slots: &[FieldDef]) -> proc_macro2::TokenStream {
+    let described = if let [slot] = slots {
+        build_tuple_element_json_schema(slot)
+    } else {
+        tuple_json_schema_value(slots)
+    };
+    match described {
+        Ok(value) => value,
+        Err(rejection) => {
+            let message = map_member_rejection_message(&format!("`{item_name}`"), &rejection);
+            quote! { compile_error!(#message) }
+        }
+    }
+}
+
+/// Builds the `ts_definition()` method for a tuple struct's schema module.
+#[cfg(feature = "typescript")]
+fn build_tuple_struct_ts_definition_method(
+    docs: &str,
+    item_name: &str,
+    ts_body: &str,
+) -> proc_macro2::TokenStream {
+    let type_str = format!("/**\n{docs}\n **/\nexport type {item_name} = {ts_body};");
+    quote! {
+        pub fn ts_definition() -> String {
+            #type_str.to_owned()
+        }
+    }
+}
+
+/// Builds the `zod_schema()` method for a tuple struct's schema module, in the same framing every
+/// unbranded type publishes: the raw schema, then the exported binding annotated with the
+/// TypeScript type the module's own `ts_definition()` writes.
+#[cfg(feature = "zod")]
+fn build_tuple_struct_zod_schema_method(
+    item_name: &str,
+    zod_body: &str,
+) -> proc_macro2::TokenStream {
+    #[cfg(feature = "typescript")]
+    let schema_str = format!(
+        "const {item_name}$RawSchema = {zod_body};\n\nexport const {item_name}$Schema: ZodType<{item_name}> = {item_name}$RawSchema;"
+    );
+    #[cfg(not(feature = "typescript"))]
+    let schema_str = format!("export const {item_name}$Schema = {zod_body};");
+    quote! {
+        pub fn zod_schema() -> String {
+            #schema_str.to_owned()
+        }
+    }
+}
+
+/// Processes a tuple struct that is not a branded newtype.
+///
+/// serde writes a one-slot tuple struct as the slot's value alone and every other arity as a
+/// fixed-arity array, so neither shape is the object the named-field emitters describe. Both are
+/// rendered from the slots read in slot position — the position a tuple field's elements are
+/// already read in, where a `None` reaches the wire as `null` rather than as an omitted key — so
+/// a tuple struct describes as the tuple of its slot types does wherever that tuple is written.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn process_tuple_struct(mut item_struct: syn::ItemStruct, rename_all: Option<&str>) -> TokenStream {
+    let name = item_struct.ident.clone();
+    let (item_name, module_name, module_ident) = struct_module_idents(&name);
+
+    let (slots, guard_errors) = collect_tuple_slots(
+        &mut item_struct.fields,
+        rename_all,
+        &module_name,
+        &name.to_string(),
+    );
+
+    // A violated slot guard makes the whole contract unsound, so the schema surface is dropped and
+    // only the original item plus the errors are emitted.
+    if let Some(output) = guard_failure_output(&item_struct, &guard_errors) {
+        return output;
+    }
+
+    #[cfg(any(feature = "typescript", feature = "zod"))]
+    let docs_and_example = struct_docs_and_example(&item_struct);
+
+    let schema_impl_items: Vec<proc_macro2::TokenStream> = vec![
+        #[cfg(feature = "jsonschema")]
+        json_schema_methods(&item_name, &tuple_struct_json_body(&item_name, &slots)),
+        #[cfg(feature = "typescript")]
+        build_tuple_struct_ts_definition_method(
+            &build_item_jsdoc(docs_and_example.0.as_deref(), &name),
+            &item_name,
+            &tuple_struct_ts_body(&slots),
+        ),
+        #[cfg(feature = "zod")]
+        build_tuple_struct_zod_schema_method(&item_name, &tuple_struct_zod_body(&slots)),
+    ];
+
+    // schema_example must be directly on the type (not in the module) because the example code
+    // uses type names that may not be accessible from the nested module.
+    #[cfg(feature = "zod")]
+    let schema_example_method = build_struct_schema_example(docs_and_example.1.as_ref(), &name);
+    #[cfg(not(feature = "zod"))]
+    let schema_example_method: Option<proc_macro2::TokenStream> = None;
+
+    let delegate_impl_items =
+        build_struct_delegate_items(&module_ident, schema_example_method.as_ref(), None);
+
+    assemble_schema_output(
+        &item_struct,
+        &module_ident,
+        &name,
+        &schema_impl_items,
+        &[],
+        &delegate_impl_items,
+    )
 }
 
 /// Processes a branded newtype (transparent single-field tuple struct) and generates

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -16,6 +16,15 @@ use super::{
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 use super::{AliasKind, branded_guard_errors, register_alias_info};
 
+#[cfg(feature = "typescript")]
+use super::tuple_struct_ts_body;
+
+#[cfg(feature = "zod")]
+use super::tuple_struct_zod_body;
+
+#[cfg(feature = "jsonschema")]
+use super::tuple_struct_json_body;
+
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 use syn::spanned::Spanned as _;
 
@@ -2788,4 +2797,61 @@ fn a_field_without_a_constrainable_value_has_no_shape() {
             "spelling {spelling} should reach no constrainable value"
         );
     }
+}
+
+/// The slots a tuple struct is read from, at the three arities the dispatch answers for. The empty
+/// one has no declaration in this crate — `struct Nothing();` is refused by the lint table — so it
+/// is read here, where the slots are built rather than parsed off an item.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn tuple_slots(spellings: &[&str]) -> Vec<super::FieldDef> {
+    spellings
+        .iter()
+        .map(|spelling| get_field_def("", &syn::parse_str(spelling).unwrap(), ""))
+        .collect()
+}
+
+/// One slot is the slot's own type — serde writes a newtype struct as that value alone — and every
+/// other arity is the fixed tuple serde writes as an array.
+#[cfg(feature = "typescript")]
+#[test]
+fn a_tuple_struct_describes_as_its_arity_in_typescript() {
+    assert_eq!(tuple_struct_ts_body(&tuple_slots(&[])), "[]");
+    assert_eq!(tuple_struct_ts_body(&tuple_slots(&["String"])), "string");
+    assert_eq!(
+        tuple_struct_ts_body(&tuple_slots(&["String", "u32"])),
+        "[string, number]"
+    );
+}
+
+/// [`a_tuple_struct_describes_as_its_arity_in_typescript`] for the Zod surface.
+#[cfg(feature = "zod")]
+#[test]
+fn a_tuple_struct_describes_as_its_arity_in_zod() {
+    assert_eq!(tuple_struct_zod_body(&tuple_slots(&[])), "z.tuple([])");
+    assert_eq!(
+        tuple_struct_zod_body(&tuple_slots(&["String"])),
+        "z.string()"
+    );
+    assert_eq!(
+        tuple_struct_zod_body(&tuple_slots(&["String", "u32"])),
+        "z.tuple([z.string(), z.number().int()])"
+    );
+}
+
+/// [`a_tuple_struct_describes_as_its_arity_in_typescript`] for the JSON-schema surface, whose
+/// fixed array carries the arity as its own bounds.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_tuple_struct_describes_as_its_arity_in_json_schema() {
+    let empty = tuple_struct_json_body("Nothing", &tuple_slots(&[])).to_string();
+    assert!(empty.contains("prefixItems"), "Got: {empty}");
+    assert!(empty.contains("minItems"), "Got: {empty}");
+
+    let single = tuple_struct_json_body("Plain", &tuple_slots(&["String"])).to_string();
+    assert!(single.contains("string"), "Got: {single}");
+    assert!(!single.contains("prefixItems"), "Got: {single}");
+
+    let pair = tuple_struct_json_body("Pair", &tuple_slots(&["String", "u32"])).to_string();
+    assert!(pair.contains("prefixItems"), "Got: {pair}");
+    assert!(pair.contains("maxItems"), "Got: {pair}");
 }

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -2853,6 +2853,8 @@ fn a_tuple_struct_describes_as_its_arity_in_json_schema() {
     let pair = tuple_struct_json_body("Pair", &tuple_slots(&["String", "u32"])).to_string();
     assert!(pair.contains("prefixItems"), "Got: {pair}");
     assert!(pair.contains("maxItems"), "Got: {pair}");
+}
+
 /// A path writes a string on the wire, which is the value the rendered constraint describes, so
 /// every spelling of one reaches a leaf the checks can land on — the borrowed form included.
 #[cfg(feature = "serde")]

--- a/tests/tuple_struct_tests.rs
+++ b/tests/tuple_struct_tests.rs
@@ -1,0 +1,9 @@
+//! Tests for tuple structs that are not branded newtypes.
+//!
+//! serde writes a one-slot tuple struct as its inner value alone and a wider one as a fixed-arity
+//! array, so neither is the object the named-field emitters describe. These tests read every
+//! surface against the wire value serde actually writes.
+
+#[cfg(test)]
+#[path = "tuple_struct_tests/tests.rs"]
+mod tests;

--- a/tests/tuple_struct_tests/tests.rs
+++ b/tests/tuple_struct_tests/tests.rs
@@ -1,0 +1,223 @@
+use serde::{Deserialize, Serialize};
+use tixschema::model_schema;
+
+/// A newtype struct: serde writes the slot's value alone, with nothing around it.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct Plain(pub String);
+
+/// A wider tuple struct: serde writes a fixed-arity array.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct Pair(pub String, pub u32);
+
+/// A slot cannot be omitted the way an object key can, so a `None` here reaches the wire as
+/// `null`.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct MaybeName(pub Option<String>);
+
+/// The wire criterion the newtype surfaces are read against.
+#[test]
+fn test_serde_writes_a_newtype_struct_as_the_inner_value_alone() {
+    assert_eq!(
+        serde_json::to_value(Plain("hello".to_owned())).unwrap(),
+        serde_json::json!("hello")
+    );
+}
+
+/// The wire criterion the wider surfaces are read against.
+#[test]
+fn test_serde_writes_a_wider_tuple_struct_as_a_fixed_array() {
+    assert_eq!(
+        serde_json::to_value(Pair("hello".to_owned(), 1_u32)).unwrap(),
+        serde_json::json!(["hello", 1_u32])
+    );
+}
+
+/// The wire criterion the nullable surfaces are read against: the slot is always written, so a
+/// `None` arrives as `null` rather than as an absent key.
+#[test]
+fn test_serde_writes_a_none_slot_as_null() {
+    assert_eq!(
+        serde_json::to_value(MaybeName(None)).unwrap(),
+        serde_json::json!(null)
+    );
+    assert_eq!(
+        serde_json::to_value(MaybeName(Some("ada".to_owned()))).unwrap(),
+        serde_json::json!("ada")
+    );
+}
+
+#[cfg(feature = "typescript")]
+#[test]
+fn test_a_newtype_struct_describes_the_bare_inner_type_in_typescript() {
+    let wire = serde_json::to_value(Plain("hello".to_owned())).unwrap();
+    assert!(wire.is_string(), "wire: {wire}");
+
+    let ts = Plain::ts_definition();
+    assert!(ts.contains("export type Plain = string;"), "Got: {ts}");
+    assert!(!ts.contains(": string;"), "Got: {ts}");
+}
+
+#[cfg(feature = "zod")]
+#[test]
+fn test_a_newtype_struct_describes_the_bare_inner_type_in_zod() {
+    let wire = serde_json::to_value(Plain("hello".to_owned())).unwrap();
+    assert!(wire.is_string(), "wire: {wire}");
+
+    let zod = Plain::zod_schema();
+    assert!(zod.contains("Plain$Schema"), "Got: {zod}");
+    assert!(zod.contains("= z.string();"), "Got: {zod}");
+    assert!(!zod.contains("{ : "), "Got: {zod}");
+    assert!(!zod.contains("strictObject"), "Got: {zod}");
+}
+
+#[cfg(feature = "jsonschema")]
+#[test]
+fn test_a_newtype_struct_describes_the_bare_inner_type_in_json_schema() {
+    let wire = serde_json::to_value(Plain("hello".to_owned())).unwrap();
+    assert!(wire.is_string(), "wire: {wire}");
+
+    assert_eq!(
+        Plain::json_schema(),
+        serde_json::json!({ "type": "string" })
+    );
+}
+
+#[cfg(feature = "typescript")]
+#[test]
+fn test_a_wider_tuple_struct_describes_a_fixed_tuple_in_typescript() {
+    let wire = serde_json::to_value(Pair("hello".to_owned(), 1_u32)).unwrap();
+    assert!(wire.is_array(), "wire: {wire}");
+
+    let ts = Pair::ts_definition();
+    assert!(
+        ts.contains("export type Pair = [string, number];"),
+        "Got: {ts}"
+    );
+    assert!(!ts.contains(": string;"), "Got: {ts}");
+}
+
+#[cfg(feature = "zod")]
+#[test]
+fn test_a_wider_tuple_struct_describes_a_fixed_tuple_in_zod() {
+    let wire = serde_json::to_value(Pair("hello".to_owned(), 1_u32)).unwrap();
+    assert!(wire.is_array(), "wire: {wire}");
+
+    let zod = Pair::zod_schema();
+    assert!(zod.contains("Pair$Schema"), "Got: {zod}");
+    assert!(
+        zod.contains("= z.tuple([z.string(), z.number().int()]);"),
+        "Got: {zod}"
+    );
+    assert!(!zod.contains("{ : "), "Got: {zod}");
+    assert!(!zod.contains("strictObject"), "Got: {zod}");
+}
+
+/// The `ZodType<...> = ...$RawSchema` framing only appears when typescript is also enabled.
+#[cfg(all(feature = "zod", feature = "typescript"))]
+#[test]
+fn test_a_tuple_struct_zod_schema_is_annotated_with_its_typescript_type() {
+    let zod = Pair::zod_schema();
+    assert!(
+        zod.contains("export const Pair$Schema: ZodType<Pair> = Pair$RawSchema;"),
+        "Got: {zod}"
+    );
+}
+
+#[cfg(feature = "jsonschema")]
+#[test]
+fn test_a_wider_tuple_struct_describes_a_fixed_tuple_in_json_schema() {
+    let wire = serde_json::to_value(Pair("hello".to_owned(), 1_u32)).unwrap();
+    assert!(wire.is_array(), "wire: {wire}");
+
+    assert_eq!(
+        Pair::json_schema(),
+        serde_json::json!({
+            "type": "array",
+            "prefixItems": [{ "type": "string" }, { "type": "integer" }],
+            "items": false,
+            "minItems": 2_u32,
+            "maxItems": 2_u32
+        })
+    );
+}
+
+#[cfg(feature = "typescript")]
+#[test]
+fn test_an_optional_slot_describes_the_null_it_writes_in_typescript() {
+    let wire = serde_json::to_value(MaybeName(None)).unwrap();
+    assert!(wire.is_null(), "wire: {wire}");
+
+    let ts = MaybeName::ts_definition();
+    assert!(
+        ts.contains("export type MaybeName = string | null;"),
+        "Got: {ts}"
+    );
+}
+
+#[cfg(feature = "zod")]
+#[test]
+fn test_an_optional_slot_describes_the_null_it_writes_in_zod() {
+    let wire = serde_json::to_value(MaybeName(None)).unwrap();
+    assert!(wire.is_null(), "wire: {wire}");
+
+    let zod = MaybeName::zod_schema();
+    assert!(zod.contains("MaybeName$Schema"), "Got: {zod}");
+    assert!(zod.contains("= z.nullable(z.string());"), "Got: {zod}");
+}
+
+#[cfg(feature = "jsonschema")]
+#[test]
+fn test_an_optional_slot_describes_the_null_it_writes_in_json_schema() {
+    let wire = serde_json::to_value(MaybeName(None)).unwrap();
+    assert!(wire.is_null(), "wire: {wire}");
+
+    assert_eq!(
+        MaybeName::json_schema(),
+        serde_json::json!({ "anyOf": [{ "type": "string" }, { "type": "null" }] })
+    );
+}
+
+/// The empty ident of an unnamed slot must not reach any surface as a key.
+#[cfg(feature = "typescript")]
+#[test]
+fn test_typescript_never_names_a_slot_by_its_absent_ident() {
+    for ts in [
+        Plain::ts_definition(),
+        Pair::ts_definition(),
+        MaybeName::ts_definition(),
+    ] {
+        assert!(!ts.contains(": string;"), "Got: {ts}");
+        assert!(!ts.contains("  : "), "Got: {ts}");
+    }
+}
+
+/// [`test_typescript_never_names_a_slot_by_its_absent_ident`] for the Zod surface.
+#[cfg(feature = "zod")]
+#[test]
+fn test_zod_never_names_a_slot_by_its_absent_ident() {
+    for zod in [
+        Plain::zod_schema(),
+        Pair::zod_schema(),
+        MaybeName::zod_schema(),
+    ] {
+        assert!(!zod.contains("{ : "), "Got: {zod}");
+        assert!(!zod.contains("  : "), "Got: {zod}");
+    }
+}
+
+/// [`test_typescript_never_names_a_slot_by_its_absent_ident`] for the JSON-schema surface, where
+/// the empty ident used to arrive as a property literally named `""`.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn test_json_schema_never_names_a_slot_by_its_absent_ident() {
+    for json in [
+        Plain::json_schema(),
+        Pair::json_schema(),
+        MaybeName::json_schema(),
+    ] {
+        assert!(!json.to_string().contains("\"\""), "Got: {json}");
+    }
+}


### PR DESCRIPTION
A non-branded tuple struct fed its ident-less slots into the named-field emitters, rendering every slot under the empty key on all three surfaces — TS and Zod text that doesn't even parse. process_struct now dispatches Fields::Unnamed (non-branded) to process_tuple_struct: one slot renders as the bare inner value (serde writes a newtype struct transparently), any other arity as the fixed-arity array via the shared slot accessors — so a tuple struct describes exactly as its tuple type does wherever that tuple is written. Slots still walk process_field, keeping the OsString and positional-constraint guards.

Byte-identity elsewhere proven empirically: a 234-line A/B capture (branded newtypes, all enum variant shapes, tuple fields) against the pre-change tree diffed clean. Wire-capture-first tests for all three arities including Option slots.

Powerset green in the lane; master merged (one both-append test conflict resolved, brace seam restored), cheap gate green on the merged state.
