### PR TITLE
fix: a flattened value serde does not write as an object is refused

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,8 @@ export const Internal$Schema: ZodType<Internal> = z.union([
 
 Only a value Serde writes as an object has members to put beside the tag. A newtype variant wrapping a string, a number, a boolean, a sequence, an `Option` or a tuple is one Serde refuses to serialize at run time (`cannot serialize tagged newtype variant ... containing a string`), and a multi-element tuple variant is one Serde's own derive refuses outright. `#[model_schema()]` rejects all of those at expansion rather than describing a value that cannot reach the wire; name a `content` key so the value gets an object of its own, or wrap it in a struct whose fields can sit beside the tag.
 
+A name is not a promise of an object either. A newtype variant wrapping a plain `#[model_schema()]` enum is rejected at expansion the same way: a plain enum writes its own variant name, which Serde puts beside the tag as a key holding null and which a schema closed around the tag rejects. Every other named type -- a struct, a newtype over a scalar -- looks alike to the expansion, so one that turns out not to be written as an object is caught when `json_schema()` runs, with a diagnostic naming the variant, the inner type and the same remedy. The TypeScript and Zod intersections for that case are a known gap: they are written, and only the JSON Schema surface refuses them.
+
 ### Intersection Types (`#[serde(flatten)]`)
 
 A struct field marked `#[serde(flatten)]` is lifted into the parent type as a TypeScript intersection (`A & B`) and a Zod `.and()` chain, instead of a nested object. This is the idiomatic way to compose a common set of fields with a discriminated union.
@@ -423,6 +425,7 @@ Notes:
 - Multiple `#[serde(flatten)]` fields chain: `{ ... } & BasePart & ExtraPart` in TypeScript and `z.strictObject({ ... }).and(BasePart$Schema).and(ExtraPart$Schema)` in Zod.
 - A struct whose only field is flattened becomes a plain alias (e.g. `export type FlattenOnly = DataElementSampleValueVariant;`).
 - **JSON Schema** stays strict: rather than `allOf` (which cannot faithfully compose a tagged union under `additionalProperties: false`), the base properties are distributed into each branch of the flattened union, keeping every branch closed. Plain-struct flattens merge into a single closed object; multiple flattened unions form a cross-product.
+- Only a value Serde writes as an object can be flattened -- Serde refuses the rest at run time (`can only flatten structs and maps`). Flattening a plain `#[model_schema()]` enum is rejected at expansion; any other type that turns out not to be written as an object is caught when `json_schema()` runs, naming the field's type and the remedy (write the field as a named member).
 
 ### Untagged Enums (`#[serde(untagged)]`)
 

--- a/src/features/jsonschema.rs
+++ b/src/features/jsonschema.rs
@@ -5,14 +5,28 @@
 /// What every pointer the crate writes opens with; what follows it is the name being deferred.
 const DEFS_PREFIX: &str = "#/$defs/";
 
-/// How a merge that closes a cycle names itself in the diagnostic it raises.
+/// How a merge that cannot proceed names itself in the diagnostic it raises.
 ///
 /// `subject` is the frame that reads the merge, `edge` what the merged schema was reached through,
-/// and `remedy` the way out in the spelling that applies where that edge was written.
-pub struct MergeCycleDiagnostic<'msg> {
+/// and each remedy the way out in the spelling that applies where that edge was written.
+pub struct MergeDiagnostic<'msg> {
+    /// The way out of a cycle: what makes the edge defer rather than merge.
+    pub cycle_remedy: &'msg str,
     pub edge: &'msg str,
-    pub remedy: &'msg str,
+    /// The way out of a merged value that is not an object: what gives that value a place of its
+    /// own.
+    pub non_object_remedy: &'msg str,
     pub subject: &'msg str,
+}
+
+/// One schema merged into a base, together with how the author named it.
+///
+/// A merged schema is a `serde_json` expression by the time it reaches the merge and no longer
+/// carries the name it came from, so the label travels beside it — it is what a diagnostic points
+/// the author at.
+pub struct MergedSource {
+    pub label: String,
+    pub value: proc_macro2::TokenStream,
 }
 
 /// Check if we should generate JSON schema methods.
@@ -96,7 +110,7 @@ pub fn json_schema_methods(
 /// fields and the flattened union together.
 pub fn generate_struct_json_schema_method(
     json_schema_fields: &[proc_macro2::TokenStream],
-    flatten_json_schemas: &[proc_macro2::TokenStream],
+    flatten_json_schemas: &[MergedSource],
     def_name: &str,
 ) -> proc_macro2::TokenStream {
     let body = if flatten_json_schemas.is_empty() {
@@ -141,73 +155,99 @@ fn closed_object_body(json_schema_fields: &[proc_macro2::TokenStream]) -> proc_m
 ///
 /// A merged schema that is itself a `oneOf` multiplies out rather than collapsing, so each branch
 /// stays a closed object naming exactly the members that branch writes.
+///
+/// Only a value serde writes as an object has members to contribute, and the expansion cannot
+/// always tell which types those are — a name reaches the merge without saying what it writes. The
+/// schema it produces does say, so the merge reads it there: a description naming any type but
+/// `object` is refused rather than merged, which is the last point at which the wrong schema can
+/// still be stopped.
+/// The four things the merge asks of a schema it is handed, as the tokens the merging block opens
+/// with: how two objects join, whether a schema is a deferred name, what type it commits its value
+/// to, and which branches it offers.
+fn merge_readers() -> proc_macro2::TokenStream {
+    let defs_prefix = DEFS_PREFIX;
+    quote::quote! {
+        fn merge_object_schemas(
+            a: &serde_json::Map<String, serde_json::Value>,
+            b: &serde_json::Map<String, serde_json::Value>,
+        ) -> serde_json::Map<String, serde_json::Value> {
+            let mut out = serde_json::Map::new();
+            out.insert("type".to_string(), serde_json::Value::String("object".to_string()));
+            let mut properties = serde_json::Map::new();
+            for src in [a, b] {
+                if let Some(p) = src.get("properties").and_then(serde_json::Value::as_object) {
+                    for (k, v) in p {
+                        properties.insert(k.clone(), v.clone());
+                    }
+                }
+            }
+            out.insert("properties".to_string(), serde_json::Value::Object(properties));
+            let mut required: Vec<serde_json::Value> = Vec::new();
+            for src in [a, b] {
+                if let Some(r) = src.get("required").and_then(serde_json::Value::as_array) {
+                    for item in r {
+                        if !required.contains(item) {
+                            required.push(item.clone());
+                        }
+                    }
+                }
+            }
+            out.insert("required".to_string(), serde_json::Value::Array(required));
+            out.insert("additionalProperties".to_string(), serde_json::Value::Bool(false));
+            out
+        }
+
+        // A flattened base that names itself describes as a reference into the definitions being
+        // hoisted, and a reference is the one thing with no properties to merge. The body it
+        // points at is written by then — the frame that deferred the name fills the entry in
+        // before it returns — so the merge reads it back.
+        fn deferred_name(schema: &serde_json::Value) -> Option<&str> {
+            schema.get("$ref")?.as_str()?.strip_prefix(#defs_prefix)
+        }
+
+        // What a description commits its value to on the wire, when it commits to anything. A
+        // union of branches and a bare reference name no type of their own, and neither is
+        // provably not an object, so both are left to the merge.
+        fn described_type(schema: &serde_json::Value) -> Option<&str> {
+            schema.get("type")?.as_str()
+        }
+
+        fn branches_of(
+            schema: &serde_json::Value,
+        ) -> Vec<serde_json::Map<String, serde_json::Value>> {
+            if let Some(one_of) = schema.get("oneOf").and_then(serde_json::Value::as_array) {
+                one_of.iter().filter_map(|b| b.as_object().cloned()).collect()
+            } else if let Some(obj) = schema.as_object() {
+                vec![obj.clone()]
+            } else {
+                Vec::new()
+            }
+        }
+    }
+}
+
 pub fn merged_object_value(
     base: &proc_macro2::TokenStream,
-    merged: &[proc_macro2::TokenStream],
-    diagnostic: &MergeCycleDiagnostic<'_>,
+    merged: &[MergedSource],
+    diagnostic: &MergeDiagnostic<'_>,
 ) -> proc_macro2::TokenStream {
-    let defs_prefix = DEFS_PREFIX;
-    let MergeCycleDiagnostic {
+    let MergeDiagnostic {
+        cycle_remedy,
         edge,
-        remedy,
+        non_object_remedy,
         subject,
     } = *diagnostic;
+    let labels = merged.iter().map(|source| source.label.as_str());
+    let values = merged.iter().map(|source| &source.value);
+    let readers = merge_readers();
     quote::quote! {
         {
-            fn merge_object_schemas(
-                a: &serde_json::Map<String, serde_json::Value>,
-                b: &serde_json::Map<String, serde_json::Value>,
-            ) -> serde_json::Map<String, serde_json::Value> {
-                let mut out = serde_json::Map::new();
-                out.insert("type".to_string(), serde_json::Value::String("object".to_string()));
-                let mut properties = serde_json::Map::new();
-                for src in [a, b] {
-                    if let Some(p) = src.get("properties").and_then(serde_json::Value::as_object) {
-                        for (k, v) in p {
-                            properties.insert(k.clone(), v.clone());
-                        }
-                    }
-                }
-                out.insert("properties".to_string(), serde_json::Value::Object(properties));
-                let mut required: Vec<serde_json::Value> = Vec::new();
-                for src in [a, b] {
-                    if let Some(r) = src.get("required").and_then(serde_json::Value::as_array) {
-                        for item in r {
-                            if !required.contains(item) {
-                                required.push(item.clone());
-                            }
-                        }
-                    }
-                }
-                out.insert("required".to_string(), serde_json::Value::Array(required));
-                out.insert("additionalProperties".to_string(), serde_json::Value::Bool(false));
-                out
-            }
+            #readers
 
-            // A flattened base that names itself describes as a reference into the definitions
-            // being hoisted, and a reference is the one thing with no properties to merge. The
-            // body it points at is written by then — the frame that deferred the name fills the
-            // entry in before it returns — so the merge reads it back.
-            fn deferred_name(schema: &serde_json::Value) -> Option<&str> {
-                schema.get("$ref")?.as_str()?.strip_prefix(#defs_prefix)
-            }
-
-            fn branches_of(
-                schema: &serde_json::Value,
-            ) -> Vec<serde_json::Map<String, serde_json::Value>> {
-                if let Some(one_of) = schema.get("oneOf").and_then(serde_json::Value::as_array) {
-                    one_of.iter().filter_map(|b| b.as_object().cloned()).collect()
-                } else if let Some(obj) = schema.as_object() {
-                    vec![obj.clone()]
-                } else {
-                    Vec::new()
-                }
-            }
-
-            let flattened: Vec<serde_json::Value> = vec![ #(#merged),* ];
+            let flattened: Vec<(&'static str, serde_json::Value)> = vec![ #((#labels, #values)),* ];
 
             let mut branches: Vec<serde_json::Map<String, serde_json::Value>> = vec![#base];
-            for fs in &flattened {
+            for (label, fs) in &flattened {
                 // An entry still only reserved is this merge coming back around to a name whose
                 // body is still being written: there is nothing to merge, and the type it would
                 // describe has no finite value to inhabit it.
@@ -220,10 +260,22 @@ pub fn merged_object_value(
                             #subject,
                             #edge,
                             name,
-                            #remedy,
+                            #cycle_remedy,
                         ),
                     },
                 };
+                if let Some(named) = described_type(fs_body) {
+                    if named != "object" {
+                        panic!(
+                            "`{}`: {} `{}` is not written as an object — its schema describes a `{}`, which has no members to merge, and what serde writes for it does not join the object being written; {}",
+                            #subject,
+                            #edge,
+                            label,
+                            named,
+                            #non_object_remedy,
+                        );
+                    }
+                }
                 let fs_branches = branches_of(fs_body);
                 if fs_branches.is_empty() {
                     continue;
@@ -260,7 +312,7 @@ pub fn merged_object_value(
 /// is the frame that reads it, and names one end of the closing edge in the diagnostic.
 fn flattened_object_body(
     json_schema_fields: &[proc_macro2::TokenStream],
-    flatten_json_schemas: &[proc_macro2::TokenStream],
+    flatten_json_schemas: &[MergedSource],
     def_name: &str,
 ) -> proc_macro2::TokenStream {
     let base = quote::quote! {
@@ -281,9 +333,10 @@ fn flattened_object_body(
     merged_object_value(
         &base,
         flatten_json_schemas,
-        &MergeCycleDiagnostic {
+        &MergeDiagnostic {
+            cycle_remedy: "write the field as a named member so the cycle defers through a reference",
             edge: "`#[serde(flatten)]` of",
-            remedy: "write the field as a named member so the cycle defers through a reference",
+            non_object_remedy: "write the field as a named member so the value gets a key of its own",
             subject: def_name,
         },
     )

--- a/src/features/jsonschema/tests.rs
+++ b/src/features/jsonschema/tests.rs
@@ -23,7 +23,10 @@ fn test_json_schema_method_flatten_emits_merge() {
     let no_flatten = generate_struct_json_schema_method(&fields, &[], "Node").to_string();
     let with_flatten = generate_struct_json_schema_method(
         &fields,
-        &[quote::quote! { serde_json::json!({ "type": "object" }) }],
+        &[MergedSource {
+            label: "Base".to_owned(),
+            value: quote::quote! { serde_json::json!({ "type": "object" }) },
+        }],
         "Node",
     )
     .to_string();

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -54,13 +54,14 @@ use crate::features::model_schema_prop::ModelSchemaPropMeta;
 
 #[cfg(feature = "jsonschema")]
 use crate::features::jsonschema::{
+    MergedSource,
     generate_plain_enum_json_schema_method as generate_plain_enum_json_schema_method_impl,
     generate_struct_json_schema_method as generate_struct_json_schema_method_impl,
     json_schema_methods,
 };
 
 #[cfg(all(feature = "serde", feature = "jsonschema"))]
-use crate::features::jsonschema::{MergeCycleDiagnostic, merged_object_value};
+use crate::features::jsonschema::{MergeDiagnostic, merged_object_value};
 
 #[cfg(any(feature = "typescript", feature = "zod"))]
 use crate::utils::{get_enum_docs, get_struct_docs, strip_examples_from_docs};
@@ -83,6 +84,15 @@ use crate::utils::register_alias_info;
 use crate::utils::to_snake_case;
 
 use crate::rename_rule::resolve_rename_rule;
+
+/// What every plain-enum flatten diagnostic says about its own reach, so an author who fixes the
+/// one declaration named there knows what was and was not checked around it.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+const FLATTENED_PLAIN_ENUM_SCOPE: &str = "Only a type the registry has already classified reaches this guard; one it has not keeps its \
+     TypeScript and Zod intersection, and is refused by the JSON surface when the merge runs.";
 
 /// One variant of a discriminated enum, carrying everything its union member is rendered from.
 struct DiscriminatedVariant {
@@ -418,6 +428,28 @@ fn alias_target_kind(alias_field_def: &FieldDef) -> AliasKind {
     lookup_alias_info(target_name).map_or(AliasKind::Unknown, |target| target.kind)
 }
 
+/// The name of a flattened value's type when the registry proves that type is a plain enum.
+///
+/// Both flattened positions — an internally tagged newtype variant's content and a
+/// `#[serde(flatten)]` field — put what the value writes into the object being written, so only a
+/// value serde writes as an object belongs there. A plain enum writes its own variant name instead,
+/// which joins nothing and which every closed schema built here rejects.
+///
+/// The registry is the only thing the expansion holds that can rule this out, and it answers for a
+/// name it has already seen: `Unknown` is not a negative, and a struct and a branded newtype
+/// register alike. So this is a partial answer by construction, and the merge is where the rest is
+/// caught.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+fn flattened_plain_enum(inner: &FieldDef) -> Option<&str> {
+    let FieldDefType::SiblingType(name, _) = &inner.field_type else {
+        return None;
+    };
+    (alias_target_kind(inner) == AliasKind::EnumMembers).then_some(name.as_str())
+}
+
 /// The alias schema module is referenced by all three schema features — `typescript` and `zod`
 /// through the alias's registered export name, `jsonschema` through a Rust path to
 /// `#module_ident::Schema::json_schema()`. So the module and its `register_alias_info` call are
@@ -671,12 +703,10 @@ fn build_struct_validate_method(
     })
 }
 
-/// Computes the TypeScript types, Zod schemas, and JSON-schema references contributed by a
-/// struct's `#[serde(flatten)]` fields (empty vectors for any disabled output feature).
-#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-fn compute_flatten_outputs(
-    flattened_fields: &[FieldDef],
-) -> (Vec<String>, Vec<String>, Vec<proc_macro2::TokenStream>) {
+/// Computes the TypeScript types and Zod schemas contributed by a struct's `#[serde(flatten)]`
+/// fields (an empty vector for either disabled output feature).
+#[cfg(any(feature = "typescript", feature = "zod"))]
+fn compute_flatten_outputs(flattened_fields: &[FieldDef]) -> (Vec<String>, Vec<String>) {
     #[cfg(feature = "typescript")]
     let ts_types = flattened_fields
         .iter()
@@ -690,15 +720,43 @@ fn compute_flatten_outputs(
     #[cfg(not(feature = "zod"))]
     let zod_schemas = Vec::new();
 
-    #[cfg(feature = "jsonschema")]
-    let json_schemas = flattened_fields
-        .iter()
-        .map(flatten_field_json_schema_ref)
-        .collect();
-    #[cfg(not(feature = "jsonschema"))]
-    let json_schemas = Vec::new();
+    (ts_types, zod_schemas)
+}
 
-    (ts_types, zod_schemas, json_schemas)
+/// The schema methods a struct's module publishes — the JSON-schema document, the TypeScript
+/// definition, the Zod schema — each built only where its feature is on.
+///
+/// The module emits `zod_schema` without examples; example injection happens in the delegating
+/// method on the type, to avoid `super::` issues.
+///
+/// `flattened_fields` are the ones whose own members join the object the struct writes; every
+/// other field is written under a key of its own.
+#[cfg(any(feature = "zod", feature = "typescript", feature = "jsonschema"))]
+fn struct_schema_impl_items(
+    field_defs: Vec<FieldDef>,
+    flattened_fields: &[FieldDef],
+    item_name: &str,
+    docs: &str,
+) -> Vec<proc_macro2::TokenStream> {
+    #[cfg(not(feature = "typescript"))]
+    let _: &str = docs;
+    // bodies: (type_code, schema_code, json_schema_fields, fields_empty)
+    let bodies = render_struct_field_bodies(field_defs, Some(item_name));
+    // flatten: (ts_types, zod_schemas)
+    #[cfg(any(feature = "typescript", feature = "zod"))]
+    let flatten = compute_flatten_outputs(flattened_fields);
+    vec![
+        #[cfg(feature = "jsonschema")]
+        generate_json_schema_method(
+            &bodies.2,
+            &flatten_merged_sources(flattened_fields),
+            item_name,
+        ),
+        #[cfg(feature = "typescript")]
+        generate_ts_definition_method(docs, item_name, &bodies.0, bodies.3, &flatten.0),
+        #[cfg(feature = "zod")]
+        generate_zod_schema_method(item_name, &bodies.1, "", &flatten.1),
+    ]
 }
 
 /// Renders the per-field TypeScript type code, Zod schema code, and JSON-schema fragments for a
@@ -978,6 +1036,44 @@ fn branded_guard_errors(
         .collect()
 }
 
+/// The `compile_error!` tokens for a `#[serde(flatten)]` field the registry proves is a plain enum,
+/// or `None` for every other field.
+///
+/// Read from the declaration rather than from the collected field so the diagnostic keeps the span
+/// of the type it rejects.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+fn flattened_field_guard_error(
+    field: &syn::Field,
+    type_name: &str,
+) -> Option<proc_macro2::TokenStream> {
+    let inner = get_field_def("_flattened", &field.ty, "");
+    let inner_name = flattened_plain_enum(&inner)?;
+    let field_name = field_label(
+        &field
+            .ident
+            .as_ref()
+            .map_or_else(String::new, ToString::to_string),
+    );
+    Some(
+        syn::Error::new_spanned(
+            &field.ty,
+            format!(
+                "model_schema: {field_name} of `{type_name}` carries `#[serde(flatten)]` over \
+                 `{inner_name}`, which serde does not write as an object: a plain enum writes its \
+                 own variant name, so it contributes no members to the object being written — \
+                 serde writes that name as a key holding null, which a schema closed around the \
+                 remaining fields rejects. Write the field as a named member so the value gets a \
+                 key of its own, or flatten a type serde writes as an object. \
+                 {FLATTENED_PLAIN_ENUM_SCOPE}"
+            ),
+        )
+        .to_compile_error(),
+    )
+}
+
 /// Processes every field of a struct, returning the regular field defs, the `#[serde(flatten)]`
 /// field defs, the per-field serde validation functions and `validate()` body fragments, and the
 /// `compile_error!` tokens for any field-level guard violations.
@@ -998,6 +1094,15 @@ fn collect_struct_fields(
         let is_flatten = parse_serde_field_attributes(&field.attrs).flatten;
         #[cfg(not(feature = "serde"))]
         let is_flatten = false;
+
+        // Read before the field is processed, which strips the attributes the declaration carried.
+        #[cfg(all(
+            feature = "serde",
+            any(feature = "typescript", feature = "zod", feature = "jsonschema")
+        ))]
+        if is_flatten {
+            guard_errors.extend(flattened_field_guard_error(field, type_name));
+        }
 
         let (f_def, validation_fn, validate_body, field_guard_errors) =
             process_field(rename_all, field, module_name_opt, None, type_name);
@@ -1144,7 +1249,7 @@ fn process_struct(mut item_struct: syn::ItemStruct, args: &ModelSchemaArgs) -> T
     // `Some(..)` selects schema-module-aware field processing; `None` (no schema output feature)
     // skips it so generated code never references a module that won't be emitted.
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-    let (module_name_opt, item_name_opt) = (Some(module_name.as_str()), Some(item_name.as_str()));
+    let module_name_opt = Some(module_name.as_str());
     #[cfg(not(any(feature = "typescript", feature = "zod", feature = "jsonschema")))]
     let module_name_opt: Option<&str> = None;
 
@@ -1169,24 +1274,14 @@ fn process_struct(mut item_struct: syn::ItemStruct, args: &ModelSchemaArgs) -> T
 
     #[cfg(feature = "typescript")]
     let docs = build_item_jsdoc(docs_and_example.0.as_deref(), &name);
+    #[cfg(all(
+        not(feature = "typescript"),
+        any(feature = "zod", feature = "jsonschema")
+    ))]
+    let docs = String::new();
 
-    // Generate the schema module methods. The schema module emits zod_schema without examples;
-    // example injection happens in the delegating method on the type to avoid `super::` issues.
     #[cfg(any(feature = "zod", feature = "typescript", feature = "jsonschema"))]
-    let schema_impl_items: Vec<proc_macro2::TokenStream> = {
-        // bodies: (type_code, schema_code, json_schema_fields, fields_empty)
-        let bodies = render_struct_field_bodies(collected.0, item_name_opt);
-        // flatten: (ts_types, zod_schemas, json_schemas)
-        let flatten = compute_flatten_outputs(&collected.1);
-        vec![
-            #[cfg(feature = "jsonschema")]
-            generate_json_schema_method(&bodies.2, &flatten.2, &item_name),
-            #[cfg(feature = "typescript")]
-            generate_ts_definition_method(&docs, &item_name, &bodies.0, bodies.3, &flatten.0),
-            #[cfg(feature = "zod")]
-            generate_zod_schema_method(&item_name, &bodies.1, "", &flatten.1),
-        ]
-    };
+    let schema_impl_items = struct_schema_impl_items(collected.0, &collected.1, &item_name, &docs);
 
     // schema_example must be directly on the type (not in the module) because the example code
     // uses type names that may not be accessible from the nested module.
@@ -3366,7 +3461,22 @@ fn internally_tagged_guard_errors(
             // An empty tuple variant carries nothing: serde writes it as the tag alone, which is
             // what the unit arm already describes.
             let field = unnamed.unnamed.first()?;
-            let message = match tagged_content(&get_field_def("_inner", &field.ty, "")) {
+            let inner = get_field_def("_inner", &field.ty, "");
+            let message = match tagged_content(&inner) {
+                #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+                TaggedContent::Flattened => {
+                    let inner_name = flattened_plain_enum(&inner)?;
+                    format!(
+                        "model_schema: variant `{variant_name}` of internally tagged enum \
+                         `{enum_name}` wraps `{inner_name}`, which serde does not write as an \
+                         object: a plain enum writes its own variant name, so nothing of it joins \
+                         the tag — serde writes that name as a key holding null, which a schema \
+                         closed around the tag rejects. Name a `content` key so the value gets an \
+                         object of its own, or wrap it in a struct whose fields can sit beside the \
+                         tag. {FLATTENED_PLAIN_ENUM_SCOPE}"
+                    )
+                }
+                #[cfg(not(any(feature = "typescript", feature = "zod", feature = "jsonschema")))]
                 TaggedContent::Flattened => return None,
                 TaggedContent::Refused(shape) => format!(
                     "model_schema: variant `{variant_name}` of internally tagged enum \
@@ -3454,10 +3564,11 @@ fn render_internal_variant(
             &tag_object,
             // The same reference a `#[serde(flatten)]` base contributes: both name a type whose
             // members join the object being written.
-            &[flatten_field_json_schema_ref(inner)],
-            &MergeCycleDiagnostic {
+            &[flatten_merged_source(inner)],
+            &MergeDiagnostic {
+                cycle_remedy: "name a `content` key so the content gets an object of its own",
                 edge: &format!("the content of variant `{variant_name}`,"),
-                remedy: "name a `content` key so the content gets an object of its own",
+                non_object_remedy: "name a `content` key so the content gets an object of its own",
                 subject: self_type_name,
             },
         )
@@ -6399,18 +6510,33 @@ fn get_final_variant_name(
 /// Generates the JSON schema method conditionally based on the jsonschema feature.
 fn generate_json_schema_method(
     json_schema_fields: &[proc_macro2::TokenStream],
-    flatten_json_schemas: &[proc_macro2::TokenStream],
+    flatten_json_schemas: &[MergedSource],
     def_name: &str,
 ) -> proc_macro2::TokenStream {
     generate_struct_json_schema_method_impl(json_schema_fields, flatten_json_schemas, def_name)
 }
 
+/// What a struct's `#[serde(flatten)]` fields contribute to the object it writes.
 #[cfg(feature = "jsonschema")]
-fn flatten_field_json_schema_ref(fld: &FieldDef) -> proc_macro2::TokenStream {
+fn flatten_merged_sources(flattened_fields: &[FieldDef]) -> Vec<MergedSource> {
+    flattened_fields.iter().map(flatten_merged_source).collect()
+}
+
+/// What a value whose members join the object being written contributes to it, labelled with the
+/// name the author gave it: the type for a named one, the field otherwise — a shape with no name of
+/// its own is only ever pointed at through where it was written.
+#[cfg(feature = "jsonschema")]
+fn flatten_merged_source(fld: &FieldDef) -> MergedSource {
     if let FieldDefType::SiblingType(name, _) = &fld.field_type {
-        sibling_json_schema_value(name, fld.type_span)
+        MergedSource {
+            label: name.clone(),
+            value: sibling_json_schema_value(name, fld.type_span),
+        }
     } else {
-        quote! { serde_json::json!({ "type": "object" }) }
+        MergedSource {
+            label: fld.name.clone(),
+            value: quote! { serde_json::json!({ "type": "object" }) },
+        }
     }
 }
 

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -418,6 +418,97 @@ fn internally_tagged_empty_tuple_variant_is_accepted() {
     assert!(errors.is_empty(), "got: {errors:?}");
 }
 
+/// A name is not the criterion — what serde writes for it is. A plain enum writes its own variant
+/// name, which joins no object, and the registry is where the expansion learns that.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn internally_tagged_newtype_over_a_registered_plain_enum_is_rejected() {
+    register_alias_info("Hue", "Hue", "hue_schema", AliasKind::EnumMembers);
+    let errors = internal_guard_errors(&syn::parse_quote! {
+        enum E { V(Hue) }
+    });
+    assert_eq!(errors.len(), 1, "got: {errors:?}");
+    assert!(errors[0].contains("variant `V`"), "got: {}", errors[0]);
+    assert!(errors[0].contains("`Hue`"), "got: {}", errors[0]);
+    assert!(
+        errors[0].contains("does not write as an object"),
+        "got: {}",
+        errors[0]
+    );
+    assert!(
+        errors[0].contains("Name a `content` key"),
+        "got: {}",
+        errors[0]
+    );
+}
+
+/// The two answers that leave the declaration alone: a type the registry rules out, and one it has
+/// never seen. Neither is a plain enum as far as this expansion can tell, and an `Unknown` is not a
+/// negative — it reaches the merge, which reads the schema instead of the name.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn internally_tagged_newtype_over_a_non_enum_or_unknown_name_is_accepted() {
+    register_alias_info(
+        "Payload",
+        "Payload",
+        "payload_schema",
+        AliasKind::NoEnumMembers,
+    );
+    for source in ["enum E { V(Payload) }", "enum E { V(NeverRegistered) }"] {
+        let errors = internal_guard_errors(&syn::parse_str(source).unwrap());
+        assert!(errors.is_empty(), "got: {errors:?} for {source}");
+    }
+}
+
+/// The same criterion at the other flattened position: a `#[serde(flatten)]` field puts what its
+/// type writes into the object being written, so a plain enum has nothing to put there either.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn flattening_a_registered_plain_enum_is_rejected() {
+    register_alias_info("Hue", "Hue", "hue_schema", AliasKind::EnumMembers);
+    register_alias_info(
+        "Payload",
+        "Payload",
+        "payload_schema",
+        AliasKind::NoEnumMembers,
+    );
+
+    let rejected: syn::Field = syn::parse_quote! { pub tone: Hue };
+    let error = super::flattened_field_guard_error(&rejected, "Holder")
+        .map(|tokens| tokens.to_string())
+        .unwrap_or_default();
+    assert!(error.contains("field `tone`"), "got: {error}");
+    assert!(error.contains("`Holder`"), "got: {error}");
+    assert!(error.contains("`Hue`"), "got: {error}");
+    assert!(error.contains("#[serde(flatten)]"), "got: {error}");
+    assert!(
+        error.contains("does not write as an object"),
+        "got: {error}"
+    );
+
+    for accepted in [
+        syn::parse_quote! { pub body: Payload },
+        syn::parse_quote! { pub body: NeverRegistered },
+        syn::parse_quote! { pub tones: Vec<Hue> },
+    ] {
+        let field: syn::Field = accepted;
+        assert!(
+            super::flattened_field_guard_error(&field, "Holder").is_none(),
+            "got a rejection for {}",
+            quote::ToTokens::to_token_stream(&field)
+        );
+    }
+}
+
 /// Collects an enum's `cfg_attr` guard failures as rendered `compile_error!` token strings.
 #[cfg(feature = "serde")]
 fn enum_cfg_attr_errors(item: &syn::ItemEnum) -> Vec<String> {

--- a/tests/flatten_tests/tests.rs
+++ b/tests/flatten_tests/tests.rs
@@ -103,6 +103,36 @@ struct NoFlatten {
     name: String,
 }
 
+/// A plain enum flattened into a struct. Declared without `#[model_schema()]`: a plain enum writes
+/// its own variant name rather than an object, so the crate refuses the declaration and the wire
+/// form is only readable from a plain serde type.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+enum FlatHue {
+    Red,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct FlatOverEnum {
+    own: String,
+    #[serde(flatten)]
+    tone: FlatHue,
+}
+
+/// A newtype over a `String` flattened into a struct: serde writes it as the string it wraps, and
+/// the registry cannot tell it apart from a struct — both register as having no enum members. So
+/// the declaration compiles and the divergence is left for the merge to catch.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct FlatSlug(String);
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct FlatOverBrand {
+    own: String,
+    #[serde(flatten)]
+    slug: FlatSlug,
+}
+
 #[test]
 fn test_flatten_structs_constructible() {
     let base = BasePart {
@@ -409,4 +439,53 @@ fn test_flatten_recursive_base_serializes_flat() {
 
     let back: FlatHolder = serde_json::from_value(json).unwrap();
     assert_eq!(back, holder);
+}
+
+/// What serde writes for a flattened plain enum: the enum's own variant name, as a key holding
+/// null. No schema closed around the struct's remaining fields names that key, which is why the
+/// declaration is refused rather than described.
+#[test]
+fn test_flattening_a_plain_enum_writes_a_key_the_struct_does_not_name() {
+    assert_eq!(
+        serde_json::to_value(FlatOverEnum {
+            own: "o".to_owned(),
+            tone: FlatHue::Red,
+        })
+        .unwrap(),
+        serde_json::json!({ "own": "o", "Red": null })
+    );
+}
+
+/// And what serde writes for a flattened newtype that reaches the wire as a string — nothing. A
+/// name got this one past the declaration guard; the value never reaches the wire at all.
+#[test]
+fn test_flattening_a_string_newtype_is_unserializable() {
+    let refusal = serde_json::to_value(FlatOverBrand {
+        own: "o".to_owned(),
+        slug: FlatSlug("s".to_owned()),
+    })
+    .unwrap_err()
+    .to_string();
+    assert!(
+        refusal.contains("can only flatten structs and maps"),
+        "Got: {refusal}"
+    );
+}
+
+/// So the merge refuses it too, rather than closing the object around the fields that are left.
+#[test]
+#[cfg(feature = "jsonschema")]
+#[should_panic(
+    expected = "`FlatOverBrand`: `#[serde(flatten)]` of `FlatSlug` is not written as an object"
+)]
+fn test_flattening_a_string_newtype_is_refused_by_the_merge() {
+    assert!(FlatOverBrand::json_schema().is_object());
+}
+
+/// The remedy the refusal names is one the author can act on.
+#[test]
+#[cfg(feature = "jsonschema")]
+#[should_panic(expected = "write the field as a named member so the value gets a key of its own")]
+fn test_the_flatten_merge_refusal_names_the_remedy() {
+    assert!(FlatOverBrand::json_schema().is_object());
 }

--- a/tests/tuple_variant_tests/tests.rs
+++ b/tests/tuple_variant_tests/tests.rs
@@ -116,6 +116,34 @@ pub enum InternalScalar {
     Single(String),
 }
 
+/// A plain enum, and a bare tag over it. Also declared without `#[model_schema()]`: a name says
+/// nothing about what serde writes for it, and this one writes no object, so the crate refuses the
+/// declaration — leaving the wire form readable only from a plain serde type.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub enum InternalHue {
+    Red,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(tag = "type")]
+pub enum InternalOverEnum {
+    EnumInner(InternalHue),
+}
+
+/// A newtype over a `String`: serde writes it as the string it wraps, and the registry cannot tell
+/// it apart from a struct — both register as having no enum members. So the declaration compiles
+/// and the divergence is left for the merge to catch.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct InternalSlug(pub String);
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(tag = "type")]
+pub enum InternalOverBrand {
+    Branded(InternalSlug),
+}
+
 /// A recursive enum with no tagging attributes: what sits under a key is the enum itself. Only the
 /// Zod surface spells the deferral, so the fixture is declared where it is read.
 #[cfg(feature = "zod")]
@@ -1676,4 +1704,62 @@ fn test_adjacent_twin_keeps_its_content_key() {
 
     let ts = Adjacent::ts_definition();
     assert!(ts.contains("value: string"), "Got: {ts}");
+}
+
+/// Test 22h: what serde writes for a bare tag over a plain enum. The enum writes its own variant
+/// name, so what lands beside the tag is a key holding null — a key no member closed around the tag
+/// names, which is why the declaration is refused rather than described.
+#[test]
+fn test_bare_tag_over_a_plain_enum_writes_a_key_the_tag_does_not_name() {
+    assert_eq!(
+        serde_json::to_value(InternalOverEnum::EnumInner(InternalHue::Red)).unwrap(),
+        serde_json::json!({ "type": "EnumInner", "Red": null })
+    );
+}
+
+/// Test 22i: and what serde writes for a bare tag over a newtype that reaches the wire as a string
+/// — nothing. The run-time refusal is the same one every scalar content gets; the name in front of
+/// it is all that let this one past the declaration guard.
+#[test]
+fn test_bare_tag_over_a_string_newtype_is_unserializable() {
+    let refusal = serde_json::to_value(InternalOverBrand::Branded(InternalSlug("s".to_owned())))
+        .unwrap_err()
+        .to_string();
+    assert!(
+        refusal.contains("cannot serialize tagged newtype variant"),
+        "Got: {refusal}"
+    );
+    assert!(refusal.contains("containing a string"), "Got: {refusal}");
+}
+
+/// Test 22j: so the merge refuses it too, rather than closing the object around the tag alone. The
+/// schema the content resolves to is what says it, and it is read at the moment the wrong document
+/// would otherwise be written.
+#[cfg(feature = "jsonschema")]
+#[test]
+#[should_panic(
+    expected = "`InternalOverBrand`: the content of variant `Branded`, `InternalSlug` is not written as an object"
+)]
+fn test_bare_tag_over_a_string_newtype_is_refused_by_the_merge() {
+    assert!(InternalOverBrand::json_schema().is_object());
+}
+
+/// Test 22k: the remedy the refusal names is one the author can act on.
+#[cfg(feature = "jsonschema")]
+#[test]
+#[should_panic(expected = "name a `content` key so the content gets an object of its own")]
+fn test_the_merge_refusal_names_the_remedy() {
+    assert!(InternalOverBrand::json_schema().is_object());
+}
+
+/// Test 22l: a struct inner is untouched by either refusal — the document a bare tag wrote before
+/// them, byte for byte. Only the flattened member goes through the merge, which is why only it
+/// carries the merge's own `"type": "object"`.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn test_bare_tag_over_a_struct_documents_byte_identically() {
+    assert_eq!(
+        serde_json::to_string(&Internal::json_schema()).unwrap(),
+        r#"{"type":"object","oneOf":[{"additionalProperties":false,"properties":{"type":{"type":"string","const":"Bare"}},"required":["type"]},{"additionalProperties":false,"properties":{"type":{"type":"string","const":"Fields"},"a":{"type":"string"},"b":{"type":"boolean"}},"required":["type","a","b"]},{"type":"object","properties":{"type":{"type":"string","const":"Wrapped"},"a":{"type":"string"},"b":{"type":"boolean"}},"required":["type","a","b"],"additionalProperties":false}]}"#
+    );
 }


### PR DESCRIPTION
The flattened arm (internal tagging's newtype content and #[serde(flatten)] fields) admitted any named type — a plain enum's variant-name wire form and a brand's scalar got schemas nothing can inhabit. Two layers, both landed:

Layer 1 (expansion): where the registry already classified the name, AliasKind::EnumMembers drives a spanned refusal at both flattened positions, read from the declaration before attributes are stripped. The powerset asymmetry (compiles serde-only, refused with schemas on) was verified as existing crate precedent — the enum-key map guard ships the identical shape — not argued.

Layer 2 (merge): MergeCycleDiagnostic generalized to MergeDiagnostic (two remedies) and merged sources now travel with their author-facing label; the emitted merge refuses any resolved body whose type names anything but object, naming the source. Bodies with no type key (anyOf, bare $ref) are deliberately left — not provably non-object (follow-through filed).

Captures re-confirmed all four divergences first; byte-identity for internal-tagging-over-struct proven via git-archive A/B.

Powerset green in the lane; cheap gate green on the merged state.
