### PR TITLE
fix: an internally tagged enum describes what serde writes beside the tag, and refuses what serde refuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,62 @@ export const External$Schema: ZodType<External> = z.union([
 
 Add `#[serde(tag = "...", content = "...")]` to get the adjacently tagged `{ type, value }` form documented above instead.
 
+#### Internally Tagged Enums (`tag` With No `content`)
+
+An enum that names `tag` but no `content` is internally tagged: there is no key for a variant's data, so Serde writes it as members of the object the tag is written in. A struct variant's fields sit beside the tag, and so do the members of a newtype variant's inner type -- which the surfaces describe as an intersection, the same composition `#[serde(flatten)]` uses.
+
+```rust
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct TagPayload {
+    pub a: String,
+    pub b: bool,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(tag = "type")]
+pub enum Internal {
+    Bare,
+    Fields { a: String, b: bool },
+    Wrapped(TagPayload),
+}
+```
+
+Serialized by Serde:
+
+```json
+{ "type": "Bare" }
+{ "type": "Fields", "a": "a", "b": true }
+{ "type": "Wrapped", "a": "a", "b": true }
+```
+
+Generated TypeScript:
+
+```typescript
+export type Internal = {
+  type: "Bare";
+} | {
+  type: "Fields";
+  a: string;
+  b: boolean;
+} | {
+  type: "Wrapped";
+} & TagPayload;
+```
+
+Generated Zod -- a flattened member is an intersection, which has no shape of its own to read the discriminator out of, so a union holding one is a plain `z.union` rather than a `z.discriminatedUnion`:
+
+```typescript
+export const Internal$Schema: ZodType<Internal> = z.union([
+  z.strictObject({ type: z.literal("Bare") }),
+  z.strictObject({ type: z.literal("Fields"), a: z.string(), b: z.boolean() }),
+  z.strictObject({ type: z.literal("Wrapped") }).and(TagPayload$Schema),
+]);
+```
+
+Only a value Serde writes as an object has members to put beside the tag. A newtype variant wrapping a string, a number, a boolean, a sequence, an `Option` or a tuple is one Serde refuses to serialize at run time (`cannot serialize tagged newtype variant ... containing a string`), and a multi-element tuple variant is one Serde's own derive refuses outright. `#[model_schema()]` rejects all of those at expansion rather than describing a value that cannot reach the wire; name a `content` key so the value gets an object of its own, or wrap it in a struct whose fields can sit beside the tag.
+
 ### Intersection Types (`#[serde(flatten)]`)
 
 A struct field marked `#[serde(flatten)]` is lifted into the parent type as a TypeScript intersection (`A & B`) and a Zod `.and()` chain, instead of a nested object. This is the idiomatic way to compose a common set of fields with a discriminated union.
@@ -1409,7 +1465,7 @@ Supported Serde attributes:
 
 - `#[serde(rename = "...")]` -- rename individual fields
 - `#[serde(rename_all = "camelCase")]` -- rename all fields with a naming convention
-- `#[serde(tag = "...")]` -- set the discriminator field for tagged enums
+- `#[serde(tag = "...")]` -- internally tagged enums: the variant's data is written beside the discriminator
 - `#[serde(tag = "...", content = "...")]` -- adjacently tagged enums
 - `#[serde(untagged)]` -- untagged enums generate a union (`A | B`) / Zod `z.union([...])` / JSON Schema `anyOf`
 - `#[serde(flatten)]` -- flatten a field into the parent as an intersection type (`A & B`) / Zod `.and(...)`

--- a/src/features/jsonschema.rs
+++ b/src/features/jsonschema.rs
@@ -5,6 +5,16 @@
 /// What every pointer the crate writes opens with; what follows it is the name being deferred.
 const DEFS_PREFIX: &str = "#/$defs/";
 
+/// How a merge that closes a cycle names itself in the diagnostic it raises.
+///
+/// `subject` is the frame that reads the merge, `edge` what the merged schema was reached through,
+/// and `remedy` the way out in the spelling that applies where that edge was written.
+pub struct MergeCycleDiagnostic<'msg> {
+    pub edge: &'msg str,
+    pub remedy: &'msg str,
+    pub subject: &'msg str,
+}
+
 /// Check if we should generate JSON schema methods.
 #[cfg(test)]
 pub const fn should_generate_json_schema() -> bool {
@@ -121,16 +131,27 @@ fn closed_object_body(json_schema_fields: &[proc_macro2::TokenStream]) -> proc_m
     }
 }
 
-/// The struct's own fields distributed into each branch of the flattened types' schemas.
+/// A base object's members with the members of every schema merged beside them.
 ///
-/// A flatten edge that closes a cycle is rejected where it is read rather than merged: `def_name`
-/// is the frame that reads it, and names one end of the closing edge in the diagnostic.
-fn flattened_object_body(
-    json_schema_fields: &[proc_macro2::TokenStream],
-    flatten_json_schemas: &[proc_macro2::TokenStream],
-    def_name: &str,
+/// serde writes a `#[serde(flatten)]` base and an internally tagged variant's newtype content the
+/// same way — what is merged contributes its members to the object the base is writing — so both
+/// describe through this one merge rather than each spelling its own. `base` is a
+/// `serde_json::Map` expression and every entry of `merged` a `serde_json::Value` one; the result
+/// is a `serde_json::Value`.
+///
+/// A merged schema that is itself a `oneOf` multiplies out rather than collapsing, so each branch
+/// stays a closed object naming exactly the members that branch writes.
+pub fn merged_object_value(
+    base: &proc_macro2::TokenStream,
+    merged: &[proc_macro2::TokenStream],
+    diagnostic: &MergeCycleDiagnostic<'_>,
 ) -> proc_macro2::TokenStream {
     let defs_prefix = DEFS_PREFIX;
+    let MergeCycleDiagnostic {
+        edge,
+        remedy,
+        subject,
+    } = *diagnostic;
     quote::quote! {
         {
             fn merge_object_schemas(
@@ -183,22 +204,11 @@ fn flattened_object_body(
                 }
             }
 
-            let mut schema_obj = serde_json::Map::new();
-            schema_obj.insert("type".to_string(), serde_json::Value::String("object".to_string()));
-            schema_obj.insert("additionalProperties".to_string(), serde_json::Value::Bool(false));
-            let mut properties = serde_json::Map::new();
-            let mut required = Vec::new();
+            let flattened: Vec<serde_json::Value> = vec![ #(#merged),* ];
 
-            #(#json_schema_fields)*
-
-            schema_obj.insert("properties".to_string(), serde_json::Value::Object(properties));
-            schema_obj.insert("required".to_string(), serde_json::Value::Array(required));
-
-            let flattened: Vec<serde_json::Value> = vec![ #(#flatten_json_schemas),* ];
-
-            let mut branches: Vec<serde_json::Map<String, serde_json::Value>> = vec![schema_obj];
+            let mut branches: Vec<serde_json::Map<String, serde_json::Value>> = vec![#base];
             for fs in &flattened {
-                // An entry still only reserved is this flatten coming back around to a name whose
+                // An entry still only reserved is this merge coming back around to a name whose
                 // body is still being written: there is nothing to merge, and the type it would
                 // describe has no finite value to inhabit it.
                 let fs_body = match deferred_name(fs) {
@@ -206,9 +216,11 @@ fn flattened_object_body(
                     Some(name) => match hoisted_defs.get(name) {
                         Some(body) if body.is_object() => body,
                         _ => panic!(
-                            "`{}`: `#[serde(flatten)]` of `{}` closes a flatten cycle — the flattened body does not exist to merge, and no finite value inhabits the type; write the field as a named member so the cycle defers through a reference",
-                            #def_name,
+                            "`{}`: {} `{}` closes a flatten cycle — the flattened body does not exist to merge, and no finite value inhabits the type; {}",
+                            #subject,
+                            #edge,
                             name,
+                            #remedy,
                         ),
                     },
                 };
@@ -240,6 +252,41 @@ fn flattened_object_body(
             }
         }
     }
+}
+
+/// The struct's own fields distributed into each branch of the flattened types' schemas.
+///
+/// A flatten edge that closes a cycle is rejected where it is read rather than merged: `def_name`
+/// is the frame that reads it, and names one end of the closing edge in the diagnostic.
+fn flattened_object_body(
+    json_schema_fields: &[proc_macro2::TokenStream],
+    flatten_json_schemas: &[proc_macro2::TokenStream],
+    def_name: &str,
+) -> proc_macro2::TokenStream {
+    let base = quote::quote! {
+        {
+            let mut schema_obj = serde_json::Map::new();
+            schema_obj.insert("type".to_string(), serde_json::Value::String("object".to_string()));
+            schema_obj.insert("additionalProperties".to_string(), serde_json::Value::Bool(false));
+            let mut properties = serde_json::Map::new();
+            let mut required = Vec::new();
+
+            #(#json_schema_fields)*
+
+            schema_obj.insert("properties".to_string(), serde_json::Value::Object(properties));
+            schema_obj.insert("required".to_string(), serde_json::Value::Array(required));
+            schema_obj
+        }
+    };
+    merged_object_value(
+        &base,
+        flatten_json_schemas,
+        &MergeCycleDiagnostic {
+            edge: "`#[serde(flatten)]` of",
+            remedy: "write the field as a named member so the cycle defers through a reference",
+            subject: def_name,
+        },
+    )
 }
 
 /// Generates the JSON schema method implementation for plain enums.

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -59,6 +59,9 @@ use crate::features::jsonschema::{
     json_schema_methods,
 };
 
+#[cfg(all(feature = "serde", feature = "jsonschema"))]
+use crate::features::jsonschema::{MergeCycleDiagnostic, merged_object_value};
+
 #[cfg(any(feature = "typescript", feature = "zod"))]
 use crate::utils::{get_enum_docs, get_struct_docs, strip_examples_from_docs};
 
@@ -256,6 +259,19 @@ enum MapKeyPath<'key> {
     Open,
     /// A key this expansion cannot narrow, leaving the members unconstrained.
     Unnarrowed,
+}
+
+/// What a newtype variant's inner value is when the tag is written beside it rather than around
+/// it.
+#[cfg(feature = "serde")]
+enum TaggedContent {
+    /// A named type: what it writes are members, and they are the ones that join the tag.
+    Flattened,
+    /// serde refuses to write it beside the tag, and names the shape the way this names it.
+    Refused(&'static str),
+    /// serde writes it, but its members are not a set the expansion can name, so no schema closed
+    /// around the tag can admit them.
+    Unnameable(&'static str),
 }
 
 #[derive(Default, Clone)]
@@ -2332,6 +2348,22 @@ fn process_enum(item_enum: syn::ItemEnum) -> TokenStream {
             );
         }
 
+        // A tag with no content is serde's internally tagged form: what a variant writes joins the
+        // tag in one object rather than sitting under a key of its own.
+        #[cfg(feature = "serde")]
+        if let (Some(tag), None) = (
+            serde_type_meta.tag.as_ref(),
+            serde_type_meta.content.as_ref(),
+        ) {
+            return process_internally_tagged_enum(
+                item_enum,
+                &name,
+                tag,
+                serde_type_meta.rename_all.as_deref(),
+                &item_name,
+            );
+        }
+
         #[cfg(feature = "serde")]
         let (tag_name, content_name, rename_all) = (
             serde_type_meta
@@ -3248,6 +3280,383 @@ fn process_externally_tagged_enum(
     }
 }
 
+/// How an internally tagged newtype variant's inner value fares beside the tag.
+///
+/// Internal tagging has no key for a content: the variant's data is written as members of the
+/// object the tag is written in, so only a value serde writes as an object has anything to put
+/// there. That is the whole of the split — a named type is one, and every shape that reaches the
+/// wire as a scalar, a sequence or an absence is not.
+///
+/// The wrappers are read before the type they wrap, in the order serde's serializer meets them: an
+/// `Option` is refused as an optional even around a sequence, and a sequence is refused as a
+/// sequence even around a named type.
+#[cfg(feature = "serde")]
+fn tagged_content(inner: &FieldDef) -> TaggedContent {
+    if inner.is_optional() {
+        return TaggedContent::Refused("an optional");
+    }
+    if inner.array_depth > 0 {
+        return TaggedContent::Refused("a sequence");
+    }
+    match inner.field_type {
+        FieldDefType::SiblingType(..) => TaggedContent::Flattened,
+        FieldDefType::Boolean => TaggedContent::Refused("a boolean"),
+        FieldDefType::F32 | FieldDefType::F64 => TaggedContent::Refused("a float"),
+        FieldDefType::I8
+        | FieldDefType::I16
+        | FieldDefType::I32
+        | FieldDefType::I64
+        | FieldDefType::Isize
+        | FieldDefType::U8
+        | FieldDefType::U16
+        | FieldDefType::U32
+        | FieldDefType::U64
+        | FieldDefType::Usize => TaggedContent::Refused("an integer"),
+        FieldDefType::String | FieldDefType::StringLiteral(_) => TaggedContent::Refused("a string"),
+        #[cfg(feature = "chrono")]
+        FieldDefType::DateTime
+        | FieldDefType::NaiveDate
+        | FieldDefType::NaiveDateTime
+        | FieldDefType::NaiveTime => TaggedContent::Refused("a string"),
+        FieldDefType::Tuple(_) => TaggedContent::Refused("a tuple"),
+        FieldDefType::Map(..) => TaggedContent::Unnameable("a map"),
+        #[cfg(feature = "object_id")]
+        FieldDefType::ObjectId => TaggedContent::Unnameable("an ObjectId"),
+        FieldDefType::Unknown => TaggedContent::Unnameable("a type the expansion cannot resolve"),
+    }
+}
+
+/// The `compile_error!` tokens for every variant an internally tagged enum cannot carry.
+///
+/// Collected from the declaration rather than from the collected variants so each diagnostic keeps
+/// the span of the thing it rejects: the inner type for a newtype variant, the variant itself for a
+/// tuple one.
+#[cfg(feature = "serde")]
+fn internally_tagged_guard_errors(
+    item_enum: &syn::ItemEnum,
+    tag_name: &str,
+) -> Vec<proc_macro2::TokenStream> {
+    let enum_name = &item_enum.ident;
+    item_enum
+        .variants
+        .iter()
+        .filter_map(|variant| {
+            let syn::Fields::Unnamed(unnamed) = &variant.fields else {
+                return None;
+            };
+            let variant_name = &variant.ident;
+            if unnamed.unnamed.len() > 1 {
+                return Some(
+                    syn::Error::new_spanned(
+                        variant,
+                        format!(
+                            "model_schema: variant `{variant_name}` of internally tagged enum \
+                             `{enum_name}` is a tuple variant, which `#[serde(tag = \
+                             \"{tag_name}\")]` cannot carry: the elements have no names to be \
+                             written under beside the tag, and serde's own derive refuses the \
+                             declaration outright — `#[serde(tag = \"...\")] cannot be used with \
+                             tuple variants`. Name a `content` key so the elements get an array \
+                             of their own, or write them as named fields."
+                        ),
+                    )
+                    .to_compile_error(),
+                );
+            }
+            // An empty tuple variant carries nothing: serde writes it as the tag alone, which is
+            // what the unit arm already describes.
+            let field = unnamed.unnamed.first()?;
+            let message = match tagged_content(&get_field_def("_inner", &field.ty, "")) {
+                TaggedContent::Flattened => return None,
+                TaggedContent::Refused(shape) => format!(
+                    "model_schema: variant `{variant_name}` of internally tagged enum \
+                     `{enum_name}` wraps {shape}, which cannot sit beside the tag: `#[serde(tag \
+                     = \"{tag_name}\")]` with no `content` writes the variant's data as members \
+                     of the object the tag is written in, and only a value serde writes as an \
+                     object has members to put there. serde refuses this one at run time — \
+                     `cannot serialize tagged newtype variant {enum_name}::{variant_name} \
+                     containing {shape}`. Name a `content` key so the value gets an object of its \
+                     own, or wrap it in a struct whose fields can sit beside the tag."
+                ),
+                TaggedContent::Unnameable(shape) => format!(
+                    "model_schema: variant `{variant_name}` of internally tagged enum \
+                     `{enum_name}` wraps {shape}, whose members the expansion cannot name: \
+                     `#[serde(tag = \"{tag_name}\")]` with no `content` writes them beside the \
+                     tag, and a schema closed around the tag alone rejects every one of them. \
+                     Name a `content` key so the value gets an object of its own, or wrap it in a \
+                     struct whose fields can sit beside the tag."
+                ),
+            };
+            Some(syn::Error::new_spanned(field, message).to_compile_error())
+        })
+        .collect()
+}
+
+/// Renders one variant of an internally tagged enum as a union member.
+///
+/// Returns `(typescript, zod, json_value, flattened)`, where the first three are the member on each
+/// surface and the last says whether it is an intersection rather than a plain object — which is
+/// what a `z.discriminatedUnion` option cannot be.
+///
+/// A unit variant is the tag alone and a struct variant is the tag beside its own fields, both of
+/// which the tagged member already spells. A newtype variant is the one the form differs on: what
+/// its inner type writes are members of the same object, so the inner's own description joins the
+/// tag's rather than sitting under a key.
+#[cfg(feature = "serde")]
+fn render_internal_variant(
+    variant: &DiscriminatedVariant,
+    tag_name: &str,
+    self_type_name: &str,
+) -> (String, String, proc_macro2::TokenStream, bool) {
+    let mut parts = tagged_variant_parts(tag_name, &variant.discriminator_value, &variant.docs);
+    match variant.kind {
+        VariantKind::Named => {
+            write_named_variant_fields(
+                &variant.field_defs,
+                Some(tag_name),
+                self_type_name,
+                &mut parts,
+            );
+        }
+        // A unit variant writes the tag alone; a tuple variant only reaches here as the flattened
+        // newtype the guard admits, whose content joins the finished member below.
+        VariantKind::Unit | VariantKind::TupleSingle | VariantKind::TupleMultiple => {}
+    }
+    parts.type_code.push('}');
+    parts.schema_code.push('}');
+
+    #[cfg(feature = "jsonschema")]
+    let tag_object =
+        tagged_variant_json_object(tag_name, &variant.discriminator_value, &parts.json_fields);
+
+    let flattened = matches!(variant.kind, VariantKind::TupleSingle)
+        .then(|| variant.field_defs.first())
+        .flatten();
+
+    let Some(inner) = flattened else {
+        #[cfg(feature = "jsonschema")]
+        let json = quote! { serde_json::Value::Object(#tag_object) };
+        #[cfg(not(feature = "jsonschema"))]
+        let json = quote! {};
+
+        return (
+            parts.type_code,
+            format!("z.strictObject({})", parts.schema_code),
+            json,
+            false,
+        );
+    };
+
+    #[cfg(feature = "jsonschema")]
+    let json = {
+        let variant_name = &variant.discriminator_value;
+        merged_object_value(
+            &tag_object,
+            // The same reference a `#[serde(flatten)]` base contributes: both name a type whose
+            // members join the object being written.
+            &[flatten_field_json_schema_ref(inner)],
+            &MergeCycleDiagnostic {
+                edge: &format!("the content of variant `{variant_name}`,"),
+                remedy: "name a `content` key so the content gets an object of its own",
+                subject: self_type_name,
+            },
+        )
+    };
+    #[cfg(not(feature = "jsonschema"))]
+    let json = quote! {};
+
+    #[cfg(feature = "zod")]
+    let zod = format!(
+        "z.strictObject({}).and({})",
+        parts.schema_code,
+        inner.zod_type()
+    );
+    #[cfg(not(feature = "zod"))]
+    let zod = String::new();
+
+    (
+        format!("{} & {}", parts.type_code, inner.typescript_typename()),
+        zod,
+        json,
+        true,
+    )
+}
+
+/// Joins an internally tagged enum's rendered members into its three union surfaces.
+///
+/// The Zod union is a `discriminatedUnion` only while every member is an object carrying the tag in
+/// its own shape. A flattened member is an intersection, which has no shape of its own to read the
+/// discriminator out of, so one of those turns the whole union into a plain `z.union`.
+#[cfg(feature = "serde")]
+fn join_internal_union(
+    members: &[(String, String, proc_macro2::TokenStream, bool)],
+    tag_name: &str,
+) -> (proc_macro2::TokenStream, String, String) {
+    // Only the Zod surface names the tag: the other two read the members alone.
+    #[cfg(not(feature = "zod"))]
+    let _: &str = tag_name;
+    #[cfg(not(any(feature = "typescript", feature = "zod", feature = "jsonschema")))]
+    let _: &_ = &members;
+
+    #[cfg(feature = "jsonschema")]
+    let main_schema_code = discriminated_main_schema_code(
+        &members
+            .iter()
+            .map(|(_, _, json, _)| json.clone())
+            .collect::<Vec<_>>(),
+    );
+    #[cfg(not(feature = "jsonschema"))]
+    let main_schema_code = quote! {};
+
+    #[cfg(feature = "typescript")]
+    let type_code = members
+        .iter()
+        .map(|(ts, _, _, _)| ts.as_str())
+        .collect::<Vec<_>>()
+        .join(" | ");
+    #[cfg(not(feature = "typescript"))]
+    let type_code = String::new();
+
+    #[cfg(feature = "zod")]
+    let schema_code = {
+        let joined = members
+            .iter()
+            .map(|(_, zod, _, _)| zod.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        if members.iter().any(|&(_, _, _, flattened)| flattened) {
+            format!("z.union([{joined}])")
+        } else {
+            format!("z.discriminatedUnion(\"{tag_name}\", [{joined}])")
+        }
+    };
+    #[cfg(not(feature = "zod"))]
+    let schema_code = String::new();
+
+    (main_schema_code, type_code, schema_code)
+}
+
+/// Processes an internally tagged enum (`#[serde(tag = "...")]` with no `content`) and generates
+/// its definitions.
+///
+/// With no content key there is nowhere for a variant's data to sit but the object the tag is
+/// written in: a struct variant's fields are written beside the tag, and so are the members of a
+/// newtype variant's inner type. Every other content has nothing to contribute there, and the
+/// guards refuse those declarations rather than describing a value serde cannot write.
+#[cfg(feature = "serde")]
+fn process_internally_tagged_enum(
+    mut item_enum: syn::ItemEnum,
+    name: &syn::Ident,
+    tag_name: &str,
+    rename_all: Option<&str>,
+    item_name: &str,
+) -> TokenStream {
+    #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+    let (module_name, module_ident) = enum_module_idents(name, item_name, AliasKind::NoEnumMembers);
+
+    #[cfg(any(feature = "typescript", feature = "zod"))]
+    let docs_vec = get_enum_docs(&item_enum);
+
+    #[cfg(feature = "zod")]
+    let example_code = docs_vec
+        .as_ref()
+        .and_then(|docs| extract_example_from_docs(docs));
+
+    #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+    let enum_module_name_opt = Some(module_name.as_str());
+    #[cfg(not(any(feature = "typescript", feature = "zod", feature = "jsonschema")))]
+    let enum_module_name_opt = None;
+
+    if let Some(output) = guard_failure_output(
+        &item_enum,
+        &internally_tagged_guard_errors(&item_enum, tag_name),
+    ) {
+        return output;
+    }
+
+    let self_type_name = item_enum.ident.to_string();
+    let variants = collect_discriminated_variants(&mut item_enum, rename_all, enum_module_name_opt);
+    if let Some(output) = guard_failure_output(&item_enum, &variants.2) {
+        return output;
+    }
+
+    let members: Vec<(String, String, proc_macro2::TokenStream, bool)> = variants
+        .0
+        .iter()
+        .map(|variant| render_internal_variant(variant, tag_name, &self_type_name))
+        .collect();
+
+    let (main_schema_code, type_code, schema_code) = join_internal_union(&members, tag_name);
+    #[cfg(not(feature = "jsonschema"))]
+    let _: &_ = &main_schema_code;
+    #[cfg(not(feature = "typescript"))]
+    let _: &_ = &type_code;
+    #[cfg(not(feature = "zod"))]
+    let _: &_ = &schema_code;
+    #[cfg(not(any(feature = "typescript", feature = "zod", feature = "jsonschema")))]
+    let _: &_ = &name;
+
+    #[cfg(feature = "typescript")]
+    let docs = build_item_jsdoc(docs_vec.as_deref(), name);
+
+    #[cfg(feature = "jsonschema")]
+    let json_schema_method =
+        generate_discriminated_enum_json_schema_method(&main_schema_code, item_name);
+
+    #[cfg(feature = "typescript")]
+    let ts_definition_method =
+        generate_discriminated_enum_ts_definition_method(&docs, item_name, &type_code);
+
+    #[cfg(feature = "zod")]
+    let zod_schema_method = generate_discriminated_enum_zod_schema_method(item_name, &schema_code);
+
+    #[cfg(not(any(feature = "typescript", feature = "zod")))]
+    let _: &_ = &item_name;
+
+    #[cfg(feature = "zod")]
+    let schema_example_method = build_struct_schema_example(example_code.as_ref(), name);
+    #[cfg(all(
+        not(feature = "zod"),
+        any(feature = "typescript", feature = "jsonschema")
+    ))]
+    let schema_example_method: Option<proc_macro2::TokenStream> = None;
+
+    #[cfg(any(feature = "zod", feature = "typescript", feature = "jsonschema"))]
+    let schema_impl_items: Vec<proc_macro2::TokenStream> = vec![
+        #[cfg(feature = "jsonschema")]
+        json_schema_method,
+        #[cfg(feature = "typescript")]
+        ts_definition_method,
+        #[cfg(feature = "zod")]
+        zod_schema_method,
+    ];
+
+    #[cfg(any(feature = "zod", feature = "typescript", feature = "jsonschema"))]
+    let delegate_impl_items =
+        build_struct_delegate_items(&module_ident, schema_example_method.as_ref(), None);
+
+    #[cfg(any(feature = "zod", feature = "typescript", feature = "jsonschema"))]
+    {
+        assemble_schema_output(
+            &item_enum,
+            &module_ident,
+            name,
+            &schema_impl_items,
+            &variants.1,
+            &delegate_impl_items,
+        )
+    }
+
+    #[cfg(not(any(feature = "zod", feature = "typescript", feature = "jsonschema")))]
+    {
+        let _: &_ = &variants.1;
+        let output = quote! {
+            #item_enum
+        };
+        log::trace!("{output}");
+        TokenStream::from(output)
+    }
+}
+
 /// Renders one variant of an untagged enum as a union member.
 ///
 /// Returns `(typescript, zod, json_value)` where:
@@ -3717,6 +4126,72 @@ fn generate_type_schema(
     }
 }
 
+/// The open TypeScript and Zod member every variant of a tagged enum starts from: the tag holding
+/// the variant's discriminator, with room for whatever the variant writes beside it.
+///
+/// Both tagged forms open the same way — the tag is a key of the variant's own object — so the
+/// spelling lives here once rather than in each form's renderer.
+fn tagged_variant_parts(
+    tag_name: &str,
+    discriminator_value: &str,
+    discriminator_docs: &str,
+) -> VariantParts {
+    VariantParts {
+        json_fields: Vec::new(),
+        optional_fields: Vec::new(),
+        schema_code: format!("{{\n  {tag_name}: z.literal(\"{discriminator_value}\"),\n"),
+        type_code: format!(
+            "{{  /**\n{discriminator_docs}\n**/\n  {tag_name}: \"{discriminator_value}\";\n"
+        ),
+    }
+}
+
+/// The closed object a tagged variant describes as, as a `serde_json::Map` expression: the tag
+/// pinned to the variant's discriminator, plus whatever the variant's own fields contributed.
+///
+/// A `Map` rather than a `Value` because the internally tagged form merges further members into it
+/// before it becomes one.
+#[cfg(feature = "jsonschema")]
+fn tagged_variant_json_object(
+    tag_name: &str,
+    discriminator_value: &str,
+    json_fields: &[proc_macro2::TokenStream],
+) -> proc_macro2::TokenStream {
+    let discriminator_value_str = discriminator_value.to_owned();
+    let tag_name_str = tag_name.to_owned();
+    quote! {
+        {
+            let mut schema_obj = serde_json::Map::new();
+            schema_obj.insert(
+                "additionalProperties".to_string(),
+                serde_json::Value::Bool(false),
+            );
+            let mut properties = serde_json::Map::new();
+            let mut required = Vec::new();
+
+            properties.insert(
+                #tag_name_str.to_string(),
+                serde_json::json!({
+                    "type": "string",
+                    "const": #discriminator_value_str,
+                }),
+            );
+            required.push(serde_json::Value::String(#tag_name_str.to_string()));
+
+            #(#json_fields)*
+
+            schema_obj.insert(
+                "properties".to_string(),
+                serde_json::Value::Object(properties),
+            );
+
+            schema_obj.insert("required".to_string(), serde_json::Value::Array(required));
+
+            schema_obj
+        }
+    }
+}
+
 /// Generates TypeScript and Zod schema code for a discriminated enum variant.
 ///
 /// Handles different variant kinds:
@@ -3735,15 +4210,7 @@ fn generate_variant_code(
     discriminator_docs: &str,
     self_type_name: &str,
 ) -> (String, String, Vec<String>, proc_macro2::TokenStream) {
-    // Start the TypeScript type and Zod schema with the discriminator.
-    let mut parts = VariantParts {
-        json_fields: Vec::new(),
-        optional_fields: Vec::new(),
-        schema_code: format!("{{\n  {tag_name}: z.literal(\"{discriminator_value}\"),\n"),
-        type_code: format!(
-            "{{  /**\n{discriminator_docs}\n**/\n  {tag_name}: \"{discriminator_value}\";\n"
-        ),
-    };
+    let mut parts = tagged_variant_parts(tag_name, discriminator_value, discriminator_docs);
 
     match variant_kind {
         VariantKind::Unit => {
@@ -3771,44 +4238,10 @@ fn generate_variant_code(
     parts.type_code.push('}');
     parts.schema_code.push('}');
 
-    // Create JSON schema for this variant
     #[cfg(feature = "jsonschema")]
     let json_schema_variant = {
-        let json_schema_variant_fields = &parts.json_fields;
-        let discriminator_value_str = discriminator_value.to_owned();
-        let tag_name_str = tag_name.to_owned();
-
-        quote! {
-            {
-                let mut schema_obj = serde_json::Map::new();
-                schema_obj.insert(
-                    "additionalProperties".to_string(),
-                    serde_json::Value::Bool(false),
-                );
-                let mut properties = serde_json::Map::new();
-                let mut required = Vec::new();
-
-                properties.insert(
-                    #tag_name_str.to_string(),
-                    serde_json::json!({
-                        "type": "string",
-                        "const": #discriminator_value_str,
-                    }),
-                );
-                required.push(serde_json::Value::String(#tag_name_str.to_string()));
-
-                #(#json_schema_variant_fields)*
-
-                schema_obj.insert(
-                    "properties".to_string(),
-                    serde_json::Value::Object(properties),
-                );
-
-                schema_obj.insert("required".to_string(), serde_json::Value::Array(required));
-
-                serde_json::Value::Object(schema_obj)
-            }
-        }
+        let object = tagged_variant_json_object(tag_name, discriminator_value, &parts.json_fields);
+        quote! { serde_json::Value::Object(#object) }
     };
 
     #[cfg(not(feature = "jsonschema"))]

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -9,8 +9,8 @@ use super::{
     ConstraintLeaf, ModelSchemaPropMeta, build_field_validation, cfg_attr_guard_error,
     check_optional_field_serialization, collect_untagged_members, constrained_shape,
     enum_cfg_attr_guard_errors, generate_field_validation, generate_numeric_validation_code,
-    generate_string_validation_code, helper_name_stem, needs_injected_default,
-    parse_serde_field_attributes, parse_serde_type_attributes,
+    generate_string_validation_code, helper_name_stem, internally_tagged_guard_errors,
+    needs_injected_default, parse_serde_field_attributes, parse_serde_type_attributes,
 };
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
@@ -303,6 +303,117 @@ fn untagged_tuple_variant_option_is_exempt() {
         enum Choice {
             Maybe(Option<i64>),
         }
+    });
+    assert!(errors.is_empty(), "got: {errors:?}");
+}
+
+/// Collects the internally tagged path's guard failures as rendered `compile_error!` token strings.
+#[cfg(feature = "serde")]
+fn internal_guard_errors(item: &syn::ItemEnum) -> Vec<String> {
+    internally_tagged_guard_errors(item, "type")
+        .iter()
+        .map(ToString::to_string)
+        .collect()
+}
+
+/// The arms serde writes beside a bare tag: a struct variant's fields, a named type's own members,
+/// and a unit variant's nothing at all.
+#[cfg(feature = "serde")]
+#[test]
+fn internally_tagged_serializable_variants_are_accepted() {
+    let errors = internal_guard_errors(&syn::parse_quote! {
+        enum TagOnly {
+            Bare,
+            Fields { a: String },
+            Wrapped(Payload),
+            Boxed(Box<Payload>),
+        }
+    });
+    assert!(errors.is_empty(), "got: {errors:?}");
+}
+
+/// Every scalar shape serde refuses to write beside the tag, named the way serde's own error names
+/// it.
+#[cfg(feature = "serde")]
+#[test]
+fn internally_tagged_newtype_over_a_scalar_is_rejected() {
+    for (source, shape) in [
+        ("enum E { V(String) }", "a string"),
+        ("enum E { V(bool) }", "a boolean"),
+        ("enum E { V(i64) }", "an integer"),
+        ("enum E { V(f64) }", "a float"),
+        ("enum E { V((u32, u32)) }", "a tuple"),
+        ("enum E { V(Vec<Payload>) }", "a sequence"),
+        ("enum E { V(Option<Payload>) }", "an optional"),
+    ] {
+        let errors = internal_guard_errors(&syn::parse_str(source).unwrap());
+        assert_eq!(errors.len(), 1, "got: {errors:?} for {source}");
+        assert!(errors[0].contains("compile_error"), "got: {}", errors[0]);
+        assert!(errors[0].contains("variant `V`"), "got: {}", errors[0]);
+        assert!(
+            errors[0].contains(&format!("containing {shape}")),
+            "expected serde's own wording for {source}. Got: {}",
+            errors[0]
+        );
+    }
+}
+
+/// An `Option` around a sequence is refused as an optional: serde's serializer meets the wrappers
+/// in that order, and reports the outermost one.
+#[cfg(feature = "serde")]
+#[test]
+fn internally_tagged_newtype_names_the_outermost_wrapper() {
+    let errors = internal_guard_errors(&syn::parse_quote! {
+        enum E { V(Option<Vec<Payload>>) }
+    });
+    assert_eq!(errors.len(), 1, "got: {errors:?}");
+    assert!(
+        errors[0].contains("containing an optional"),
+        "got: {}",
+        errors[0]
+    );
+}
+
+/// A map's members are written beside the tag, but the expansion cannot name them, so no schema
+/// closed around the tag admits them. serde's restriction is not what is quoted here — serde writes
+/// this one.
+#[cfg(feature = "serde")]
+#[test]
+fn internally_tagged_newtype_over_a_map_is_rejected_as_unnameable() {
+    let errors = internal_guard_errors(&syn::parse_quote! {
+        enum E { V(std::collections::HashMap<String, u32>) }
+    });
+    assert_eq!(errors.len(), 1, "got: {errors:?}");
+    assert!(errors[0].contains("wraps a map"), "got: {}", errors[0]);
+    assert!(
+        !errors[0].contains("serde refuses"),
+        "serde writes a map beside the tag. Got: {}",
+        errors[0]
+    );
+}
+
+/// A multi-element tuple variant is a declaration serde's own derive refuses; the guard names that
+/// rather than describing elements that have no key to sit under.
+#[cfg(feature = "serde")]
+#[test]
+fn internally_tagged_tuple_variant_is_rejected() {
+    let errors = internal_guard_errors(&syn::parse_quote! {
+        enum E { V(String, u32) }
+    });
+    assert_eq!(errors.len(), 1, "got: {errors:?}");
+    assert!(
+        errors[0].contains("cannot be used with tuple variants"),
+        "got: {}",
+        errors[0]
+    );
+}
+
+/// An empty tuple variant carries nothing: serde writes the tag alone, which is the unit arm.
+#[cfg(feature = "serde")]
+#[test]
+fn internally_tagged_empty_tuple_variant_is_accepted() {
+    let errors = internal_guard_errors(&syn::parse_quote! {
+        enum E { V() }
     });
     assert!(errors.is_empty(), "got: {errors:?}");
 }

--- a/tests/chrono_tests/tests.rs
+++ b/tests/chrono_tests/tests.rs
@@ -87,10 +87,11 @@ struct EventWithDate {
     name: String,
 }
 
-// Test enum with DateTime variant (the original use case!).
+// Test enum with DateTime variant (the original use case!). The content key is named because every
+// variant here wraps a scalar, and serde refuses to write one beside a bare tag.
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-#[serde(tag = "type")]
+#[serde(tag = "type", content = "value")]
 pub enum FixedValue {
     Alphanumeric(String),
     Boolean(bool),
@@ -157,10 +158,11 @@ struct Sample {
     start_time: NaiveTime,
 }
 
-// Test enum with a TupleSingle DateTime variant honoring the as_number opt-out.
+// Test enum with a TupleSingle DateTime variant honoring the as_number opt-out. A `DateTime` is
+// written as a string, so it needs a content key of its own to sit under.
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-#[serde(tag = "type")]
+#[serde(tag = "type", content = "value")]
 pub enum DynamicValue {
     Native(DateTime<Utc>),
     Number(#[model_schema_prop(as_number)] DateTime<Utc>),

--- a/tests/tuple_variant_tests/tests.rs
+++ b/tests/tuple_variant_tests/tests.rs
@@ -76,6 +76,46 @@ pub enum RenamedExternal {
     UnitThing,
 }
 
+/// The type an internally tagged newtype variant wraps. Its fields are what serde writes beside
+/// the tag, so they are the ones the surfaces owe.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct TagPayload {
+    pub a: String,
+    pub b: bool,
+}
+
+/// An enum carrying `#[serde(tag = ...)]` and no `content` is internally tagged: there is no key
+/// for a variant's data, so what it writes are members of the object the tag is written in. The
+/// three variants are the three things that can be written there — nothing at all, a struct
+/// variant's own fields, and the members of a newtype variant's inner type.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(tag = "type")]
+pub enum Internal {
+    Bare,
+    Fields { a: String, b: bool },
+    Wrapped(TagPayload),
+}
+
+/// The same form with no newtype variant, which is every member a `z.discriminatedUnion` can hold.
+/// Only the Zod surface names that union, so the fixture is declared where it is read.
+#[cfg(feature = "zod")]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(tag = "type")]
+pub enum InternalNamedOnly {
+    Fields { a: String },
+}
+
+/// The shape the crate refuses to describe, declared without `#[model_schema()]` so serde's own
+/// answer for it can be read off the wire.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(tag = "type")]
+pub enum InternalScalar {
+    Single(String),
+}
+
 /// A recursive enum with no tagging attributes: what sits under a key is the enum itself. Only the
 /// Zod surface spells the deferral, so the fixture is declared where it is read.
 #[cfg(feature = "zod")]
@@ -1434,4 +1474,206 @@ fn test_explicitly_tagged_twin_keeps_the_adjacent_json_schema_form() {
             "maxItems": 2_u64
         })
     );
+}
+
+/// Test 22: what serde writes for a bare tag. There is no content key: a struct variant's fields
+/// and a newtype variant's inner members are both written beside the tag, in the same object.
+#[test]
+fn test_bare_tag_writes_the_variant_data_beside_the_tag() {
+    assert_eq!(
+        serde_json::to_value(Internal::Fields {
+            a: "a".to_owned(),
+            b: true
+        })
+        .unwrap(),
+        serde_json::json!({ "type": "Fields", "a": "a", "b": true }),
+        "A struct variant's fields sit beside the tag"
+    );
+    assert_eq!(
+        serde_json::to_value(Internal::Wrapped(TagPayload {
+            a: "a".to_owned(),
+            b: true
+        }))
+        .unwrap(),
+        serde_json::json!({ "type": "Wrapped", "a": "a", "b": true }),
+        "A newtype variant's inner members sit beside the tag too: no key holds them"
+    );
+    assert_eq!(
+        serde_json::to_value(Internal::Bare).unwrap(),
+        serde_json::json!({ "type": "Bare" }),
+        "A unit variant is the tag alone"
+    );
+}
+
+/// Test 22a: and the shape that has no members to write there. serde refuses it at run time, which
+/// is why the crate refuses the declaration: there is no schema to write for a value that cannot
+/// exist on the wire.
+#[test]
+fn test_bare_tag_newtype_over_a_scalar_is_unserializable() {
+    let refusal = serde_json::to_value(InternalScalar::Single("a".to_owned()))
+        .unwrap_err()
+        .to_string();
+    assert!(
+        refusal.contains("cannot serialize tagged newtype variant"),
+        "Got: {refusal}"
+    );
+    assert!(refusal.contains("containing a string"), "Got: {refusal}");
+}
+
+/// Test 22b: TypeScript spreads the inner type beside the tag rather than putting it under a key.
+/// `&` binds tighter than `|`, so the intersection is one member of the union.
+#[test]
+fn test_bare_tag_typescript_spreads_the_inner_type_beside_the_tag() {
+    let ts = Internal::ts_definition();
+
+    assert!(
+        ts.contains("type: \"Wrapped\";\n} & TagPayload"),
+        "The inner type joins the tag's object. Got: {ts}"
+    );
+    assert!(
+        !ts.contains("value:"),
+        "Nothing writes a content key under a bare tag. Got: {ts}"
+    );
+    assert!(ts.contains("type: \"Fields\";"), "Got: {ts}");
+    assert!(ts.contains("  a: string;"), "Got: {ts}");
+    assert!(ts.contains("type: \"Bare\";"), "Got: {ts}");
+}
+
+/// Test 22c: the Zod member for a newtype variant is the tag's object intersected with the inner
+/// schema. An intersection has no shape of its own to read a discriminator out of, so the union
+/// that holds it is a plain `z.union`.
+#[cfg(feature = "zod")]
+#[test]
+fn test_bare_tag_zod_intersects_the_inner_schema() {
+    let zod = Internal::zod_schema();
+
+    assert!(
+        zod.contains(
+            "z.strictObject({\n  type: z.literal(\"Wrapped\"),\n}).and(TagPayload$Schema)"
+        ),
+        "Got: {zod}"
+    );
+    assert!(zod.contains("z.union(["), "Got: {zod}");
+    assert!(
+        !zod.contains("z.discriminatedUnion"),
+        "An intersection member cannot be discriminated on. Got: {zod}"
+    );
+    assert!(!zod.contains("value:"), "Got: {zod}");
+}
+
+/// Test 22d: with no newtype variant every member is an object carrying the tag, so the union still
+/// switches on it.
+#[cfg(feature = "zod")]
+#[test]
+fn test_bare_tag_without_a_newtype_variant_still_discriminates() {
+    let zod = InternalNamedOnly::zod_schema();
+
+    assert!(
+        zod.contains("z.discriminatedUnion(\"type\", [z.strictObject({\n  type: z.literal(\"Fields\"),\n  a: z.string(),\n})])"),
+        "Got: {zod}"
+    );
+}
+
+/// Test 22e: the JSON schema holds the inner type's fields beside the tag, required where the inner
+/// requires them, and closed around exactly the members serde writes.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn test_bare_tag_json_schema_holds_the_inner_fields_beside_the_tag() {
+    let schema = Internal::json_schema();
+    let wrapped = schema["oneOf"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|member| member["properties"]["type"]["const"] == "Wrapped")
+        .unwrap();
+
+    assert_eq!(
+        wrapped["properties"],
+        serde_json::json!({
+            "type": { "type": "string", "const": "Wrapped" },
+            "a": { "type": "string" },
+            "b": { "type": "boolean" }
+        })
+    );
+    assert_eq!(
+        wrapped["required"],
+        serde_json::json!(["type", "a", "b"]),
+        "The tag and everything the inner type requires"
+    );
+    assert_eq!(wrapped["additionalProperties"], false);
+    assert!(
+        wrapped["properties"]["value"].is_null(),
+        "There is no content key. Got: {wrapped}"
+    );
+}
+
+/// Test 22f: the round trip the schema owes. Every payload serde writes is admitted by the member
+/// the schema names for it, and reads back into the value it describes.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn test_bare_tag_round_trips_against_its_schema() {
+    let schema = Internal::json_schema();
+
+    for value in [
+        Internal::Bare,
+        Internal::Fields {
+            a: "a".to_owned(),
+            b: true,
+        },
+        Internal::Wrapped(TagPayload {
+            a: "a".to_owned(),
+            b: true,
+        }),
+    ] {
+        let written = serde_json::to_value(&value).unwrap();
+        let member = schema["oneOf"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|member| member["properties"]["type"]["const"] == written["type"])
+            .cloned()
+            .unwrap_or(serde_json::Value::Null);
+        assert!(!member.is_null(), "No member for {written}");
+
+        let declared = member["properties"].as_object().unwrap();
+        for key in written.as_object().unwrap().keys() {
+            assert!(
+                declared.contains_key(key),
+                "The member admits every key serde writes. Missing `{key}` in {member}"
+            );
+        }
+        for required in member["required"].as_array().unwrap() {
+            assert!(
+                written[required.as_str().unwrap()] != serde_json::Value::Null,
+                "The member requires only keys serde writes. Got: {written}"
+            );
+        }
+
+        assert_eq!(
+            serde_json::from_value::<Internal>(written.clone()).unwrap(),
+            value,
+            "What serde writes must read back. Got: {written}"
+        );
+    }
+
+    // And the adjacent form the schema no longer describes is one the type cannot read either.
+    assert!(
+        serde_json::from_value::<Internal>(
+            serde_json::json!({ "type": "Wrapped", "value": { "a": "a", "b": true } })
+        )
+        .is_err(),
+        "A content key is not what this enum reads"
+    );
+}
+
+/// Test 22g: naming a content key beside the tag keeps the adjacent form, content key and all.
+#[test]
+fn test_adjacent_twin_keeps_its_content_key() {
+    assert_eq!(
+        serde_json::to_value(Adjacent::Single("a".to_owned())).unwrap(),
+        serde_json::json!({ "type": "Single", "value": "a" })
+    );
+
+    let ts = Adjacent::ts_definition();
+    assert!(ts.contains("value: string"), "Got: {ts}");
 }


### PR DESCRIPTION
#[serde(tag)] with no content reused the adjacent renderer, inventing a value key serde never writes — and emitting schemas for shapes serde refuses to serialize at runtime. Captures established every arm first: a newtype over a named type flattens its fields beside the tag; scalars/tuples/sequences/optionals are serde runtime refusals; multi-tuple variants are refused by serde's own derive.

New dedicated path mirrors the external-tagging precedent: struct/unit arms reuse the adjacent helpers (extracted as tagged_variant_parts / tagged_variant_json_object, byte-identical); the flattened newtype arm reuses the #[serde(flatten)] merge (flattened_object_body split into merged_object_value + MergeCycleDiagnostic, cycle panic text preserved verbatim); Zod renders strictObject(tag).and(Inner$Schema) and downgrades discriminatedUnion to union only when an intersection member exists. Unsupported shapes get spanned compile errors quoting serde's own refusal, with the remedy. The chrono fixtures declared exactly the unserializable shape and now name content = "value".

Powerset green in the lane; lint-all also run (caught three feature-subset breaks, fixed at the root); cheap gate green on the merged state.
