### PR TITLE
fix: the sibling dispatch renders no map of its own

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -5222,20 +5222,15 @@ fn build_sibling_type_field_schema(
         && is_sequence_wrapper(name)
     {
         build_field_type_schema(&fld.collection_element_field(element), field_name_str)
-    } else if (name == "HashMap" || name == "BTreeMap") && lst.len() == 2 {
-        log::trace!("HashMap => field_name: {field_name_str}, lst: {lst:?}");
-        quote! {
-            properties.insert(#field_name_str.to_string(), {
-                serde_json::json!({
-                    "type": "object",
-                    "additionalProperties": true
-                })
-            });
-        }
     } else {
-        // Covers both non-generic sibling types (lst.is_empty()) and generic branded wrappers
-        // like DocumentTypeId<String>: for a transparent newtype the JSON schema is defined on
-        // the wrapper type's own schema module, and type params don't affect it.
+        // Every remaining shape is carried by the named type's own schema module: the non-generic
+        // sibling (lst.is_empty()), and the generic branded wrapper like DocumentTypeId<String>,
+        // whose schema is defined on the wrapper and whose type params do not affect it. A map is
+        // not among them — the parser claims both 2-argument map idents before the sibling fallback
+        // is reached, so a map arrives as a `Map` and is rendered once, there. A name this arm
+        // cannot resolve is the compile error the reference raises at the type, which is what keeps
+        // a second rendering — free to widen or to drop the array the one rendering carries — from
+        // growing back here.
         generate_type_schema(
             fld,
             field_name_str,

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -2219,6 +2219,30 @@ fn a_sibling_string_keyed_map_value_emits_the_sibling_schema() {
     }
 }
 
+/// A map is a `Map` wherever it is written, never a sibling named after the container: the parser
+/// claims both 2-argument map idents ahead of the sibling fallback, and the wrappers a map can be
+/// written under either collapse onto it or hold it as a value. The sibling dispatch therefore
+/// renders no map of its own — a rendering there answers for nothing, and is free to drift from the
+/// one the map arm states.
+#[test]
+fn a_map_never_parses_as_a_sibling_named_after_its_container() {
+    for spelling in [
+        "HashMap<String, u32>",
+        "BTreeMap<String, u32>",
+        "std::collections::BTreeMap<String, u32>",
+        "Option<HashMap<String, u32>>",
+        "Box<HashMap<String, u32>>",
+        "Vec<BTreeMap<String, u32>>",
+    ] {
+        let ty: syn::Type = syn::parse_str(spelling).unwrap();
+        let field_type = get_field_def("m", &ty, "").field_type;
+        assert!(
+            matches!(field_type, FieldDefType::Map(..)),
+            "for {spelling}, got: {field_type:?}"
+        );
+    }
+}
+
 /// An alias's schema module is named after its registered export name, which the raw ident does
 /// not reproduce — the reference has to come from the registry or it names a module that was never
 /// emitted.


### PR DESCRIPTION
build_sibling_type_field_schema kept a second HashMap/BTreeMap rendering ({"type":"object","additionalProperties":true}) that widened the value type and dropped the array. Phase-0 enumeration of every SiblingType construction site proved the shape unconstructible: the parser claims both 2-argument map idents before the sibling fallback, nothing mutates a field_type into SiblingType afterward, and no test hand-built one. The arm is deleted; the else-branch comment now states the invariant (a map is a Map wherever written, rendered once), and an ungated test pins the parse across six spellings and the powerset.

Zero behavior change for anything reachable — the full suite green unchanged.

Powerset green in the lane; cheap gate green on the merged state.
