### PR TITLE
fix: untagged members run the non-enum map-key guard

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -4127,9 +4127,10 @@ fn field_json_schema_value(fld: &FieldDef) -> proc_macro2::TokenStream {
 /// guard violations. The first three are always returned; the caller selects which to use based on
 /// the enabled features.
 ///
-/// This path builds its field defs directly rather than through [`process_field`], so it runs
-/// [`check_optional_field_serialization`] itself — a named `Option` in a struct variant renders in
-/// the absent form here exactly as it does in a struct, and must carry the same guarantee.
+/// This path builds its field defs directly rather than through [`process_field`], so it runs the
+/// field guards itself. A member renders exactly as a struct field of the same written type does —
+/// a named `Option` in the absent form, a map from its key's members — so each guard it escapes
+/// would be a rendering this position alone is allowed to write.
 #[cfg(feature = "serde")]
 fn collect_untagged_members(item_enum: &mut syn::ItemEnum) -> UntaggedMemberData {
     let enum_type_name = item_enum.ident.to_string();
@@ -4151,6 +4152,10 @@ fn collect_untagged_members(item_enum: &mut syn::ItemEnum) -> UntaggedMemberData
                 .unwrap_or_default();
             let mut field_def = get_field_def(&field_name, &field.ty, "");
             if let Err(err) = check_os_string_field(field, &field_def, &field_label(&field_name)) {
+                guard_errors.push(err.to_compile_error());
+            }
+            #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+            if let Err(err) = check_non_enum_map_key(field, &field_def, &field_label(&field_name)) {
                 guard_errors.push(err.to_compile_error());
             }
             let serde_field_meta = parse_serde_field_attributes(&field.attrs);

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -325,6 +325,77 @@ fn untagged_tuple_variant_option_is_exempt() {
     assert!(errors.is_empty(), "got: {errors:?}");
 }
 
+/// A variant's member renders the map its written type earns exactly as a struct field does, so the
+/// key the registry rules out is refused in this position too rather than naming keys nothing can
+/// supply.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn untagged_member_reaching_a_map_key_with_no_members_is_refused() {
+    register_alias_info(
+        "Ledger",
+        "Ledger",
+        "ledger_schema",
+        AliasKind::NoEnumMembers,
+    );
+    for member_type in [
+        quote::quote! { HashMap<Ledger, u32> },
+        quote::quote! { Vec<HashMap<Ledger, u32>> },
+        quote::quote! { HashMap<String, HashMap<Ledger, u32>> },
+    ] {
+        let errors = untagged_guard_errors(syn::parse_quote! {
+            enum Untagged {
+                Counts { counts: #member_type },
+            }
+        });
+        assert_eq!(errors.len(), 1, "for {member_type}, got: {errors:?}");
+        assert!(
+            errors[0].contains("compile_error"),
+            "for {member_type}: {}",
+            errors[0]
+        );
+        assert!(
+            errors[0].contains("field `counts`"),
+            "for {member_type}: {}",
+            errors[0]
+        );
+        assert!(
+            errors[0].contains("a map key must be a plain"),
+            "for {member_type}: {}",
+            errors[0]
+        );
+        assert!(
+            errors[0].contains("Ledger"),
+            "for {member_type}: {}",
+            errors[0]
+        );
+    }
+}
+
+/// The guard turns away only what the registry proves has no members: a member keyed by a plain
+/// enum, or by a `String`, keeps the variant it had.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn untagged_member_with_an_enumerable_map_key_is_left_alone() {
+    register_alias_info("Bucket", "Bucket", "bucket_schema", AliasKind::EnumMembers);
+    for member_type in [
+        quote::quote! { HashMap<Bucket, u32> },
+        quote::quote! { HashMap<String, u32> },
+    ] {
+        let errors = untagged_guard_errors(syn::parse_quote! {
+            enum Untagged {
+                Counts { counts: #member_type },
+            }
+        });
+        assert!(errors.is_empty(), "for {member_type}, got: {errors:?}");
+    }
+}
+
 /// Collects the internally tagged path's guard failures as rendered `compile_error!` token strings.
 #[cfg(feature = "serde")]
 fn internal_guard_errors(item: &syn::ItemEnum) -> Vec<String> {

--- a/tests/untagged_tests/tests.rs
+++ b/tests/untagged_tests/tests.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use tixschema::model_schema;
 
 // ISO-8601 date string. Branded newtype carries the regex pattern.
@@ -67,6 +68,23 @@ enum CompliantUnion {
 enum SlotUnion {
     Maybe(Option<i64>),
     Plain(String),
+}
+
+// A plain enum's members are what a map keyed by it writes its object's keys from.
+#[model_schema()]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+enum Bucket {
+    Large,
+    Small,
+}
+
+// The map keys a variant's member may carry: one the registry enumerates, one open by nature.
+#[model_schema()]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+enum KeyedUnion {
+    Counts { counts: HashMap<Bucket, u32> },
+    Labels { labels: HashMap<String, String> },
 }
 
 #[test]
@@ -351,4 +369,52 @@ fn test_untagged_newtype_option_content_json_schema_null_flavor() {
         })
     );
     assert_eq!(any_of[1], serde_json::json!({ "type": "string" }));
+}
+
+// ========================================================================
+// Untagged member holding a map — the key the guard reads off the written type
+// ========================================================================
+
+/// A key that enumerates its members, and an open one, both render the map their written type
+/// earns: the guard is a filter over keys the registry rules out, never a rewrite of the ones it
+/// admits.
+#[test]
+#[cfg(feature = "typescript")]
+fn test_untagged_map_member_keys_typescript() {
+    let ts = KeyedUnion::ts_definition();
+    assert!(
+        ts.contains(
+            "export type KeyedUnion = { counts: Partial<Record<Bucket, number>> } \
+             | { labels: Partial<Record<string, string>> };"
+        ),
+        "Got:\n{ts}"
+    );
+}
+
+#[test]
+#[cfg(feature = "zod")]
+fn test_untagged_map_member_keys_zod() {
+    let zod = KeyedUnion::zod_schema();
+    assert!(
+        zod.contains("z.strictObject({ counts: z.record(Bucket$Schema, z.number().int()), })"),
+        "Got:\n{zod}"
+    );
+    assert!(
+        zod.contains("z.strictObject({ labels: z.record(z.string(), z.string()), })"),
+        "Got:\n{zod}"
+    );
+}
+
+/// A map is one of the inner shapes an untagged member leaves open for v1, so each branch keeps
+/// the member as a required key carrying the permissive empty schema.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_untagged_map_member_keys_json_schema() {
+    let schema = KeyedUnion::json_schema();
+    let any_of = schema["anyOf"].as_array().unwrap();
+    assert_eq!(any_of.len(), 2, "Got:\n{schema}");
+    for (branch, member) in any_of.iter().zip(["counts", "labels"]) {
+        assert_eq!(branch["properties"][member], serde_json::json!({}));
+        assert_eq!(branch["required"], serde_json::json!([member]));
+    }
 }


### PR DESCRIPTION
collect_untagged_members builds field defs without process_field, so the guard landed in #86 never reached untagged members — TS/Zod kept emitting records keyed by a memberless type. check_non_enum_map_key now runs in the per-member walk, after the OsString guard and before the cfg_attr/Option guards, matching field position's order and gate.

Red-first at unit level; the task's repro fails the derive with the shared spanned message; enum/String-keyed members pinned byte-identical on all three surfaces.

Powerset green in the lane; cheap gate green on the merged state.
