### PR TITLE
cfg-gate item_description_tests fixtures to the features that consume them

### DIFF
--- a/tests/item_description_tests.rs
+++ b/tests/item_description_tests.rs
@@ -6,6 +6,7 @@
 //! and the `Json` suffix stripped off a declared ident. Both are covered here, alongside the
 //! un-suffixed un-renamed items whose output this must leave exactly where it was.
 
+#[cfg(any(feature = "typescript", feature = "zod"))]
 #[cfg(test)]
 #[path = "item_description_tests/tests.rs"]
 mod tests;

--- a/tests/item_description_tests/tests.rs
+++ b/tests/item_description_tests/tests.rs
@@ -1,18 +1,21 @@
 use serde::{Deserialize, Serialize};
 use tixschema::model_schema;
 
+#[cfg(feature = "typescript")]
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct PlainStruct {
     pub label: String,
 }
 
+#[cfg(feature = "typescript")]
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct SuffixedStructJson {
     pub label: String,
 }
 
+#[cfg(feature = "typescript")]
 #[model_schema(name = "RenamedStruct")]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct StructUnderRustName {
@@ -20,24 +23,29 @@ pub struct StructUnderRustName {
 }
 
 /// A documented struct.
+#[cfg(feature = "typescript")]
 #[model_schema(name = "RenamedDocStruct")]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct DocStructUnderRustName {
     pub label: String,
 }
 
+#[cfg(feature = "typescript")]
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct PlainTuple(pub String, pub u32);
 
+#[cfg(feature = "typescript")]
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct SuffixedTupleJson(pub String, pub u32);
 
+#[cfg(feature = "typescript")]
 #[model_schema(name = "RenamedTuple")]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct TupleUnderRustName(pub String, pub u32);
 
+#[cfg(any(feature = "typescript", feature = "zod"))]
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
 pub enum PlainSlot {
@@ -45,6 +53,7 @@ pub enum PlainSlot {
     Secondary,
 }
 
+#[cfg(any(feature = "typescript", feature = "zod"))]
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
 pub enum SuffixedSlotJson {
@@ -52,6 +61,7 @@ pub enum SuffixedSlotJson {
     Secondary,
 }
 
+#[cfg(any(feature = "typescript", feature = "zod"))]
 #[model_schema(name = "RenamedSlot")]
 #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
 pub enum SlotUnderRustName {
@@ -59,6 +69,7 @@ pub enum SlotUnderRustName {
     Secondary,
 }
 
+#[cfg(feature = "typescript")]
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug)]
 pub enum PlainShape {
@@ -66,6 +77,7 @@ pub enum PlainShape {
     Unit,
 }
 
+#[cfg(feature = "typescript")]
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug)]
 pub enum SuffixedShapeJson {
@@ -73,6 +85,7 @@ pub enum SuffixedShapeJson {
     Unit,
 }
 
+#[cfg(feature = "typescript")]
 #[model_schema(name = "RenamedShape")]
 #[derive(Serialize, Deserialize, Debug)]
 pub enum ShapeUnderRustName {
@@ -80,6 +93,7 @@ pub enum ShapeUnderRustName {
     Unit,
 }
 
+#[cfg(feature = "typescript")]
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "kind", content = "payload")]
@@ -88,6 +102,7 @@ pub enum PlainAdjacent {
     Unit,
 }
 
+#[cfg(feature = "typescript")]
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "kind", content = "payload")]
@@ -96,6 +111,7 @@ pub enum SuffixedAdjacentJson {
     Unit,
 }
 
+#[cfg(feature = "typescript")]
 #[model_schema(name = "RenamedAdjacent")]
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "kind", content = "payload")]
@@ -104,6 +120,7 @@ pub enum AdjacentUnderRustName {
     Unit,
 }
 
+#[cfg(feature = "typescript")]
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(untagged)]
@@ -112,6 +129,7 @@ pub enum PlainEither {
     Label(String),
 }
 
+#[cfg(feature = "typescript")]
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(untagged)]
@@ -120,6 +138,7 @@ pub enum SuffixedEitherJson {
     Label(String),
 }
 
+#[cfg(feature = "typescript")]
 #[model_schema(name = "RenamedEither")]
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(untagged)]
@@ -128,16 +147,19 @@ pub enum EitherUnderRustName {
     Label(String),
 }
 
+#[cfg(feature = "zod")]
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(transparent)]
 pub struct PlainBrand(pub String);
 
+#[cfg(feature = "zod")]
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(transparent)]
 pub struct SuffixedBrandJson(pub String);
 
+#[cfg(feature = "zod")]
 #[model_schema(name = "RenamedBrand")]
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(transparent)]


### PR DESCRIPTION
CI's lint-across-feature-combinations job has been red on master for four pushes: every fixture in tests/item_description_tests/tests.rs is declared ungated while the tests consuming them are cfg-gated, so any combo missing the consuming feature fails -D warnings on dead_code (struct/tuple/doc fixtures and the typescript-only enums without typescript; brand fixtures without zod).

Fix mirrors the earlier tuple_variant_tests CI repair: each fixture is gated to the feature(s) of the tests that construct it — typescript for the struct/tuple/doc-struct fixtures and the Shape/Adjacent/Either enums, zod for the brands, any(typescript, zod) for the Slot enums used by both surfaces — and the wrapper's mod inclusion is gated any(typescript, zod) so featureless combos skip the file (which would otherwise fail on the then-unused imports).

item_rename_tests was suspected too but is clean: its ungated first test constructs every fixture in all combos. Full local powerset tests + lint-all green with exit codes verified unpiped.