### PR TITLE
fix: a pattern the regex crate rejects fails at expansion, not at the first validation

### DIFF
--- a/src/features/model_schema_prop.rs
+++ b/src/features/model_schema_prop.rs
@@ -5,6 +5,8 @@
 
 use syn::{Attribute, LitStr, Type};
 
+use crate::utils::regex_rejection;
+
 /// Metadata for `model_schema_prop` attributes applied to a field.
 ///
 /// # Supported attributes
@@ -78,6 +80,8 @@ pub struct ModelSchemaPropMeta {
     pub min_length: Option<usize>, // e.g., 1 from minLength = 1
     pub minimum: Option<f64>, // e.g., 0.0 from minimum = 0
     pub pattern: Option<String>, // e.g., "^[0-9a-fA-F]{24}$" from pattern = "^[0-9a-fA-F]{24}$"
+    /// The `regex` crate's rejection of `pattern`, spanned on the literal it was written as.
+    pub pattern_rejection: Option<syn::Error>,
     pub preprocess: Vec<String>, // e.g., ["epoch_to_date", "trim"] from preprocess = ["epoch_to_date", "trim"]
     pub ts_optional: bool,
 }
@@ -155,6 +159,7 @@ pub fn parse_model_schema_prop_attributes(attrs: &[Attribute]) -> ModelSchemaPro
                 else if nested.path.is_ident("pattern") {
                     let value = nested.value()?;
                     let lit: LitStr = value.parse()?;
+                    meta.pattern_rejection = regex_rejection(&lit);
                     meta.pattern = Some(lit.value());
                 }
                 // Handle `preprocess = ["fn1", "fn2"]`

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -33,7 +33,7 @@ use crate::{
 use crate::utils::{escape_js_regex_literal, extract_example_from_docs};
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-use crate::utils::{AliasKind, lookup_alias_info};
+use crate::utils::{AliasKind, lookup_alias_info, regex_rejection};
 
 #[cfg(feature = "serde")]
 use crate::features::serde::{SerdeFieldMeta, SerdeTypeMeta, has_serde_default};
@@ -267,6 +267,11 @@ struct ModelSchemaArgs {
     /// whose inner type is a container rather than a scalar.
     no_display: bool,
     pattern: Option<String>,
+    /// The `regex` crate's rejection of `pattern`, spanned on the literal it was written as. Only
+    /// the brand path splices the argument, and only a schema feature builds that path; without
+    /// one, a type-level constraint never reaches a surface at all.
+    #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+    pattern_rejection: Option<syn::Error>,
 }
 
 /// Mutable output buffers shared by the discriminated-enum variant writers. Bundled so each writer
@@ -333,6 +338,15 @@ fn parse_model_schema_args(args: proc_macro2::TokenStream) -> ModelSchemaArgs {
     result
 }
 
+/// Records the `regex` crate's verdict on a `pattern` argument, for the brand path that splices it.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn record_pattern_rejection(result: &mut ModelSchemaArgs, lit_str: &syn::LitStr) {
+    result.pattern_rejection = regex_rejection(lit_str);
+}
+
+#[cfg(not(any(feature = "typescript", feature = "zod", feature = "jsonschema")))]
+const fn record_pattern_rejection(_result: &mut ModelSchemaArgs, _lit_str: &syn::LitStr) {}
+
 /// Applies one `key = value` argument to `result`, ignoring unknown keys and mistyped literals.
 fn apply_named_arg(result: &mut ModelSchemaArgs, meta: &MetaNameValue) {
     if meta.path.is_ident("name")
@@ -344,6 +358,7 @@ fn apply_named_arg(result: &mut ModelSchemaArgs, meta: &MetaNameValue) {
         && let syn::Expr::Lit(expr_lit) = &meta.value
         && let syn::Lit::Str(lit_str) = &expr_lit.lit
     {
+        record_pattern_rejection(result, lit_str);
         result.pattern = Some(lit_str.value());
     } else if meta.path.is_ident("minLength")
         && let syn::Expr::Lit(expr_lit) = &meta.value
@@ -748,6 +763,24 @@ fn cfg_attr_guard_error(rejection: &syn::Error, item: &str) -> proc_macro2::Toke
     .to_compile_error()
 }
 
+/// Turns a rejected `pattern` into `compile_error!` tokens naming what carries it, keeping the
+/// literal's span so the diagnostic points at the pattern as written.
+///
+/// The generated validator builds the pattern with `regex::Regex::new(...).unwrap()`, so accepting
+/// one the crate cannot parse only moves the failure to the first value that reaches it — as a
+/// panic, from inside a `LazyLock` the author never wrote.
+fn pattern_guard_error(rejection: &syn::Error, subject: &str) -> proc_macro2::TokenStream {
+    syn::Error::new(
+        rejection.span(),
+        format!(
+            "model_schema: {subject}: `pattern` is not a regex the `regex` crate can parse. The \
+             generated validator builds it with `regex::Regex::new(...).unwrap()`, so accepting \
+             it here would turn the first validated value into a panic. {rejection}"
+        ),
+    )
+    .to_compile_error()
+}
+
 /// Names a field in a guard message; tuple slots have no ident to name.
 fn field_label(raw_field_ident: &str) -> String {
     if raw_field_ident.is_empty() {
@@ -939,9 +972,22 @@ const fn branded_cfg_attr_guard_errors(
     Vec::new()
 }
 
+/// The `compile_error!` tokens for a brand whose `pattern` argument the `regex` crate rejects, or
+/// `None` when it carries none or it parses.
+///
+/// The brand is the only shape that reads a type-level `pattern`, and it splices the string into
+/// the Rust validator, the Zod literal and the JSON schema alike; every other shape is refused the
+/// argument before a surface is built.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn branded_pattern_error(name: &Ident, args: &ModelSchemaArgs) -> Option<proc_macro2::TokenStream> {
+    args.pattern_rejection
+        .as_ref()
+        .map(|rejection| pattern_guard_error(rejection, &format!("type `{name}`")))
+}
+
 /// The `compile_error!` tokens for every guard a branded newtype violates: a `cfg_attr`-wrapped
-/// serde attribute on the type or on its inner slot, an `Option` inner type, and string
-/// constraints over an inner type that cannot carry them.
+/// serde attribute on the type or on its inner slot, an `Option` inner type, string constraints
+/// over an inner type that cannot carry them, and a `pattern` that is not a regex.
 ///
 /// The branded path renders the inner type straight into the brand instead of walking fields, so
 /// it has to collect these itself; the ordinary struct walk never sees a transparent newtype.
@@ -959,6 +1005,7 @@ fn branded_guard_errors(
             inner_field,
             args,
         ))
+        .chain(branded_pattern_error(&item_struct.ident, args))
         .collect()
 }
 
@@ -5571,17 +5618,24 @@ fn field_guard_errors(
 }
 
 /// Every guard error the field violates: the `OsString` guard first — it reads the written type,
-/// which no attribute can hide — then the serde-side guards when any fired.
+/// which no attribute can hide — then the unparseable `pattern`, then the serde-side guards when
+/// any fired.
+///
+/// The `pattern` guard stands under every feature subset: the string reaches the Rust validator,
+/// the Zod literal and the JSON schema alike, and no toggle makes an unparseable one mean anything.
 fn collect_field_guard_errors(
     field: &Field,
     field_def: &FieldDef,
     raw_field_ident: &str,
+    pattern_rejection: Option<&syn::Error>,
     serde_guard_errors: Vec<proc_macro2::TokenStream>,
 ) -> Vec<proc_macro2::TokenStream> {
-    check_os_string_field(field, field_def, &field_label(raw_field_ident))
+    let label = field_label(raw_field_ident);
+    check_os_string_field(field, field_def, &label)
         .err()
         .map(|err| err.to_compile_error())
         .into_iter()
+        .chain(pattern_rejection.map(|rejection| pattern_guard_error(rejection, &label)))
         .chain(serde_guard_errors)
         .collect()
 }
@@ -5697,8 +5751,13 @@ fn process_field(
     #[cfg(not(feature = "serde"))]
     let serde_guard_errors: Vec<proc_macro2::TokenStream> = Vec::new();
 
-    let guard_errors =
-        collect_field_guard_errors(field, &field_def, &raw_field_ident, serde_guard_errors);
+    let guard_errors = collect_field_guard_errors(
+        field,
+        &field_def,
+        &raw_field_ident,
+        model_schema_prop_meta.pattern_rejection.as_ref(),
+        serde_guard_errors,
+    );
 
     // Resolve `Self` references to the concrete type name so recursive fields
     // (e.g. `Vec<Self>`) are treated exactly like `Vec<EnclosingType>`.

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -31,6 +31,21 @@ use syn::spanned::Spanned as _;
 /// The variants of [`rendered_discriminated_union`]'s enum, in the order they are declared.
 const DECLARED_VARIANTS: [&str; 6] = ["Upload", "Generate", "Delete", "Rename", "Move", "Archive"];
 
+/// Every pattern the `pattern` guards must decide, invalid ones first, then the valid shapes the
+/// shipped tests write.
+const PROBE_PATTERNS: [&str; 10] = [
+    r"^ab\",
+    "^ab(",
+    "*ab",
+    "^[a-",
+    r"\p{NotAClass}",
+    "^[a-z]+$",
+    r"^\d{3}\.\d{3}$",
+    r"^a\n[a-z]+$",
+    "^/[a-z]+$",
+    r"^\/[a-z]+$",
+];
+
 /// The covered wrappers, under the names a dispatch reads them by.
 #[cfg(any(feature = "jsonschema", feature = "serde"))]
 const SEQUENCE_WRAPPERS: [&str; 6] = [
@@ -449,6 +464,89 @@ fn a_path_field_is_left_alone() {
     }
 }
 
+/// Runs the field walk the way [`super::process_field`] does and renders the guard failures its
+/// `model_schema_prop` attributes earn, so an unparseable `pattern` is read off the same channel
+/// that carries it to the emitted item.
+fn field_pattern_errors(item: &syn::ItemStruct) -> Vec<String> {
+    let field = item.fields.iter().next().unwrap();
+    let name = field
+        .ident
+        .as_ref()
+        .map(ToString::to_string)
+        .unwrap_or_default();
+    let field_def = get_field_def(&name, &field.ty, "");
+    let meta = super::parse_model_schema_prop_attributes(&field.attrs);
+    super::collect_field_guard_errors(
+        field,
+        &field_def,
+        &name,
+        meta.pattern_rejection.as_ref(),
+        Vec::new(),
+    )
+    .iter()
+    .map(ToString::to_string)
+    .collect()
+}
+
+/// The guard's verdict is the `regex` crate's verdict: the parse the generated validator's
+/// `Regex::new` would run, moved to expansion. Driving the expectation off `Regex::new` itself is
+/// what keeps the two from drifting as the crate's grammar changes.
+#[test]
+fn the_field_pattern_guard_follows_the_regex_crate() {
+    for pattern in PROBE_PATTERNS {
+        let rejected = regex::Regex::new(pattern).is_err();
+        let errors = field_pattern_errors(&syn::parse_quote! {
+            struct Report {
+                #[model_schema_prop(pattern = #pattern)]
+                name: String,
+            }
+        });
+        assert_eq!(
+            errors.len(),
+            usize::from(rejected),
+            "for {pattern}, got: {errors:?}"
+        );
+    }
+}
+
+/// The trailing backslash from the report: it terminates no escape, so `Regex::new` fails and the
+/// Zod literal it would otherwise feed swallows its own closing delimiter.
+#[test]
+fn a_field_pattern_the_regex_crate_rejects_names_the_field_and_quotes_the_parse_error() {
+    let errors = field_pattern_errors(&syn::parse_quote! {
+        struct Report {
+            #[model_schema_prop(pattern = r"^ab\")]
+            name: String,
+        }
+    });
+    assert_eq!(errors.len(), 1, "got: {errors:?}");
+    for needle in [
+        "compile_error",
+        "field `name`",
+        "pattern",
+        "regex parse error",
+        "incomplete escape sequence",
+    ] {
+        assert!(
+            errors[0].contains(needle),
+            "{needle} missing: {}",
+            errors[0]
+        );
+    }
+}
+
+/// A field carrying no `pattern` at all must not acquire one of these errors.
+#[test]
+fn an_unpatterned_field_is_left_alone() {
+    let errors = field_pattern_errors(&syn::parse_quote! {
+        struct Report {
+            #[model_schema_prop(minLength = 3)]
+            name: String,
+        }
+    });
+    assert!(errors.is_empty(), "got: {errors:?}");
+}
+
 #[cfg(feature = "serde")]
 #[test]
 fn cfg_attr_without_serde_leaves_a_field_alone() {
@@ -697,6 +795,55 @@ fn branded_errors_with(item: &syn::ItemStruct, args: &super::ModelSchemaArgs) ->
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn pattern_args() -> super::ModelSchemaArgs {
     super::parse_model_schema_args(quote::quote! { pattern = "^[a-z]+$" })
+}
+
+/// A brand's guard failures for the given `pattern`, over a `String` inner that clears every other
+/// guard.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn brand_pattern_errors(pattern: &str) -> Vec<String> {
+    branded_errors_with(
+        &syn::parse_quote! {
+            #[serde(transparent)]
+            struct UserId(pub String);
+        },
+        &super::parse_model_schema_args(quote::quote! { pattern = #pattern }),
+    )
+}
+
+/// The brand splice reaches the same three surfaces the field splice does, so it answers to the
+/// same parse.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn the_brand_pattern_guard_follows_the_regex_crate() {
+    for pattern in PROBE_PATTERNS {
+        let rejected = regex::Regex::new(pattern).is_err();
+        let errors = brand_pattern_errors(pattern);
+        assert_eq!(
+            errors.len(),
+            usize::from(rejected),
+            "for {pattern}, got: {errors:?}"
+        );
+    }
+}
+
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn a_brand_pattern_the_regex_crate_rejects_names_the_type_and_quotes_the_parse_error() {
+    let errors = brand_pattern_errors(r"^ab\");
+    assert_eq!(errors.len(), 1, "got: {errors:?}");
+    for needle in [
+        "compile_error",
+        "type `UserId`",
+        "pattern",
+        "regex parse error",
+        "incomplete escape sequence",
+    ] {
+        assert!(
+            errors[0].contains(needle),
+            "{needle} missing: {}",
+            errors[0]
+        );
+    }
 }
 
 /// Every constraint the guard reacts to, applied one at a time: `has_string_constraints` is an

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,7 +2,7 @@ use core::cell::RefCell;
 #[cfg(feature = "typescript")]
 use core::iter;
 use std::collections::HashMap;
-use syn::{Attribute, Expr, Field, Lit, Meta, Variant};
+use syn::{Attribute, Expr, Field, Lit, LitStr, Meta, Variant};
 
 #[cfg(any(feature = "typescript", feature = "zod"))]
 use syn::{ItemEnum, ItemStruct};
@@ -321,6 +321,18 @@ const fn js_line_terminator_escape(ch: char) -> Option<&'static str> {
         '\u{2029}' => Some("u2029"),
         _ => None,
     }
+}
+
+/// The `regex` crate's own rejection of a `pattern` attribute value, spanned on the literal the
+/// author wrote, or `None` when the pattern parses.
+///
+/// Both splice points hand the string to `regex::Regex::new(...).unwrap()` inside the generated
+/// validator, so a pattern that does not parse here is a panic at the first validation there. The
+/// macro holds the string and links `regex`, so the parse happens at expansion instead.
+pub fn regex_rejection(lit: &LitStr) -> Option<syn::Error> {
+    regex::Regex::new(&lit.value())
+        .err()
+        .map(|err| syn::Error::new_spanned(lit, err))
 }
 
 /// Escapes a regex pattern for splicing between the `/` delimiters of a JavaScript regex literal.


### PR DESCRIPTION
An unparseable pattern (trailing backslash, unclosed group) passed the derive, emitted an unterminated Zod literal, and panicked at the first runtime validation via the generated Regex::new(...).unwrap(). The pattern is now parsed once at expansion (regex_rejection over the LitStr) and a failure emits the crate's spanned compile_error at the literal the author wrote, carrying regex's own error text, through the existing guard channels (field guards + branded_guard_errors) — schema surface dropped, valid patterns byte-identical.

End-to-end proven at both splice points with probes; two unit tests drive their expectations off Regex::new itself over a shared valid/invalid probe set so the guard can't drift from the crate. Process note recorded honestly: implemented before tests, verified by probe + unit suite rather than a recorded red state.

Powerset green in the lane; lint-all green across all 68 combos; cheap gate green on the merged state.
