### PR TITLE
fix: a deferred union branch resolves through the hoisted definitions, or names its cycle

### DIFF
--- a/src/features/jsonschema.rs
+++ b/src/features/jsonschema.rs
@@ -199,10 +199,11 @@ fn merge_readers() -> proc_macro2::TokenStream {
             out
         }
 
-        // A flattened base that names itself describes as a reference into the definitions being
+        // A merged schema that names itself describes as a reference into the definitions being
         // hoisted, and a reference is the one thing with no properties to merge. The body it
         // points at is written by then — the frame that deferred the name fills the entry in
-        // before it returns — so the merge reads it back.
+        // before it returns — so the merge reads it back. A union member defers the same way the
+        // whole merged body does, so both ends read it through here.
         fn deferred_name(schema: &serde_json::Value) -> Option<&str> {
             schema.get("$ref")?.as_str()?.strip_prefix(#defs_prefix)
         }
@@ -233,6 +234,61 @@ fn merge_readers() -> proc_macro2::TokenStream {
     }
 }
 
+/// The objects one merged schema contributes, as the tokens that bind them.
+///
+/// A union names no type of its own, so the branch is where the questions the whole merged body was
+/// asked are asked again — and serde cannot write a branch that is not an object into the object
+/// being written any more than it could write the whole value that way. A branch that is a deferred
+/// name carries none of the members it stands for, so it is read back out of the definitions first,
+/// the same way the whole merged body is.
+///
+/// Reads `fs_body` and `label` from the frame that merges, and binds `fs_objects`.
+fn branch_objects(diagnostic: &MergeDiagnostic<'_>) -> proc_macro2::TokenStream {
+    let MergeDiagnostic {
+        cycle_remedy,
+        edge,
+        non_object_remedy,
+        subject,
+    } = *diagnostic;
+    quote::quote! {
+        let fs_branches = branches_of(fs_body);
+        let mut fs_objects: Vec<&serde_json::Map<String, serde_json::Value>> = Vec::new();
+        for (position, fb) in fs_branches.iter().enumerate() {
+            let branch = match deferred_name(fb) {
+                None => *fb,
+                Some(name) => match hoisted_defs.get(name) {
+                    Some(body) if body.is_object() => body,
+                    _ => panic!(
+                        "`{}`: {} `{}` closes a flatten cycle through a union member — its branch {} is `{}`, whose body does not exist to merge, and no finite value inhabits the type; {}",
+                        #subject,
+                        #edge,
+                        label,
+                        position + 1,
+                        name,
+                        #cycle_remedy,
+                    ),
+                },
+            };
+            if let Some(named) = described_type(branch) {
+                if named != "object" {
+                    panic!(
+                        "`{}`: {} `{}` writes a union member that is not an object — its branch {} describes a `{}`, which has no members to merge, and what serde writes for that member does not join the object being written; {}",
+                        #subject,
+                        #edge,
+                        label,
+                        position + 1,
+                        named,
+                        #non_object_remedy,
+                    );
+                }
+            }
+            if let Some(members) = branch.as_object() {
+                fs_objects.push(members);
+            }
+        }
+    }
+}
+
 pub fn merged_object_value(
     base: &proc_macro2::TokenStream,
     merged: &[MergedSource],
@@ -244,6 +300,7 @@ pub fn merged_object_value(
         non_object_remedy,
         subject,
     } = *diagnostic;
+    let branch_reader = branch_objects(diagnostic);
     let labels = merged.iter().map(|source| source.label.as_str());
     let values = merged.iter().map(|source| &source.value);
     let readers = merge_readers();
@@ -283,27 +340,7 @@ pub fn merged_object_value(
                         );
                     }
                 }
-                // A union names no type of its own, so the branch is where the same question is
-                // asked again — and serde cannot write a branch that is not an object into the
-                // object being written any more than it could write the whole value that way.
-                let fs_branches = branches_of(fs_body);
-                for (position, fb) in fs_branches.iter().enumerate() {
-                    if let Some(named) = described_type(fb) {
-                        if named != "object" {
-                            panic!(
-                                "`{}`: {} `{}` writes a union member that is not an object — its branch {} describes a `{}`, which has no members to merge, and what serde writes for that member does not join the object being written; {}",
-                                #subject,
-                                #edge,
-                                label,
-                                position + 1,
-                                named,
-                                #non_object_remedy,
-                            );
-                        }
-                    }
-                }
-                let fs_objects: Vec<&serde_json::Map<String, serde_json::Value>> =
-                    fs_branches.iter().filter_map(|fb| fb.as_object()).collect();
+                #branch_reader
                 if fs_objects.is_empty() {
                     continue;
                 }

--- a/tests/flatten_tests/tests.rs
+++ b/tests/flatten_tests/tests.rs
@@ -54,6 +54,25 @@ struct CycleSecond {
     second_own: String,
 }
 
+/// The same cycle with a union in the middle: the branch that closes it is the deferred name, and
+/// a reference carries none of the members it stands for.
+#[cfg(feature = "jsonschema")]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct CycleUnionNode {
+    #[serde(flatten)]
+    either: CycleUnionEither,
+    own: String,
+}
+
+#[cfg(feature = "jsonschema")]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(untagged)]
+enum CycleUnionEither {
+    Only(Box<CycleUnionNode>),
+}
+
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct ExtraPart {
@@ -179,6 +198,34 @@ enum FlatScalarEither {
 struct FlatOverScalarUntagged {
     #[serde(flatten)]
     either: FlatScalarEither,
+    own: String,
+}
+
+/// A union member that names itself, and the struct that flattens the union. The member describes
+/// as a reference into the definitions, and the body it points at is written by the time the merge
+/// asks for it.
+#[cfg(feature = "jsonschema")]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct FlatSelfNode {
+    kids: Vec<Self>,
+    leaf: String,
+}
+
+#[cfg(feature = "jsonschema")]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(untagged)]
+enum FlatSelfEither {
+    Node(FlatSelfNode),
+}
+
+#[cfg(feature = "jsonschema")]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct FlatOverSelfUntagged {
+    #[serde(flatten)]
+    either: FlatSelfEither,
     own: String,
 }
 
@@ -440,6 +487,28 @@ fn test_flatten_cycle_is_rejected_from_either_end() {
     assert!(CycleSecond::json_schema().is_object());
 }
 
+/// A cycle that closes through one member of a union is the same cycle — there is no body to merge
+/// at the branch either — so the branch is named rather than merged as the reference it is, which
+/// contributes nothing and closes the document around the base alone.
+#[test]
+#[cfg(feature = "jsonschema")]
+#[should_panic(
+    expected = "`CycleUnionNode`: `#[serde(flatten)]` of `CycleUnionEither` closes a flatten cycle through a union member — its branch 1 is `CycleUnionNode`"
+)]
+fn test_a_flatten_cycle_through_a_union_member_is_rejected() {
+    assert!(CycleUnionNode::json_schema().is_object());
+}
+
+/// The remedy is the one a cycle closed through the value itself names.
+#[test]
+#[cfg(feature = "jsonschema")]
+#[should_panic(
+    expected = "write the field as a named member so the cycle defers through a reference"
+)]
+fn test_the_union_member_cycle_refusal_names_the_remedy() {
+    assert!(CycleUnionNode::json_schema().is_object());
+}
+
 /// Flattening a base that does not name itself writes the document it wrote before, byte for byte.
 #[test]
 #[cfg(feature = "jsonschema")]
@@ -459,6 +528,17 @@ fn test_non_recursive_flatten_documents_are_byte_identical() {
     assert_eq!(
         serde_json::to_string(&NoFlatten::json_schema()).unwrap(),
         r#"{"type":"object","additionalProperties":false,"properties":{"id":{"type":"string"},"name":{"type":"string"}},"required":["id","name"]}"#
+    );
+}
+
+/// And flattening a base that names itself with no union in the middle writes the document it wrote
+/// before, byte for byte: the whole-body path reads the deferred name as it always did.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_the_deferred_flatten_document_is_byte_identical() {
+    assert_eq!(
+        serde_json::to_string(&FlatHolder::json_schema()).unwrap(),
+        r##"{"$defs":{"FlatNode":{"type":"object","additionalProperties":false,"properties":{"children":{"type":"array","items":{"$ref":"#/$defs/FlatNode"}},"val":{"type":"string"}},"required":["children","val"]}},"type":"object","properties":{"extra":{"type":"string"},"children":{"type":"array","items":{"$ref":"#/$defs/FlatNode"}},"val":{"type":"string"}},"required":["extra","children","val"],"additionalProperties":false}"##
     );
 }
 
@@ -652,4 +732,57 @@ fn test_a_string_member_of_a_flattened_untagged_enum_is_refused_by_the_merge() {
 #[should_panic(expected = "write the field as a named member so the value gets a key of its own")]
 fn test_the_untagged_branch_refusal_names_the_remedy() {
     assert!(FlatOverScalarUntagged::json_schema().is_object());
+}
+
+/// A union member that names itself writes its own keys beside the struct's, the same as any other
+/// member: what it describes as says nothing about what it writes.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_flattening_a_self_naming_union_member_writes_its_keys() {
+    assert_eq!(
+        serde_json::to_value(FlatOverSelfUntagged {
+            own: "o".to_owned(),
+            either: FlatSelfEither::Node(FlatSelfNode {
+                kids: Vec::new(),
+                leaf: "l".to_owned(),
+            }),
+        })
+        .unwrap(),
+        serde_json::json!({ "own": "o", "kids": [], "leaf": "l" })
+    );
+}
+
+/// So the member merges as the body it names, reference and all: before it was read back it carried
+/// no members, and the document closed around the base alone.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_a_deferred_union_member_merges_as_the_body_it_names() {
+    assert_eq!(
+        serde_json::to_string(&FlatOverSelfUntagged::json_schema()).unwrap(),
+        r##"{"$defs":{"FlatSelfNode":{"type":"object","additionalProperties":false,"properties":{"kids":{"type":"array","items":{"$ref":"#/$defs/FlatSelfNode"}},"leaf":{"type":"string"}},"required":["kids","leaf"]}},"type":"object","properties":{"own":{"type":"string"},"kids":{"type":"array","items":{"$ref":"#/$defs/FlatSelfNode"}},"leaf":{"type":"string"}},"required":["own","kids","leaf"],"additionalProperties":false}"##
+    );
+}
+
+/// And the document accepts what serde writes, self-reference resolving from the container's root.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_the_deferred_union_member_schema_accepts_the_payload_serde_writes() {
+    let schema = FlatOverSelfUntagged::json_schema();
+    let payload = serde_json::json!({ "own": "o", "kids": [], "leaf": "l" });
+    assert!(
+        closed_document_accepts(&schema, &payload),
+        "{payload} is rejected by {schema}"
+    );
+    let reference = schema["properties"]["kids"]["items"]["$ref"]
+        .as_str()
+        .unwrap();
+    let resolved = schema
+        .pointer(reference.strip_prefix('#').unwrap())
+        .unwrap();
+    assert!(
+        resolved["properties"]
+            .as_object()
+            .unwrap()
+            .contains_key("leaf")
+    );
 }


### PR DESCRIPTION
A $ref union branch survives as_object() but carries no properties, so the merge folded nothing in and the object closed around the base alone — and the flatten-cycle diagnostic never fired through a union. Each branch now resolves through deferred_name/hoisted_defs exactly as the whole body does: a filled entry becomes the branch (then the non-object question applies to the resolved body), a still-reserved entry raises the cycle diagnostic naming the branch by position. branch_objects extracted for clippy's line limit, no allow.

Red-first: the repro emitted the silent base-only schema before; now it panics. A resolvable branch (self-recursive struct behind a one-member untagged enum) contributes its fields with the self-reference resolving from the container root.

Powerset green in the lane; full lint-all green on the merged state (the widened acceptance gate after the CI break).
