### PR TITLE
fix: model_schema(name) renames structs, enums and brands, and refuses non-identifier values

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@ mod utils;
 
 use model_schema::exec_model_schema;
 use proc_macro::TokenStream;
-use utils::safe_type_name;
 
 /// # `model_schema`
 ///

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -25,9 +25,14 @@ use crate::{
     field_type::{
         FieldDef, FieldDefType, VariantKind, classify_variant, get_field_def, is_plain_enum,
     },
-    safe_type_name,
     utils::{get_field_docs, get_variant_docs},
 };
+
+// The item paths take their exported name from `compute_item_export_name`, which applies this
+// itself; what is left is the naming a reference falls back to for a type this expansion never saw,
+// and the parameter list a generic alias writes.
+#[cfg(any(feature = "typescript", feature = "jsonschema"))]
+use crate::utils::safe_type_name;
 
 #[cfg(feature = "zod")]
 use crate::utils::{escape_js_regex_literal, extract_example_from_docs};
@@ -65,6 +70,8 @@ use crate::utils::{get_enum_docs, get_struct_docs, strip_examples_from_docs};
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 use crate::utils::compute_alias_export_name;
+
+use crate::utils::compute_item_export_name;
 
 #[cfg(feature = "typescript")]
 use crate::utils::{format_docs_for_ts, get_item_docs};
@@ -381,7 +388,7 @@ fn parse_model_schema_args(args: proc_macro2::TokenStream) -> ModelSchemaArgs {
 fn apply_arg(result: &mut ModelSchemaArgs, meta: &Meta) -> syn::Result<()> {
     let path = meta.path();
     if path.is_ident("name") {
-        result.name_override = Some(str_arg(meta, "name")?.value());
+        result.name_override = Some(name_arg_value(str_arg(meta, "name")?)?);
     } else if path.is_ident("pattern") {
         let lit_str = str_arg(meta, "pattern")?;
         record_pattern_rejection(result, lit_str);
@@ -422,6 +429,31 @@ fn str_arg<'meta>(meta: &'meta Meta, name: &str) -> syn::Result<&'meta syn::LitS
     } else {
         Err(arg_rejection(lit, name, &takes))
     }
+}
+
+/// The name a `name = "…"` argument was written as, once it is one a name can be spelled from.
+///
+/// The value is the type's name on every surface and, snake-cased, the Rust module its schema is
+/// published from. `Ident::new` builds that module, and it panics on a string that is not an
+/// identifier — a panic reports no span and names no argument, so the check is here, where the
+/// literal the author wrote is still in hand.
+fn name_arg_value(lit: &syn::LitStr) -> syn::Result<String> {
+    let value = lit.value();
+    let mut chars = value.chars();
+    let opens = chars
+        .next()
+        .is_some_and(|ch| ch.is_ascii_alphabetic() || ch == '_');
+    if opens && chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_') {
+        return Ok(value);
+    }
+    Err(arg_rejection(
+        lit,
+        "name",
+        "a string literal spelling an identifier: ASCII letters, digits and underscores, not \
+         opening with a digit. The value names the type on every surface and, snake-cased, the \
+         Rust module its schema is published from, so one an identifier cannot be spelled from is \
+         a name no surface can carry",
+    ))
 }
 
 /// The length a `minLength = N` argument was written as.
@@ -504,7 +536,7 @@ pub fn exec_model_schema(args: TokenStream, input: TokenStream) -> TokenStream {
     if let Item::Struct(item_struct) = item {
         process_struct(item_struct, &parsed_args)
     } else if let Item::Enum(item_enum) = item {
-        process_enum(item_enum)
+        process_enum(item_enum, &parsed_args)
     } else if let Item::Type(item_type) = item {
         process_type_alias(item_type, &parsed_args)
     } else {
@@ -582,7 +614,7 @@ fn process_type_alias(item_type: ItemType, args: &ModelSchemaArgs) -> TokenStrea
 
     let rust_ident = alias.ident.clone();
     let rust_ident_str = rust_ident.to_string();
-    let export_name = compute_alias_export_name(&rust_ident_str, args.name_override.clone());
+    let export_name = compute_alias_export_name(&rust_ident_str, args.name_override.as_deref());
     let module_name = format!("{}_schema", to_snake_case(&export_name));
     let module_ident = Ident::new(&module_name, rust_ident.span());
 
@@ -1338,9 +1370,13 @@ fn is_branded_newtype(item_struct: &syn::ItemStruct) -> bool {
 
 /// Computes the TypeScript name, schema-module name, and module ident for a struct, and registers
 /// it in the alias registry so other types can resolve references to it.
+///
+/// The registration carries the exported name, so a `name = "…"` override reaches every reference
+/// to the struct as well as its own surfaces — a sibling names it in Rust and resolves to the name
+/// it is exported under.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-fn struct_module_idents(name: &syn::Ident) -> (String, String, Ident) {
-    let item_name = safe_type_name(&name.to_string());
+fn struct_module_idents(name: &syn::Ident, name_override: Option<&str>) -> (String, String, Ident) {
+    let item_name = compute_item_export_name(&name.to_string(), name_override);
     let module_name = format!("{}_schema", to_snake_case(&item_name));
     let module_ident = Ident::new(&module_name, name.span());
     register_alias_info(
@@ -1423,12 +1459,13 @@ fn process_struct(mut item_struct: syn::ItemStruct, args: &ModelSchemaArgs) -> T
     // one of them under the empty ident it carries.
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
     if is_tuple_struct(&item_struct) {
-        return process_tuple_struct(item_struct, rename_all.as_deref());
+        return process_tuple_struct(item_struct, rename_all.as_deref(), args);
     }
 
     // Compute schema-module identifiers and register the struct in the alias registry.
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-    let (item_name, module_name, module_ident) = struct_module_idents(&name);
+    let (item_name, module_name, module_ident) =
+        struct_module_idents(&name, args.name_override.as_deref());
 
     // Extract docs early for example extraction
     #[cfg(any(feature = "typescript", feature = "zod"))]
@@ -1654,9 +1691,14 @@ fn build_tuple_struct_zod_schema_method(
 /// already read in, where a `None` reaches the wire as `null` rather than as an omitted key — so
 /// a tuple struct describes as the tuple of its slot types does wherever that tuple is written.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-fn process_tuple_struct(mut item_struct: syn::ItemStruct, rename_all: Option<&str>) -> TokenStream {
+fn process_tuple_struct(
+    mut item_struct: syn::ItemStruct,
+    rename_all: Option<&str>,
+    args: &ModelSchemaArgs,
+) -> TokenStream {
     let name = item_struct.ident.clone();
-    let (item_name, module_name, module_ident) = struct_module_idents(&name);
+    let (item_name, module_name, module_ident) =
+        struct_module_idents(&name, args.name_override.as_deref());
 
     let (slots, guard_errors) = collect_tuple_slots(
         &mut item_struct.fields,
@@ -2429,7 +2471,7 @@ fn process_branded_newtype(item_struct: syn::ItemStruct, args: &ModelSchemaArgs)
     }
 
     let name = item_struct.ident.clone();
-    let item_name = safe_type_name(&name.to_string());
+    let item_name = compute_item_export_name(&name.to_string(), args.name_override.as_deref());
     let module_name = format!("{}_schema", to_snake_case(&item_name));
     let module_ident = Ident::new(&module_name, name.span());
 
@@ -2589,7 +2631,7 @@ fn branded_impl_generics(
 }
 
 /// Processes an enum item and generates TypeScript and Zod schema definitions for it.
-fn process_enum(item_enum: syn::ItemEnum) -> TokenStream {
+fn process_enum(item_enum: syn::ItemEnum, args: &ModelSchemaArgs) -> TokenStream {
     let name = item_enum.ident.clone();
 
     #[cfg(feature = "serde")]
@@ -2603,7 +2645,9 @@ fn process_enum(item_enum: syn::ItemEnum) -> TokenStream {
         return output;
     }
 
-    let item_name = safe_type_name(&name.to_string());
+    // Every enum shape below is written under this one name, and `enum_module_idents` registers it,
+    // so the override reaches the shape's own surfaces and every reference to it alike.
+    let item_name = compute_item_export_name(&name.to_string(), args.name_override.as_deref());
 
     if is_plain_enum(&item_enum) {
         #[cfg(feature = "serde")]
@@ -7196,7 +7240,7 @@ fn generate_alias_ts_definition_method(
             .iter()
             .filter_map(|param| {
                 if let GenericParam::Type(tp) = param {
-                    Some(crate::safe_type_name(&tp.ident.to_string()))
+                    Some(safe_type_name(&tp.ident.to_string()))
                 } else {
                     None
                 }

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -1409,6 +1409,38 @@ fn a_misspelled_name_argument_is_refused_by_the_name_as_written() {
     assert!(rejection.contains("name"), "got: {rejection}");
 }
 
+/// A name the item paths splice into `Ident::new` — the schema module every reference to the item
+/// resolves through — so one no identifier can be spelled from panicked the macro, reporting no
+/// span and naming no argument.
+#[test]
+fn a_name_no_identifier_can_be_spelled_from_is_refused() {
+    for value in [
+        "",
+        " ",
+        "Not Valid",
+        "9Leading",
+        "Foo$Bar",
+        "Foo::Bar",
+        "\u{dc}n\u{ef}code",
+    ] {
+        let rejection = args_rejection(quote::quote! { name = #value });
+        assert!(rejection.is_some(), "accepted `name = {value:?}`");
+    }
+}
+
+#[test]
+fn a_name_an_identifier_can_be_spelled_from_is_read() {
+    for value in ["Slug", "_Slug", "Slug2", "slug_case", "S"] {
+        let args = super::parse_model_schema_args(quote::quote! { name = #value });
+        assert_eq!(
+            args.arg_rejection.map(|e| e.to_string()),
+            None,
+            "for {value}"
+        );
+        assert_eq!(args.name_override.as_deref(), Some(value));
+    }
+}
+
 /// The refusal offers every argument the parser reads, and the probes below prove each offered
 /// name is one it actually reads — the list and the arms cannot drift apart while both hold.
 #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -72,13 +72,26 @@ pub fn safe_type_name(key: &str) -> String {
 
 /// The export name is what `register_alias_info` stores and what the alias schema module is
 /// named after, so every feature that references an alias needs it — not just `typescript`.
+///
+/// An override is taken verbatim: the parser has already refused a value no surface can carry, so
+/// what arrives here is the name the author wrote.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-pub fn compute_alias_export_name(rust_ident: &str, override_name: Option<String>) -> String {
-    match override_name {
-        Some(name) if name.trim().is_empty() => format!("{rust_ident}Type"),
-        Some(name) => name,
-        None => format!("{}Type", safe_type_name(rust_ident)),
-    }
+pub fn compute_alias_export_name(rust_ident: &str, override_name: Option<&str>) -> String {
+    override_name.map_or_else(
+        || format!("{}Type", safe_type_name(rust_ident)),
+        ToOwned::to_owned,
+    )
+}
+
+/// [`compute_alias_export_name`] for a declared item — a struct, an enum, a tuple struct, a branded
+/// newtype. Without an override the item keeps the name it is declared under, which is the one
+/// difference from an alias: an alias has no surface name of its own and is given the `Type` suffix.
+///
+/// This is the single seam every item path takes its exported name from, and the registry is keyed
+/// by the Rust ident and answers with it, so a sibling naming the type in Rust resolves to whatever
+/// it is exported as.
+pub fn compute_item_export_name(rust_ident: &str, override_name: Option<&str>) -> String {
+    override_name.map_or_else(|| safe_type_name(rust_ident), ToOwned::to_owned)
 }
 
 #[cfg(feature = "typescript")]

--- a/tests/item_rename_tests.rs
+++ b/tests/item_rename_tests.rs
@@ -1,0 +1,10 @@
+//! Tests for `#[model_schema(name = "…")]` written on a declared item — a struct, a tuple struct,
+//! an enum, a branded newtype — and on the types that reference one.
+//!
+//! Deliberately **not** feature-gated at the fixtures: the override renames the Rust module the
+//! item's schema is published from, so a build that emits a reference to that module without
+//! emitting the module under the same name is exactly what these must catch.
+
+#[cfg(test)]
+#[path = "item_rename_tests/tests.rs"]
+mod tests;

--- a/tests/item_rename_tests/tests.rs
+++ b/tests/item_rename_tests/tests.rs
@@ -1,0 +1,243 @@
+use serde::{Deserialize, Serialize};
+use tixschema::model_schema;
+
+#[model_schema(name = "RenamedItem")]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ItemUnderRustName {
+    pub count: u32,
+    pub label: String,
+}
+
+#[model_schema(name = "RenamedPair")]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct PairUnderRustName(pub String, pub u32);
+
+#[model_schema(name = "RenamedBrand")]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(transparent)]
+pub struct BrandUnderRustName(pub String);
+
+#[model_schema(name = "RenamedSlot")]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SlotUnderRustName {
+    Primary,
+    Secondary,
+}
+
+#[model_schema(name = "RenamedShape")]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum ShapeUnderRustName {
+    Named { side: u8 },
+    Unit,
+}
+
+/// A renamed type that names itself: the recursion is what forces the JSON surface to publish a
+/// definition and point at it, which is the only place the definition's name is written out.
+#[model_schema(name = "RenamedTree")]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct TreeUnderRustName {
+    pub children: Vec<Self>,
+    pub label: String,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ReferencesRenamedItems {
+    pub brand: BrandUnderRustName,
+    pub item: ItemUnderRustName,
+    pub pair: PairUnderRustName,
+    pub shape: ShapeUnderRustName,
+    pub slot: SlotUnderRustName,
+    pub tree: TreeUnderRustName,
+}
+
+#[test]
+fn every_renamed_shape_expands_in_this_feature_combination() {
+    let value = ReferencesRenamedItems {
+        brand: BrandUnderRustName("three".to_owned()),
+        item: ItemUnderRustName {
+            count: 1,
+            label: "one".to_owned(),
+        },
+        pair: PairUnderRustName("two".to_owned(), 2),
+        shape: ShapeUnderRustName::Named { side: 4 },
+        slot: SlotUnderRustName::Primary,
+        tree: TreeUnderRustName {
+            children: vec![],
+            label: "five".to_owned(),
+        },
+    };
+    assert_eq!(value.item.count, 1);
+    assert_eq!(value.pair.1, 2);
+    assert_eq!(value.brand.0, "three");
+    assert_eq!(value.slot, SlotUnderRustName::Primary);
+    assert!(value.tree.children.is_empty());
+}
+
+#[cfg(feature = "typescript")]
+#[test]
+fn every_renamed_shape_is_written_under_the_override() {
+    for (ts, declared) in [
+        (
+            ItemUnderRustName::ts_definition(),
+            "export type RenamedItem",
+        ),
+        (
+            PairUnderRustName::ts_definition(),
+            "export type RenamedPair",
+        ),
+        (
+            BrandUnderRustName::ts_definition(),
+            "export type RenamedBrand",
+        ),
+        (
+            SlotUnderRustName::ts_definition(),
+            "export type RenamedSlot",
+        ),
+        (
+            ShapeUnderRustName::ts_definition(),
+            "export type RenamedShape",
+        ),
+    ] {
+        assert!(ts.contains(declared), "{declared} missing from: {ts}");
+    }
+}
+
+/// The brand is the one shape whose name reaches the surface twice: once as the exported type and
+/// once as the brand tag the values carry, which is what makes two brands distinct in TypeScript.
+#[cfg(all(feature = "typescript", feature = "zod"))]
+#[test]
+fn a_renamed_brand_is_tagged_by_the_override() {
+    let ts = BrandUnderRustName::ts_definition();
+    assert!(ts.contains("$brand<\"RenamedBrand\">"), "got: {ts}");
+    let zod = BrandUnderRustName::zod_schema();
+    assert!(zod.contains(".brand<\"RenamedBrand\">()"), "got: {zod}");
+}
+
+#[cfg(feature = "zod")]
+#[test]
+fn every_renamed_shape_publishes_its_zod_schema_under_the_override() {
+    for (zod, declared) in [
+        (
+            ItemUnderRustName::zod_schema(),
+            "export const RenamedItem$Schema",
+        ),
+        (
+            PairUnderRustName::zod_schema(),
+            "export const RenamedPair$Schema",
+        ),
+        (
+            BrandUnderRustName::zod_schema(),
+            "export const RenamedBrand$Schema",
+        ),
+        (
+            SlotUnderRustName::zod_schema(),
+            "export const RenamedSlot$Schema",
+        ),
+        (
+            ShapeUnderRustName::zod_schema(),
+            "export const RenamedShape$Schema",
+        ),
+    ] {
+        assert!(zod.contains(declared), "{declared} missing from: {zod}");
+    }
+}
+
+#[cfg(feature = "typescript")]
+#[test]
+fn a_reference_to_a_renamed_item_resolves_the_override() {
+    let ts = ReferencesRenamedItems::ts_definition();
+    for referenced in [
+        "item: RenamedItem;",
+        "pair: RenamedPair;",
+        "brand: RenamedBrand;",
+        "slot: RenamedSlot;",
+        "shape: RenamedShape;",
+        "tree: RenamedTree;",
+    ] {
+        assert!(ts.contains(referenced), "{referenced} missing from: {ts}");
+    }
+}
+
+#[cfg(feature = "zod")]
+#[test]
+fn a_zod_reference_to_a_renamed_item_resolves_the_override() {
+    let zod = ReferencesRenamedItems::zod_schema();
+    for referenced in [
+        "item: RenamedItem$Schema",
+        "pair: RenamedPair$Schema",
+        "brand: RenamedBrand$Schema",
+        "slot: RenamedSlot$Schema",
+        "shape: RenamedShape$Schema",
+        "tree: RenamedTree$Schema",
+    ] {
+        assert!(zod.contains(referenced), "{referenced} missing from: {zod}");
+    }
+}
+
+/// The reported failure was a rename that reached no surface, leaving every reference spelled from
+/// the Rust ident. A referencing type carries nothing but references, so the Rust names of the
+/// types it names must not appear in what it publishes.
+#[cfg(any(feature = "typescript", feature = "zod"))]
+#[test]
+fn a_reference_to_a_renamed_item_never_carries_its_rust_name() {
+    #[cfg(feature = "typescript")]
+    let ts = ReferencesRenamedItems::ts_definition();
+    #[cfg(not(feature = "typescript"))]
+    let ts = String::new();
+    #[cfg(feature = "zod")]
+    let zod = ReferencesRenamedItems::zod_schema();
+    #[cfg(not(feature = "zod"))]
+    let zod = String::new();
+    for surface in [&ts, &zod] {
+        assert!(
+            !surface.contains("UnderRustName"),
+            "rust name reached: {surface}"
+        );
+    }
+}
+
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_renamed_item_names_its_json_definition_by_the_override() {
+    let schema = TreeUnderRustName::json_schema();
+    let pointer = serde_json::json!({ "$ref": "#/$defs/RenamedTree" });
+    assert_eq!(
+        schema.get("$ref").unwrap(),
+        &pointer["$ref"],
+        "got: {schema}"
+    );
+    let definition = schema.get("$defs").unwrap().get("RenamedTree").unwrap();
+    assert_eq!(
+        definition
+            .get("properties")
+            .unwrap()
+            .get("children")
+            .unwrap()
+            .get("items")
+            .unwrap(),
+        &pointer,
+        "got: {schema}"
+    );
+}
+
+/// The JSON reference is a Rust path to the renamed item's schema module, so this is the one
+/// surface where the override has to reach the module name as well as the exported name.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn the_module_a_json_reference_resolves_to_is_the_one_the_override_named() {
+    let referencing = ReferencesRenamedItems::json_schema();
+    let properties = referencing.get("properties").unwrap();
+    assert_eq!(
+        properties.get("item").unwrap(),
+        &renamed_item_schema::Schema::json_schema()
+    );
+    assert_eq!(
+        properties.get("slot").unwrap(),
+        &renamed_slot_schema::Schema::json_schema()
+    );
+    assert_eq!(
+        properties.get("brand").unwrap(),
+        &renamed_brand_schema::Schema::json_schema()
+    );
+}


### PR DESCRIPTION
name = "..." was read then dropped on everything but type aliases. Capture-first finding: the registry is keyed by Rust ident and answers with the export name, and every reference reads it — so registering the override makes sibling references resolve the rename for free. compute_item_export_name (mirror of the alias helper) now feeds struct_module_idents (structs + tuple structs), process_branded_newtype, and process_enum's single item_name.

A second capture forced a companion guard: an invalid name value already panicked the macro on the alias path (Ident::new on the snake-cased module). The parser now refuses a value no identifier can be spelled from, spanned on the literal — covering aliases too and retiring the silent empty-name fallback.

Byte-identity proven by git-archive A/B probe: 14 shapes, 1364 lines of surface output each, identical.

Powerset + full lint-all green on the merged state.
