### PR TITLE
describe an ObjectId-inner brand as the $oid object on every surface

### DIFF
--- a/src/features/object_id.rs
+++ b/src/features/object_id.rs
@@ -15,8 +15,18 @@ pub fn get_object_id_typescript_type() -> String {
 
 #[cfg(all(feature = "object_id", any(test, feature = "zod")))]
 pub fn get_object_id_zod_schema() -> String {
-    "z.object({ $oid: z.string().regex(/^[a-f\\d]{24}$/i, { message: \"Invalid ObjectId\" }) })"
-        .to_owned()
+    get_object_id_zod_schema_with("")
+}
+
+/// The `$oid` object's Zod schema with `hex_checks` appended to the hex string it holds.
+///
+/// String checks belong on that member and never on the object around it: `$oid` is the only
+/// string an `ObjectId` writes, and a `z.object` has no string check to take.
+#[cfg(all(feature = "object_id", any(test, feature = "zod")))]
+pub fn get_object_id_zod_schema_with(hex_checks: &str) -> String {
+    format!(
+        "z.object({{ $oid: z.string().regex(/^[a-f\\d]{{24}}$/i, {{ message: \"Invalid ObjectId\" }}){hex_checks} }})"
+    )
 }
 
 /// Check if we should handle this type as `ObjectId`.

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -37,6 +37,9 @@ use crate::utils::safe_type_name;
 #[cfg(feature = "zod")]
 use crate::utils::{escape_js_regex_literal, extract_example_from_docs};
 
+#[cfg(all(feature = "zod", feature = "object_id"))]
+use crate::features::object_id::get_object_id_zod_schema_with;
+
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 use crate::utils::{AliasKind, lookup_alias_info, regex_rejection};
 
@@ -182,6 +185,17 @@ struct BrandedValidation {
     checked_inner: proc_macro2::TokenStream,
     deserialize_fn: proc_macro2::TokenStream,
     validate_fn: proc_macro2::TokenStream,
+}
+
+/// The JSON schema shape a branded newtype's inner field describes.
+#[cfg(feature = "jsonschema")]
+enum BrandedJsonInner {
+    /// The `$oid` object an `ObjectId` writes, whose hex member carries the brand's string
+    /// constraints.
+    #[cfg(feature = "object_id")]
+    ObjectId,
+    /// A `"type"` keyword those constraints sit beside.
+    Scalar(String),
 }
 
 /// What a field bottoms out in, under the wrappers it was written beneath.
@@ -1150,8 +1164,12 @@ fn branded_constraint_inner_error(
     )
 }
 
-/// Names the non-string schema shape an inner type resolves to, or `None` when it renders as a
-/// string and so can carry the string constraints.
+/// Names the shape an inner type resolves to that has no string for the constraints to measure, or
+/// `None` when it writes exactly one and so can carry them.
+///
+/// An `ObjectId` answers `None` on that reading rather than on its schema's shape: it writes the
+/// `$oid` object, whose single hex member is both what `Display` renders and where every surface
+/// puts the checks.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 const fn non_string_inner_shape(inner: &FieldDef) -> Option<&'static str> {
     if inner.is_array() {
@@ -1914,12 +1932,12 @@ fn branded_checked_value(
     }
 }
 
-/// Builds the `json_schema()` method for a branded newtype's schema module.
+/// Builds the string schema a branded newtype's constraints are written into: `type_name` as the
+/// `"type"`, then one insert per constraint the brand declares.
 #[cfg(feature = "jsonschema")]
-fn build_branded_json_schema_method(
+fn branded_constrained_schema_obj(
     args: &ModelSchemaArgs,
-    json_inner_type: &str,
-    def_name: &str,
+    type_name: &str,
 ) -> proc_macro2::TokenStream {
     let mut constraint_inserts: Vec<proc_macro2::TokenStream> = Vec::new();
 
@@ -1939,12 +1957,28 @@ fn build_branded_json_schema_method(
         });
     }
 
-    let body = quote! {
+    quote! {
         {
             let mut schema_obj = serde_json::Map::new();
-            schema_obj.insert("type".to_string(), serde_json::Value::String(#json_inner_type.to_string()));
+            schema_obj.insert("type".to_string(), serde_json::Value::String(#type_name.to_string()));
             #(#constraint_inserts)*
             serde_json::Value::Object(schema_obj)
+        }
+    }
+}
+
+/// Builds the `json_schema()` method for a branded newtype's schema module.
+#[cfg(feature = "jsonschema")]
+fn build_branded_json_schema_method(
+    args: &ModelSchemaArgs,
+    json_inner: &BrandedJsonInner,
+    def_name: &str,
+) -> proc_macro2::TokenStream {
+    let body = match json_inner {
+        BrandedJsonInner::Scalar(type_name) => branded_constrained_schema_obj(args, type_name),
+        #[cfg(feature = "object_id")]
+        BrandedJsonInner::ObjectId => {
+            object_id_json_schema_value(&branded_constrained_schema_obj(args, "string"))
         }
     };
     json_schema_methods(def_name, &body)
@@ -1967,7 +2001,7 @@ fn branded_generic_params(generics: &syn::Generics) -> Vec<String> {
 }
 
 /// Resolves the TypeScript inner type name and generic parameter list for a branded newtype.
-#[cfg(any(feature = "typescript", feature = "zod"))]
+#[cfg(feature = "typescript")]
 fn branded_ts_type_and_generics(
     is_generic: bool,
     generic_params: &[String],
@@ -1986,24 +2020,26 @@ fn branded_ts_type_and_generics(
     (ts_inner_type, ts_generics)
 }
 
-/// Resolves the JSON schema type for a branded newtype's inner field.
+/// Resolves the JSON schema shape for a branded newtype's inner field.
 ///
-/// For generic newtypes this is always `"string"` (mirrors the Zod logic); for non-generic
-/// newtypes it maps from the resolved TypeScript type name.
+/// For generic newtypes this is always `"string"` (mirrors the Zod logic). An `ObjectId` is read
+/// off its own `FieldDef`, because the object it writes has no `"type"` keyword that describes it;
+/// every other non-generic inner maps from the resolved TypeScript type name.
 #[cfg(feature = "jsonschema")]
-fn branded_json_inner_type(is_generic: bool, inner_ty: &syn::Type) -> String {
+fn branded_json_inner(is_generic: bool, inner_ty: &syn::Type) -> BrandedJsonInner {
     if is_generic {
-        "string".to_owned()
-    } else {
-        match get_field_def("_inner", inner_ty, "")
-            .typescript_typename()
-            .as_str()
-        {
-            "number" => "number".to_owned(),
-            "boolean" => "boolean".to_owned(),
-            _ => "string".to_owned(),
-        }
+        return BrandedJsonInner::Scalar("string".to_owned());
     }
+    let inner = get_field_def("_inner", inner_ty, "");
+    #[cfg(feature = "object_id")]
+    if branded_inner_is_object_id(&inner) {
+        return BrandedJsonInner::ObjectId;
+    }
+    BrandedJsonInner::Scalar(match inner.typescript_typename().as_str() {
+        "number" => "number".to_owned(),
+        "boolean" => "boolean".to_owned(),
+        _ => "string".to_owned(),
+    })
 }
 
 /// Flattens a branded newtype's doc comments into a single escaped description string,
@@ -2036,26 +2072,73 @@ fn branded_plain_description(docs_vec: Option<&[String]>, item_name: &str) -> St
     )
 }
 
-/// Resolves the Zod base schema for a branded newtype's inner type, applying string constraints.
+/// The Zod string checks a branded newtype's `minLength`, `maxLength`, and `pattern` render to,
+/// or the empty string when it carries none.
 #[cfg(feature = "zod")]
-fn branded_zod_inner(args: &ModelSchemaArgs, is_generic: bool, inner_ty: &syn::Type) -> String {
-    let base = if is_generic {
-        "z.string()".to_owned()
-    } else {
-        get_field_def("_inner", inner_ty, "").zod_type()
-    };
-    let mut result = base;
+fn branded_zod_string_checks(args: &ModelSchemaArgs) -> String {
+    let mut checks = String::new();
     if let Some(min_len) = args.min_length {
-        result = format!("{result}.min({min_len})");
+        checks = format!("{checks}.min({min_len})");
     }
     if let Some(max_len) = args.max_length {
-        result = format!("{result}.max({max_len})");
+        checks = format!("{checks}.max({max_len})");
     }
     if let Some(pattern) = &args.pattern {
         let literal_body = escape_js_regex_literal(pattern);
-        result = format!("{result}.check(z.regex(/{literal_body}/))");
+        checks = format!("{checks}.check(z.regex(/{literal_body}/))");
     }
-    result
+    checks
+}
+
+/// Whether a branded newtype's inner is an `ObjectId` written on its own, and so reaches the wire
+/// as the `$oid` object rather than as any string.
+///
+/// An arrayed inner is excluded: what it writes is the array around that object, which is not a
+/// shape this dispatch describes.
+#[cfg(all(feature = "object_id", any(feature = "zod", feature = "jsonschema")))]
+const fn branded_inner_is_object_id(inner: &FieldDef) -> bool {
+    matches!(inner.field_type, FieldDefType::ObjectId) && !inner.is_array()
+}
+
+/// Resolves the Zod base schema for a branded newtype's inner type, applying string constraints.
+///
+/// The constraints measure the inner's `Display` rendering, which for every inner but an
+/// `ObjectId` is the value the schema itself describes. An `ObjectId` writes `{"$oid": hex}`, so
+/// its `Display` is the `$oid` member and the checks land there.
+#[cfg(feature = "zod")]
+fn branded_zod_inner(args: &ModelSchemaArgs, is_generic: bool, inner_ty: &syn::Type) -> String {
+    let checks = branded_zod_string_checks(args);
+    if is_generic {
+        return format!("z.string(){checks}");
+    }
+    let inner = get_field_def("_inner", inner_ty, "");
+    #[cfg(feature = "object_id")]
+    if branded_inner_is_object_id(&inner) {
+        return get_object_id_zod_schema_with(&checks);
+    }
+    format!("{}{checks}", inner.zod_type())
+}
+
+/// The Zod class a branded newtype's base schema is an instance of, for the exported binding's
+/// type annotation.
+///
+/// Read off the inner's own `FieldDef` rather than off its TypeScript name, so a user type merely
+/// spelled `ObjectId` is not mistaken for the `$oid` object.
+#[cfg(all(feature = "zod", feature = "typescript"))]
+fn branded_zod_type_name(is_generic: bool, inner_ty: &syn::Type) -> String {
+    if is_generic {
+        return "ZodString".to_owned();
+    }
+    let inner = get_field_def("_inner", inner_ty, "");
+    #[cfg(feature = "object_id")]
+    if branded_inner_is_object_id(&inner) {
+        return "ZodObject".to_owned();
+    }
+    match inner.typescript_typename().as_str() {
+        "number" => "ZodNumber".to_owned(),
+        "boolean" => "ZodBoolean".to_owned(),
+        _ => "ZodString".to_owned(),
+    }
 }
 
 /// Builds the `ts_definition()` method for a branded newtype's schema module.
@@ -2095,21 +2178,13 @@ fn build_branded_ts_definition_method(
 fn build_branded_zod_schema_method(
     item_name: &str,
     is_generic: bool,
-    ts_inner_type: &str,
+    inner_ty: &syn::Type,
     zod_inner: &str,
     plain_description: &str,
 ) -> proc_macro2::TokenStream {
     #[cfg(feature = "typescript")]
     {
-        let zod_type_name = if is_generic {
-            "ZodString".to_owned()
-        } else {
-            match ts_inner_type {
-                "number" => "ZodNumber".to_owned(),
-                "boolean" => "ZodBoolean".to_owned(),
-                _ => "ZodString".to_owned(),
-            }
-        };
+        let zod_type_name = branded_zod_type_name(is_generic, inner_ty);
         let zod_type_annotation = format!("$ZodBranded<{zod_type_name}, \"{item_name}\">");
         quote! {
             pub fn zod_schema() -> String {
@@ -2122,7 +2197,7 @@ fn build_branded_zod_schema_method(
     }
     #[cfg(not(feature = "typescript"))]
     {
-        let _: &_ = &(is_generic, ts_inner_type);
+        let _: &_ = &(is_generic, inner_ty);
         quote! {
             pub fn zod_schema() -> String {
                 format!(
@@ -2506,16 +2581,15 @@ fn process_branded_newtype(item_struct: syn::ItemStruct, args: &ModelSchemaArgs)
     let inner_field = item_struct.fields.iter().next().unwrap();
     let inner_ty = &inner_field.ty;
 
-    // `ts_pair`: (ts_inner_type, ts_generics). Bound whole so zod-only builds (which use only the
-    // inner type) don't trip an unused-variable warning on the generics half.
-    #[cfg(any(feature = "typescript", feature = "zod"))]
+    // `ts_pair`: (ts_inner_type, ts_generics).
+    #[cfg(feature = "typescript")]
     let ts_pair = branded_ts_type_and_generics(is_generic, &generic_params, inner_ty);
 
     #[cfg(not(any(feature = "typescript", feature = "zod")))]
     let _: &_ = &inner_ty;
 
     #[cfg(feature = "jsonschema")]
-    let json_inner_type = branded_json_inner_type(is_generic, inner_ty);
+    let json_inner = branded_json_inner(is_generic, inner_ty);
 
     #[cfg(feature = "zod")]
     let zod_inner = branded_zod_inner(args, is_generic, inner_ty);
@@ -2530,7 +2604,7 @@ fn process_branded_newtype(item_struct: syn::ItemStruct, args: &ModelSchemaArgs)
     let zod_schema_method = build_branded_zod_schema_method(
         &item_name,
         is_generic,
-        &ts_pair.0,
+        inner_ty,
         &zod_inner,
         &plain_description,
     );
@@ -2541,7 +2615,7 @@ fn process_branded_newtype(item_struct: syn::ItemStruct, args: &ModelSchemaArgs)
 
     // --- Build schema module impl items ---
     #[cfg(feature = "jsonschema")]
-    let json_schema_method = build_branded_json_schema_method(args, &json_inner_type, &item_name);
+    let json_schema_method = build_branded_json_schema_method(args, &json_inner, &item_name);
 
     let schema_impl_items: Vec<proc_macro2::TokenStream> = vec![
         #[cfg(feature = "jsonschema")]
@@ -5696,21 +5770,31 @@ fn build_sibling_type_field_schema(
     }
 }
 
+/// The JSON schema an `ObjectId` describes — the closed `$oid` object serde writes — with
+/// `hex_schema` as the schema of the hex string it holds.
+///
+/// Field position and the branded path read this one spelling, so the transparent brand and the
+/// inner it wraps cannot drift apart. The map-member positions still carry their own renderings.
+#[cfg(all(feature = "jsonschema", feature = "object_id"))]
+fn object_id_json_schema_value(hex_schema: &proc_macro2::TokenStream) -> proc_macro2::TokenStream {
+    quote! {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "$oid": (#hex_schema)
+            },
+            "required": ["$oid"],
+            "additionalProperties": false
+        })
+    }
+}
+
 /// Builds the JSON schema for a `MongoDB` `ObjectId` field (`{ "$oid": string }`).
 #[cfg(all(feature = "jsonschema", feature = "object_id"))]
 fn build_object_id_field_schema(fld: &FieldDef, field_name_str: &str) -> proc_macro2::TokenStream {
     let schema = arrayed_json_schema_value(
         fld,
-        quote! {
-            serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "$oid": { "type": "string" }
-                },
-                "required": ["$oid"],
-                "additionalProperties": false
-            })
-        },
+        object_id_json_schema_value(&quote! { serde_json::json!({ "type": "string" }) }),
     );
     quote! {
         properties.insert(#field_name_str.to_string(), { #schema });

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -1050,8 +1050,20 @@ fn struct_schema_example_carries_no_cfg_attribute() {
 #[test]
 fn branded_json_schema_method_carries_no_cfg_attribute() {
     let args = super::ModelSchemaArgs::default();
-    let tokens = super::build_branded_json_schema_method(&args, "string", "DocumentId");
-    assert_no_cfg_attribute(&tokens, "build_branded_json_schema_method");
+    for inner in branded_json_inners() {
+        let tokens = super::build_branded_json_schema_method(&args, &inner, "DocumentId");
+        assert_no_cfg_attribute(&tokens, "build_branded_json_schema_method");
+    }
+}
+
+/// Every shape [`super::branded_json_inner`] resolves to, so the dispatch is covered whole.
+#[cfg(feature = "jsonschema")]
+fn branded_json_inners() -> Vec<super::BrandedJsonInner> {
+    vec![
+        super::BrandedJsonInner::Scalar("string".to_owned()),
+        #[cfg(feature = "object_id")]
+        super::BrandedJsonInner::ObjectId,
+    ]
 }
 
 #[cfg(feature = "zod")]

--- a/tests/branded_newtype_tests/tests.rs
+++ b/tests/branded_newtype_tests/tests.rs
@@ -359,6 +359,125 @@ mod constrained_objectid_branded_tests {
         let result: Result<StrictObjectId, _> = serde_json::from_str(json);
         assert!(result.is_ok(), "Should accept valid ObjectId via serde");
     }
+
+    /// The wire an `ObjectId` brand is described against: serde writes the extended-JSON `$oid`
+    /// object, never the bare hex, for the brand exactly as for the `ObjectId` it wraps.
+    #[test]
+    fn an_objectid_brand_writes_the_oid_object_its_inner_writes() {
+        let oid = ObjectId::parse_str("507f1f77bcf86cd799439011").unwrap();
+        assert_eq!(
+            serde_json::to_string(&StrictObjectId(oid)).unwrap(),
+            r#"{"$oid":"507f1f77bcf86cd799439011"}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&oid).unwrap(),
+            serde_json::to_string(&StrictObjectId(oid)).unwrap()
+        );
+    }
+}
+
+/// The three surfaces of an `ObjectId`-inner brand, pinned against the `$oid` object serde writes
+/// for it. The `ObjectId` wire form is an object, so no surface may describe the brand as a string.
+#[cfg(all(
+    feature = "object_id",
+    feature = "serde",
+    feature = "zod",
+    feature = "typescript",
+    feature = "jsonschema"
+))]
+mod objectid_branded_surface_tests {
+    use super::*;
+    use mongodb::bson::oid::ObjectId;
+
+    const OID_ZOD_BASE: &str =
+        r#"z.object({ $oid: z.string().regex(/^[a-f\d]{24}$/i, { message: "Invalid ObjectId" })"#;
+
+    #[model_schema()]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct PlainObjectId(pub ObjectId);
+
+    #[model_schema(pattern = "^[0-9a-fA-F]{24}$")]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct HexObjectId(pub ObjectId);
+
+    #[model_schema()]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    pub struct HoldsObjectId {
+        pub id: ObjectId,
+    }
+
+    #[test]
+    fn an_unconstrained_objectid_brand_describes_the_oid_object_on_every_surface() {
+        assert_eq!(
+            PlainObjectId::ts_definition(),
+            r#"export type PlainObjectId = ObjectId & $brand<"PlainObjectId">;"#
+        );
+        let zod = PlainObjectId::zod_schema();
+        assert!(
+            zod.contains(&format!(
+                "const PlainObjectId$RawSchema = {OID_ZOD_BASE} }}).brand<"
+            )),
+            "Got:\n{zod}"
+        );
+        assert!(
+            zod.contains(r#"PlainObjectId$Schema: $ZodBranded<ZodObject, "PlainObjectId">"#),
+            "Got:\n{zod}"
+        );
+        assert_eq!(
+            PlainObjectId::json_schema(),
+            serde_json::json!({
+                "type": "object",
+                "properties": { "$oid": { "type": "string" } },
+                "required": ["$oid"],
+                "additionalProperties": false
+            })
+        );
+    }
+
+    /// A brand's string constraints measure the inner's `Display` — the bare hex — which on the
+    /// wire is the `$oid` member, so both schema surfaces carry them there. Zod has no string
+    /// check to apply to the object itself.
+    #[test]
+    fn a_constrained_objectid_brand_carries_its_constraints_on_the_oid_member() {
+        let zod = HexObjectId::zod_schema();
+        assert!(
+            zod.contains(&format!(
+                "const HexObjectId$RawSchema = {OID_ZOD_BASE}.check(z.regex(/^[0-9a-fA-F]{{24}}$/)) }}).brand<"
+            )),
+            "Got:\n{zod}"
+        );
+        assert!(
+            !zod.contains(") }).check("),
+            "a string check must never sit on the $oid object. Got:\n{zod}"
+        );
+        assert!(
+            zod.contains(r#"HexObjectId$Schema: $ZodBranded<ZodObject, "HexObjectId">"#),
+            "Got:\n{zod}"
+        );
+        assert_eq!(
+            HexObjectId::json_schema(),
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "$oid": { "type": "string", "pattern": "^[0-9a-fA-F]{24}$" }
+                },
+                "required": ["$oid"],
+                "additionalProperties": false
+            })
+        );
+    }
+
+    /// A transparent brand is nothing on the wire, so it describes exactly what its inner
+    /// describes where that inner is named directly.
+    #[test]
+    fn an_unconstrained_objectid_brand_describes_what_the_field_position_describes() {
+        assert_eq!(
+            PlainObjectId::json_schema(),
+            HoldsObjectId::json_schema()["properties"]["id"]
+        );
+    }
 }
 
 // Branded newtype referenced from a struct (all features enabled)


### PR DESCRIPTION
serde writes the extended-JSON $oid object — never the bare hex — for an ObjectId through a transparent brand, exactly as for the bare inner (capture-pinned). Three surface defects fixed in the branded emission:

- String constraints landed as .check(z.regex(...)) on the z.object() wrapper, where they measure nothing; they now land on the $oid member's z.string(), which is what the brand's validate() actually checks (Display renders the bare hex).
- The exported binding's annotation claimed $ZodBranded<ZodString, ...>; it is now ZodObject, resolved off the inner's FieldDef rather than its TypeScript name so a user type merely spelled ObjectId is not mistaken for the $oid object.
- The JSON schema collapsed to {"type":"string"}; it is now the closed $oid object with the constraints on the hex member. Field position and the branded path now read one shared builder, so the two spellings cannot drift.

Red-first surface tests pin all three (unconstrained brand, constrained brand, and brand-equals-field-position parity). Full powerset tests + lint-all green locally on the merged tree.