### PR TITLE
describe a composite-inner brand by the shape its inner writes

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -49,7 +49,11 @@ use crate::features::serde::{SerdeFieldMeta, SerdeTypeMeta, has_serde_default};
 #[cfg(feature = "serde")]
 use crate::field_type::{parse_serde_field_attributes, parse_serde_type_attributes};
 
-#[cfg(any(feature = "jsonschema", feature = "serde"))]
+#[cfg(any(
+    feature = "jsonschema",
+    feature = "serde",
+    all(feature = "typescript", feature = "zod")
+))]
 use crate::field_type::is_sequence_wrapper;
 
 #[cfg(feature = "serde")]
@@ -187,6 +191,25 @@ struct BrandedValidation {
     validate_fn: proc_macro2::TokenStream,
 }
 
+/// What a branded newtype's inner writes when what it writes is a composite: an array, a map, a
+/// tuple, or a value the parser could not classify at all.
+///
+/// These are the shapes no one `"type"` keyword and no one Zod class names, so a brand over one of
+/// them is described by nothing but the type it holds — the array, the object, or the fixed-arity
+/// array `#[serde(transparent)]` puts on the wire.
+///
+/// A `SiblingType` is absent: it is a name, not a shape. This expansion cannot resolve it, and the
+/// type it names may itself be a brand over one string — which is a shape the brand's own
+/// constraints *are* permitted over — so it keeps the description it has.
+#[cfg(any(feature = "jsonschema", all(feature = "typescript", feature = "zod")))]
+enum BrandedComposite {
+    Array,
+    Map,
+    /// A value with no type name to narrow with, which admits anything.
+    Opaque,
+    Tuple,
+}
+
 /// The JSON schema shape a branded newtype's inner field describes.
 #[cfg(feature = "jsonschema")]
 enum BrandedJsonInner {
@@ -196,6 +219,10 @@ enum BrandedJsonInner {
     ObjectId,
     /// A `"type"` keyword those constraints sit beside.
     Scalar(String),
+    /// An inner no one keyword names, carried by the dispatch that describes the same type
+    /// wherever else it is written. Boxed so the whole field def does not set the size of an enum
+    /// whose other shapes are a type name and a unit.
+    Slot(Box<FieldDef>),
 }
 
 /// What a field bottoms out in, under the wrappers it was written beneath.
@@ -1972,6 +1999,27 @@ fn branded_constrained_schema_obj(
     }
 }
 
+/// The description a brand carries for an inner no `"type"` keyword names: the one the slot
+/// dispatch gives that type, so the brand describes as the type it wraps describes wherever else
+/// it is written. An inner the dispatch cannot render replaces the body with the single diagnostic
+/// naming the brand, as an unrenderable slot does in every other position.
+///
+/// The brand's own constraints are not written beside it. [`branded_constraint_inner_error`]
+/// refuses them over an array, a map, a tuple, and an opaque inner, so there is nothing to write —
+/// except through the one spelling that guard reads as a name rather than as the array it writes,
+/// a sequence wrapper, where they were being written onto a `"type": "string"` describing no value
+/// the type can hold.
+#[cfg(feature = "jsonschema")]
+fn branded_slot_json_schema(inner: &FieldDef, def_name: &str) -> proc_macro2::TokenStream {
+    match build_tuple_element_json_schema(inner) {
+        Ok(value) => value,
+        Err(rejection) => {
+            let message = map_member_rejection_message(&format!("`{def_name}`"), &rejection);
+            quote! { compile_error!(#message) }
+        }
+    }
+}
+
 /// Builds the `json_schema()` method for a branded newtype's schema module.
 #[cfg(feature = "jsonschema")]
 fn build_branded_json_schema_method(
@@ -1985,6 +2033,7 @@ fn build_branded_json_schema_method(
         BrandedJsonInner::ObjectId => {
             object_id_json_schema_value(&branded_constrained_schema_obj(args, "string"))
         }
+        BrandedJsonInner::Slot(inner) => branded_slot_json_schema(inner, def_name),
     };
     json_schema_methods(def_name, &body)
 }
@@ -2027,9 +2076,10 @@ fn branded_ts_type_and_generics(
 
 /// Resolves the JSON schema shape for a branded newtype's inner field.
 ///
-/// For generic newtypes this is always `"string"` (mirrors the Zod logic). An `ObjectId` is read
-/// off its own `FieldDef`, because the object it writes has no `"type"` keyword that describes it;
-/// every other non-generic inner maps from the resolved TypeScript type name.
+/// For generic newtypes this is always `"string"` (mirrors the Zod logic). An `ObjectId` and a
+/// composite are read off their own `FieldDef`, because neither writes a value one `"type"`
+/// keyword describes; every remaining non-generic inner maps from the resolved TypeScript type
+/// name.
 #[cfg(feature = "jsonschema")]
 fn branded_json_inner(is_generic: bool, inner_ty: &syn::Type) -> BrandedJsonInner {
     if is_generic {
@@ -2039,6 +2089,9 @@ fn branded_json_inner(is_generic: bool, inner_ty: &syn::Type) -> BrandedJsonInne
     #[cfg(feature = "object_id")]
     if branded_inner_is_object_id(&inner) {
         return BrandedJsonInner::ObjectId;
+    }
+    if branded_inner_composite(&inner).is_some() {
+        return BrandedJsonInner::Slot(Box::new(inner));
     }
     BrandedJsonInner::Scalar(match inner.typescript_typename().as_str() {
         "number" => "number".to_owned(),
@@ -2075,6 +2128,58 @@ const fn branded_inner_is_object_id(inner: &FieldDef) -> bool {
     matches!(inner.field_type, FieldDefType::ObjectId) && !inner.is_array()
 }
 
+/// What a branded newtype's inner writes when it writes a composite, and `None` when it writes a
+/// value one `"type"` keyword and one Zod class already name.
+///
+/// The array level is asked first, so an arrayed inner answers for the array around whatever it
+/// holds — which is what `#[serde(transparent)]` puts on the wire — rather than for the item. That
+/// is the same question [`branded_inner_is_object_id`] asks to exclude an arrayed `ObjectId`, whose
+/// array reaches here instead. A sequence wrapper is that same array under another name, and is
+/// read through the one list every surface reads it through.
+///
+/// Named exhaustively rather than caught by a wildcard: a new variant must be classified, not
+/// silently collapsed into the scalar mapping.
+#[cfg(any(feature = "jsonschema", all(feature = "typescript", feature = "zod")))]
+fn branded_inner_composite(inner: &FieldDef) -> Option<BrandedComposite> {
+    if inner.is_array() {
+        return Some(BrandedComposite::Array);
+    }
+    if let FieldDefType::SiblingType(name, args) = &inner.field_type
+        && matches!(args.as_slice(), [_])
+        && is_sequence_wrapper(name)
+    {
+        return Some(BrandedComposite::Array);
+    }
+    match &inner.field_type {
+        FieldDefType::Map(..) => Some(BrandedComposite::Map),
+        FieldDefType::Tuple(..) => Some(BrandedComposite::Tuple),
+        FieldDefType::Unknown => Some(BrandedComposite::Opaque),
+        FieldDefType::Boolean
+        | FieldDefType::F32
+        | FieldDefType::F64
+        | FieldDefType::I8
+        | FieldDefType::I16
+        | FieldDefType::I32
+        | FieldDefType::I64
+        | FieldDefType::Isize
+        | FieldDefType::SiblingType(..)
+        | FieldDefType::String
+        | FieldDefType::StringLiteral(_)
+        | FieldDefType::U8
+        | FieldDefType::U16
+        | FieldDefType::U32
+        | FieldDefType::U64
+        | FieldDefType::Usize => None,
+        #[cfg(feature = "object_id")]
+        FieldDefType::ObjectId => None,
+        #[cfg(feature = "chrono")]
+        FieldDefType::DateTime
+        | FieldDefType::NaiveDate
+        | FieldDefType::NaiveDateTime
+        | FieldDefType::NaiveTime => None,
+    }
+}
+
 /// Resolves the Zod base schema for a branded newtype's inner type, applying string constraints.
 ///
 /// The constraints measure the inner's `Display` rendering, which for every inner but an
@@ -2098,7 +2203,11 @@ fn branded_zod_inner(args: &ModelSchemaArgs, is_generic: bool, inner_ty: &syn::T
 /// type annotation.
 ///
 /// Read off the inner's own `FieldDef` rather than off its TypeScript name, so a user type merely
-/// spelled `ObjectId` is not mistaken for the `$oid` object.
+/// spelled `ObjectId` is not mistaken for the `$oid` object, and so a composite is annotated with
+/// the class its own value rendering produces instead of falling through to `ZodString`.
+///
+/// Each name is the class bare, as `ZodObject` is: every one of them defaults its type parameters,
+/// so the annotation widens the raw schema rather than restating its element types.
 #[cfg(all(feature = "zod", feature = "typescript"))]
 fn branded_zod_type_name(is_generic: bool, inner_ty: &syn::Type) -> String {
     if is_generic {
@@ -2108,6 +2217,14 @@ fn branded_zod_type_name(is_generic: bool, inner_ty: &syn::Type) -> String {
     #[cfg(feature = "object_id")]
     if branded_inner_is_object_id(&inner) {
         return "ZodObject".to_owned();
+    }
+    if let Some(composite) = branded_inner_composite(&inner) {
+        return match composite {
+            BrandedComposite::Array => "ZodArray".to_owned(),
+            BrandedComposite::Map => "ZodRecord".to_owned(),
+            BrandedComposite::Opaque => "ZodUnknown".to_owned(),
+            BrandedComposite::Tuple => "ZodTuple".to_owned(),
+        };
     }
     match inner.typescript_typename().as_str() {
         "number" => "ZodNumber".to_owned(),

--- a/tests/branded_newtype_tests/tests.rs
+++ b/tests/branded_newtype_tests/tests.rs
@@ -402,6 +402,11 @@ mod objectid_branded_surface_tests {
     #[serde(transparent)]
     pub struct HexObjectId(pub ObjectId);
 
+    #[model_schema(no_display)]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct ObjectIdList(pub Vec<ObjectId>);
+
     #[model_schema()]
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     pub struct HoldsObjectId {
@@ -476,6 +481,37 @@ mod objectid_branded_surface_tests {
         assert_eq!(
             PlainObjectId::json_schema(),
             HoldsObjectId::json_schema()["properties"]["id"]
+        );
+    }
+
+    /// An arrayed `ObjectId` writes the array around the `$oid` object, which is a container and
+    /// so is described by the slot dispatch — the same rendering the unbranded tuple struct over
+    /// the same `Vec` publishes, hex pattern and open object included. Slot position and field
+    /// position spell the `$oid` object differently; the brand follows the slot it is
+    /// rendered through.
+    #[test]
+    fn an_arrayed_objectid_brand_describes_the_array_of_oid_objects() {
+        let zod = ObjectIdList::zod_schema();
+        assert!(
+            zod.contains(&format!(
+                "const ObjectIdList$RawSchema = z.array({OID_ZOD_BASE} }})).brand<"
+            )),
+            "Got:\n{zod}"
+        );
+        assert!(
+            zod.contains(r#"ObjectIdList$Schema: $ZodBranded<ZodArray, "ObjectIdList">"#),
+            "Got:\n{zod}"
+        );
+        assert_eq!(
+            ObjectIdList::json_schema(),
+            serde_json::json!({
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": { "$oid": { "type": "string", "pattern": "^[a-f\\d]{24}$" } },
+                    "required": ["$oid"]
+                }
+            })
         );
     }
 }
@@ -815,6 +851,321 @@ mod branded_no_display_tests {
     fn test_no_display_brand_still_generates_zod() {
         let zod = Tags::zod_schema();
         assert!(zod.contains("brand<\"Tags\">"), "Got: {zod}");
+    }
+}
+
+/// The four surfaces of a brand whose inner writes a container, pinned against what serde writes
+/// for it.
+///
+/// `#[serde(transparent)]` puts the inner on the wire by itself, so an array inner writes an
+/// array, a map inner an object, and a tuple inner the fixed-arity array — never a string. The
+/// TypeScript type and the Zod value already described those; the Zod type annotation and the JSON
+/// schema are pinned here beside them, so a consumer type-checking the exported binding and one
+/// validating a payload read the same shape.
+#[cfg(all(
+    feature = "jsonschema",
+    feature = "serde",
+    feature = "typescript",
+    feature = "zod"
+))]
+mod branded_composite_inner_tests {
+    use super::*;
+    use alloc::collections::BTreeSet;
+    use std::collections::HashMap;
+
+    #[model_schema(no_display)]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct ByteQuad(pub [u8; 4]);
+
+    #[model_schema(no_display)]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct Grid(pub Vec<Vec<i32>>);
+
+    #[model_schema(no_display)]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct LabelList(pub Vec<String>);
+
+    #[model_schema(no_display)]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct LabelPair(pub (String, u32));
+
+    #[model_schema(no_display)]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct LabelSet(pub BTreeSet<String>);
+
+    #[model_schema(no_display)]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct Payload(pub serde_json::Value);
+
+    #[model_schema(no_display)]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct SparseLabels(pub Vec<Option<String>>);
+
+    #[model_schema(no_display)]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct WeightMap(pub HashMap<String, u32>);
+
+    #[model_schema()]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    pub struct Label {
+        pub key: String,
+    }
+
+    #[model_schema(no_display)]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct LabelRow(pub Vec<Label>);
+
+    #[model_schema()]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    pub struct HoldsComposites {
+        pub labels: Vec<String>,
+        pub pair: (String, u32),
+        pub weights: HashMap<String, u32>,
+    }
+
+    #[test]
+    fn a_container_brand_writes_the_container_its_inner_writes() {
+        for (rendered, expected) in [
+            (
+                serde_json::to_string(&LabelList(vec!["a".to_owned()])).unwrap(),
+                r#"["a"]"#,
+            ),
+            (
+                serde_json::to_string(&WeightMap(HashMap::from([("a".to_owned(), 1_u32)])))
+                    .unwrap(),
+                r#"{"a":1}"#,
+            ),
+            (
+                serde_json::to_string(&LabelPair(("a".to_owned(), 1_u32))).unwrap(),
+                r#"["a",1]"#,
+            ),
+            (
+                serde_json::to_string(&LabelSet(BTreeSet::from(["a".to_owned()]))).unwrap(),
+                r#"["a"]"#,
+            ),
+            (
+                serde_json::to_string(&ByteQuad([1, 2, 3, 4])).unwrap(),
+                "[1,2,3,4]",
+            ),
+            (
+                serde_json::to_string(&Payload(serde_json::json!({ "x": 1_u32 }))).unwrap(),
+                r#"{"x":1}"#,
+            ),
+            (
+                serde_json::to_string(&SparseLabels(vec![Some("a".to_owned()), None])).unwrap(),
+                r#"["a",null]"#,
+            ),
+            (
+                serde_json::to_string(&Grid(vec![vec![1_i32, 2_i32]])).unwrap(),
+                "[[1,2]]",
+            ),
+        ] {
+            assert_eq!(rendered, expected);
+        }
+    }
+
+    #[test]
+    fn a_container_brand_reads_back_what_it_wrote() {
+        let labels = LabelList(vec!["a".to_owned()]);
+        assert_eq!(
+            serde_json::from_str::<LabelList>(&serde_json::to_string(&labels).unwrap()).unwrap(),
+            labels
+        );
+        let weights = WeightMap(HashMap::from([("a".to_owned(), 1_u32)]));
+        assert_eq!(
+            serde_json::from_str::<WeightMap>(&serde_json::to_string(&weights).unwrap()).unwrap(),
+            weights
+        );
+        let pair = LabelPair(("a".to_owned(), 1_u32));
+        assert_eq!(
+            serde_json::from_str::<LabelPair>(&serde_json::to_string(&pair).unwrap()).unwrap(),
+            pair
+        );
+    }
+
+    #[test]
+    fn an_array_brand_describes_the_array_on_every_surface() {
+        assert_eq!(
+            LabelList::ts_definition(),
+            r#"export type LabelList = Array<string> & $brand<"LabelList">;"#
+        );
+        let zod = LabelList::zod_schema();
+        assert!(
+            zod.contains(r#"const LabelList$RawSchema = z.array(z.string()).brand<"LabelList">()"#),
+            "Got:\n{zod}"
+        );
+        assert!(
+            zod.contains(r#"LabelList$Schema: $ZodBranded<ZodArray, "LabelList">"#),
+            "Got:\n{zod}"
+        );
+        assert_eq!(
+            LabelList::json_schema(),
+            serde_json::json!({ "type": "array", "items": { "type": "string" } })
+        );
+    }
+
+    #[test]
+    fn a_map_brand_describes_the_object_on_every_surface() {
+        assert_eq!(
+            WeightMap::ts_definition(),
+            r#"export type WeightMap = Partial<Record<string, number>> & $brand<"WeightMap">;"#
+        );
+        let zod = WeightMap::zod_schema();
+        assert!(
+            zod.contains(
+                r#"const WeightMap$RawSchema = z.record(z.string(), z.number().int()).brand<"WeightMap">()"#
+            ),
+            "Got:\n{zod}"
+        );
+        assert!(
+            zod.contains(r#"WeightMap$Schema: $ZodBranded<ZodRecord, "WeightMap">"#),
+            "Got:\n{zod}"
+        );
+        assert_eq!(
+            WeightMap::json_schema(),
+            serde_json::json!({ "type": "object", "additionalProperties": { "type": "integer" } })
+        );
+    }
+
+    #[test]
+    fn a_tuple_brand_describes_the_fixed_arity_array_on_every_surface() {
+        assert_eq!(
+            LabelPair::ts_definition(),
+            r#"export type LabelPair = [string, number] & $brand<"LabelPair">;"#
+        );
+        let zod = LabelPair::zod_schema();
+        assert!(
+            zod.contains(
+                r#"const LabelPair$RawSchema = z.tuple([z.string(), z.number().int()]).brand<"LabelPair">()"#
+            ),
+            "Got:\n{zod}"
+        );
+        assert!(
+            zod.contains(r#"LabelPair$Schema: $ZodBranded<ZodTuple, "LabelPair">"#),
+            "Got:\n{zod}"
+        );
+        assert_eq!(
+            LabelPair::json_schema(),
+            serde_json::json!({
+                "type": "array",
+                "prefixItems": [{ "type": "string" }, { "type": "integer" }],
+                "items": false,
+                "minItems": 2_u32,
+                "maxItems": 2_u32
+            })
+        );
+    }
+
+    /// A sequence wrapper describes as the `Vec` of the same element does, and a fixed-size
+    /// `[T; N]` carries the arity serde reads back — both through the brand, as they do everywhere
+    /// else.
+    #[test]
+    fn a_set_and_a_fixed_array_brand_describe_their_arrays() {
+        assert_eq!(
+            LabelSet::json_schema(),
+            serde_json::json!({ "type": "array", "items": { "type": "string" } })
+        );
+        assert!(
+            LabelSet::zod_schema().contains(r#"$ZodBranded<ZodArray, "LabelSet">"#),
+            "Got:\n{}",
+            LabelSet::zod_schema()
+        );
+        assert_eq!(
+            ByteQuad::json_schema(),
+            serde_json::json!({
+                "type": "array",
+                "items": { "type": "integer" },
+                "minItems": 4_u32,
+                "maxItems": 4_u32
+            })
+        );
+        assert!(
+            ByteQuad::zod_schema().contains(r#"$ZodBranded<ZodArray, "ByteQuad">"#),
+            "Got:\n{}",
+            ByteQuad::zod_schema()
+        );
+    }
+
+    /// An opaque inner carries no type name to narrow with, so the brand admits any value — the
+    /// permissive empty schema, matching the `unknown` type and the `z.unknown()` value.
+    #[test]
+    fn an_opaque_brand_admits_any_value() {
+        assert_eq!(
+            Payload::ts_definition(),
+            r#"export type Payload = unknown & $brand<"Payload">;"#
+        );
+        let zod = Payload::zod_schema();
+        assert!(
+            zod.contains(r#"const Payload$RawSchema = z.unknown().brand<"Payload">()"#),
+            "Got:\n{zod}"
+        );
+        assert!(
+            zod.contains(r#"Payload$Schema: $ZodBranded<ZodUnknown, "Payload">"#),
+            "Got:\n{zod}"
+        );
+        assert_eq!(Payload::json_schema(), serde_json::json!({}));
+    }
+
+    /// A `None` inside the array is an item rather than an omission, and the levels nest — the
+    /// brand carries both, because the array levels are the inner's own.
+    #[test]
+    fn a_nested_and_a_nullable_element_brand_keep_their_levels() {
+        assert_eq!(
+            Grid::json_schema(),
+            serde_json::json!({
+                "type": "array",
+                "items": { "type": "array", "items": { "type": "integer" } }
+            })
+        );
+        assert_eq!(
+            SparseLabels::json_schema(),
+            serde_json::json!({
+                "type": "array",
+                "items": { "anyOf": [{ "type": "string" }, { "type": "null" }] }
+            })
+        );
+    }
+
+    /// An element that names another type is carried by that type's own schema, as it is in every
+    /// other position — so the brand defers rather than describing an open object.
+    #[test]
+    fn an_arrayed_sibling_brand_carries_the_siblings_own_schema() {
+        assert_eq!(
+            LabelRow::json_schema(),
+            serde_json::json!({
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": { "key": { "type": "string" } },
+                    "required": ["key"]
+                }
+            })
+        );
+        assert!(
+            LabelRow::zod_schema().contains(r#"$ZodBranded<ZodArray, "LabelRow">"#),
+            "Got:\n{}",
+            LabelRow::zod_schema()
+        );
+    }
+
+    /// A transparent brand is nothing on the wire, so it describes exactly what its inner
+    /// describes where that inner is named directly.
+    #[test]
+    fn a_container_brand_describes_what_the_field_position_describes() {
+        let holder = HoldsComposites::json_schema();
+        assert_eq!(LabelList::json_schema(), holder["properties"]["labels"]);
+        assert_eq!(LabelPair::json_schema(), holder["properties"]["pair"]);
+        assert_eq!(WeightMap::json_schema(), holder["properties"]["weights"]);
     }
 }
 


### PR DESCRIPTION
A branded newtype over a composite inner (array, map, tuple, or an unclassifiable value) collapsed to {"type":"string"} in its JSON schema and to $ZodBranded<ZodString, ...> in its Zod annotation — while the TypeScript type and the Zod value expression already described the real shape. serde(transparent) puts the inner on the wire by itself, so an array inner writes an array and never a string (capture-pinned with round-trips for eight composite shapes).

The two lying arms now read the inner's own FieldDef, picking up exactly where the ObjectId exclusion left off: the JSON schema routes composites through the same slot dispatch plain tuple structs use (every composite brand's schema is byte-identical to the unbranded tuple struct over the same inner, field-position parity pinned), and the Zod annotation names the class the value side's own rendering produces — ZodArray, ZodRecord, ZodTuple, ZodUnknown — each bare, as every one defaults its type parameters. A sequence wrapper reads as the array it writes, through the shared wrapper list. A sibling-type inner is deliberately excluded: it is a name, not a shape, and the type it names may be a brand over one string — the shape the brand's own constraints are permitted over; tracked separately.

Classification is exhaustive with no wildcard arm, so a new field type must be placed, not silently collapsed. Scalar and ObjectId brands are byte-identical (the ObjectId baseline re-captured against current output, only the composite lines moved in the before/after diff). The one clippy finding (large_enum_variant) was fixed by boxing, not suppressed. Full powerset tests and lint-all green locally on the merged tree.