### PR TITLE
fix: a doc comment crosses the Vec/Option collapse onto the element

### DIFF
--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -1019,14 +1019,20 @@ fn get_field_def_from_generic_type(
             #[cfg(feature = "jsonschema")]
             type_span: type_ident.span(),
         }
-    } else if arg_types.len() == 1 && ident == "Option" {
+    }
+    // A collapse keeps the field and drops only the wrapper. The docs were written where the field
+    // was, not around what it holds, so they cross onto the element the field's own name crosses
+    // onto — the element was parsed with none of its own to lose.
+    else if arg_types.len() == 1 && ident == "Option" {
         let mut result = arg_types[0].clone();
         result.name = safe_name;
+        field_docs.clone_into(&mut result.docs);
         result.mark_nullable_at(result.array_depth);
         result
     } else if arg_types.len() == 1 && ident == "Vec" {
         let mut result = arg_types[0].clone();
         result.name = safe_name;
+        field_docs.clone_into(&mut result.docs);
         result.array_depth = result.array_depth.saturating_add(1);
         result
     }

--- a/tests/collection_tests/tests.rs
+++ b/tests/collection_tests/tests.rs
@@ -360,6 +360,26 @@ struct NestedSequenceSlots {
     tuple_rows: (String, Vec<Vec<u32>>),
 }
 
+// A doc comment is written on the field, not on the shape its type spells, so the wrappers the
+// parser collapses onto their element describe with the same comment the spellings it leaves alone
+// describe with.
+#[cfg(feature = "typescript")]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct DocumentedSequenceFields {
+    /// Documented nested field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    documented_nested: Option<Vec<u32>>,
+    /// Documented optional field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    documented_optional: Option<String>,
+    /// Documented set field.
+    documented_set: HashSet<String>,
+    /// Documented vec field.
+    documented_vec: Vec<String>,
+    undocumented_vec: Vec<String>,
+}
+
 fn one<T, C>(item: T) -> C
 where
     C: FromIterator<T>,
@@ -2328,4 +2348,22 @@ fn test_an_alias_of_a_nested_sequence_publishes_its_depth() {
             "items": { "type": "array", "items": { "type": "integer" } }
         })
     );
+}
+
+/// A field's doc comment reaches the generated TypeScript from every spelling: the wrappers the
+/// parser collapses onto their element carry the docs across the collapse, so a `Vec` and an
+/// `Option` describe with the comment the set spelling they share a wire form with already carried.
+#[test]
+#[cfg(feature = "typescript")]
+fn test_a_doc_comment_reaches_ts_from_a_collapsed_wrapper_field() {
+    let ts = DocumentedSequenceFields::ts_definition();
+    for spelling in [
+        " * Documented nested field.\n * \n**/\n  documented_nested: Array<number> | undefined;",
+        " * Documented optional field.\n * \n**/\n  documented_optional: string | undefined;",
+        " * Documented set field.\n * \n**/\n  documented_set: Array<string>;",
+        " * Documented vec field.\n * \n**/\n  documented_vec: Array<string>;",
+        " * undocumented_vec\n * \n**/\n  undocumented_vec: Array<string>;",
+    ] {
+        assert!(ts.contains(spelling), "Got: {ts}");
+    }
 }


### PR DESCRIPTION
The Option/Vec collapse cloned the element's FieldDef (parsed with empty docs) and fixed up only the name, so the field's doc comment died with the wrapper — while HashSet and every other spelling carried it. Both collapse arms now carry field_docs onto the clone, exactly as the transparent-wrapper arm below them already did.

Recorded deviation from the byte-identity criterion, accepted at review: an UNDOCUMENTED Vec/Option field now emits the same name-fallback jsdoc block every other spelling emits (previously an empty block). By collapse time the fallback and an authored doc are the same string — build_field_docs applies the fallback upstream — so preserving the empty block would mean refactoring the parse API to thread raw docs separately, to keep an inconsistency the bug itself reported from the other direction. Pinned by the undocumented_vec assertion.

Powerset green in the lane; cheap gate green on the merged state.
