### PR TITLE
fix: raw line terminators in a pattern escape for the Zod regex literal

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -309,12 +309,28 @@ pub fn strip_examples_from_docs(docs: &[String]) -> Vec<String> {
     result
 }
 
+/// The escape body a JavaScript regex literal spells a line terminator with, i.e. what follows
+/// the backslash. The literal grammar excludes a raw line terminator outright, both on its own
+/// and as the character a backslash escapes, so these are the only spellings available.
+#[cfg(feature = "zod")]
+const fn js_line_terminator_escape(ch: char) -> Option<&'static str> {
+    match ch {
+        '\n' => Some("n"),
+        '\r' => Some("r"),
+        '\u{2028}' => Some("u2028"),
+        '\u{2029}' => Some("u2029"),
+        _ => None,
+    }
+}
+
 /// Escapes a regex pattern for splicing between the `/` delimiters of a JavaScript regex literal.
 ///
-/// The pattern is already a regex, so the delimiter is the only character the literal syntax adds
-/// a meaning to: every unescaped `/` becomes `\/`. A backslash escape is consumed whole, which
-/// keeps an authored `\/` from gaining a second backslash and keeps a literal `\\` from being read
-/// as the escape for the `/` that follows it.
+/// The pattern is already a regex, so what needs work is what the literal syntax alone gives a
+/// meaning to: the `/` delimiter, which becomes `\/`, and a raw line terminator, which the literal
+/// cannot carry at all and so becomes its escape. A backslash escape is consumed whole, which keeps
+/// an authored `\/` from gaining a second backslash and keeps a literal `\\` from being read as the
+/// escape for the `/` that follows it. A backslash before a raw line terminator is an identity
+/// escape, and the escape form denotes that same character.
 #[cfg(feature = "zod")]
 pub fn escape_js_regex_literal(pattern: &str) -> String {
     let mut result = String::with_capacity(pattern.len());
@@ -324,11 +340,20 @@ pub fn escape_js_regex_literal(pattern: &str) -> String {
             '\\' => {
                 result.push('\\');
                 if let Some(escaped) = chars.next() {
-                    result.push(escaped);
+                    match js_line_terminator_escape(escaped) {
+                        Some(escape) => result.push_str(escape),
+                        None => result.push(escaped),
+                    }
                 }
             }
             '/' => result.push_str("\\/"),
-            _ => result.push(ch),
+            _ => match js_line_terminator_escape(ch) {
+                Some(escape) => {
+                    result.push('\\');
+                    result.push_str(escape);
+                }
+                None => result.push(ch),
+            },
         }
     }
     result

--- a/src/utils/tests.rs
+++ b/src/utils/tests.rs
@@ -227,3 +227,27 @@ fn test_escape_js_regex_literal_consumes_a_backslash_escape_whole() {
     assert_eq!(escape_js_regex_literal(r"^\\/x$"), r"^\\\/x$");
     assert_eq!(escape_js_regex_literal(r"trailing\"), r"trailing\");
 }
+
+#[cfg(feature = "zod")]
+#[test]
+fn test_escape_js_regex_literal_escapes_every_raw_line_terminator() {
+    assert_eq!(escape_js_regex_literal("^a\nb$"), r"^a\nb$");
+    assert_eq!(escape_js_regex_literal("^a\rb$"), r"^a\rb$");
+    assert_eq!(escape_js_regex_literal("^a\u{2028}b$"), r"^a\u2028b$");
+    assert_eq!(escape_js_regex_literal("^a\u{2029}b$"), r"^a\u2029b$");
+    assert_eq!(escape_js_regex_literal("a\r\nb"), r"a\r\nb");
+}
+
+#[cfg(feature = "zod")]
+#[test]
+fn test_escape_js_regex_literal_leaves_an_authored_line_terminator_escape_alone() {
+    assert_eq!(escape_js_regex_literal(r"^a\nb$"), r"^a\nb$");
+    assert_eq!(escape_js_regex_literal(r"^a\u2028b$"), r"^a\u2028b$");
+}
+
+#[cfg(feature = "zod")]
+#[test]
+fn test_escape_js_regex_literal_rewrites_an_identity_escaped_line_terminator() {
+    assert_eq!(escape_js_regex_literal("^a\\\nb$"), r"^a\nb$");
+    assert_eq!(escape_js_regex_literal("^a\\\\\nb$"), r"^a\\\nb$");
+}

--- a/tests/pattern_preprocess_tests/tests.rs
+++ b/tests/pattern_preprocess_tests/tests.rs
@@ -564,3 +564,154 @@ fn test_the_escaped_zod_pattern_matches_the_value_set_the_validator_enforces() {
         );
     }
 }
+
+// ==================== Line terminators inside the Zod regex literal ====================
+
+// A JS regex literal cannot carry a raw line terminator: the literal ends at the line break and
+// the emitted TypeScript stops parsing, exactly as an unescaped delimiter did. The escape form
+// denotes the same character, so the literal keeps matching what the Rust-side validator enforces,
+// and the surfaces that carry the pattern as a plain string still see it byte for byte.
+
+#[cfg(feature = "zod")]
+#[test]
+fn test_a_raw_newline_in_a_field_pattern_escapes_for_the_zod_regex_literal() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize)]
+    pub struct NewlineField {
+        #[model_schema_prop(pattern = "^a\n[a-z]+$")]
+        pub name: String,
+    }
+
+    let schema = NewlineField::zod_schema();
+    assert!(
+        schema.contains(r".check(z.regex(/^a\n[a-z]+$/))"),
+        "Expected the newline escaped inside the regex literal: {schema}"
+    );
+    assert!(
+        !schema.contains("z.regex(/^a\n"),
+        "The regex literal must not be split by a raw line terminator: {schema}"
+    );
+}
+
+#[cfg(all(feature = "zod", feature = "serde"))]
+#[test]
+fn test_a_raw_newline_in_a_brand_pattern_escapes_for_the_zod_regex_literal() {
+    #[model_schema(pattern = "^a\n[a-z]+$")]
+    #[derive(Serialize, Deserialize, Debug)]
+    #[serde(transparent)]
+    pub struct NewlineBrand(pub String);
+
+    let schema = NewlineBrand::zod_schema();
+    assert!(
+        schema.contains(r".check(z.regex(/^a\n[a-z]+$/))"),
+        "Expected the newline escaped inside the regex literal: {schema}"
+    );
+}
+
+#[cfg(feature = "zod")]
+#[test]
+fn test_every_other_raw_line_terminator_escapes_for_the_zod_regex_literal() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize)]
+    pub struct CarriageReturnField {
+        #[model_schema_prop(pattern = "^a\r[a-z]+$")]
+        pub name: String,
+    }
+
+    #[model_schema()]
+    #[derive(Serialize, Deserialize)]
+    pub struct LineSeparatorField {
+        #[model_schema_prop(pattern = "^a\u{2028}[a-z]+$")]
+        pub name: String,
+    }
+
+    #[model_schema()]
+    #[derive(Serialize, Deserialize)]
+    pub struct ParagraphSeparatorField {
+        #[model_schema_prop(pattern = "^a\u{2029}[a-z]+$")]
+        pub name: String,
+    }
+
+    let cr = CarriageReturnField::zod_schema();
+    assert!(
+        cr.contains(r".check(z.regex(/^a\r[a-z]+$/))"),
+        "Expected the carriage return escaped: {cr}"
+    );
+    let ls = LineSeparatorField::zod_schema();
+    assert!(
+        ls.contains(r".check(z.regex(/^a\u2028[a-z]+$/))"),
+        "Expected the line separator escaped: {ls}"
+    );
+    let ps = ParagraphSeparatorField::zod_schema();
+    assert!(
+        ps.contains(r".check(z.regex(/^a\u2029[a-z]+$/))"),
+        "Expected the paragraph separator escaped: {ps}"
+    );
+    for schema in [&cr, &ls, &ps] {
+        assert!(
+            !schema.contains('\r') && !schema.contains('\u{2028}') && !schema.contains('\u{2029}'),
+            "No raw line terminator may reach the emitted schema: {schema}"
+        );
+    }
+}
+
+#[cfg(feature = "zod")]
+#[test]
+fn test_an_authored_newline_escape_is_not_escaped_twice() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize)]
+    pub struct EscapedNewlineField {
+        #[model_schema_prop(pattern = r"^a\n[a-z]+$")]
+        pub name: String,
+    }
+
+    let schema = EscapedNewlineField::zod_schema();
+    assert!(
+        schema.contains(r".check(z.regex(/^a\n[a-z]+$/))"),
+        "Expected the existing escape carried through untouched: {schema}"
+    );
+    assert!(
+        !schema.contains(r"\\n"),
+        "An escaped newline must not gain a second backslash: {schema}"
+    );
+}
+
+#[cfg(feature = "jsonschema")]
+#[test]
+fn test_a_raw_newline_pattern_reaches_json_schema_unescaped() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize)]
+    pub struct NewlineJsonSchema {
+        #[model_schema_prop(pattern = "^a\n[a-z]+$")]
+        pub name: String,
+    }
+
+    let schema_str = serde_json::to_string(&NewlineJsonSchema::json_schema()).unwrap();
+    assert!(
+        schema_str.contains(r#""pattern":"^a\n[a-z]+$""#),
+        "JSON Schema must carry the pattern as written: {schema_str}"
+    );
+}
+
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn test_the_escaped_newline_literal_matches_the_value_set_the_validator_enforces() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug)]
+    pub struct NewlineValidated {
+        #[model_schema_prop(pattern = "^a\n[a-z]+$")]
+        pub name: String,
+    }
+
+    serde_json::from_str::<NewlineValidated>(r#"{"name": "a\nbc"}"#).unwrap();
+    for rejected in [r#"{"name": "abc"}"#, r#"{"name": "a\n\nbc"}"#] {
+        let err = serde_json::from_str::<NewlineValidated>(rejected).unwrap_err();
+        assert!(
+            err.to_string().contains("does not match pattern"),
+            "Expected a pattern rejection for {rejected}: {err}"
+        );
+    }
+}


### PR DESCRIPTION
A JS regex literal cannot carry a raw line terminator — the literal ends at the break, same failure as the unescaped slash. escape_js_regex_literal now escapes \n, \r, U+2028, U+2029 at the same walk, sharing the escape body between the bare arm and the identity-escape arm (a backslash before a raw terminator is an identity escape; emitting the escape form alone closes the hole whole-unit consumption would leave). Authored escapes pass untouched; JSON schema and Regex::new still get the raw pattern, asserted byte-identical. Emitted literals for all four terminators verified parsing and matching in node.

Powerset green in the lane; cheap gate green on the merged state.
