### PR TITLE
fix: a flattened untagged enum merges as the cross-product of its object branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,8 +424,8 @@ Notes:
 
 - Multiple `#[serde(flatten)]` fields chain: `{ ... } & BasePart & ExtraPart` in TypeScript and `z.strictObject({ ... }).and(BasePart$Schema).and(ExtraPart$Schema)` in Zod.
 - A struct whose only field is flattened becomes a plain alias (e.g. `export type FlattenOnly = DataElementSampleValueVariant;`).
-- **JSON Schema** stays strict: rather than `allOf` (which cannot faithfully compose a tagged union under `additionalProperties: false`), the base properties are distributed into each branch of the flattened union, keeping every branch closed. Plain-struct flattens merge into a single closed object; multiple flattened unions form a cross-product.
-- Only a value Serde writes as an object can be flattened -- Serde refuses the rest at run time (`can only flatten structs and maps`). Flattening a plain `#[model_schema()]` enum is rejected at expansion; any other type that turns out not to be written as an object is caught when `json_schema()` runs, naming the field's type and the remedy (write the field as a named member).
+- **JSON Schema** stays strict: rather than `allOf` (which cannot faithfully compose a tagged union under `additionalProperties: false`), the base properties are distributed into each branch of the flattened union, keeping every branch closed. Both spellings of a union are distributed into: a discriminated enum's `oneOf` and an untagged enum's `anyOf`. Plain-struct flattens merge into a single closed object; multiple flattened unions form a cross-product.
+- Only a value Serde writes as an object can be flattened -- Serde refuses the rest at run time (`can only flatten structs and maps`). Flattening a plain `#[model_schema()]` enum is rejected at expansion; any other type that turns out not to be written as an object is caught when `json_schema()` runs, naming the field's type and the remedy (write the field as a named member). A flattened union whose members are described one by one is checked the same way, member by member: a member Serde does not write as an object is refused with its branch named.
 
 ### Untagged Enums (`#[serde(untagged)]`)
 

--- a/src/features/jsonschema.rs
+++ b/src/features/jsonschema.rs
@@ -153,8 +153,10 @@ fn closed_object_body(json_schema_fields: &[proc_macro2::TokenStream]) -> proc_m
 /// `serde_json::Map` expression and every entry of `merged` a `serde_json::Value` one; the result
 /// is a `serde_json::Value`.
 ///
-/// A merged schema that is itself a `oneOf` multiplies out rather than collapsing, so each branch
-/// stays a closed object naming exactly the members that branch writes.
+/// A merged schema that is itself a union multiplies out rather than collapsing, so each branch
+/// stays a closed object naming exactly the members that branch writes. Both spellings of a union
+/// are read: a discriminated enum's `oneOf` and an untagged one's `anyOf` alike name what serde
+/// picked one of, and the merged schema is the union of the merges.
 ///
 /// Only a value serde writes as an object has members to contribute, and the expansion cannot
 /// always tell which types those are — a name reaches the merge without saying what it writes. The
@@ -212,13 +214,18 @@ fn merge_readers() -> proc_macro2::TokenStream {
             schema.get("type")?.as_str()
         }
 
-        fn branches_of(
-            schema: &serde_json::Value,
-        ) -> Vec<serde_json::Map<String, serde_json::Value>> {
-            if let Some(one_of) = schema.get("oneOf").and_then(serde_json::Value::as_array) {
-                one_of.iter().filter_map(|b| b.as_object().cloned()).collect()
-            } else if let Some(obj) = schema.as_object() {
-                vec![obj.clone()]
+        // What serde picked one of. A discriminated enum spells its union `oneOf` and an untagged
+        // one `anyOf`, and the merge owes both the same answer: the value that reached it wrote
+        // whichever branch matched, so the branch is what the base joins.
+        fn branches_of(schema: &serde_json::Value) -> Vec<&serde_json::Value> {
+            if let Some(union) = schema
+                .get("oneOf")
+                .or_else(|| schema.get("anyOf"))
+                .and_then(serde_json::Value::as_array)
+            {
+                union.iter().collect()
+            } else if schema.is_object() {
+                vec![schema]
             } else {
                 Vec::new()
             }
@@ -276,13 +283,33 @@ pub fn merged_object_value(
                         );
                     }
                 }
+                // A union names no type of its own, so the branch is where the same question is
+                // asked again — and serde cannot write a branch that is not an object into the
+                // object being written any more than it could write the whole value that way.
                 let fs_branches = branches_of(fs_body);
-                if fs_branches.is_empty() {
+                for (position, fb) in fs_branches.iter().enumerate() {
+                    if let Some(named) = described_type(fb) {
+                        if named != "object" {
+                            panic!(
+                                "`{}`: {} `{}` writes a union member that is not an object — its branch {} describes a `{}`, which has no members to merge, and what serde writes for that member does not join the object being written; {}",
+                                #subject,
+                                #edge,
+                                label,
+                                position + 1,
+                                named,
+                                #non_object_remedy,
+                            );
+                        }
+                    }
+                }
+                let fs_objects: Vec<&serde_json::Map<String, serde_json::Value>> =
+                    fs_branches.iter().filter_map(|fb| fb.as_object()).collect();
+                if fs_objects.is_empty() {
                     continue;
                 }
                 let mut next = Vec::new();
                 for base in &branches {
-                    for fb in &fs_branches {
+                    for fb in &fs_objects {
                         next.push(merge_object_schemas(base, fb));
                     }
                 }

--- a/tests/flatten_tests/tests.rs
+++ b/tests/flatten_tests/tests.rs
@@ -133,6 +133,75 @@ struct FlatOverBrand {
     slug: FlatSlug,
 }
 
+/// An untagged enum every member of which serde writes as an object, and the struct that flattens
+/// it. serde writes whichever member matched into the object the struct is writing, so what the
+/// struct writes is one key set per member.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct FlatFirst {
+    a: String,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct FlatSecond {
+    b: bool,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(untagged)]
+enum FlatEither {
+    First(FlatFirst),
+    Second(FlatSecond),
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct FlatOverUntagged {
+    #[serde(flatten)]
+    either: FlatEither,
+    own: String,
+}
+
+/// The same shape with one member serde writes as a string rather than an object. The union names
+/// no type of its own, so nothing before the merge can tell the two apart.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(untagged)]
+enum FlatScalarEither {
+    Obj(FlatFirst),
+    Text(String),
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct FlatOverScalarUntagged {
+    #[serde(flatten)]
+    either: FlatScalarEither,
+    own: String,
+}
+
+/// Whether `payload` is accepted by a document every branch of which is an object closed by
+/// `additionalProperties: false`: some branch names every key the payload carries and requires no
+/// key it does not.
+#[cfg(feature = "jsonschema")]
+fn closed_document_accepts(schema: &serde_json::Value, payload: &serde_json::Value) -> bool {
+    let written = payload.as_object().unwrap();
+    let branches = schema.get("oneOf").map_or_else(
+        || vec![schema.clone()],
+        |one_of| one_of.as_array().unwrap().clone(),
+    );
+    branches.iter().any(|branch| {
+        let named = branch["properties"].as_object().unwrap();
+        let required = branch["required"].as_array().unwrap();
+        written.keys().all(|key| named.contains_key(key))
+            && required
+                .iter()
+                .all(|key| written.contains_key(key.as_str().unwrap()))
+    })
+}
+
 #[test]
 fn test_flatten_structs_constructible() {
     let base = BasePart {
@@ -488,4 +557,99 @@ fn test_flattening_a_string_newtype_is_refused_by_the_merge() {
 #[should_panic(expected = "write the field as a named member so the value gets a key of its own")]
 fn test_the_flatten_merge_refusal_names_the_remedy() {
     assert!(FlatOverBrand::json_schema().is_object());
+}
+
+/// What serde writes for a flattened untagged enum: the struct's own fields, and beside them the
+/// members of whichever union member matched. One key set per member, and no key naming the field.
+#[test]
+fn test_flattening_an_untagged_enum_writes_the_matched_members_keys() {
+    assert_eq!(
+        serde_json::to_value(FlatOverUntagged {
+            own: "o".to_owned(),
+            either: FlatEither::First(FlatFirst { a: "x".to_owned() }),
+        })
+        .unwrap(),
+        serde_json::json!({ "own": "o", "a": "x" })
+    );
+    assert_eq!(
+        serde_json::to_value(FlatOverUntagged {
+            own: "o".to_owned(),
+            either: FlatEither::Second(FlatSecond { b: true }),
+        })
+        .unwrap(),
+        serde_json::json!({ "own": "o", "b": true })
+    );
+}
+
+/// So the merged schema is the union of the merges: the base multiplied over every member of the
+/// union, each branch closed around exactly the keys that member writes.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_flattening_an_untagged_enum_multiplies_the_base_over_its_members() {
+    assert_eq!(
+        serde_json::to_string(&FlatOverUntagged::json_schema()).unwrap(),
+        r#"{"type":"object","oneOf":[{"type":"object","properties":{"own":{"type":"string"},"a":{"type":"string"}},"required":["own","a"],"additionalProperties":false},{"type":"object","properties":{"own":{"type":"string"},"b":{"type":"boolean"}},"required":["own","b"],"additionalProperties":false}]}"#
+    );
+}
+
+/// And every payload serde writes is accepted by it. Before the base multiplied out, the document
+/// closed around `own` alone and rejected both.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_the_untagged_flatten_schema_accepts_every_payload_serde_writes() {
+    let schema = FlatOverUntagged::json_schema();
+    for payload in [
+        serde_json::json!({ "own": "o", "a": "x" }),
+        serde_json::json!({ "own": "o", "b": true }),
+    ] {
+        assert!(
+            closed_document_accepts(&schema, &payload),
+            "{payload} is rejected by {schema}"
+        );
+    }
+    assert!(
+        !closed_document_accepts(
+            &serde_json::json!({
+                "type": "object",
+                "properties": { "own": { "type": "string" } },
+                "required": ["own"],
+                "additionalProperties": false
+            }),
+            &serde_json::json!({ "own": "o", "a": "x" })
+        ),
+        "the document closed around the base alone accepts a key it does not name"
+    );
+}
+
+/// A union member serde writes as a string is a member serde cannot flatten at all.
+#[test]
+fn test_flattening_an_untagged_enum_over_a_string_member_is_unserializable() {
+    let refusal = serde_json::to_value(FlatOverScalarUntagged {
+        own: "o".to_owned(),
+        either: FlatScalarEither::Text("t".to_owned()),
+    })
+    .unwrap_err()
+    .to_string();
+    assert!(
+        refusal.contains("can only flatten structs and maps"),
+        "Got: {refusal}"
+    );
+}
+
+/// So the merge refuses the whole union, naming the branch that cannot join the object.
+#[test]
+#[cfg(feature = "jsonschema")]
+#[should_panic(
+    expected = "`FlatOverScalarUntagged`: `#[serde(flatten)]` of `FlatScalarEither` writes a union member that is not an object — its branch 2 describes a `string`"
+)]
+fn test_a_string_member_of_a_flattened_untagged_enum_is_refused_by_the_merge() {
+    assert!(FlatOverScalarUntagged::json_schema().is_object());
+}
+
+/// The remedy that refusal names is the same one every flattened non-object gets.
+#[test]
+#[cfg(feature = "jsonschema")]
+#[should_panic(expected = "write the field as a named member so the value gets a key of its own")]
+fn test_the_untagged_branch_refusal_names_the_remedy() {
+    assert!(FlatOverScalarUntagged::json_schema().is_object());
 }

--- a/tests/tuple_variant_tests/tests.rs
+++ b/tests/tuple_variant_tests/tests.rs
@@ -144,6 +144,52 @@ pub enum InternalOverBrand {
     Branded(InternalSlug),
 }
 
+/// An untagged enum every member of which serde writes as an object, wrapped by a bare tag. The
+/// content joins the tag the same way a `#[serde(flatten)]` base does, so what lands beside the tag
+/// is the members of whichever union member matched.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct InternalFirst {
+    pub a: String,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct InternalSecond {
+    pub b: bool,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum InternalEither {
+    First(InternalFirst),
+    Second(InternalSecond),
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(tag = "type")]
+pub enum InternalOverUntagged {
+    Wrapped(InternalEither),
+}
+
+/// The same wrapping over a union with one member serde writes as a string.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum InternalScalarEither {
+    Obj(InternalFirst),
+    Text(String),
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(tag = "type")]
+pub enum InternalOverScalarUntagged {
+    Wrapped(InternalScalarEither),
+}
+
 /// A recursive enum with no tagging attributes: what sits under a key is the enum itself. Only the
 /// Zod surface spells the deferral, so the fixture is declared where it is read.
 #[cfg(feature = "zod")]
@@ -1762,4 +1808,70 @@ fn test_bare_tag_over_a_struct_documents_byte_identically() {
         serde_json::to_string(&Internal::json_schema()).unwrap(),
         r#"{"type":"object","oneOf":[{"additionalProperties":false,"properties":{"type":{"type":"string","const":"Bare"}},"required":["type"]},{"additionalProperties":false,"properties":{"type":{"type":"string","const":"Fields"},"a":{"type":"string"},"b":{"type":"boolean"}},"required":["type","a","b"]},{"type":"object","properties":{"type":{"type":"string","const":"Wrapped"},"a":{"type":"string"},"b":{"type":"boolean"}},"required":["type","a","b"],"additionalProperties":false}]}"#
     );
+}
+
+/// Test 22m: what serde writes for a bare tag over an untagged enum. The union names no type of its
+/// own, but every member of this one writes an object, so what lands beside the tag is that member's
+/// members — one key set per member.
+#[test]
+fn test_bare_tag_over_an_untagged_enum_writes_the_matched_members_keys() {
+    assert_eq!(
+        serde_json::to_value(InternalOverUntagged::Wrapped(InternalEither::First(
+            InternalFirst { a: "x".to_owned() }
+        )))
+        .unwrap(),
+        serde_json::json!({ "type": "Wrapped", "a": "x" })
+    );
+    assert_eq!(
+        serde_json::to_value(InternalOverUntagged::Wrapped(InternalEither::Second(
+            InternalSecond { b: true }
+        )))
+        .unwrap(),
+        serde_json::json!({ "type": "Wrapped", "b": true })
+    );
+}
+
+/// Test 22n: so the tag multiplies over the union the way it already multiplies over a discriminated
+/// one — a branch per member, each closed around the tag plus that member's members.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn test_bare_tag_over_an_untagged_enum_multiplies_over_its_members() {
+    assert_eq!(
+        serde_json::to_string(&InternalOverUntagged::json_schema()).unwrap(),
+        r#"{"type":"object","oneOf":[{"type":"object","oneOf":[{"type":"object","properties":{"type":{"type":"string","const":"Wrapped"},"a":{"type":"string"}},"required":["type","a"],"additionalProperties":false},{"type":"object","properties":{"type":{"type":"string","const":"Wrapped"},"b":{"type":"boolean"}},"required":["type","b"],"additionalProperties":false}]}]}"#
+    );
+}
+
+/// Test 22o: and the keys those branches require are exactly the keys the captures carry. Before the
+/// tag multiplied out, one branch required the tag alone and named nothing else, so neither capture
+/// was accepted.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn test_bare_tag_over_an_untagged_enum_requires_every_key_serde_writes() {
+    let schema = InternalOverUntagged::json_schema();
+    let required: Vec<&serde_json::Value> = schema["oneOf"][0]["oneOf"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|branch| &branch["required"])
+        .collect();
+    assert_eq!(
+        required,
+        vec![
+            &serde_json::json!(["type", "a"]),
+            &serde_json::json!(["type", "b"])
+        ],
+        "Got: {schema}"
+    );
+}
+
+/// Test 22p: a union member serde writes as a string is a member serde cannot put beside the tag at
+/// all, so the merge refuses the whole union and names the branch that cannot join it.
+#[cfg(feature = "jsonschema")]
+#[test]
+#[should_panic(
+    expected = "`InternalOverScalarUntagged`: the content of variant `Wrapped`, `InternalScalarEither` writes a union member that is not an object — its branch 2 describes a `string`"
+)]
+fn test_a_string_member_of_a_tagged_untagged_enum_is_refused_by_the_merge() {
+    assert!(InternalOverScalarUntagged::json_schema().is_object());
 }


### PR DESCRIPTION
An untagged enum's schema is anyOf with no type key, so branches_of fell through to the one-object path, found no properties, and the merged schema closed around the base alone — the union dropped entirely (same drop through internal tagging). The emitted reader now takes the first of oneOf/anyOf and expands its branches: each gets the same non-object question the whole body gets (refusal through the labeled diagnostic naming the branch — backed by a serde capture showing flattening the string member is unserializable), then object branches cross-product into the base.

Captures first, red-first: all four assertions failed against the pre-fix documents. oneOf multiplication, plain flatten, and internal-tagging-over-struct byte-identical.

Powerset green in the lane; cheap gate green on the merged state.
