### PR TITLE
fix: an unclassified map key's enum_members call is spanned on the key the field names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1569,6 +1569,37 @@ pub struct Config {
 }
 ```
 
+#### Map Keys Without Enumerable Members
+
+**Error:** `no associated function or constant named enum_members found for <type>` (`E0599`), reported at the map's key type.
+
+A map key written as a type path must be a plain `#[model_schema()]` enum, whose members become the object's keys. A key the expansion has already seen is named directly — *a map key must be a plain `#[model_schema()]` enum ...* — but items expand in the order they are written, so a key declared after the type that writes the map, like one from another crate, has not been seen yet and is emitted as an enumerating key. When such a key carries no `enum_members()`, the requirement surfaces as an `E0599` at the key type:
+
+```rust
+// Wrong: `LateKey` resolves to `String`, which has no members to enumerate
+#[model_schema()]
+pub struct BadConfig {
+    pub slots: HashMap<LateKey, String>, // E0599, reported at `LateKey`
+}
+
+#[model_schema()]
+pub type LateKey = String;
+
+// Correct: the key is a plain enum, and its members become the object's keys
+#[model_schema()]
+pub enum Slot {
+    Primary,
+    Secondary,
+}
+
+#[model_schema()]
+pub struct Config {
+    pub slots: HashMap<Slot, String>,
+}
+```
+
+Declaration order decides only which of the two diagnostics is reported. A plain enum key works wherever it is declared.
+
 #### Function-Local Types
 
 **Error:** `cannot find module or crate <type>_schema in this scope` (`E0433`), reported at the field's type.

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -5228,9 +5228,9 @@ fn build_nested_map_member_item(
     );
 
     Ok(match map_key_path(inner_key) {
-        MapKeyPath::Enumerated(key_type_name) => {
-            MapMemberItem::Value(enum_key_map_json_schema_value(key_type_name, inner_value)?)
-        }
+        MapKeyPath::Enumerated(key_type_name) => MapMemberItem::Value(
+            enum_key_map_json_schema_value(key_type_name, inner_key.type_span, inner_value)?,
+        ),
         MapKeyPath::Open => {
             let inner_member = build_map_member_schema(inner_value)?;
             MapMemberItem::Fragment(
@@ -5448,9 +5448,16 @@ fn build_enum_key_map_member_item(value: &FieldDef) -> Result<MapMemberItem, Map
 /// sound for a key that has them: whatever reaches this dispatch, a key the registry rules out
 /// leaves with a diagnostic naming it rather than with rustc blaming `#[model_schema()]` for a
 /// method the author never wrote.
+///
+/// The registry rules out only what it has already seen, and it is filled as items expand: a key
+/// declared after the type that writes the map, like one foreign to this crate, is unclassified
+/// here and keeps the emitting path — it must, since nothing distinguishes it from a type that
+/// does carry `enum_members()`. So the call is spanned on the key the field names, and the `E0599`
+/// a key without the method raises is reported at the user's type instead of at `#[model_schema()]`.
 #[cfg(feature = "jsonschema")]
 fn enum_key_map_json_schema_value(
     key_type_name: &str,
+    key_span: proc_macro2::Span,
     value: &FieldDef,
 ) -> Result<proc_macro2::TokenStream, MapMemberRejection> {
     if proves_no_enum_members(key_type_name) {
@@ -5459,14 +5466,15 @@ fn enum_key_map_json_schema_value(
 
     let normalized = normalized_slot_value(value);
     let member_value = build_enum_key_map_member_item(&normalized)?.into_member_value(&normalized);
-    let key_type_name_ident = Ident::new(key_type_name, proc_macro2::Span::call_site());
+    let key_type_name_ident = Ident::new(key_type_name, key_span);
+    let key_members = quote_spanned! {key_span=> #key_type_name_ident::enum_members() };
     Ok(quote! {
         serde_json::json!({
             "type": "object",
             "properties": ({
                 let value_schema = #member_value;
                 let mut map_properties = serde_json::Map::new();
-                for enum_key in #key_type_name_ident::enum_members() {
+                for enum_key in #key_members {
                     map_properties.insert(enum_key.to_string(), value_schema.clone());
                 }
                 map_properties
@@ -5495,7 +5503,7 @@ fn build_map_field_schema(
 
     let rendered = match map_key_path(key) {
         MapKeyPath::Enumerated(key_type_name) => {
-            enum_key_map_json_schema_value(key_type_name, value)
+            enum_key_map_json_schema_value(key_type_name, key.type_span, value)
         }
         MapKeyPath::Open => string_key_map_json_schema_value(value),
         MapKeyPath::Unnarrowed => Ok(unnarrowed_key_map_json_schema_value(key)),

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -1962,7 +1962,7 @@ fn enum_key_map_value_binding(field_type: FieldDefType) -> String {
     let ty: syn::Type = syn::parse_str("String").unwrap();
     let mut value = super::get_field_def("m", &ty, "");
     value.field_type = field_type;
-    super::enum_key_map_json_schema_value("Slot", &value)
+    super::enum_key_map_json_schema_value("Slot", proc_macro2::Span::call_site(), &value)
         .unwrap()
         .to_string()
 }
@@ -2994,6 +2994,31 @@ fn a_sibling_reference_emits_the_tokens_it_always_has() {
         sole_field_json_schema("struct Outer { inner: Inner }").to_string(),
         "properties . insert (\"inner\" . to_string () , inner_schema :: Schema :: json_schema_within (in_flight , hoisted_defs)) ;"
     );
+}
+
+/// The registry is filled as items expand, so a key declared after the type that writes the map —
+/// like a key foreign to this crate — reads as unclassified and keeps the emitting path. Its
+/// `enum_members()` call is therefore spanned on the key the field names, so a key that carries no
+/// such method is blamed at the user's type instead of at `#[model_schema()]`. Every position a
+/// map is written in names the key the same way.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn an_enum_keyed_map_points_its_members_call_at_the_key_the_field_names() {
+    for source in [
+        "struct Outer { m: HashMap<Slot, String> }",
+        "struct Outer { m: Vec<HashMap<Slot, String>> }",
+        "struct Outer { m: HashMap<String, HashMap<Slot, String>> }",
+        "struct Outer { m: (HashMap<Slot, String>, u32) }",
+    ] {
+        let tokens = sole_field_json_schema(source);
+        for named in ["Slot", "enum_members"] {
+            assert_eq!(
+                ident_source_texts(&tokens, named),
+                vec![Some("Slot".to_owned())],
+                "for {source}, at `{named}`, got: {tokens}"
+            );
+        }
+    }
 }
 
 /// The tuple-field insertion for a field type built by hand.


### PR DESCRIPTION
A map key declared after the referencing struct (or foreign to the crate) is unclassified at expansion and keeps the emitting path — it must, per the registry-absence verdict. Its E0599 was blamed on #[model_schema()] with a macro-origin note; the enum_members path and call now carry the key's span (mirroring the #79 technique), so the error lands on the user's key type. Only the call is spanned; the surrounding json! scaffolding stays call_site so consumer lints don't judge generated code as hand-written.

The spec's preferred const-assertion was tried and rejected on evidence: it emits the identical E0599 at the identical span while breaking byte-identity, and the trait variant that improves the words leaks dead_code into every consumer. Byte-identity holds (spans don't affect token strings — all exact-token tests untouched); a README troubleshooting entry documents the two diagnostics and that declaration order only picks between them.

Powerset + full lint-all green.
