### PR TITLE
fix: a constrained brand over a wrapped path compiles — transparent wraps deref to the path

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,7 +606,7 @@ You can add `pattern`, `minLength`, and `maxLength` constraints directly on the 
 
 **The inner type also has to implement `Display`,** since validation runs against `to_string()`. That holds whether or not the brand passes `no_display`: the flag drops the `Display` impl, not the requirement.
 
-A `PathBuf` inner is the one exception, and needs no `Display`: its checks read the path's `to_string_lossy` rendering — the string serde writes for it — exactly as a constrained `PathBuf` field's do. Such a brand still passes `no_display`, since the impl a brand gets by default has no inner `Display` to delegate to:
+A path inner is the one exception, and needs no `Display`: its checks read the path's `to_string_lossy` rendering — the string serde writes for it — exactly as a constrained path field's do. Such a brand still passes `no_display`, since the impl a brand gets by default has no inner `Display` to delegate to:
 
 ```rust
 #[model_schema(no_display, minLength = 3, pattern = "^/[a-z]+$")]
@@ -614,6 +614,8 @@ A `PathBuf` inner is the one exception, and needs no `Display`: its checks read 
 #[serde(transparent)]
 pub struct AssetPath(pub std::path::PathBuf);
 ```
+
+That holds for every spelling of a path: a transparent wrapper writes nothing of its own on the wire and derefs to what it holds, so `Arc<Path>`, `Box<Path>`, `Cow<'static, Path>`, and `Rc<Path>` are branded and bounded exactly as `PathBuf` is.
 
 ```rust
 #[model_schema(pattern = "^[a-z0-9_]+$", minLength = 3, maxLength = 50)]

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -1534,17 +1534,26 @@ fn build_branded_validation(
 ///
 /// A brand's constrained value is the inner field itself, with no walk to reach it, so only an
 /// inner that *is* a path answers here — one merely holding paths writes no string of its own for
-/// the checks to measure, and is refused by [`branded_constraint_inner_error`] before this.
+/// the checks to measure, and is refused by [`branded_constraint_inner_error`] before this. A
+/// transparent wrapper is nothing on the wire and derefs to what it holds, so a path written under
+/// any stack of them is still that same path, borrowed one coercion further out; an `Option` or a
+/// sequence is not, which is why only the transparent wraps pass.
 #[cfg(all(
     feature = "serde",
     any(feature = "typescript", feature = "zod", feature = "jsonschema")
 ))]
 fn branded_inner_measures_path(inner_ty: &syn::Type) -> bool {
-    constrained_shape(inner_ty)
-        .is_some_and(|shape| shape.wraps.is_empty() && matches!(shape.leaf, ConstraintLeaf::Path))
+    constrained_shape(inner_ty).is_some_and(|shape| {
+        matches!(shape.leaf, ConstraintLeaf::Path)
+            && shape
+                .wraps
+                .iter()
+                .all(|wrap| matches!(wrap, ConstraintWrap::Transparent))
+    })
 }
 
-/// How a constrained brand hands `receiver` to `validate_value`: a path goes borrowed, since the
+/// How a constrained brand hands `receiver` to `validate_value`: a path goes borrowed — deref
+/// coercion carries it through whatever transparent wrappers it was written under — since the
 /// validator renders it itself; every other inner is rendered through `Display` first.
 #[cfg(all(
     feature = "serde",

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -1149,40 +1149,54 @@ fn constrained_brand_emission(inner: &str, module: &str) -> (String, String, Str
     )
 }
 
-/// The constrained path's generated text is what it has always been.
+/// The constrained path's generated text is what it has always been. A wrapper that is not
+/// transparent stays here too: only a deref reaches a path from outside it, and an `Option` or a
+/// sequence has none to offer.
 #[cfg(all(
     feature = "serde",
     any(feature = "typescript", feature = "zod", feature = "jsonschema")
 ))]
 #[test]
 fn the_constrained_path_renders_the_same_to_string_calls_it_always_has() {
-    let (validate_fn, deserialize_fn, validate_method) =
-        constrained_brand_emission("String", "slug_id_schema");
-    assert!(
-        validate_fn
-            .starts_with("pub fn validate_value (value : & str) -> Result < () , String > {"),
-        "got: {validate_fn}"
-    );
-    assert!(
-        deserialize_fn.contains("validate_value (& v . to_string ())"),
-        "got: {deserialize_fn}"
-    );
-    assert!(
-        validate_method.contains("slug_id_schema :: validate_value (& self . 0 . to_string ())"),
-        "got: {validate_method}"
-    );
+    for spelling in ["String", "Option<PathBuf>", "Vec<PathBuf>"] {
+        let (validate_fn, deserialize_fn, validate_method) =
+            constrained_brand_emission(spelling, "slug_id_schema");
+        assert!(
+            validate_fn
+                .starts_with("pub fn validate_value (value : & str) -> Result < () , String > {"),
+            "for {spelling}, got: {validate_fn}"
+        );
+        assert!(
+            deserialize_fn.contains("validate_value (& v . to_string ())"),
+            "for {spelling}, got: {deserialize_fn}"
+        );
+        assert!(
+            validate_method
+                .contains("slug_id_schema :: validate_value (& self . 0 . to_string ())"),
+            "for {spelling}, got: {validate_method}"
+        );
+    }
 }
 
 /// A brand's constrained value is its inner field, so a path inner is reached the way a path field
 /// is: the validator takes the borrowed path and renders it once, and neither call site names a
-/// `to_string()` a path has none of.
+/// `to_string()` a path has none of. A transparent wrapper adds no call of its own — the borrow the
+/// bare spelling already writes is what deref coercion carries through it.
 #[cfg(all(
     feature = "serde",
     any(feature = "typescript", feature = "zod", feature = "jsonschema")
 ))]
 #[test]
 fn a_path_brand_is_checked_through_its_lossy_rendering() {
-    for spelling in ["PathBuf", "std::path::PathBuf"] {
+    for spelling in [
+        "PathBuf",
+        "std::path::PathBuf",
+        "Arc<Path>",
+        "Box<Path>",
+        "Cow<'static, Path>",
+        "Rc<std::path::Path>",
+        "Box<Arc<Path>>",
+    ] {
         let (validate_fn, deserialize_fn, validate_method) =
             constrained_brand_emission(spelling, "asset_path_schema");
         assert!(

--- a/tests/branded_newtype_tests.rs
+++ b/tests/branded_newtype_tests.rs
@@ -1,3 +1,5 @@
+extern crate alloc;
+
 #[cfg(test)]
 #[path = "branded_newtype_tests/tests.rs"]
 mod tests;

--- a/tests/branded_newtype_tests/tests.rs
+++ b/tests/branded_newtype_tests/tests.rs
@@ -771,6 +771,163 @@ mod constrained_path_brand_tests {
     }
 }
 
+// A transparent wrapper writes nothing of its own and derefs to what it holds, so a path branded
+// under one is the same path on every surface a bare one is — and the constrained checks reach it
+// through that deref, not through a `Display` none of these spellings has. Compiling this module is
+// the assertion that each spelling is emitted at all.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+mod wrapped_path_brand_tests {
+    use super::*;
+    use alloc::borrow::Cow;
+    use alloc::rc::Rc;
+    use alloc::sync::Arc;
+    use core::fmt::Debug;
+    use serde::de::DeserializeOwned;
+    use std::path::{Path, PathBuf};
+
+    #[model_schema(no_display, minLength = 3, pattern = "^/[a-z]+$")]
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct ArcedPath(pub Arc<Path>);
+
+    #[model_schema(no_display, minLength = 3, pattern = "^/[a-z]+$")]
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct BoxedPath(pub Box<Path>);
+
+    #[model_schema(no_display, minLength = 3, pattern = "^/[a-z]+$")]
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct CowedPath(pub Cow<'static, Path>);
+
+    #[model_schema(no_display, minLength = 3, pattern = "^/[a-z]+$")]
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct RcedPath(pub Rc<Path>);
+
+    /// The wire criterion each spelling is held to: the bound rejects, the accepted payload is the
+    /// path it spelled, and what the wire admits `validate()` admits too.
+    fn assert_wire_bound<Brand>(
+        name: &str,
+        inner: fn(&Brand) -> &Path,
+        validate: fn(&Brand) -> Result<(), Vec<String>>,
+    ) where
+        Brand: Debug + DeserializeOwned,
+    {
+        let too_short = serde_json::from_str::<Brand>("\"/a\"").unwrap_err();
+        assert!(
+            too_short
+                .to_string()
+                .contains("value is too short: minimum length is 3, got 2"),
+            "for {name}, unexpected error: {too_short}"
+        );
+
+        let unmatched = serde_json::from_str::<Brand>("\"etc\"").unwrap_err();
+        assert!(
+            unmatched
+                .to_string()
+                .contains("value does not match pattern '^/[a-z]+$'"),
+            "for {name}, unexpected error: {unmatched}"
+        );
+
+        let accepted = serde_json::from_str::<Brand>("\"/etc\"").unwrap();
+        assert_eq!(inner(&accepted), Path::new("/etc"), "for {name}");
+        assert!(
+            validate(&accepted).is_ok(),
+            "for {name}, a payload the wire admits must be one validate() admits: {:?}",
+            validate(&accepted).err()
+        );
+    }
+
+    /// The same bound reached from Rust rather than the wire, on a value built directly.
+    fn assert_validate_bound<Brand>(
+        name: &str,
+        wrap: fn(&str) -> Brand,
+        validate: fn(&Brand) -> Result<(), Vec<String>>,
+    ) {
+        validate(&wrap("/etc")).unwrap();
+        assert_eq!(
+            validate(&wrap("/a")).unwrap_err(),
+            vec!["value is too short: minimum length is 3, got 2"],
+            "for {name}"
+        );
+        assert_eq!(
+            validate(&wrap("etcetera")).unwrap_err(),
+            vec!["value does not match pattern '^/[a-z]+$'"],
+            "for {name}"
+        );
+    }
+
+    #[test]
+    fn test_every_wrapped_path_brand_is_held_to_its_bound_on_the_wire() {
+        assert_wire_bound::<ArcedPath>("ArcedPath", |brand| &brand.0, ArcedPath::validate);
+        assert_wire_bound::<BoxedPath>("BoxedPath", |brand| &brand.0, BoxedPath::validate);
+        assert_wire_bound::<CowedPath>("CowedPath", |brand| &brand.0, CowedPath::validate);
+        assert_wire_bound::<RcedPath>("RcedPath", |brand| &brand.0, RcedPath::validate);
+    }
+
+    #[test]
+    fn test_every_wrapped_path_brand_is_held_to_its_bound_by_validate() {
+        assert_validate_bound(
+            "ArcedPath",
+            |raw| ArcedPath(Arc::from(Path::new(raw))),
+            ArcedPath::validate,
+        );
+        assert_validate_bound(
+            "BoxedPath",
+            |raw| BoxedPath(Box::from(Path::new(raw))),
+            BoxedPath::validate,
+        );
+        assert_validate_bound(
+            "CowedPath",
+            |raw| CowedPath(Cow::Owned(PathBuf::from(raw))),
+            CowedPath::validate,
+        );
+        assert_validate_bound(
+            "RcedPath",
+            |raw| RcedPath(Rc::from(Path::new(raw))),
+            RcedPath::validate,
+        );
+    }
+
+    // The wrapper is nothing on the wire, so what a wrapped path brand renders is what the bare one
+    // renders; a bound that moved with the spelling would be one the three surfaces no longer share.
+    #[cfg(feature = "zod")]
+    #[test]
+    fn test_a_wrapped_path_brand_renders_the_bare_brands_zod_schema() {
+        let bare = super::constrained_path_brand_tests::AssetPath::zod_schema();
+        for (rendered, name) in [
+            (ArcedPath::zod_schema(), "ArcedPath"),
+            (BoxedPath::zod_schema(), "BoxedPath"),
+            (CowedPath::zod_schema(), "CowedPath"),
+            (RcedPath::zod_schema(), "RcedPath"),
+        ] {
+            assert_eq!(
+                rendered,
+                bare.replace("AssetPath", name),
+                "for {name}, got:\n{rendered}"
+            );
+        }
+    }
+
+    #[cfg(feature = "jsonschema")]
+    #[test]
+    fn test_a_wrapped_path_brand_renders_the_bare_brands_json_schema() {
+        let bare = super::constrained_path_brand_tests::AssetPath::json_schema();
+        for (rendered, name) in [
+            (ArcedPath::json_schema(), "ArcedPath"),
+            (BoxedPath::json_schema(), "BoxedPath"),
+            (CowedPath::json_schema(), "CowedPath"),
+            (RcedPath::json_schema(), "RcedPath"),
+        ] {
+            assert_eq!(rendered, bare, "for {name}, got:\n{rendered}");
+        }
+    }
+}
+
 // `no_display` drops the `Display` impl, not the `Display` requirement: a brand whose checks read
 // the inner's `to_string()` still needs it to render. Compiling this module is the assertion that
 // the combination is accepted and still wired to the constraints.


### PR DESCRIPTION
branded_inner_measures_path required an empty wrap stack, so Box<Path>/Arc<Path>/Cow<Path>/Rc<Path> brands still routed through to_string() and failed with the same E0277/E0599 the bare-PathBuf brand did. The predicate now answers true when the leaf is Path and every wrap is Transparent — deref coercion carries the existing &self.0 borrow through the wrapper stack, so checked_value_parts/branded_checked_value are untouched. Option/sequence wraps stay on the Display route (both already refused earlier with spanned errors, pinned by tests).

Red-first: 10 compile errors reproduced on the three spellings before the fix. New wrapped_path_brand_tests pin wire bound, validate() bound, and zod/JSON equality against the bare brand.

Powerset green in the lane; cheap gate green on the merged state.
