### PR TITLE
fix: the non-enum map-key guard answers for every surface, not only jsonschema

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -251,7 +251,7 @@ enum MapMemberRejection {
 ///
 /// Every position a map is written in reads its key through this one classification, so a key
 /// cannot enumerate its members in field position and stay open in a slot.
-#[cfg(feature = "jsonschema")]
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 enum MapKeyPath<'key> {
     /// A key named by a type path, whose `enum_members()` become the object's keys.
     Enumerated(&'key str),
@@ -433,6 +433,20 @@ fn alias_target_kind(alias_field_def: &FieldDef) -> AliasKind {
     lookup_alias_info(target_name).map_or(AliasKind::Unknown, |target| target.kind)
 }
 
+/// The `compile_error!` tokens an alias whose target reaches a map key with no `enum_members()`
+/// earns, or `None` when it reaches none. Spanned on the target, which is where the key was
+/// written.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn alias_map_key_guard_error(
+    alias: &ItemType,
+    export_name: &str,
+    alias_field_def: &FieldDef,
+) -> Option<proc_macro2::TokenStream> {
+    let key_type_name = non_enum_map_key(alias_field_def)?;
+    let message = non_enum_map_key_message(&format!("type alias `{export_name}`"), key_type_name);
+    Some(syn::Error::new_spanned(&alias.ty, message).to_compile_error())
+}
+
 /// The alias schema module is referenced by all three schema features — `typescript` and `zod`
 /// through the alias's registered export name, `jsonschema` through a Rust path to
 /// `#module_ident::Schema::json_schema()`. So the module and its `register_alias_info` call are
@@ -456,6 +470,14 @@ fn process_type_alias(item_type: ItemType, args: &ModelSchemaArgs) -> TokenStrea
     let alias_field_def = get_field_def(export_name.as_str(), &alias.ty, "");
     let kind = alias_target_kind(&alias_field_def);
     register_alias_info(&rust_ident_str, &export_name, &module_name, kind);
+
+    // Registered above whatever the outcome, so a type naming a refused alias still resolves to the
+    // export name the author wrote and the alias's own diagnostic stays the one they act on.
+    if let Some(error) = alias_map_key_guard_error(&alias, &export_name, &alias_field_def)
+        && let Some(output) = guard_failure_output(&alias, &[error])
+    {
+        return output;
+    }
 
     let ts_method = generate_alias_ts_definition_method(&alias, &export_name, &alias_field_def);
     let json_schema_method =
@@ -4810,7 +4832,7 @@ fn tuple_json_schema_value(
 ///
 /// Only a bare type path can name an enum: a generic spelling is a type this expansion has no
 /// `enum_members()` for, and every other type names keys the schema cannot enumerate.
-#[cfg(feature = "jsonschema")]
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 const fn map_key_path(key: &FieldDef) -> MapKeyPath<'_> {
     match &key.field_type {
         FieldDefType::String => MapKeyPath::Open,
@@ -4843,6 +4865,104 @@ const fn map_key_path(key: &FieldDef) -> MapKeyPath<'_> {
         | FieldDefType::NaiveDateTime
         | FieldDefType::NaiveTime => MapKeyPath::Unnarrowed,
     }
+}
+
+/// The name a map key carries when the registry proves it has no `enum_members()`, and `None` for
+/// every key that may still have them.
+///
+/// Only a target the registry positively rules out is named: an unregistered name — a foreign
+/// type, or one expanded after the type that writes the map — cannot be ruled out at this
+/// expansion, and is left alone.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn key_without_enum_members(key: &FieldDef) -> Option<&str> {
+    let MapKeyPath::Enumerated(key_type_name) = map_key_path(key) else {
+        return None;
+    };
+    proves_no_enum_members(key_type_name).then_some(key_type_name)
+}
+
+/// Whether the registry rules the named type out as a source of `enum_members()`. `false` covers
+/// both the plain enums that have them and the names this expansion never saw registered.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn proves_no_enum_members(key_type_name: &str) -> bool {
+    lookup_alias_info(key_type_name)
+        .is_some_and(|key_alias| key_alias.kind == AliasKind::NoEnumMembers)
+}
+
+/// The name of the first map key this field reaches, at any depth, that the registry proves has no
+/// `enum_members()`.
+///
+/// Every surface names such a key: TypeScript writes it as a `Record`'s key type, Zod as a
+/// `z.record` key schema, and the JSON schema calls `enum_members()` on it to spell the object's
+/// properties. So the key is answered for once, off the field all three render from, rather than
+/// by whichever of them a build happens to enable.
+///
+/// Recurses through `SiblingType` generics, `Map` keys/values, and `Tuple` elements — the walk
+/// [`FieldDef::os_string_name`] makes. What position the map sits in is not what decides whether
+/// its key can enumerate.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn non_enum_map_key(fld: &FieldDef) -> Option<&str> {
+    match &fld.field_type {
+        FieldDefType::Map(key, value) => key_without_enum_members(key)
+            .or_else(|| non_enum_map_key(key))
+            .or_else(|| non_enum_map_key(value)),
+        FieldDefType::SiblingType(_, generics) => generics.iter().find_map(non_enum_map_key),
+        FieldDefType::Tuple(elements) => elements.iter().find_map(non_enum_map_key),
+        FieldDefType::Unknown
+        | FieldDefType::StringLiteral(_)
+        | FieldDefType::Boolean
+        | FieldDefType::String
+        | FieldDefType::U8
+        | FieldDefType::U16
+        | FieldDefType::U32
+        | FieldDefType::U64
+        | FieldDefType::I8
+        | FieldDefType::I16
+        | FieldDefType::I32
+        | FieldDefType::I64
+        | FieldDefType::Usize
+        | FieldDefType::Isize
+        | FieldDefType::F32
+        | FieldDefType::F64 => None,
+        #[cfg(feature = "object_id")]
+        FieldDefType::ObjectId => None,
+        #[cfg(feature = "chrono")]
+        FieldDefType::NaiveDate
+        | FieldDefType::NaiveTime
+        | FieldDefType::NaiveDateTime
+        | FieldDefType::DateTime => None,
+    }
+}
+
+/// What a key with no members is reported as. The `subject` names where the map was written — a
+/// field, an alias — which is what the author can act on and all that differs between them.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn non_enum_map_key_message(subject: &str, key_type_name: &str) -> String {
+    format!(
+        "{subject}: a map key must be a plain `#[model_schema()]` enum, whose members become the object's keys — `{key_type_name}` resolves to a type with no `enum_members()`"
+    )
+}
+
+/// Rejects a field reaching a map key the registry proves carries no `enum_members()`.
+///
+/// Those members are what every surface writes the map's keys from, so a key that has none leaves
+/// each of them describing an object whose keys nothing can supply — and leaves the JSON schema
+/// calling a method the author never wrote, which rustc blames `#[model_schema()]` for. The key is
+/// written as a *type path*, which resolves through any alias, so an alias of a non-enum is named
+/// here as the alias the author wrote.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn check_non_enum_map_key(
+    field: &Field,
+    field_def: &FieldDef,
+    label: &str,
+) -> Result<(), syn::Error> {
+    let Some(key_type_name) = non_enum_map_key(field_def) else {
+        return Ok(());
+    };
+    Err(syn::Error::new_spanned(
+        field,
+        non_enum_map_key_message(label, key_type_name),
+    ))
 }
 
 /// The `json!` literal a map whose keys cannot be narrowed describes as: an object, with nothing
@@ -5020,9 +5140,9 @@ fn build_map_member_schema(
 #[cfg(feature = "jsonschema")]
 fn map_member_rejection_message(subject: &str, rejection: &MapMemberRejection) -> String {
     match rejection {
-        MapMemberRejection::NonEnumKey(key_type_name) => format!(
-            "{subject}: a map key must be a plain `#[model_schema()]` enum, whose members become the object's keys — `{key_type_name}` resolves to a type with no `enum_members()`"
-        ),
+        MapMemberRejection::NonEnumKey(key_type_name) => {
+            non_enum_map_key_message(subject, key_type_name)
+        }
         MapMemberRejection::Tuple => format!(
             "{subject}: a tuple is not supported as a map value — give the value a `#[model_schema()]` struct instead"
         ),
@@ -5087,19 +5207,18 @@ fn build_enum_key_map_member_item(value: &FieldDef) -> Result<MapMemberItem, Map
 /// in: a field's insertion, a member of an enclosing map, a tuple's `prefixItems` slot. A key that
 /// enumerates its members therefore enumerates them at any depth.
 ///
-/// The key is written as a *type path*, which resolves through any alias, so an alias of a non-enum
-/// lands on a type with no `enum_members()` and rustc blames `#[model_schema()]` for a method the
-/// author never wrote. Only a target the registry positively rules out is turned away here: an
-/// unregistered name — a foreign type, or one expanded after this struct — stays on the emitting
-/// path, where it behaves as it always has.
+/// [`check_non_enum_map_key`] walks every field an item renders from and drops the whole schema
+/// surface when one reaches a key with no members, so no such key should arrive here. The question
+/// is asked again because the `enum_members()` call is *this* function's to emit, and it is only
+/// sound for a key that has them: whatever reaches this dispatch, a key the registry rules out
+/// leaves with a diagnostic naming it rather than with rustc blaming `#[model_schema()]` for a
+/// method the author never wrote.
 #[cfg(feature = "jsonschema")]
 fn enum_key_map_json_schema_value(
     key_type_name: &str,
     value: &FieldDef,
 ) -> Result<proc_macro2::TokenStream, MapMemberRejection> {
-    if lookup_alias_info(key_type_name)
-        .is_some_and(|key_alias| key_alias.kind == AliasKind::NoEnumMembers)
-    {
+    if proves_no_enum_members(key_type_name) {
         return Err(MapMemberRejection::NonEnumKey(key_type_name.to_owned()));
     }
 
@@ -6060,12 +6179,14 @@ fn field_guard_errors(
         .collect()
 }
 
-/// Every guard error the field violates: the `OsString` guard first — it reads the written type,
-/// which no attribute can hide — then the unparseable `pattern`, then the serde-side guards when
-/// any fired.
+/// Every guard error the field violates: the two the written type earns — the `OsString` guard and
+/// the map-key guard, neither of which any attribute can hide — then the unparseable `pattern`,
+/// then the serde-side guards when any fired.
 ///
 /// The `pattern` guard stands under every feature subset: the string reaches the Rust validator,
 /// the Zod literal and the JSON schema alike, and no toggle makes an unparseable one mean anything.
+/// The map-key guard stands under every subset that emits a schema at all, which is the same set
+/// the registry it reads is populated under.
 fn collect_field_guard_errors(
     field: &Field,
     field_def: &FieldDef,
@@ -6074,10 +6195,19 @@ fn collect_field_guard_errors(
     serde_guard_errors: Vec<proc_macro2::TokenStream>,
 ) -> Vec<proc_macro2::TokenStream> {
     let label = field_label(raw_field_ident);
+
+    #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+    let map_key_error = check_non_enum_map_key(field, field_def, &label)
+        .err()
+        .map(|err| err.to_compile_error());
+    #[cfg(not(any(feature = "typescript", feature = "zod", feature = "jsonschema")))]
+    let map_key_error: Option<proc_macro2::TokenStream> = None;
+
     check_os_string_field(field, field_def, &label)
         .err()
         .map(|err| err.to_compile_error())
         .into_iter()
+        .chain(map_key_error)
         .chain(pattern_rejection.map(|rejection| pattern_guard_error(rejection, &label)))
         .chain(serde_guard_errors)
         .collect()
@@ -6183,6 +6313,11 @@ fn process_field(
     // Create the field definition and apply any model_schema_prop overrides
     let mut field_def = get_field_def(&final_name, field_type, &field_docs);
 
+    // Resolve `Self` references to the concrete type name so recursive fields
+    // (e.g. `Vec<Self>`) are treated exactly like `Vec<EnclosingType>`. Resolved before the guards
+    // read the field so each one asks its question of the type the surfaces will render.
+    field_def.resolve_self_references(type_name);
+
     #[cfg(feature = "serde")]
     let serde_guard_errors = field_guard_errors(
         field,
@@ -6202,9 +6337,6 @@ fn process_field(
         serde_guard_errors,
     );
 
-    // Resolve `Self` references to the concrete type name so recursive fields
-    // (e.g. `Vec<Self>`) are treated exactly like `Vec<EnclosingType>`.
-    field_def.resolve_self_references(type_name);
     field_def.model_schema_prop_meta = (model_schema_prop_meta.as_type.is_some()
         || model_schema_prop_meta.literal.is_some()
         || model_schema_prop_meta.min_length.is_some()

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -14,7 +14,10 @@ use super::{
 };
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-use super::{AliasKind, branded_guard_errors, register_alias_info};
+use super::{
+    AliasKind, alias_map_key_guard_error, branded_guard_errors, check_non_enum_map_key,
+    register_alias_info,
+};
 
 #[cfg(feature = "typescript")]
 use super::tuple_struct_ts_body;
@@ -573,6 +576,99 @@ fn a_path_field_is_left_alone() {
         });
         assert!(error.is_none(), "for {ty}, got: {error:?}");
     }
+}
+
+/// Runs the field walk the way [`super::process_field`] does and renders the map-key guard failure
+/// the field's written type earns, or the empty string when it earns none.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn field_map_key_error(field_type: &proc_macro2::TokenStream) -> String {
+    let item: syn::ItemStruct = syn::parse_quote! {
+        struct Report {
+            counts: #field_type,
+        }
+    };
+    let field = item.fields.iter().next().unwrap();
+    let field_def = get_field_def("counts", &field.ty, "");
+    check_non_enum_map_key(field, &field_def, &field_label("counts"))
+        .err()
+        .map_or_else(String::new, |err| err.to_compile_error().to_string())
+}
+
+/// The registry proves a struct-keyed map has no members to name, and it proves it whatever surface
+/// is being generated: the key is read off the field every one of them renders from, so the same
+/// source cannot be a schema under one feature set and a refusal under another.
+///
+/// Every depth the key can be written at is covered, those being the positions the surfaces reach
+/// it through: a field's own map, a map nested under either key flavor, a tuple slot, a sequence
+/// wrapper, and a sibling's generic argument.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn a_map_key_proved_to_lack_enum_members_is_refused_wherever_it_is_written() {
+    register_alias_info("Doc", "Doc", "doc_schema", AliasKind::NoEnumMembers);
+    register_alias_info("Slot", "Slot", "slot_schema", AliasKind::EnumMembers);
+    for field_type in [
+        quote::quote! { HashMap<Doc, u32> },
+        quote::quote! { HashMap<String, HashMap<Doc, u32>> },
+        quote::quote! { HashMap<Slot, HashMap<Doc, u32>> },
+        quote::quote! { Vec<HashMap<Doc, u32>> },
+        quote::quote! { Option<HashMap<Doc, u32>> },
+        quote::quote! { (String, HashMap<Doc, u32>) },
+        quote::quote! { Wrapper<HashMap<Doc, u32>> },
+        quote::quote! { HashMap<Doc, HashMap<Doc, u32>> },
+    ] {
+        let error = field_map_key_error(&field_type);
+        assert!(error.contains("compile_error"), "for {field_type}: {error}");
+        assert!(
+            error.contains("field `counts`"),
+            "for {field_type}: {error}"
+        );
+        assert!(
+            error.contains("a map key must be a plain"),
+            "for {field_type}: {error}"
+        );
+        assert!(error.contains("Doc"), "for {field_type}: {error}");
+    }
+}
+
+/// The guard is a filter, never a rewrite: a key the registry names as a plain enum, one it never
+/// saw registered, and one no position enumerates all keep the field they had.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn a_map_key_that_may_have_enum_members_is_left_alone() {
+    register_alias_info("Slot", "Slot", "slot_schema", AliasKind::EnumMembers);
+    for field_type in [
+        quote::quote! { HashMap<Slot, u32> },
+        quote::quote! { HashMap<String, u32> },
+        quote::quote! { HashMap<Ghost, u32> },
+        quote::quote! { HashMap<u32, u64> },
+        quote::quote! { HashMap<String, HashMap<Slot, u32>> },
+    ] {
+        let error = field_map_key_error(&field_type);
+        assert!(error.is_empty(), "for {field_type}, got: {error}");
+    }
+}
+
+/// An alias publishes the target type's own schema, so a target reaching a key with no members
+/// leaves every surface naming keys nothing can supply — the same refusal a field of that type
+/// earns, named for the alias the author wrote.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn an_alias_targeting_a_map_key_with_no_members_is_refused() {
+    register_alias_info("Doc", "Doc", "doc_schema", AliasKind::NoEnumMembers);
+    let alias: syn::ItemType = syn::parse_quote! {
+        pub type CountsByDoc = HashMap<Doc, u32>;
+    };
+    let field_def = get_field_def("CountsByDocType", &alias.ty, "");
+    let error = alias_map_key_guard_error(&alias, "CountsByDocType", &field_def)
+        .unwrap_or_default()
+        .to_string();
+    assert!(error.contains("compile_error"), "got: {error}");
+    assert!(
+        error.contains("type alias `CountsByDocType`"),
+        "got: {error}"
+    );
+    assert!(error.contains("a map key must be a plain"), "got: {error}");
+    assert!(error.contains("Doc"), "got: {error}");
 }
 
 /// Runs the field walk the way [`super::process_field`] does and renders the guard failures its


### PR DESCRIPTION
The guard lived inside the jsonschema renderer, so with that feature off TS/Zod rendered Record/z.record keyed by a type with no members. MapKeyPath and map_key_path lifted to any(typescript,zod,jsonschema); a new feature-independent field guard (non_enum_map_key walking SiblingType generics, map keys/values, and tuple elements — the os_string_name walk) wires into the shared guard channel, covering struct fields, tuple-struct slots, and every discriminated-variant field. Type aliases get the same walk over their target (identical drift). Self resolves before guards read the field. The jsonschema arm keeps its refusal through the now-shared registry predicate.

The task's repro yields identical spanned errors under zod alone, typescript+zod, jsonschema alone, and the full set; enum-keyed maps byte-identical. lint-all green across all 68 combos in the lane. Merge with master unified this guard chain with the attribute-parser guards from PRs #84/#85.

Powerset green in the lane; cheap gate green on the merged state.
