### PR TITLE
fix: a sibling the schema module cannot resolve is blamed on the type the field names

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,8 @@ pub struct UserWithAddress {
 }
 ```
 
+A referenced type must be declared at item scope — in a module or at crate level, not inside a function body. Each type publishes its schema in a module beside itself, and a type that references one reaches that module through `use super::*`, which a module nested in a function body is not part of. The referencing type is unconstrained: it may sit inside a function body as long as everything it names does not. See [Function-Local Types](#function-local-types) for the error a violation produces.
+
 ### Recursive Types
 
 The library supports recursive and self-referential types. In the generated Zod schema, recursive fields use JavaScript getter syntax to defer the reference and avoid "use before declaration" errors.
@@ -1446,6 +1448,42 @@ pub struct BadConfig {
 // Correct: use string keys
 pub struct Config {
     pub settings: HashMap<String, String>,
+}
+```
+
+#### Function-Local Types
+
+**Error:** `cannot find module or crate <type>_schema in this scope` (`E0433`), reported at the field's type.
+
+A referenced type must be declared at item scope. A type declared inside a function body publishes its schema module inside that same body, where the `use super::*` of the referencing type's own module never reaches it:
+
+```rust
+// Wrong: `Inner` is declared inside the function body
+#[test]
+fn builds_the_schema() {
+    #[model_schema()]
+    pub struct Inner {
+        pub id: String,
+    }
+
+    #[model_schema()]
+    pub struct Outer {
+        pub inner: Inner, // E0433: cannot find module or crate `inner_schema` in this scope
+    }
+}
+
+// Correct: `Inner` is declared at item scope; `Outer` may stay in the function body
+#[model_schema()]
+pub struct Inner {
+    pub id: String,
+}
+
+#[test]
+fn builds_the_schema() {
+    #[model_schema()]
+    pub struct Outer {
+        pub inner: Inner,
+    }
 }
 ```
 

--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -1,4 +1,9 @@
-use syn::{Fields, GenericArgument, ItemEnum, PathArguments, Type, Variant};
+use syn::{Fields, GenericArgument, Ident, ItemEnum, PathArguments, Type, Variant};
+
+#[cfg(feature = "jsonschema")]
+use proc_macro2::Span;
+#[cfg(feature = "jsonschema")]
+use syn::spanned::Spanned as _;
 
 #[cfg(feature = "serde")]
 use syn::Attribute;
@@ -155,6 +160,12 @@ pub enum FieldDefType {
 /// - `model_schema_prop_meta`: Optional metadata from #[`model_schema_prop`] attribute
 ///   - Used for overrides like literals, minLength, etc.
 ///   - See Phase 5 in `notes/20250707_field_features.md` for minLength details
+/// - `type_span`: where the type this field carries was written — the name segment of a path, the
+///   whole type otherwise, and the innermost name under a wrapper, so `Vec<Inner>` points at
+///   `Inner`. The JSON schema is the one surface that emits a Rust path built from a type name, so
+///   it is the one that can fail to resolve, and this is what its reference carries so the failure
+///   is reported at the user's type instead of at `#[model_schema()]`. Present only under
+///   `jsonschema` for that reason.
 ///
 /// Usage notes:
 /// - Created recursively for nested types
@@ -171,6 +182,8 @@ pub struct FieldDef {
     pub model_schema_prop_meta: Option<ModelSchemaPropMeta>,
     pub name: String,
     pub nullable_levels: Vec<u8>,
+    #[cfg(feature = "jsonschema")]
+    pub type_span: Span,
 }
 
 impl FieldDef {
@@ -926,6 +939,8 @@ fn get_field_def_from_type_path(
             docs: field_docs.to_owned(),
             model_schema_prop_meta: None,
             nullable_levels: Vec::new(),
+            #[cfg(feature = "jsonschema")]
+            type_span: type_path.span(),
         };
     };
     let ident = segment.ident.to_string();
@@ -938,9 +953,13 @@ fn get_field_def_from_type_path(
             docs: field_docs.to_owned(),
             model_schema_prop_meta: None,
             nullable_levels: Vec::new(),
+            // The name segment, not the whole path: it is what a generated module is named after,
+            // so a reference the module cannot resolve is blamed on the name it was built from.
+            #[cfg(feature = "jsonschema")]
+            type_span: segment.ident.span(),
         },
         PathArguments::AngleBracketed(args) => {
-            get_field_def_from_generic_type(&ident, args, safe_name, field_docs)
+            get_field_def_from_generic_type(&segment.ident, args, safe_name, field_docs)
         }
         // Function pointer types are unsupported; fall back to `unknown`.
         PathArguments::Parenthesized(_) => FieldDef {
@@ -951,6 +970,8 @@ fn get_field_def_from_type_path(
             docs: field_docs.to_owned(),
             model_schema_prop_meta: None,
             nullable_levels: Vec::new(),
+            #[cfg(feature = "jsonschema")]
+            type_span: segment.ident.span(),
         },
     }
 }
@@ -964,11 +985,13 @@ fn get_field_def_from_type_path(
 /// with the arguments it would have without it — which is what lets `Cow<'a, T>` be answered for by
 /// the same single-argument arms as `Box<T>`.
 fn get_field_def_from_generic_type(
-    ident: &str,
+    type_ident: &Ident,
     args: &syn::AngleBracketedGenericArguments,
     safe_name: String,
     field_docs: &str,
 ) -> FieldDef {
+    let ident_name = type_ident.to_string();
+    let ident = ident_name.as_str();
     let arg_types: Vec<FieldDef> = args
         .args
         .iter()
@@ -989,6 +1012,8 @@ fn get_field_def_from_generic_type(
             docs: field_docs.to_owned(),
             model_schema_prop_meta: None,
             nullable_levels: Vec::new(),
+            #[cfg(feature = "jsonschema")]
+            type_span: type_ident.span(),
         }
     } else if arg_types.len() == 1 && ident == "Option" {
         let mut result = arg_types[0].clone();
@@ -1028,10 +1053,22 @@ fn get_field_def_from_generic_type(
             docs: field_docs.to_owned(),
             model_schema_prop_meta: None,
             nullable_levels: Vec::new(),
+            #[cfg(feature = "jsonschema")]
+            type_span: type_ident.span(),
         }
     } else if arg_types.len() == 1 && is_datetime_generic_type(ident) {
         // The timezone type parameter says nothing about what is written.
-        handle_datetime_generic_type(safe_name, field_docs)
+        FieldDef {
+            name: safe_name,
+            field_type: datetime_field_type(),
+            array_depth: 0,
+            array_lengths: Vec::new(),
+            docs: field_docs.to_owned(),
+            model_schema_prop_meta: None,
+            nullable_levels: Vec::new(),
+            #[cfg(feature = "jsonschema")]
+            type_span: type_ident.span(),
+        }
     } else {
         log::trace!("Creating SiblingType - name: {ident}, arg_types: {arg_types:?}");
         FieldDef {
@@ -1042,6 +1079,8 @@ fn get_field_def_from_generic_type(
             docs: field_docs.to_owned(),
             model_schema_prop_meta: None,
             nullable_levels: Vec::new(),
+            #[cfg(feature = "jsonschema")]
+            type_span: type_ident.span(),
         }
     }
 }
@@ -1103,6 +1142,8 @@ pub fn get_field_def(name: &str, ty: &Type, field_docs: &str) -> FieldDef {
             docs: field_docs.to_owned(),
             model_schema_prop_meta: None,
             nullable_levels: Vec::new(),
+            #[cfg(feature = "jsonschema")]
+            type_span: ty.span(),
         }
     } else {
         // Fallback for BareFn, ImplTrait, etc.
@@ -1114,6 +1155,8 @@ pub fn get_field_def(name: &str, ty: &Type, field_docs: &str) -> FieldDef {
             docs: field_docs.to_owned(),
             model_schema_prop_meta: None,
             nullable_levels: Vec::new(),
+            #[cfg(feature = "jsonschema")]
+            type_span: ty.span(),
         }
     }
 }
@@ -1236,33 +1279,18 @@ const fn is_datetime_generic_type(_type_name: &str) -> bool {
     false
 }
 
-/// Handle `DateTime<Tz>` generic type (chrono feature).
-/// Creates a `FieldDef` with `DateTime` type, ignoring the timezone parameter.
+/// What a `DateTime<Tz>` field carries: the chrono type, the timezone parameter saying nothing
+/// about what is written.
 #[cfg(feature = "chrono")]
-fn handle_datetime_generic_type(safe_name: String, field_docs: &str) -> FieldDef {
-    FieldDef {
-        name: safe_name,
-        field_type: FieldDefType::DateTime,
-        array_depth: 0,
-        array_lengths: Vec::new(),
-        docs: field_docs.to_owned(),
-        model_schema_prop_meta: None,
-        nullable_levels: Vec::new(),
-    }
+const fn datetime_field_type() -> FieldDefType {
+    FieldDefType::DateTime
 }
 
+/// Unreachable without chrono — `is_datetime_generic_type` answers `false` there — and named as
+/// any other unknown type would be.
 #[cfg(not(feature = "chrono"))]
-fn handle_datetime_generic_type(safe_name: String, field_docs: &str) -> FieldDef {
-    // Fallback - should never be called since is_datetime_generic_type returns false
-    FieldDef {
-        name: safe_name,
-        field_type: FieldDefType::SiblingType("DateTime".to_owned(), vec![]),
-        array_depth: 0,
-        array_lengths: Vec::new(),
-        docs: field_docs.to_owned(),
-        model_schema_prop_meta: None,
-        nullable_levels: Vec::new(),
-    }
+fn datetime_field_type() -> FieldDefType {
+    FieldDefType::SiblingType("DateTime".to_owned(), vec![])
 }
 
 #[cfg(test)]

--- a/src/field_type/tests.rs
+++ b/src/field_type/tests.rs
@@ -19,6 +19,8 @@ fn field(field_type: FieldDefType) -> FieldDef {
         model_schema_prop_meta: None,
         nullable_levels: Vec::new(),
         name: "items".to_owned(),
+        #[cfg(feature = "jsonschema")]
+        type_span: proc_macro2::Span::call_site(),
     }
 }
 

--- a/src/generation/tests.rs
+++ b/src/generation/tests.rs
@@ -21,6 +21,8 @@ fn test_typescript_field_formatting() {
         array_lengths: Vec::new(),
         model_schema_prop_meta: None,
         nullable_levels: Vec::new(),
+        #[cfg(feature = "jsonschema")]
+        type_span: proc_macro2::Span::call_site(),
     };
 
     let formatted = GenerationUtils::format_typescript_field(&field);

--- a/src/generation/typescript/tests.rs
+++ b/src/generation/typescript/tests.rs
@@ -20,6 +20,8 @@ fn test_generate_struct_type_with_fields() {
             array_lengths: Vec::new(),
             model_schema_prop_meta: None,
             nullable_levels: Vec::new(),
+            #[cfg(feature = "jsonschema")]
+            type_span: proc_macro2::Span::call_site(),
         },
         FieldDef {
             name: "name".to_owned(),
@@ -29,6 +31,8 @@ fn test_generate_struct_type_with_fields() {
             array_lengths: Vec::new(),
             model_schema_prop_meta: None,
             nullable_levels: vec![0],
+            #[cfg(feature = "jsonschema")]
+            type_span: proc_macro2::Span::call_site(),
         },
     ];
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,6 +173,28 @@ pub struct Document {
 /// `ObjectId` fields are serialized using `MongoDB`'s standard format: `{ "$oid": "hex_string" }`
 /// and include proper validation for 24-character hexadecimal `ObjectId` strings.
 ///
+/// ## Where a Referenced Type Must Be Declared
+///
+/// A `#[model_schema()]` type publishes its schema in a module beside the type, and a type that
+/// references it reaches that module through `use super::*`. **A type referenced by another must
+/// therefore be declared at item scope** — in a module or at crate level, not inside a function
+/// body, which no generated module is a child of. The referencing type itself is unconstrained: it
+/// may be declared inside a function body as long as everything it names is not.
+///
+/// A reference to a function-local type fails to compile with an `E0433` naming the module the
+/// macro built from that type's name, reported at the field's type:
+///
+/// ```text
+/// error[E0433]: cannot find module or crate `inner_schema` in this scope
+///   --> src/lib.rs:9:20
+///    |
+///  9 |     pub inner: Inner,
+///    |                ^^^^^ use of unresolved module or unlinked crate `inner_schema`
+/// ```
+///
+/// Moving the named type out of the function body — to the module the referencing type is written
+/// in, or any module in scope there — is what resolves it.
+///
 /// ## Branded Newtypes and `no_display`
 ///
 /// A `#[serde(transparent)]` single-field tuple struct becomes a branded type, and the macro gives

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -3065,7 +3065,7 @@ fn string_field_json_schema_value(fld: &FieldDef) -> proc_macro2::TokenStream {
 #[cfg(all(feature = "serde", feature = "jsonschema"))]
 fn field_json_schema_value(fld: &FieldDef) -> proc_macro2::TokenStream {
     let inner = match &fld.field_type {
-        FieldDefType::SiblingType(name, _) => sibling_json_schema_value(name),
+        FieldDefType::SiblingType(name, _) => sibling_json_schema_value(name, fld.type_span),
         FieldDefType::String => string_field_json_schema_value(fld),
         FieldDefType::StringLiteral(literal) => {
             quote! { serde_json::json!({ "type": "string", "const": #literal }) }
@@ -3835,13 +3835,19 @@ fn nullable_slot_json_schema_value(
 /// reproduce, so the registry answers first. A name it does not hold is one this expansion has not
 /// seen — a type expanded later, or one from another crate — and takes the naming every
 /// `#[model_schema()]` type follows.
+///
+/// The ident is spanned on where the sibling was named rather than on the attribute. Nothing the
+/// macro can read tells it whether the module will be in scope — a generated module reaches its
+/// siblings through `use super::*`, which a type declared inside a function body never joins — so
+/// the `E0433` naming a module the author never wrote is the only report there is, and the span is
+/// what lands it on the type they did write.
 #[cfg(feature = "jsonschema")]
-fn sibling_schema_module_ident(name: &str) -> Ident {
+fn sibling_schema_module_ident(name: &str, span: proc_macro2::Span) -> Ident {
     let module_name = match lookup_alias_info(name) {
         Some(alias) => alias.module_name,
         None => format!("{}_schema", to_snake_case(&safe_type_name(name))),
     };
-    Ident::new(module_name.as_str(), proc_macro2::Span::call_site())
+    Ident::new(module_name.as_str(), span)
 }
 
 /// A sibling's own schema as a standalone `serde_json::Value` expression: the module the reference
@@ -3855,10 +3861,15 @@ fn sibling_schema_module_ident(name: &str) -> Ident {
 /// written into a document already in progress, and it is the run that knows whether asking has
 /// come back around to a name still being written. So the names in flight and the definitions the
 /// root will carry travel into the call.
+///
+/// The whole call is spanned on where the sibling was named, so every failure it can raise — the
+/// unresolved module a function-local sibling produces, the missing method a type expanded without
+/// `#[model_schema()]` produces — is reported at the type rather than at the attribute. Only the
+/// spans change; the tokens are the ones a reference has always carried.
 #[cfg(feature = "jsonschema")]
-fn sibling_json_schema_value(name: &str) -> proc_macro2::TokenStream {
-    let module_ident = sibling_schema_module_ident(name);
-    quote! { #module_ident::Schema::json_schema_within(in_flight, hoisted_defs) }
+fn sibling_json_schema_value(name: &str, span: proc_macro2::Span) -> proc_macro2::TokenStream {
+    let module_ident = sibling_schema_module_ident(name, span);
+    quote_spanned! {span=> #module_ident::Schema::json_schema_within(in_flight, hoisted_defs) }
 }
 
 /// Builds JSON schema for a tuple element (used for tuple fields and for tuple variants), or the
@@ -4056,7 +4067,7 @@ fn build_map_member_item(value: &FieldDef) -> Result<MapMemberItem, MapMemberRej
             log::trace!(
                 "Slot SiblingType => value_type_name: {value_type_name}, value_args: {value_args:?}"
             );
-            MapMemberItem::Value(sibling_json_schema_value(value_type_name))
+            MapMemberItem::Value(sibling_json_schema_value(value_type_name, value.type_span))
         }
         // A map member's `$oid` object is closed and unpatterned, where the shared mapping's
         // field-position rendering carries the hex pattern and leaves the object open.
@@ -4383,7 +4394,11 @@ fn build_sibling_type_field_schema(
         // Covers both non-generic sibling types (lst.is_empty()) and generic branded wrappers
         // like DocumentTypeId<String>: for a transparent newtype the JSON schema is defined on
         // the wrapper type's own schema module, and type params don't affect it.
-        generate_type_schema(fld, field_name_str, &sibling_json_schema_value(name))
+        generate_type_schema(
+            fld,
+            field_name_str,
+            &sibling_json_schema_value(name, fld.type_span),
+        )
     }
 }
 
@@ -5551,7 +5566,7 @@ fn generate_json_schema_method(
 #[cfg(feature = "jsonschema")]
 fn flatten_field_json_schema_ref(fld: &FieldDef) -> proc_macro2::TokenStream {
     if let FieldDefType::SiblingType(name, _) = &fld.field_type {
-        sibling_json_schema_value(name)
+        sibling_json_schema_value(name, fld.type_span)
     } else {
         quote! { serde_json::json!({ "type": "object" }) }
     }

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -2145,6 +2145,7 @@ fn wrapped_u32_value(wrapper: &str) -> super::FieldDef {
         model_schema_prop_meta: None,
         nullable_levels: Vec::new(),
         name: "items".to_owned(),
+        type_span: proc_macro2::Span::call_site(),
     }
 }
 
@@ -2222,6 +2223,75 @@ fn a_sibling_slot_carries_the_schema_module_reference() {
             super::build_map_member_schema(&parsed).unwrap().to_string()
         );
     }
+}
+
+/// The JSON-schema insertion for the sole field of `source`, parsed from text so its spans carry
+/// file locations and `source_text()` can report what they point at.
+#[cfg(feature = "jsonschema")]
+fn sole_field_json_schema(source: &str) -> proc_macro2::TokenStream {
+    let item: syn::ItemStruct = syn::parse_str(source).unwrap();
+    let field = item.fields.iter().next().unwrap();
+    let field_name = field.ident.as_ref().unwrap().to_string();
+    let def = get_field_def(&field_name, &field.ty, "");
+    super::build_field_type_schema(&def, &field_name)
+}
+
+/// The source text each occurrence of the ident `name` points at, `None` for an occurrence carrying
+/// no location.
+#[cfg(feature = "jsonschema")]
+fn ident_source_texts(tokens: &proc_macro2::TokenStream, name: &str) -> Vec<Option<String>> {
+    let mut found = Vec::new();
+    for tree in tokens.clone() {
+        match &tree {
+            proc_macro2::TokenTree::Group(group) => {
+                found.extend(ident_source_texts(&group.stream(), name));
+            }
+            proc_macro2::TokenTree::Ident(ident) if ident == name => {
+                found.push(tree.span().source_text());
+            }
+            proc_macro2::TokenTree::Ident(_)
+            | proc_macro2::TokenTree::Punct(_)
+            | proc_macro2::TokenTree::Literal(_) => {}
+        }
+    }
+    found
+}
+
+/// A generated module reaches its siblings through `use super::*`, which a type declared inside a
+/// function body never joins, and nothing the macro can read says whether it will resolve. So the
+/// whole reference is spanned on the name the module was built from — the module ident included,
+/// that being the one the `E0433` blames — and the failure is reported at the user's type instead
+/// of at `#[model_schema()]`. Every position that carries a sibling names it the same way.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_sibling_reference_points_at_the_type_the_field_names() {
+    for source in [
+        "struct Outer { inner: Inner }",
+        "struct Outer { inner: Vec<Inner> }",
+        "struct Outer { inner: Box<Inner> }",
+        "struct Outer { inner: HashMap<String, Inner> }",
+        "struct Outer { inner: (Inner, u32) }",
+    ] {
+        let tokens = sole_field_json_schema(source);
+        for named in ["inner_schema", "Schema", "json_schema_within"] {
+            assert_eq!(
+                ident_source_texts(&tokens, named),
+                vec![Some("Inner".to_owned())],
+                "for {source}, at `{named}`, got: {tokens}"
+            );
+        }
+    }
+}
+
+/// The reference an item-scope sibling emits is the one it has always emitted — only the spans its
+/// tokens carry are new.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_sibling_reference_emits_the_tokens_it_always_has() {
+    assert_eq!(
+        sole_field_json_schema("struct Outer { inner: Inner }").to_string(),
+        "properties . insert (\"inner\" . to_string () , inner_schema :: Schema :: json_schema_within (in_flight , hoisted_defs)) ;"
+    );
 }
 
 /// The tuple-field insertion for a field type built by hand.


### PR DESCRIPTION
A #[model_schema] type referencing a fn-body-local sibling failed with a raw E0433 pointing at the attribute macro — the macro cannot detect scope, so the failure is now attributed instead of prevented. FieldDef gains type_span (jsonschema-gated — the JSON schema is the only surface emitting a Rust path from a type name), recording the path's name segment so Vec<Inner>/Box<Inner>/map values/tuple slots all point at Inner. The sibling reference emits via quote_spanned, so E0433 lands on the user's type with the module name in the message. Verified: only the REFERENCED type must be at item scope — a fn-local #[model_schema] type referencing an item-scope sibling compiles; docs say so.

Token output pinned byte-identical for the resolving case; span asserted across five positions. The duplicated datetime cfg pair collapsed to one const fn as a consequence of threading the ident.

Powerset green in the lane; cheap gate green on the merged state.
