### PR TITLE
fix: every item shape spells its no-docs description from the export name

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -687,11 +687,14 @@ fn has_serde_transparent(attrs: &[syn::Attribute]) -> bool {
 
 /// Processes a struct item and generates TypeScript and Zod schema definitions for it.
 /// Builds the `JSDoc` comment body (lines prefixed with ` * `) for a struct or enum type.
+///
+/// The fallback names the item as it is exported, not as it is declared in Rust, so a `JSDoc`
+/// header never contradicts the `export type` one line under it.
 #[cfg(feature = "typescript")]
-fn build_item_jsdoc(docs_vec: Option<&[String]>, name: &syn::Ident) -> String {
+fn build_item_jsdoc(docs_vec: Option<&[String]>, item_name: &str) -> String {
     docs_vec.map_or_else(
         || {
-            [name.to_string(), String::new()]
+            [item_name.to_owned(), String::new()]
                 .into_iter()
                 .map(|l| format!(" * {l}"))
                 .collect::<Vec<_>>()
@@ -1498,7 +1501,7 @@ fn process_struct(mut item_struct: syn::ItemStruct, args: &ModelSchemaArgs) -> T
     }
 
     #[cfg(feature = "typescript")]
-    let docs = build_item_jsdoc(docs_and_example.0.as_deref(), &name);
+    let docs = build_item_jsdoc(docs_and_example.0.as_deref(), &item_name);
     #[cfg(all(
         not(feature = "typescript"),
         any(feature = "zod", feature = "jsonschema")
@@ -1721,7 +1724,7 @@ fn process_tuple_struct(
         json_schema_methods(&item_name, &tuple_struct_json_body(&item_name, &slots)),
         #[cfg(feature = "typescript")]
         build_tuple_struct_ts_definition_method(
-            &build_item_jsdoc(docs_and_example.0.as_deref(), &name),
+            &build_item_jsdoc(docs_and_example.0.as_deref(), &item_name),
             &item_name,
             &tuple_struct_ts_body(&slots),
         ),
@@ -2004,7 +2007,8 @@ fn branded_json_inner_type(is_generic: bool, inner_ty: &syn::Type) -> String {
 }
 
 /// Flattens a branded newtype's doc comments into a single escaped description string,
-/// stripping ` ```rust example ` fences. Falls back to the type name when there are no docs.
+/// stripping ` ```rust example ` fences. Falls back to the exported name when there are no docs,
+/// which is the spelling every other item path falls back to as well.
 #[cfg(feature = "zod")]
 fn branded_plain_description(docs_vec: Option<&[String]>, item_name: &str) -> String {
     docs_vec.map_or_else(
@@ -2721,21 +2725,21 @@ fn process_enum(item_enum: syn::ItemEnum, args: &ModelSchemaArgs) -> TokenStream
 }
 
 /// Flattens an item's doc comments into a `JSDoc` body and an escaped one-line description, both
-/// derived from the same lines (with ` ```rust example ` blocks stripped). Falls back to the type
-/// name when there are no docs.
+/// derived from the same lines (with ` ```rust example ` blocks stripped). Falls back to the
+/// exported name when there are no docs, matching every other item path.
 #[cfg(any(feature = "typescript", feature = "zod"))]
 fn build_item_docs_and_description(
     docs_vec: Option<&[String]>,
-    name: &syn::Ident,
+    item_name: &str,
 ) -> (String, String) {
     docs_vec.map_or_else(
         || {
-            let docs_formatted = [name.to_string(), String::new()]
+            let docs_formatted = [item_name.to_owned(), String::new()]
                 .into_iter()
                 .map(|l| format!(" * {l}"))
                 .collect::<Vec<_>>()
                 .join("\n");
-            (docs_formatted, name.to_string())
+            (docs_formatted, item_name.to_owned())
         },
         |doc_lines| {
             let doc_lines_without_examples = strip_examples_from_docs(doc_lines);
@@ -2875,7 +2879,7 @@ fn process_plain_enum(
         .collect();
 
     #[cfg(any(feature = "typescript", feature = "zod"))]
-    let docs_and_description = build_item_docs_and_description(docs_vec.as_deref(), name);
+    let docs_and_description = build_item_docs_and_description(docs_vec.as_deref(), item_name);
 
     // Generate schema module methods
     #[cfg(feature = "jsonschema")]
@@ -3149,7 +3153,7 @@ fn process_discriminated_enum(
     );
 
     #[cfg(feature = "typescript")]
-    let docs = build_item_jsdoc(docs_vec.as_deref(), name);
+    let docs = build_item_jsdoc(docs_vec.as_deref(), item_name);
 
     // Generate schema module methods
     #[cfg(feature = "jsonschema")]
@@ -3547,7 +3551,7 @@ fn process_externally_tagged_enum(
     let _: &_ = &name;
 
     #[cfg(feature = "typescript")]
-    let docs = build_item_jsdoc(docs_vec.as_deref(), name);
+    let docs = build_item_jsdoc(docs_vec.as_deref(), item_name);
 
     #[cfg(feature = "jsonschema")]
     let json_schema_method =
@@ -3940,7 +3944,7 @@ fn process_internally_tagged_enum(
     let _: &_ = &name;
 
     #[cfg(feature = "typescript")]
-    let docs = build_item_jsdoc(docs_vec.as_deref(), name);
+    let docs = build_item_jsdoc(docs_vec.as_deref(), item_name);
 
     #[cfg(feature = "jsonschema")]
     let json_schema_method =
@@ -4397,7 +4401,7 @@ fn process_untagged_enum(
     let schema_code = format!("z.union([{}])", zod_parts.join(", "));
 
     #[cfg(feature = "typescript")]
-    let docs = build_item_jsdoc(docs_vec.as_deref(), name);
+    let docs = build_item_jsdoc(docs_vec.as_deref(), item_name);
 
     // Generate schema module methods
     #[cfg(feature = "jsonschema")]

--- a/tests/item_description_tests.rs
+++ b/tests/item_description_tests.rs
@@ -1,0 +1,11 @@
+//! Tests for the description an item falls back to when it carries no doc comment — the `JSDoc`
+//! header a `TypeScript` definition opens with and the `description` a Zod schema publishes.
+//!
+//! The fallback names the item as it is **exported**, so it agrees with the `export type` written
+//! one line under it. An export name parts from the Rust ident two ways: a `name = "…"` override,
+//! and the `Json` suffix stripped off a declared ident. Both are covered here, alongside the
+//! un-suffixed un-renamed items whose output this must leave exactly where it was.
+
+#[cfg(test)]
+#[path = "item_description_tests/tests.rs"]
+mod tests;

--- a/tests/item_description_tests/tests.rs
+++ b/tests/item_description_tests/tests.rs
@@ -1,0 +1,277 @@
+use serde::{Deserialize, Serialize};
+use tixschema::model_schema;
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug)]
+pub struct PlainStruct {
+    pub label: String,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug)]
+pub struct SuffixedStructJson {
+    pub label: String,
+}
+
+#[model_schema(name = "RenamedStruct")]
+#[derive(Serialize, Deserialize, Debug)]
+pub struct StructUnderRustName {
+    pub label: String,
+}
+
+/// A documented struct.
+#[model_schema(name = "RenamedDocStruct")]
+#[derive(Serialize, Deserialize, Debug)]
+pub struct DocStructUnderRustName {
+    pub label: String,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug)]
+pub struct PlainTuple(pub String, pub u32);
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug)]
+pub struct SuffixedTupleJson(pub String, pub u32);
+
+#[model_schema(name = "RenamedTuple")]
+#[derive(Serialize, Deserialize, Debug)]
+pub struct TupleUnderRustName(pub String, pub u32);
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+pub enum PlainSlot {
+    Primary,
+    Secondary,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+pub enum SuffixedSlotJson {
+    Primary,
+    Secondary,
+}
+
+#[model_schema(name = "RenamedSlot")]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+pub enum SlotUnderRustName {
+    Primary,
+    Secondary,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug)]
+pub enum PlainShape {
+    Named { side: u8 },
+    Unit,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug)]
+pub enum SuffixedShapeJson {
+    Named { side: u8 },
+    Unit,
+}
+
+#[model_schema(name = "RenamedShape")]
+#[derive(Serialize, Deserialize, Debug)]
+pub enum ShapeUnderRustName {
+    Named { side: u8 },
+    Unit,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "kind", content = "payload")]
+pub enum PlainAdjacent {
+    Named { side: u8 },
+    Unit,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "kind", content = "payload")]
+pub enum SuffixedAdjacentJson {
+    Named { side: u8 },
+    Unit,
+}
+
+#[model_schema(name = "RenamedAdjacent")]
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "kind", content = "payload")]
+pub enum AdjacentUnderRustName {
+    Named { side: u8 },
+    Unit,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(untagged)]
+pub enum PlainEither {
+    Count(u32),
+    Label(String),
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(untagged)]
+pub enum SuffixedEitherJson {
+    Count(u32),
+    Label(String),
+}
+
+#[model_schema(name = "RenamedEither")]
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(untagged)]
+pub enum EitherUnderRustName {
+    Count(u32),
+    Label(String),
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(transparent)]
+pub struct PlainBrand(pub String);
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(transparent)]
+pub struct SuffixedBrandJson(pub String);
+
+#[model_schema(name = "RenamedBrand")]
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(transparent)]
+pub struct BrandUnderRustName(pub String);
+
+#[cfg(feature = "typescript")]
+fn assert_jsdoc_opens_with(ts: &str, expected: &str) {
+    let header = format!("/**\n * {expected}\n");
+    assert!(ts.starts_with(&header), "expected {expected} to open: {ts}");
+}
+
+#[cfg(feature = "typescript")]
+#[test]
+fn an_undocumented_item_names_itself_in_jsdoc_as_it_is_exported() {
+    for (ts, exported) in [
+        (StructUnderRustName::ts_definition(), "RenamedStruct"),
+        (TupleUnderRustName::ts_definition(), "RenamedTuple"),
+        (SlotUnderRustName::ts_definition(), "RenamedSlot"),
+        (ShapeUnderRustName::ts_definition(), "RenamedShape"),
+        (AdjacentUnderRustName::ts_definition(), "RenamedAdjacent"),
+        (EitherUnderRustName::ts_definition(), "RenamedEither"),
+        (SuffixedStructJson::ts_definition(), "SuffixedStruct"),
+        (SuffixedTupleJson::ts_definition(), "SuffixedTuple"),
+        (SuffixedSlotJson::ts_definition(), "SuffixedSlot"),
+        (SuffixedShapeJson::ts_definition(), "SuffixedShape"),
+        (SuffixedAdjacentJson::ts_definition(), "SuffixedAdjacent"),
+        (SuffixedEitherJson::ts_definition(), "SuffixedEither"),
+    ] {
+        assert_jsdoc_opens_with(&ts, exported);
+        assert!(
+            ts.contains(&format!("export type {exported} ")),
+            "{exported} not exported by: {ts}"
+        );
+    }
+}
+
+/// The reported failure was a `JSDoc` header contradicting the `export type` one line under it, so
+/// the name the item is declared under must reach neither.
+#[cfg(feature = "typescript")]
+#[test]
+fn an_undocumented_item_never_writes_its_rust_ident() {
+    for ts in [
+        StructUnderRustName::ts_definition(),
+        TupleUnderRustName::ts_definition(),
+        SlotUnderRustName::ts_definition(),
+        ShapeUnderRustName::ts_definition(),
+        AdjacentUnderRustName::ts_definition(),
+        EitherUnderRustName::ts_definition(),
+    ] {
+        assert!(!ts.contains("UnderRustName"), "rust ident reached: {ts}");
+    }
+    for (ts, ident) in [
+        (SuffixedStructJson::ts_definition(), "SuffixedStructJson"),
+        (SuffixedTupleJson::ts_definition(), "SuffixedTupleJson"),
+        (SuffixedSlotJson::ts_definition(), "SuffixedSlotJson"),
+        (SuffixedShapeJson::ts_definition(), "SuffixedShapeJson"),
+        (
+            SuffixedAdjacentJson::ts_definition(),
+            "SuffixedAdjacentJson",
+        ),
+        (SuffixedEitherJson::ts_definition(), "SuffixedEitherJson"),
+    ] {
+        assert!(!ts.contains(ident), "rust ident reached: {ts}");
+    }
+}
+
+/// The overwhelming case: an item declared under the name it exports, whose header this must leave
+/// exactly where it was.
+#[cfg(feature = "typescript")]
+#[test]
+fn an_item_exported_under_its_rust_ident_keeps_the_header_it_had() {
+    for (ts, declared) in [
+        (PlainStruct::ts_definition(), "PlainStruct"),
+        (PlainTuple::ts_definition(), "PlainTuple"),
+        (PlainSlot::ts_definition(), "PlainSlot"),
+        (PlainShape::ts_definition(), "PlainShape"),
+        (PlainAdjacent::ts_definition(), "PlainAdjacent"),
+        (PlainEither::ts_definition(), "PlainEither"),
+    ] {
+        assert_jsdoc_opens_with(&ts, declared);
+    }
+}
+
+/// The fallback fires only for an item with nothing to say, so a documented one keeps its docs
+/// whatever it is exported as.
+#[cfg(feature = "typescript")]
+#[test]
+fn a_documented_item_keeps_its_docs_over_either_name() {
+    let ts = DocStructUnderRustName::ts_definition();
+    assert_jsdoc_opens_with(&ts, "A documented struct.");
+    assert!(
+        ts.contains("export type RenamedDocStruct "),
+        "override missing from: {ts}"
+    );
+}
+
+/// A plain enum is the one shape that writes the fallback twice — once as the `JSDoc` header and
+/// once as the Zod `description` — and the two are the same string.
+#[cfg(feature = "zod")]
+#[test]
+fn a_plain_enum_describes_itself_as_it_is_exported() {
+    for (zod, exported) in [
+        (SlotUnderRustName::zod_schema(), "RenamedSlot"),
+        (SuffixedSlotJson::zod_schema(), "SuffixedSlot"),
+        (PlainSlot::zod_schema(), "PlainSlot"),
+    ] {
+        assert!(
+            zod.contains(&format!("description: \"{exported}\"")),
+            "{exported} not described by: {zod}"
+        );
+    }
+    assert!(
+        !SlotUnderRustName::zod_schema().contains("UnderRustName"),
+        "rust ident reached the description"
+    );
+    assert!(
+        !SuffixedSlotJson::zod_schema().contains("SuffixedSlotJson"),
+        "rust ident reached the description"
+    );
+}
+
+/// The brand path already spelled its description from the export name; it is the spelling the
+/// other shapes were brought onto, so it must not move.
+#[cfg(feature = "zod")]
+#[test]
+fn a_brand_describes_itself_as_it_is_exported() {
+    for (zod, exported) in [
+        (BrandUnderRustName::zod_schema(), "RenamedBrand"),
+        (SuffixedBrandJson::zod_schema(), "SuffixedBrand"),
+        (PlainBrand::zod_schema(), "PlainBrand"),
+    ] {
+        assert!(
+            zod.contains(&format!("description: \"{exported}\"")),
+            "{exported} not described by: {zod}"
+        );
+    }
+}


### PR DESCRIPTION
Structs, tuple structs and all five enum paths spelled their JSDoc/description fallback from the Rust ident while the brand path used the export name — a renamed struct's TS read export type RenamedStruct under a JSDoc saying NamedStruct. Capture table across every shape x plain/suffixed/renamed decided the unification: only the export-name spelling keeps un-renamed non-suffixed items byte-identical. Two helpers now take the computed export name; seven call sites swapped.

A/B probe: 32 changed lines across 17 items, every one either UnderRustName->Renamed or SuffixedJson->Suffixed — the intentional delta the bug reported. Everything else byte-identical.

Powerset + full lint-all green on the merged state.
