### PR TITLE
ci: gate the internal-tagging scalar fixtures on the surface that reads them

### DIFF
--- a/tests/tuple_variant_tests/tests.rs
+++ b/tests/tuple_variant_tests/tests.rs
@@ -174,7 +174,9 @@ pub enum InternalOverUntagged {
     Wrapped(InternalEither),
 }
 
-/// The same wrapping over a union with one member serde writes as a string.
+/// The same wrapping over a union with one member serde writes as a string. Only the JSON-schema
+/// merge reads the pair, so both fixtures are declared where they are read.
+#[cfg(feature = "jsonschema")]
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(untagged)]
@@ -183,6 +185,7 @@ pub enum InternalScalarEither {
     Text(String),
 }
 
+#[cfg(feature = "jsonschema")]
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "type")]


### PR DESCRIPTION
CI's just lint-all failed on master since #88: InternalScalarEither and InternalOverScalarUntagged are consumed only by a jsonschema-gated should_panic test, so the serde,typescript clippy combination flagged both as dead code. Both now carry #[cfg(feature = "jsonschema")] with the file's declare-where-read convention note (same as RecursiveExternal beside them).

Full just lint-all green locally across all 68 combinations; the failing combination and its neighbors verified individually. No suppressions — the fix is the gate the fixtures were missing, not an allow.