### PR TITLE
rewrite build_item_jsdoc's rustdoc to describe the function it sits on

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -685,11 +685,16 @@ fn has_serde_transparent(attrs: &[syn::Attribute]) -> bool {
     false
 }
 
-/// Processes a struct item and generates TypeScript and Zod schema definitions for it.
-/// Builds the `JSDoc` comment body (lines prefixed with ` * `) for a struct or enum type.
+/// Builds the `JSDoc` comment body (lines prefixed with ` * `) that precedes an item's
+/// `export type`. Serves the shapes that publish no zod `description` of their own — structs,
+/// tuple structs, and the tagged and untagged enums; the shapes that publish both surfaces spell
+/// them from the same lines in `build_item_docs_and_description`.
 ///
-/// The fallback names the item as it is exported, not as it is declared in Rust, so a `JSDoc`
-/// header never contradicts the `export type` one line under it.
+/// The no-docs fallback names the item as it is exported, not as it is declared in Rust, so a
+/// `JSDoc` header never contradicts the `export type` one line under it.
+///
+/// Doc lines reach the body as written: unlike the `item_plain_doc_lines` path, this one strips no
+/// ` ```rust example ` block.
 #[cfg(feature = "typescript")]
 fn build_item_jsdoc(docs_vec: Option<&[String]>, item_name: &str) -> String {
     docs_vec.map_or_else(


### PR DESCRIPTION
build_item_jsdoc's rustdoc opened with a line describing process_struct ("Processes a struct item and generates TypeScript and Zod schema definitions for it") — a leftover that predates the recent JSDoc work — so cargo doc published the JSDoc builder as something that processes struct items. Docs-only: the rustdoc now describes the function itself — which shapes it serves (the ones publishing no zod description of their own), the export-name fallback invariant, and the fact that this path strips no rust-example block (unlike item_plain_doc_lines). The stray line is dropped rather than moved, per the task's spec. No code change; full powerset tests and lint-all green locally.
