### PR TITLE
fix: an unknown or malformed model_schema_prop key fails the derive with a spanned error

### DIFF
--- a/src/features/model_schema_prop.rs
+++ b/src/features/model_schema_prop.rs
@@ -3,9 +3,27 @@
 //! This module handles parsing of model_schema_prop attributes for field-level customization
 //! of TypeScript type and Zod schema generation.
 
+use syn::meta::ParseNestedMeta;
 use syn::{Attribute, LitStr, Type};
 
 use crate::utils::regex_rejection;
+
+/// Every key the parser reads, in the order it tries them, as the unknown-key rejection names them.
+///
+/// A key added to [`parse_prop_key`] belongs here too: `no_key_the_parser_reads_is_rejected` walks
+/// this list back through the parser and fails on any name here it does not read.
+const KNOWN_KEYS: &[&str] = &[
+    "as",
+    "literal",
+    "minLength",
+    "maxLength",
+    "minimum",
+    "maximum",
+    "pattern",
+    "preprocess",
+    "ts_optional",
+    "as_number",
+];
 
 /// Metadata for `model_schema_prop` attributes applied to a field.
 ///
@@ -74,11 +92,14 @@ use crate::utils::regex_rejection;
 pub struct ModelSchemaPropMeta {
     pub as_number: bool, // DateTime<Tz>: epoch-number + codegen coercer instead of the native Date default
     pub as_type: Option<String>, // e.g., "String" from as = String
+    /// The parser's refusal of the attribute — a key it does not read, or a value it cannot read —
+    /// spanned on the tokens that earned it.
+    pub attr_rejection: Option<syn::Error>,
     pub literal: Option<String>, // e.g., "Tixena" from literal = "Tixena"
     pub max_length: Option<usize>, // e.g., 50 from maxLength = 50
-    pub maximum: Option<f64>, // e.g., 100.0 from maximum = 100
+    pub maximum: Option<f64>,    // e.g., 100.0 from maximum = 100
     pub min_length: Option<usize>, // e.g., 1 from minLength = 1
-    pub minimum: Option<f64>, // e.g., 0.0 from minimum = 0
+    pub minimum: Option<f64>,    // e.g., 0.0 from minimum = 0
     pub pattern: Option<String>, // e.g., "^[0-9a-fA-F]{24}$" from pattern = "^[0-9a-fA-F]{24}$"
     /// The `regex` crate's rejection of `pattern`, spanned on the literal it was written as.
     pub pattern_rejection: Option<syn::Error>,
@@ -87,114 +108,107 @@ pub struct ModelSchemaPropMeta {
 }
 
 /// Parses `model_schema_prop` attributes from a field.
+///
+/// What the parser cannot read is recorded as [`ModelSchemaPropMeta::attr_rejection`] rather than
+/// dropped: this attribute is read here and nowhere else, so a key or value that stops at this
+/// parser reaches no emitter, and the field it was written to constrain is emitted as though the
+/// attribute had been left off.
 pub fn parse_model_schema_prop_attributes(attrs: &[Attribute]) -> ModelSchemaPropMeta {
     let mut meta = ModelSchemaPropMeta::default();
 
     for attr in attrs {
-        if attr.path().is_ident("model_schema_prop") {
-            attr.parse_nested_meta(|nested| {
-                // Handle `as = Type`
-                if nested.path.is_ident("as") {
-                    let value = nested.value()?;
-                    if let Ok(ty) = value.parse::<Type>() {
-                        // Convert the type to a string representation
-                        meta.as_type = Some(quote::quote!(#ty).to_string());
-                    }
-                }
-                // Handle `literal = "value"`
-                else if nested.path.is_ident("literal") {
-                    let value = nested.value()?;
-                    let lit: LitStr = value.parse()?;
-                    meta.literal = Some(lit.value());
-                }
-                // Handle `minLength = N`
-                else if nested.path.is_ident("minLength") {
-                    let value = nested.value()?;
-                    let lit = value.parse::<syn::LitInt>()?;
-                    if let Ok(min_len) = lit.base10_parse::<usize>() {
-                        meta.min_length = Some(min_len);
-                    }
-                }
-                // Handle `maxLength = N`
-                else if nested.path.is_ident("maxLength") {
-                    let value = nested.value()?;
-                    let lit = value.parse::<syn::LitInt>()?;
-                    if let Ok(max_len) = lit.base10_parse::<usize>() {
-                        meta.max_length = Some(max_len);
-                    }
-                }
-                // Handle `minimum = N` (integer or float)
-                else if nested.path.is_ident("minimum") {
-                    let value = nested.value()?;
-                    let lit: syn::Lit = value.parse()?;
-                    if let syn::Lit::Int(li) = lit {
-                        if let Ok(n) = li.base10_parse::<f64>() {
-                            meta.minimum = Some(n);
-                        }
-                    } else if let syn::Lit::Float(lf) = lit
-                        && let Ok(n) = lf.base10_parse::<f64>()
-                    {
-                        meta.minimum = Some(n);
-                    } else {
-                        // Non-numeric literals are ignored.
-                    }
-                }
-                // Handle `maximum = N` (integer or float)
-                else if nested.path.is_ident("maximum") {
-                    let value = nested.value()?;
-                    let lit: syn::Lit = value.parse()?;
-                    if let syn::Lit::Int(li) = lit {
-                        if let Ok(n) = li.base10_parse::<f64>() {
-                            meta.maximum = Some(n);
-                        }
-                    } else if let syn::Lit::Float(lf) = lit
-                        && let Ok(n) = lf.base10_parse::<f64>()
-                    {
-                        meta.maximum = Some(n);
-                    } else {
-                        // Non-numeric literals are ignored.
-                    }
-                }
-                // Handle `pattern = "regex"`
-                else if nested.path.is_ident("pattern") {
-                    let value = nested.value()?;
-                    let lit: LitStr = value.parse()?;
-                    meta.pattern_rejection = regex_rejection(&lit);
-                    meta.pattern = Some(lit.value());
-                }
-                // Handle `preprocess = ["fn1", "fn2"]`
-                else if nested.path.is_ident("preprocess") {
-                    let value = nested.value()?;
-                    let arr: syn::ExprArray = value.parse()?;
-                    let fns: Vec<String> = arr
-                        .elems
-                        .iter()
-                        .filter_map(|elem| {
-                            if let syn::Expr::Lit(expr_lit) = elem
-                                && let syn::Lit::Str(s) = &expr_lit.lit
-                            {
-                                return Some(s.value());
-                            }
-                            None
-                        })
-                        .collect();
-                    meta.preprocess = fns;
-                } else if nested.path.is_ident("ts_optional") {
-                    meta.ts_optional = true;
-                } else if nested.path.is_ident("as_number") {
-                    meta.as_number = true;
-                } else {
-                    // Ignore unknown model_schema_prop keys.
-                }
-                Ok(())
-            })
-            .unwrap_or_else(|e| {
-                log::trace!("Failed to parse model_schema_prop attribute: {e}");
-            });
+        if attr.path().is_ident("model_schema_prop")
+            && let Err(rejection) =
+                attr.parse_nested_meta(|nested| parse_prop_key(&nested, &mut meta))
+        {
+            meta.attr_rejection.get_or_insert(rejection);
         }
     }
 
     meta
+}
+
+/// Reads one `key` or `key = value` of a `model_schema_prop` attribute into `meta`.
+fn parse_prop_key(nested: &ParseNestedMeta, meta: &mut ModelSchemaPropMeta) -> syn::Result<()> {
+    if nested.path.is_ident("as") {
+        let ty: Type = nested.value()?.parse()?;
+        meta.as_type = Some(quote::quote!(#ty).to_string());
+    } else if nested.path.is_ident("literal") {
+        let lit: LitStr = nested.value()?.parse()?;
+        meta.literal = Some(lit.value());
+    } else if nested.path.is_ident("minLength") {
+        meta.min_length = Some(nested.value()?.parse::<syn::LitInt>()?.base10_parse()?);
+    } else if nested.path.is_ident("maxLength") {
+        meta.max_length = Some(nested.value()?.parse::<syn::LitInt>()?.base10_parse()?);
+    } else if nested.path.is_ident("minimum") {
+        meta.minimum = Some(numeric_bound(nested, "minimum")?);
+    } else if nested.path.is_ident("maximum") {
+        meta.maximum = Some(numeric_bound(nested, "maximum")?);
+    } else if nested.path.is_ident("pattern") {
+        let lit: LitStr = nested.value()?.parse()?;
+        meta.pattern_rejection = regex_rejection(&lit);
+        meta.pattern = Some(lit.value());
+    } else if nested.path.is_ident("preprocess") {
+        let arr: syn::ExprArray = nested.value()?.parse()?;
+        meta.preprocess = arr
+            .elems
+            .iter()
+            .map(preprocess_fn_name)
+            .collect::<syn::Result<_>>()?;
+    } else if nested.path.is_ident("ts_optional") {
+        meta.ts_optional = true;
+    } else if nested.path.is_ident("as_number") {
+        meta.as_number = true;
+    } else {
+        return Err(unknown_key_rejection(nested));
+    }
+    Ok(())
+}
+
+/// The `f64` a numeric bound was written as.
+///
+/// Both bounds reach a numeric comparison in the Rust validator and a numeric literal in the Zod
+/// and JSON schemas, so a value that is not a number is one no surface can carry.
+fn numeric_bound(nested: &ParseNestedMeta, key: &str) -> syn::Result<f64> {
+    let lit: syn::Lit = nested.value()?.parse()?;
+    if let syn::Lit::Int(int) = &lit {
+        int.base10_parse()
+    } else if let syn::Lit::Float(float) = &lit {
+        float.base10_parse()
+    } else {
+        Err(syn::Error::new_spanned(
+            &lit,
+            format!("`model_schema_prop` key `{key}` takes an integer or float literal"),
+        ))
+    }
+}
+
+/// The name one `preprocess` element carries: the function is spliced into the emitted Zod schema
+/// by name, so a string literal is the only element that names one.
+fn preprocess_fn_name(elem: &syn::Expr) -> syn::Result<String> {
+    if let syn::Expr::Lit(expr_lit) = elem
+        && let syn::Lit::Str(name) = &expr_lit.lit
+    {
+        Ok(name.value())
+    } else {
+        Err(syn::Error::new_spanned(
+            elem,
+            "`model_schema_prop` key `preprocess` takes an array of string literals, each naming a \
+             function to wrap the Zod schema with",
+        ))
+    }
+}
+
+/// Rejects a key the parser does not read, spanned on the name as written.
+fn unknown_key_rejection(nested: &ParseNestedMeta) -> syn::Error {
+    let path = &nested.path;
+    nested.error(format!(
+        "unknown `model_schema_prop` key `{}`. This attribute is this crate's own, so a key it \
+         does not read reaches no emitter: the field would be written as though the key had been \
+         left off, unconstrained on every surface. Valid keys: {}",
+        quote::quote!(#path),
+        KNOWN_KEYS.join(", ")
+    ))
 }
 
 #[cfg(test)]

--- a/src/features/model_schema_prop/tests.rs
+++ b/src/features/model_schema_prop/tests.rs
@@ -99,3 +99,88 @@ fn test_parse_all_attributes() {
     assert!(meta.min_length.is_some());
     assert_eq!(meta.min_length.unwrap(), 3);
 }
+
+/// The parser's refusal of `attr`, rendered, or `None` when it read the attribute whole.
+fn attr_rejection(attr: Attribute) -> Option<String> {
+    parse_model_schema_prop_attributes(&[attr])
+        .attr_rejection
+        .as_ref()
+        .map(ToString::to_string)
+}
+
+/// The reported repro: a misspelled `pattern` compiled clean and emitted an unconstrained string.
+/// The refusal names the key as written and the one that was meant.
+#[test]
+fn a_misspelled_string_constraint_key_is_refused_by_the_name_as_written() {
+    let rejection =
+        attr_rejection(parse_quote! { #[model_schema_prop(patern = "^[a-z]+$")] }).unwrap();
+    assert!(rejection.contains("patern"), "got: {rejection}");
+    assert!(rejection.contains("pattern"), "got: {rejection}");
+}
+
+#[test]
+fn a_misspelled_length_constraint_key_is_refused_by_the_name_as_written() {
+    let rejection = attr_rejection(parse_quote! { #[model_schema_prop(minLenght = 3)] }).unwrap();
+    assert!(rejection.contains("minLenght"), "got: {rejection}");
+    assert!(rejection.contains("minLength"), "got: {rejection}");
+}
+
+/// The refusal offers every key the parser reads, and the probes below prove each offered name is
+/// one it actually reads — the list and the arms cannot drift apart while both hold.
+#[test]
+fn no_key_the_parser_reads_is_rejected() {
+    let attrs: [Attribute; 10] = [
+        parse_quote! { #[model_schema_prop(as = String)] },
+        parse_quote! { #[model_schema_prop(literal = "Tixena")] },
+        parse_quote! { #[model_schema_prop(minLength = 1)] },
+        parse_quote! { #[model_schema_prop(maxLength = 50)] },
+        parse_quote! { #[model_schema_prop(minimum = 0)] },
+        parse_quote! { #[model_schema_prop(maximum = 1.5)] },
+        parse_quote! { #[model_schema_prop(pattern = "^[a-z]+$")] },
+        parse_quote! { #[model_schema_prop(preprocess = ["trim"])] },
+        parse_quote! { #[model_schema_prop(ts_optional)] },
+        parse_quote! { #[model_schema_prop(as_number)] },
+    ];
+    assert_eq!(attrs.len(), KNOWN_KEYS.len());
+
+    let offered = attr_rejection(parse_quote! { #[model_schema_prop(nonsense)] }).unwrap();
+    for key in KNOWN_KEYS {
+        assert!(offered.contains(key), "{key} not offered: {offered}");
+    }
+    for attr in attrs {
+        let rendered = quote::quote!(#attr).to_string();
+        assert_eq!(attr_rejection(attr), None, "for {rendered}");
+    }
+}
+
+/// Every value the old parser dropped on the floor: a wrong literal kind, a length the target type
+/// cannot hold, and a `preprocess` element that names no function.
+#[test]
+fn a_value_the_parser_cannot_read_is_refused() {
+    let attrs: [Attribute; 9] = [
+        parse_quote! { #[model_schema_prop(as = 3)] },
+        parse_quote! { #[model_schema_prop(literal = Tixena)] },
+        parse_quote! { #[model_schema_prop(minLength = "3")] },
+        parse_quote! { #[model_schema_prop(minLength = -1)] },
+        parse_quote! { #[model_schema_prop(maxLength = 99999999999999999999999999999999999999999)] },
+        parse_quote! { #[model_schema_prop(minimum = "0")] },
+        parse_quote! { #[model_schema_prop(maximum = "0")] },
+        parse_quote! { #[model_schema_prop(pattern = 3)] },
+        parse_quote! { #[model_schema_prop(preprocess = ["trim", 3])] },
+    ];
+    for attr in attrs {
+        let rendered = quote::quote!(#attr).to_string();
+        assert!(attr_rejection(attr).is_some(), "for {rendered}");
+    }
+}
+
+/// A key the parser reads before the refused one still lands: the refusal reports the attribute,
+/// it does not discard what was already read.
+#[test]
+fn a_refusal_keeps_what_the_parser_had_already_read() {
+    let meta = parse_model_schema_prop_attributes(&[parse_quote! {
+        #[model_schema_prop(minLength = 3, patern = "^[a-z]+$")]
+    }]);
+    assert_eq!(meta.min_length, Some(3));
+    assert!(meta.attr_rejection.is_some());
+}

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -47,10 +47,7 @@ use crate::field_type::is_sequence_wrapper;
 #[cfg(feature = "serde")]
 use crate::field_type::is_transparent_wrapper;
 
-use crate::features::model_schema_prop::parse_model_schema_prop_attributes;
-
-#[cfg(feature = "serde")]
-use crate::features::model_schema_prop::ModelSchemaPropMeta;
+use crate::features::model_schema_prop::{ModelSchemaPropMeta, parse_model_schema_prop_attributes};
 
 #[cfg(feature = "jsonschema")]
 use crate::features::jsonschema::{
@@ -793,6 +790,21 @@ fn pattern_guard_error(rejection: &syn::Error, subject: &str) -> proc_macro2::To
              generated validator builds it with `regex::Regex::new(...).unwrap()`, so accepting \
              it here would turn the first validated value into a panic. {rejection}"
         ),
+    )
+    .to_compile_error()
+}
+
+/// Turns the parser's refusal of a `model_schema_prop` attribute into `compile_error!` tokens
+/// naming what carries it, keeping the refusal's span so the diagnostic points at the key or value
+/// as written.
+///
+/// Reading the attribute is the only thing that acts on it, so a key or value the parser stops at
+/// is one no emitter ever sees: without this the field is emitted as though the attribute had been
+/// left off, and the author gets a schema that enforces nothing.
+fn prop_attr_guard_error(rejection: &syn::Error, subject: &str) -> proc_macro2::TokenStream {
+    syn::Error::new(
+        rejection.span(),
+        format!("model_schema: {subject}: {rejection}"),
     )
     .to_compile_error()
 }
@@ -6066,16 +6078,17 @@ fn field_guard_errors(
 }
 
 /// Every guard error the field violates: the `OsString` guard first — it reads the written type,
-/// which no attribute can hide — then the unparseable `pattern`, then the serde-side guards when
-/// any fired.
+/// which no attribute can hide — then what the `model_schema_prop` parser refused, then the
+/// unparseable `pattern`, then the serde-side guards when any fired.
 ///
-/// The `pattern` guard stands under every feature subset: the string reaches the Rust validator,
-/// the Zod literal and the JSON schema alike, and no toggle makes an unparseable one mean anything.
+/// Both `model_schema_prop` guards stand under every feature subset: an unread key and an
+/// unparseable `pattern` alike reach the Rust validator, the Zod literal and the JSON schema, and
+/// no toggle makes either one mean anything.
 fn collect_field_guard_errors(
     field: &Field,
     field_def: &FieldDef,
     raw_field_ident: &str,
-    pattern_rejection: Option<&syn::Error>,
+    prop_meta: &ModelSchemaPropMeta,
     serde_guard_errors: Vec<proc_macro2::TokenStream>,
 ) -> Vec<proc_macro2::TokenStream> {
     let label = field_label(raw_field_ident);
@@ -6083,7 +6096,18 @@ fn collect_field_guard_errors(
         .err()
         .map(|err| err.to_compile_error())
         .into_iter()
-        .chain(pattern_rejection.map(|rejection| pattern_guard_error(rejection, &label)))
+        .chain(
+            prop_meta
+                .attr_rejection
+                .as_ref()
+                .map(|rejection| prop_attr_guard_error(rejection, &label)),
+        )
+        .chain(
+            prop_meta
+                .pattern_rejection
+                .as_ref()
+                .map(|rejection| pattern_guard_error(rejection, &label)),
+        )
         .chain(serde_guard_errors)
         .collect()
 }
@@ -6203,7 +6227,7 @@ fn process_field(
         field,
         &field_def,
         &raw_field_ident,
-        model_schema_prop_meta.pattern_rejection.as_ref(),
+        &model_schema_prop_meta,
         serde_guard_errors,
     );
 

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -576,9 +576,9 @@ fn a_path_field_is_left_alone() {
 }
 
 /// Runs the field walk the way [`super::process_field`] does and renders the guard failures its
-/// `model_schema_prop` attributes earn, so an unparseable `pattern` is read off the same channel
-/// that carries it to the emitted item.
-fn field_pattern_errors(item: &syn::ItemStruct) -> Vec<String> {
+/// `model_schema_prop` attributes earn, so a refused key and an unparseable `pattern` are read off
+/// the same channel that carries them to the emitted item.
+fn field_prop_guard_errors(item: &syn::ItemStruct) -> Vec<String> {
     let field = item.fields.iter().next().unwrap();
     let name = field
         .ident
@@ -587,16 +587,10 @@ fn field_pattern_errors(item: &syn::ItemStruct) -> Vec<String> {
         .unwrap_or_default();
     let field_def = get_field_def(&name, &field.ty, "");
     let meta = super::parse_model_schema_prop_attributes(&field.attrs);
-    super::collect_field_guard_errors(
-        field,
-        &field_def,
-        &name,
-        meta.pattern_rejection.as_ref(),
-        Vec::new(),
-    )
-    .iter()
-    .map(ToString::to_string)
-    .collect()
+    super::collect_field_guard_errors(field, &field_def, &name, &meta, Vec::new())
+        .iter()
+        .map(ToString::to_string)
+        .collect()
 }
 
 /// The guard's verdict is the `regex` crate's verdict: the parse the generated validator's
@@ -606,7 +600,7 @@ fn field_pattern_errors(item: &syn::ItemStruct) -> Vec<String> {
 fn the_field_pattern_guard_follows_the_regex_crate() {
     for pattern in PROBE_PATTERNS {
         let rejected = regex::Regex::new(pattern).is_err();
-        let errors = field_pattern_errors(&syn::parse_quote! {
+        let errors = field_prop_guard_errors(&syn::parse_quote! {
             struct Report {
                 #[model_schema_prop(pattern = #pattern)]
                 name: String,
@@ -624,7 +618,7 @@ fn the_field_pattern_guard_follows_the_regex_crate() {
 /// Zod literal it would otherwise feed swallows its own closing delimiter.
 #[test]
 fn a_field_pattern_the_regex_crate_rejects_names_the_field_and_quotes_the_parse_error() {
-    let errors = field_pattern_errors(&syn::parse_quote! {
+    let errors = field_prop_guard_errors(&syn::parse_quote! {
         struct Report {
             #[model_schema_prop(pattern = r"^ab\")]
             name: String,
@@ -649,13 +643,67 @@ fn a_field_pattern_the_regex_crate_rejects_names_the_field_and_quotes_the_parse_
 /// A field carrying no `pattern` at all must not acquire one of these errors.
 #[test]
 fn an_unpatterned_field_is_left_alone() {
-    let errors = field_pattern_errors(&syn::parse_quote! {
+    let errors = field_prop_guard_errors(&syn::parse_quote! {
         struct Report {
             #[model_schema_prop(minLength = 3)]
             name: String,
         }
     });
     assert!(errors.is_empty(), "got: {errors:?}");
+}
+
+/// The reported repro: two misspelled keys, which emitted `z.string()` with nothing on it. The
+/// misspelling reaches the author on the same channel the `pattern` guard uses, naming the field
+/// and the key as written; parsing stops there, so the second misspelling is not reached.
+#[test]
+fn a_misspelled_field_prop_key_names_the_field_and_the_key_as_written() {
+    let errors = field_prop_guard_errors(&syn::parse_quote! {
+        struct Report {
+            #[model_schema_prop(patern = "^[a-z]+$", minLenght = 3)]
+            name: String,
+        }
+    });
+    assert_eq!(errors.len(), 1, "got: {errors:?}");
+    for needle in ["compile_error", "field `name`", "patern", "pattern"] {
+        assert!(
+            errors[0].contains(needle),
+            "{needle} missing: {}",
+            errors[0]
+        );
+    }
+}
+
+/// A value the parser cannot read is the same class of loss as a key it cannot read — the
+/// constraint reaches no surface — and leaves by the same channel.
+#[test]
+fn a_field_prop_value_the_parser_cannot_read_names_the_field() {
+    let errors = field_prop_guard_errors(&syn::parse_quote! {
+        struct Report {
+            #[model_schema_prop(minLength = "3")]
+            name: String,
+        }
+    });
+    assert_eq!(errors.len(), 1, "got: {errors:?}");
+    assert!(errors[0].contains("field `name`"), "got: {}", errors[0]);
+}
+
+/// The two `model_schema_prop` guards are independent: a refused key does not swallow the
+/// unparseable `pattern` the same attribute already carried.
+#[test]
+fn a_refused_key_and_an_unparseable_pattern_are_both_reported() {
+    let errors = field_prop_guard_errors(&syn::parse_quote! {
+        struct Report {
+            #[model_schema_prop(pattern = r"^ab\", patern = "^[a-z]+$")]
+            name: String,
+        }
+    });
+    assert_eq!(errors.len(), 2, "got: {errors:?}");
+    assert!(errors[0].contains("patern"), "got: {}", errors[0]);
+    assert!(
+        errors[1].contains("regex parse error"),
+        "got: {}",
+        errors[1]
+    );
 }
 
 #[cfg(feature = "serde")]


### PR DESCRIPTION
A misspelled key (patern, minLenght) compiled clean and emitted an unconstrained schema. The parser's silent-drop arms are gone: unknown keys get a spanned error at the ident naming all ten valid keys (the real arm list — as, literal, minLength, maxLength, minimum, maximum, pattern, preprocess, ts_optional, as_number — differed from the task's enumeration), and five more swallow sites now propagate (if-let-Ok on as, base10_parse on both lengths, the non-numeric-literal else on both bounds, the preprocess filter_map). Surfaced through the existing field guard channel; the parse_nested_meta log-trace swallow propagates too.

Red-first at the guard channel; end-to-end proven in a scratch consumer crate (caret under the misspelled key); byte-identity for all ten valid keys proven by an A/B probe against pristine master via git archive — 2779 bytes each, diff clean.

Powerset green in the lane; cheap gate green on the merged state.
