### PR TITLE
fix: a constrained brand over PathBuf compiles and enforces through the path's rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,7 +584,7 @@ error[E0277]: `Vec<String>` doesn't implement `std::fmt::Display`
    |                     ^^^^^^^^^^^ the trait `std::fmt::Display` is not implemented for `Vec<String>`
 ```
 
-Pass `no_display` for brands over container inner types. The brand then gets no `Display` impl and carries no such requirement; its schema and its serde transparency are unchanged. String constraints are a separate matter: `pattern`, `minLength`, and `maxLength` validate through `to_string()`, so a constrained brand needs a `Display` inner whether or not it passes `no_display` — and a container inner cannot carry them at all (see [Branded Newtype Validation Constraints](#branded-newtype-validation-constraints)).
+Pass `no_display` for brands over an inner type that has none — a container, or a `PathBuf`. The brand then gets no `Display` impl and carries no such requirement; its schema and its serde transparency are unchanged. String constraints are a separate matter: `pattern`, `minLength`, and `maxLength` validate through `to_string()` for every inner but a path, so a constrained brand over one of the others needs a `Display` inner whether or not it passes `no_display` — and a container inner cannot carry them at all (see [Branded Newtype Validation Constraints](#branded-newtype-validation-constraints)).
 
 ```rust
 use tixschema::model_schema;
@@ -605,6 +605,15 @@ You can add `pattern`, `minLength`, and `maxLength` constraints directly on the 
 **The inner type has to be one whose schema is a string** — `String`, `PathBuf`, `ObjectId`, a chrono date/time type, another brand, or a generic parameter. A numeric, boolean, container (`Vec`, array, `HashMap`, tuple), or opaque (`serde_json::Value`) inner is rejected at expansion time, because the three constraints are string checks and each surface would read them differently: Zod's `.min`/`.max` become bounds on the value itself, JSON Schema ignores `minLength`/`maxLength`/`pattern` outside `"type": "string"`, and `validate()` measures the inner's `Display` rendering.
 
 **The inner type also has to implement `Display`,** since validation runs against `to_string()`. That holds whether or not the brand passes `no_display`: the flag drops the `Display` impl, not the requirement.
+
+A `PathBuf` inner is the one exception, and needs no `Display`: its checks read the path's `to_string_lossy` rendering — the string serde writes for it — exactly as a constrained `PathBuf` field's do. Such a brand still passes `no_display`, since the impl a brand gets by default has no inner `Display` to delegate to:
+
+```rust
+#[model_schema(no_display, minLength = 3, pattern = "^/[a-z]+$")]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct AssetPath(pub std::path::PathBuf);
+```
 
 ```rust
 #[model_schema(pattern = "^[a-z0-9_]+$", minLength = 3, maxLength = 50)]

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -148,6 +148,18 @@ struct BrandedNewtypeOutput<'parts> {
     validation_tokens: &'parts proc_macro2::TokenStream,
 }
 
+/// A constrained brand's generated validation: the two schema-module functions, and the expression
+/// through which `validate()` reaches the inner value it hands to the first of them.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+struct BrandedValidation {
+    checked_inner: proc_macro2::TokenStream,
+    deserialize_fn: proc_macro2::TokenStream,
+    validate_fn: proc_macro2::TokenStream,
+}
+
 /// What a field bottoms out in, under the wrappers it was written beneath.
 #[cfg(feature = "serde")]
 struct ConstrainedShape {
@@ -1210,8 +1222,10 @@ fn process_struct(mut item_struct: syn::ItemStruct, args: &ModelSchemaArgs) -> T
 /// cannot be resolved at macro-expansion time.
 /// Builds the `validate_value`/`deserialize_value` functions for a constrained branded newtype.
 ///
-/// Returns `None` when the newtype has no string constraints. Uses `ToString` so it works for
-/// `String`, `ObjectId`, and any generic `ID_TYPE` that implements `Display`.
+/// Returns `None` when the newtype has no string constraints. A path inner is measured by the
+/// string serde writes for it, exactly as a path field is; every other inner is reached through
+/// `ToString`, so it works for `String`, `ObjectId`, and any generic `ID_TYPE` implementing
+/// `Display`.
 #[cfg(all(
     feature = "serde",
     any(feature = "typescript", feature = "zod", feature = "jsonschema")
@@ -1220,8 +1234,11 @@ fn build_branded_validation(
     args: &ModelSchemaArgs,
     is_generic: bool,
     inner_ty: &syn::Type,
-) -> Option<(proc_macro2::TokenStream, proc_macro2::TokenStream)> {
+) -> Option<BrandedValidation> {
     args.has_string_constraints().then(|| {
+        let measures_path = branded_inner_measures_path(inner_ty);
+        let (checked_param, rendering) = checked_value_parts(measures_path);
+        let checked_v = branded_checked_value(measures_path, &quote! { v });
         let mut checks: Vec<proc_macro2::TokenStream> = Vec::new();
 
         if let Some(min_len) = args.min_length {
@@ -1263,7 +1280,8 @@ fn build_branded_validation(
         }
 
         let validate_fn = quote! {
-            pub fn validate_value(value: &str) -> Result<(), String> {
+            pub fn validate_value(#checked_param) -> Result<(), String> {
+                #rendering
                 #(#checks)*
                 Ok(())
             }
@@ -1278,7 +1296,7 @@ fn build_branded_validation(
                 {
                     use serde::Deserialize;
                     let v = T::deserialize(deserializer)?;
-                    validate_value(&v.to_string()).map_err(serde::de::Error::custom)?;
+                    validate_value(#checked_v).map_err(serde::de::Error::custom)?;
                     Ok(v)
                 }
             }
@@ -1294,14 +1312,50 @@ fn build_branded_validation(
                 {
                     use serde::Deserialize;
                     let v = <#inner_ty>::deserialize(deserializer)?;
-                    validate_value(&v.to_string()).map_err(serde::de::Error::custom)?;
+                    validate_value(#checked_v).map_err(serde::de::Error::custom)?;
                     Ok(v)
                 }
             }
         };
 
-        (validate_fn, deserialize_fn)
+        BrandedValidation {
+            checked_inner: branded_checked_value(measures_path, &quote! { self.0 }),
+            deserialize_fn,
+            validate_fn,
+        }
     })
+}
+
+/// Whether a brand's constrained checks reach its inner value as a path rather than through
+/// `Display`.
+///
+/// A brand's constrained value is the inner field itself, with no walk to reach it, so only an
+/// inner that *is* a path answers here — one merely holding paths writes no string of its own for
+/// the checks to measure, and is refused by [`branded_constraint_inner_error`] before this.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+fn branded_inner_measures_path(inner_ty: &syn::Type) -> bool {
+    constrained_shape(inner_ty)
+        .is_some_and(|shape| shape.wraps.is_empty() && matches!(shape.leaf, ConstraintLeaf::Path))
+}
+
+/// How a constrained brand hands `receiver` to `validate_value`: a path goes borrowed, since the
+/// validator renders it itself; every other inner is rendered through `Display` first.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+fn branded_checked_value(
+    measures_path: bool,
+    receiver: &proc_macro2::TokenStream,
+) -> proc_macro2::TokenStream {
+    if measures_path {
+        quote! { &#receiver }
+    } else {
+        quote! { &#receiver.to_string() }
+    }
 }
 
 /// Builds the `json_schema()` method for a branded newtype's schema module.
@@ -1614,7 +1668,9 @@ fn build_branded_display_impl(
 ///
 /// A constrained brand validates through `value.to_string()`, so the requirement outlives the impl
 /// the brand opted out of. Keeping the assertion is what turns that into an `E0277` at the inner
-/// field instead of the `E0599` the `to_string()` call raises against the attribute.
+/// field instead of the `E0599` the `to_string()` call raises against the attribute. A path inner
+/// is the exception: its checks read the path's own rendering and call no `to_string()`, so there
+/// is nothing left for the assertion to blame.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn build_branded_display_tokens(
     generics: &syn::Generics,
@@ -1624,7 +1680,8 @@ fn build_branded_display_tokens(
 ) -> proc_macro2::TokenStream {
     // Only the serde build emits the validation functions that call `to_string()`.
     #[cfg(feature = "serde")]
-    let validation_needs_display = args.has_string_constraints();
+    let validation_needs_display =
+        args.has_string_constraints() && !branded_inner_measures_path(&inner_field.ty);
     #[cfg(not(feature = "serde"))]
     let validation_needs_display = false;
 
@@ -1742,7 +1799,7 @@ fn build_branded_schema_example(
 ))]
 fn inject_branded_serde_attrs(
     mut owned_struct: syn::ItemStruct,
-    branded_validation: Option<&(proc_macro2::TokenStream, proc_macro2::TokenStream)>,
+    branded_validation: Option<&BrandedValidation>,
     is_generic: bool,
     generic_params: &[String],
     module_name: &str,
@@ -1752,7 +1809,7 @@ fn inject_branded_serde_attrs(
     proc_macro2::TokenStream,
     proc_macro2::TokenStream,
 ) {
-    let Some((validate_fn, deserialize_fn)) = branded_validation else {
+    let Some(validation) = branded_validation else {
         return (owned_struct, quote! {}, quote! {});
     };
 
@@ -1784,6 +1841,9 @@ fn inject_branded_serde_attrs(
         fields.unnamed.first_mut().unwrap().attrs.push(serde_attr);
     }
 
+    let validate_fn = &validation.validate_fn;
+    let deserialize_fn = &validation.deserialize_fn;
+    let checked_inner = &validation.checked_inner;
     let validation_tokens = quote! {
         #validate_fn
         #deserialize_fn
@@ -1791,7 +1851,7 @@ fn inject_branded_serde_attrs(
     let validate_method = quote! {
         pub fn validate(&self) -> Result<(), Vec<String>> {
             let mut errors = Vec::new();
-            if let Err(e) = #module_ident::validate_value(&self.0.to_string()) {
+            if let Err(e) = #module_ident::validate_value(#checked_inner) {
                 errors.push(e);
             }
             if errors.is_empty() { Ok(()) } else { Err(errors) }
@@ -4439,6 +4499,28 @@ fn helper_name_stem(field_ident: &str, variant_ident: Option<&str>) -> String {
     )
 }
 
+/// The parameter a string validator takes and the rendering its checks read `value` from.
+///
+/// A path is the one leaf the checks cannot be handed as-is: it arrives borrowed — the form every
+/// reach into one already ends at — and is rendered once through `to_string_lossy`, the string
+/// serde writes for it. Every other leaf already is that string, and renders nothing.
+#[cfg(feature = "serde")]
+fn checked_value_parts(
+    measures_path: bool,
+) -> (proc_macro2::TokenStream, proc_macro2::TokenStream) {
+    if measures_path {
+        (
+            quote! { path: &std::path::Path },
+            quote! {
+                let rendered = path.to_string_lossy();
+                let value: &str = &rendered;
+            },
+        )
+    } else {
+        (quote! { value: &str }, quote! {})
+    }
+}
+
 /// Generates the static validator for a string-shaped field with constraints, plus the serde
 /// deserializer — written against the constrained value itself when the field is bare, and against
 /// the field's declared type when it is wrapped.
@@ -4465,17 +4547,7 @@ fn generate_string_validation_code(
         proc_macro2::Ident::new(&deserialize_fn_name, proc_macro2::Span::call_site());
 
     let measures_path = matches!(shape.leaf, ConstraintLeaf::Path);
-    let (checked_param, rendering) = if measures_path {
-        (
-            quote! { path: &std::path::Path },
-            quote! {
-                let rendered = path.to_string_lossy();
-                let value: &str = &rendered;
-            },
-        )
-    } else {
-        (quote! { value: &str }, quote! {})
-    };
+    let (checked_param, rendering) = checked_value_parts(measures_path);
 
     let field_name_lit = field_ident.to_owned();
 

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -1083,7 +1083,7 @@ fn constrained_brand_inner_spanned_tokens(source: &str, inner: &str) -> (usize, 
             .filter(|text| text.as_str() == inner)
             .count()
     };
-    (count(&validation.1), count(&validate_method))
+    (count(&validation.deserialize_fn), count(&validate_method))
 }
 
 /// Neither `to_string()` the constrained path emits may carry the inner field's span. Spanned
@@ -1109,6 +1109,37 @@ fn neither_constrained_to_string_call_carries_the_inner_fields_span() {
     );
 }
 
+/// A constrained brand's emitted text for an inner spelled `inner`, as the three streams it is made
+/// of: the validator, the deserializer, and the `validate()` method that calls into the first.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+fn constrained_brand_emission(inner: &str, module: &str) -> (String, String, String) {
+    let ty: syn::Type = syn::parse_str(inner).unwrap();
+    let item: syn::ItemStruct = syn::parse_quote!(
+        pub struct Branded(pub #ty);
+    );
+    let args = super::parse_model_schema_args(quote::quote! { pattern = "^[a-z]+$" });
+    let validation =
+        super::build_branded_validation(&args, false, &item.fields.iter().next().unwrap().ty)
+            .unwrap();
+    let module_ident = syn::Ident::new(module, proc_macro2::Span::call_site());
+    let (_, _, validate_method) = super::inject_branded_serde_attrs(
+        item,
+        Some(&validation),
+        false,
+        &[],
+        module,
+        &module_ident,
+    );
+    (
+        validation.validate_fn.to_string(),
+        validation.deserialize_fn.to_string(),
+        validate_method.to_string(),
+    )
+}
+
 /// The constrained path's generated text is what it has always been.
 #[cfg(all(
     feature = "serde",
@@ -1116,36 +1147,51 @@ fn neither_constrained_to_string_call_carries_the_inner_fields_span() {
 ))]
 #[test]
 fn the_constrained_path_renders_the_same_to_string_calls_it_always_has() {
-    let item: syn::ItemStruct = syn::parse_quote!(
-        pub struct SlugId(pub String);
-    );
-    let args = super::parse_model_schema_args(quote::quote! { pattern = "^[a-z]+$" });
-    let validation =
-        super::build_branded_validation(&args, false, &item.fields.iter().next().unwrap().ty)
-            .unwrap();
-    let module_ident = syn::Ident::new("slug_id_schema", proc_macro2::Span::call_site());
-    let (_, _, validate_method) = super::inject_branded_serde_attrs(
-        item,
-        Some(&validation),
-        false,
-        &[],
-        "slug_id_schema",
-        &module_ident,
+    let (validate_fn, deserialize_fn, validate_method) =
+        constrained_brand_emission("String", "slug_id_schema");
+    assert!(
+        validate_fn
+            .starts_with("pub fn validate_value (value : & str) -> Result < () , String > {"),
+        "got: {validate_fn}"
     );
     assert!(
-        validation
-            .1
-            .to_string()
-            .contains("validate_value (& v . to_string ())"),
-        "got: {}",
-        validation.1
+        deserialize_fn.contains("validate_value (& v . to_string ())"),
+        "got: {deserialize_fn}"
     );
     assert!(
-        validate_method
-            .to_string()
-            .contains("slug_id_schema :: validate_value (& self . 0 . to_string ())"),
+        validate_method.contains("slug_id_schema :: validate_value (& self . 0 . to_string ())"),
         "got: {validate_method}"
     );
+}
+
+/// A brand's constrained value is its inner field, so a path inner is reached the way a path field
+/// is: the validator takes the borrowed path and renders it once, and neither call site names a
+/// `to_string()` a path has none of.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn a_path_brand_is_checked_through_its_lossy_rendering() {
+    for spelling in ["PathBuf", "std::path::PathBuf"] {
+        let (validate_fn, deserialize_fn, validate_method) =
+            constrained_brand_emission(spelling, "asset_path_schema");
+        assert!(
+            validate_fn.starts_with(
+                "pub fn validate_value (path : & std :: path :: Path) -> Result < () , String > { \
+                 let rendered = path . to_string_lossy () ; let value : & str = & rendered ;"
+            ),
+            "for {spelling}, got: {validate_fn}"
+        );
+        assert!(
+            deserialize_fn.contains("validate_value (& v)"),
+            "for {spelling}, got: {deserialize_fn}"
+        );
+        assert!(
+            validate_method.contains("asset_path_schema :: validate_value (& self . 0)"),
+            "for {spelling}, got: {validate_method}"
+        );
+    }
 }
 
 /// The JSON schema statements a map-typed field expands to, parsed from the map type's source and

--- a/tests/branded_newtype_tests/tests.rs
+++ b/tests/branded_newtype_tests/tests.rs
@@ -699,9 +699,81 @@ mod branded_no_display_tests {
     }
 }
 
-// `no_display` drops the `Display` impl, not the `Display` requirement: a constrained brand
-// validates through `to_string()`, so its inner still has to render. Compiling this module is the
-// assertion that the combination is accepted and still wired to the constraints.
+// A brand's constrained value is its inner field itself, so a path inner is measured the way a
+// path field is: by the string serde writes for it. `no_display` is what the brand's own `Display`
+// impl needs — a path has none to delegate to — and the constraints reach the value without one.
+// Compiling this module is the assertion that a path brand is emitted at all.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+mod constrained_path_brand_tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[model_schema(no_display, minLength = 3, pattern = "^/[a-z]+$")]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct AssetPath(pub PathBuf);
+
+    #[test]
+    fn test_a_constrained_path_brand_is_held_to_its_bound_on_the_wire() {
+        let too_short = serde_json::from_str::<AssetPath>("\"/a\"").unwrap_err();
+        assert!(
+            too_short
+                .to_string()
+                .contains("value is too short: minimum length is 3, got 2"),
+            "Unexpected error: {too_short}"
+        );
+
+        let unmatched = serde_json::from_str::<AssetPath>("\"etc\"").unwrap_err();
+        assert!(
+            unmatched
+                .to_string()
+                .contains("value does not match pattern '^/[a-z]+$'"),
+            "Unexpected error: {unmatched}"
+        );
+
+        let accepted = serde_json::from_str::<AssetPath>("\"/etc\"").unwrap();
+        assert_eq!(accepted, AssetPath(PathBuf::from("/etc")));
+        assert!(
+            accepted.validate().is_ok(),
+            "A payload the wire admits must be one validate() admits: {:?}",
+            accepted.validate().err()
+        );
+    }
+
+    #[test]
+    fn test_a_constrained_path_brand_is_held_to_its_bound_by_validate() {
+        AssetPath(PathBuf::from("/etc")).validate().unwrap();
+        assert_eq!(
+            AssetPath(PathBuf::from("/a")).validate().unwrap_err(),
+            vec!["value is too short: minimum length is 3, got 2"]
+        );
+        assert_eq!(
+            AssetPath(PathBuf::from("etcetera")).validate().unwrap_err(),
+            vec!["value does not match pattern '^/[a-z]+$'"]
+        );
+    }
+
+    // The bound the brand renders and the bound it enforces are one bound; a schema that
+    // constrains what nothing checks is the disagreement this covers.
+    #[cfg(feature = "zod")]
+    #[test]
+    fn test_the_zod_bound_on_a_path_brand_is_the_bound_the_wire_enforces() {
+        let zod = AssetPath::zod_schema();
+        assert!(zod.contains("z.string().min(3)"), "Got:\n{zod}");
+        assert!(zod.contains("brand<\"AssetPath\">"), "Got:\n{zod}");
+        assert!(
+            serde_json::from_str::<AssetPath>("\"/a\"").is_err(),
+            "the rendered minimum admits no shorter value on the wire"
+        );
+    }
+}
+
+// `no_display` drops the `Display` impl, not the `Display` requirement: a brand whose checks read
+// the inner's `to_string()` still needs it to render. Compiling this module is the assertion that
+// the combination is accepted and still wired to the constraints.
 #[cfg(all(
     feature = "serde",
     any(feature = "typescript", feature = "zod", feature = "jsonschema")


### PR DESCRIPTION
Every admission surface accepted PathBuf as a string-shaped brand inner, but build_branded_validation went through to_string() — no Display on PathBuf, so the derive failed with E0277 at the field and E0599 at the attribute. The emission now dispatches on the inner's ConstraintLeaf: a path inner is measured by its to_string_lossy rendering exactly as a constrained path field is (the (parameter, rendering) pair lifted into checked_value_parts, shared, not duplicated); every other inner keeps the Display path byte-for-byte. The Display static assertion is excepted for path inners — no to_string() remains for it to blame. README's two always-needs-Display sentences corrected.

Red-first: the fixture reproduced the exact reported errors before the fix.

Powerset green in the lane; cheap gate green on the merged state.
