### PR TITLE
refuse or rewrite a pattern only the Rust regex grammar reads before it reaches the Zod and JSON Schema surfaces

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,12 @@ quote = "1"
 proc-macro2 = "1"
 log = "0.4"
 regex = ">=1.10"
+# The parser `regex::Regex::new` itself is built on. The `pattern` guard reads its AST to tell a
+# construct only the `regex` crate can read from one a JavaScript regex literal carries too, which
+# no second grammar written here could do without drifting from the one that actually applies. The
+# requirement is capped below `0.9` on purpose: the AST is matched exhaustively, so a grammar that
+# grows a construct has to be classified rather than silently waved through.
+regex-syntax = "0.8"
 
 [dev-dependencies]
 mongodb = ">=3.7"

--- a/src/features/model_schema_prop.rs
+++ b/src/features/model_schema_prop.rs
@@ -6,7 +6,7 @@
 use syn::meta::ParseNestedMeta;
 use syn::{Attribute, LitStr, Type};
 
-use crate::utils::regex_rejection;
+use crate::utils::portable_pattern;
 
 /// Every key the parser reads, in the order it tries them, as the unknown-key rejection names them.
 ///
@@ -31,7 +31,9 @@ const KNOWN_KEYS: &[&str] = &[
 ///
 /// ## String constraints
 ///
-/// - `pattern = "regex"` — validates the string matches the regex pattern.
+/// - `pattern = "regex"` — validates the string matches the regex pattern. Must be a regex all
+///   three engines read the same way; see [`crate::utils::portable_pattern`] for what that rules
+///   out and what it rewrites.
 ///   - Zod: `.check(z.regex(/regex/))`
 ///   - JSON Schema: `"pattern"`
 ///   - Rust: auto-generates a `deserialize_{field}` serde hook and a `validate_{field}_value()` static function
@@ -100,8 +102,12 @@ pub struct ModelSchemaPropMeta {
     pub maximum: Option<f64>,    // e.g., 100.0 from maximum = 100
     pub min_length: Option<usize>, // e.g., 1 from minLength = 1
     pub minimum: Option<f64>,    // e.g., 0.0 from minimum = 0
+    /// `pattern` in the spelling every surface reads the same way, or as it was written when it
+    /// earned a [`Self::pattern_rejection`].
     pub pattern: Option<String>, // e.g., "^[0-9a-fA-F]{24}$" from pattern = "^[0-9a-fA-F]{24}$"
-    /// The `regex` crate's rejection of `pattern`, spanned on the literal it was written as.
+    /// What keeps `pattern` off the surfaces it was written for -- a regex the `regex` crate
+    /// cannot parse, or a construct a JavaScript regex literal cannot carry -- spanned on the
+    /// literal it was written as.
     pub pattern_rejection: Option<syn::Error>,
     pub preprocess: Vec<String>, // e.g., ["epoch_to_date", "trim"] from preprocess = ["epoch_to_date", "trim"]
     pub ts_optional: bool,
@@ -146,8 +152,15 @@ fn parse_prop_key(nested: &ParseNestedMeta, meta: &mut ModelSchemaPropMeta) -> s
         meta.maximum = Some(numeric_bound(nested, "maximum")?);
     } else if nested.path.is_ident("pattern") {
         let lit: LitStr = nested.value()?.parse()?;
-        meta.pattern_rejection = regex_rejection(&lit);
-        meta.pattern = Some(lit.value());
+        // A refused pattern is recorded as written: the guards that answer for what a `pattern`
+        // may sit on read that one was given, not what it says.
+        match portable_pattern(&lit) {
+            Ok(pattern) => meta.pattern = Some(pattern),
+            Err(rejection) => {
+                meta.pattern_rejection = Some(rejection);
+                meta.pattern = Some(lit.value());
+            }
+        }
     } else if nested.path.is_ident("preprocess") {
         let arr: syn::ExprArray = nested.value()?.parse()?;
         meta.preprocess = arr

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,6 +264,15 @@ pub fn model_schema(args: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// Generated JSON Schema: `{ "type": "string", "minLength": 3, "maxLength": 50, "pattern": "^[a-z0-9_]+$" }`.
 ///
+/// One `pattern` string reaches three engines — the Rust validator's `regex::Regex`, the Zod
+/// schema's JavaScript regex literal, and the JSON Schema `pattern` keyword, which ECMA-262
+/// defines as a JavaScript regex — so it has to be a regex all three read the same way. A pattern
+/// only the `regex` crate reads is refused at expansion, with the construct named: Unicode classes
+/// (`\p{L}`), POSIX classes (`[[:alpha:]]`), class set operators (`&&`, `--`, `~~`), nested
+/// classes, `\A` and `\z`, `\b{start}`, `\<` and `\>`, braced code point escapes (`\x{41}`), `\a`,
+/// and inline flag directives (`(?i)`). `(?P<name>...)` is accepted and emitted as the
+/// `(?<name>...)` both grammars read.
+///
 /// A `PathBuf` field carries these too, as does the `Path` borrow behind a wrapper: serde writes a
 /// path as a JSON string, and the checks measure that string — the path's `to_string_lossy`
 /// rendering, which is the exact wire value for every path serde can write.

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -41,7 +41,7 @@ use crate::utils::{escape_js_regex_literal, extract_example_from_docs};
 use crate::features::object_id::get_object_id_zod_schema_with;
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-use crate::utils::{AliasKind, lookup_alias_info, regex_rejection};
+use crate::utils::{AliasKind, lookup_alias_info, portable_pattern};
 
 #[cfg(feature = "serde")]
 use crate::features::serde::{SerdeFieldMeta, SerdeTypeMeta, has_serde_default};
@@ -320,10 +320,14 @@ struct ModelSchemaArgs {
     /// Opt-out of the branded newtype `Display` impl (and its inner-type assertion) for brands
     /// whose inner type is a container rather than a scalar.
     no_display: bool,
+    /// `pattern` in the spelling every surface reads the same way, or as it was written when it
+    /// earned a `pattern_rejection`.
     pattern: Option<String>,
-    /// The `regex` crate's rejection of `pattern`, spanned on the literal it was written as. Only
-    /// the brand path splices the argument, and only a schema feature builds that path; without
-    /// one, a type-level constraint never reaches a surface at all.
+    /// What keeps `pattern` off the surfaces it was written for -- a regex the `regex` crate
+    /// cannot parse, or a construct a JavaScript regex literal cannot carry -- spanned on the
+    /// literal it was written as. Only the brand path splices the argument, and only a schema
+    /// feature builds that path; without one, a type-level constraint never reaches a surface at
+    /// all.
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
     pattern_rejection: Option<syn::Error>,
 }
@@ -404,9 +408,7 @@ fn apply_arg(result: &mut ModelSchemaArgs, meta: &Meta) -> syn::Result<()> {
     if path.is_ident("name") {
         result.name_override = Some(name_arg_value(str_arg(meta, "name")?)?);
     } else if path.is_ident("pattern") {
-        let lit_str = str_arg(meta, "pattern")?;
-        record_pattern_rejection(result, lit_str);
-        result.pattern = Some(lit_str.value());
+        record_pattern(result, str_arg(meta, "pattern")?);
     } else if path.is_ident("minLength") {
         result.min_length = Some(length_arg(meta, "minLength")?);
     } else if path.is_ident("maxLength") {
@@ -524,14 +526,28 @@ fn unknown_arg_rejection(meta: &Meta) -> syn::Error {
     )
 }
 
-/// Records the `regex` crate's verdict on a `pattern` argument, for the brand path that splices it.
+/// Records a `pattern` argument, in the spelling the brand path can splice into every surface, or
+/// as written alongside what keeps it off them.
+///
+/// A refused pattern is recorded as written: the guards that answer for what a `pattern` may sit on
+/// read that one was given, not what it says.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-fn record_pattern_rejection(result: &mut ModelSchemaArgs, lit_str: &syn::LitStr) {
-    result.pattern_rejection = regex_rejection(lit_str);
+fn record_pattern(result: &mut ModelSchemaArgs, lit_str: &syn::LitStr) {
+    match portable_pattern(lit_str) {
+        Ok(pattern) => result.pattern = Some(pattern),
+        Err(rejection) => {
+            result.pattern_rejection = Some(rejection);
+            result.pattern = Some(lit_str.value());
+        }
+    }
 }
 
+/// Without a schema feature no surface reads the argument, so it is kept as written and never
+/// judged.
 #[cfg(not(any(feature = "typescript", feature = "zod", feature = "jsonschema")))]
-const fn record_pattern_rejection(_result: &mut ModelSchemaArgs, _lit_str: &syn::LitStr) {}
+fn record_pattern(result: &mut ModelSchemaArgs, lit_str: &syn::LitStr) {
+    result.pattern = Some(lit_str.value());
+}
 
 /// Executes the `model_schema` macro processing to generate TypeScript and Zod schema definitions.
 ///
@@ -1005,17 +1021,12 @@ fn cfg_attr_guard_error(rejection: &syn::Error, item: &str) -> proc_macro2::Toke
 /// Turns a rejected `pattern` into `compile_error!` tokens naming what carries it, keeping the
 /// literal's span so the diagnostic points at the pattern as written.
 ///
-/// The generated validator builds the pattern with `regex::Regex::new(...).unwrap()`, so accepting
-/// one the crate cannot parse only moves the failure to the first value that reaches it — as a
-/// panic, from inside a `LazyLock` the author never wrote.
+/// Why a pattern is refused is [`crate::utils::portable_pattern`]'s to say — the crate cannot parse
+/// it, or JavaScript reads it as something else — so the refusal is quoted rather than restated.
 fn pattern_guard_error(rejection: &syn::Error, subject: &str) -> proc_macro2::TokenStream {
     syn::Error::new(
         rejection.span(),
-        format!(
-            "model_schema: {subject}: `pattern` is not a regex the `regex` crate can parse. The \
-             generated validator builds it with `regex::Regex::new(...).unwrap()`, so accepting \
-             it here would turn the first validated value into a panic. {rejection}"
-        ),
+        format!("model_schema: {subject}: {rejection}"),
     )
     .to_compile_error()
 }

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -49,6 +49,21 @@ const PROBE_PATTERNS: [&str; 10] = [
     r"^\/[a-z]+$",
 ];
 
+/// Patterns the `regex` crate parses that no JavaScript regex literal carries, one per family the
+/// guard sorts them into, beside the words the refusal names each by. Both splice points reach the
+/// Zod literal and the JSON Schema `pattern`, so both have to answer for them.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+const UNPORTABLE_PROBE_PATTERNS: [(&str, &str); 6] = [
+    ("(?i)abc", "inline flag directive"),
+    (r"^\p{L}+$", "Unicode class"),
+    // The needle is doubled because the guard error is read back off rendered `compile_error!`
+    // tokens, where the string literal's own escaping is still in place.
+    (r"\Aabc", r"`\\A` anchor"),
+    ("^[[:alpha:]]+$", "POSIX class"),
+    (r"[\w&&\d]", "`&&` class intersection"),
+    (r"\x{41}", "braced code point escape"),
+];
+
 /// The covered wrappers, under the names a dispatch reads them by.
 #[cfg(any(feature = "jsonschema", feature = "serde"))]
 const SEQUENCE_WRAPPERS: [&str; 6] = [
@@ -898,6 +913,47 @@ fn a_field_pattern_the_regex_crate_rejects_names_the_field_and_quotes_the_parse_
     }
 }
 
+/// A pattern the `regex` crate parses is still refused when no JavaScript regex literal carries
+/// it: the field's Zod schema and JSON Schema are generated from the same string the validator
+/// gets, so a construct only one of the two grammars reads reaches a surface that cannot say it.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn a_field_pattern_javascript_cannot_carry_names_the_field_and_the_construct() {
+    for (pattern, construct) in UNPORTABLE_PROBE_PATTERNS {
+        assert!(
+            regex::Regex::new(pattern).is_ok(),
+            "{pattern} is not a pattern the `regex` crate accepts, so it probes nothing"
+        );
+        let errors = field_prop_guard_errors(&syn::parse_quote! {
+            struct Report {
+                #[model_schema_prop(pattern = #pattern)]
+                name: String,
+            }
+        });
+        assert_eq!(errors.len(), 1, "for {pattern}, got: {errors:?}");
+        for needle in ["compile_error", "field `name`", construct] {
+            assert!(
+                errors[0].contains(needle),
+                "{needle} missing for {pattern}: {}",
+                errors[0]
+            );
+        }
+    }
+}
+
+/// `(?P<name>...)` is the one construct the two grammars merely spell differently, so it clears the
+/// guard rather than tripping it.
+#[test]
+fn a_field_pattern_naming_a_group_the_rust_way_clears_the_guard() {
+    let errors = field_prop_guard_errors(&syn::parse_quote! {
+        struct Report {
+            #[model_schema_prop(pattern = r"^(?P<word>[a-z]+)$")]
+            name: String,
+        }
+    });
+    assert!(errors.is_empty(), "got: {errors:?}");
+}
+
 /// A field carrying no `pattern` at all must not acquire one of these errors.
 #[test]
 fn an_unpatterned_field_is_left_alone() {
@@ -1273,6 +1329,31 @@ fn a_brand_pattern_the_regex_crate_rejects_names_the_type_and_quotes_the_parse_e
             errors[0]
         );
     }
+}
+
+/// The brand splices the same string into the Zod literal and the JSON Schema `pattern` that the
+/// field splice does, so the portability verdict has to reach it too.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn a_brand_pattern_javascript_cannot_carry_names_the_type_and_the_construct() {
+    for (pattern, construct) in UNPORTABLE_PROBE_PATTERNS {
+        let errors = brand_pattern_errors(pattern);
+        assert_eq!(errors.len(), 1, "for {pattern}, got: {errors:?}");
+        for needle in ["compile_error", "type `UserId`", construct] {
+            assert!(
+                errors[0].contains(needle),
+                "{needle} missing for {pattern}: {}",
+                errors[0]
+            );
+        }
+    }
+}
+
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn a_brand_pattern_naming_a_group_the_rust_way_clears_the_guard() {
+    let errors = brand_pattern_errors("^(?P<word>[a-z]+)$");
+    assert!(errors.is_empty(), "got: {errors:?}");
 }
 
 /// Every constraint the guard reacts to, applied one at a time: `has_string_constraints` is an

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,11 +1,30 @@
 use core::cell::RefCell;
 #[cfg(feature = "typescript")]
 use core::iter;
+use regex_syntax::ast::parse::Parser as PatternParser;
+use regex_syntax::ast::{
+    Assertion, AssertionKind, Ast, ClassSet, ClassSetBinaryOpKind, ClassSetItem, Flag,
+    FlagsItemKind, Group, GroupKind, HexLiteralKind, Literal, LiteralKind, SpecialLiteralKind,
+};
 use std::collections::HashMap;
 use syn::{Attribute, Expr, Field, Lit, LitStr, Meta, Variant};
 
 #[cfg(any(feature = "typescript", feature = "zod"))]
 use syn::{ItemEnum, ItemStruct};
+
+/// What a JavaScript regex literal makes of a flag the `(?...:...)` form cannot carry. ES2025's
+/// regular expression modifiers spell `i`, `m` and `s`, and the parse fails on anything else.
+const MODIFIER_GROUP_READ_AS: &str = "a group opening no JavaScript regex parses: its modifier \
+                                      groups carry `i`, `m` and `s` and nothing else";
+
+/// What a JavaScript regex literal makes of a `\p{...}` class, shared by the two places one can be
+/// written.
+const UNICODE_CLASS_READ_AS: &str = "an escaped `p` or `P` followed by a literal `{...}`, since a \
+                                     Unicode class there needs the `u` flag and a spliced literal \
+                                     carries no flags";
+
+/// A Unicode class, in the three spellings the `regex` crate reads one by.
+const UNICODE_CLASS_WRITTEN: &str = "a Unicode class -- `\\p{...}`, `\\pL` or `\\P{...}`";
 
 /// Whether a registered Rust ident, *written as a type path*, resolves to something carrying an
 /// inherent `enum_members()` — the enumeration the JSON-schema map-key expansion calls. Only a
@@ -30,6 +49,240 @@ pub struct AliasInfo {
     pub kind: AliasKind,
     #[cfg(feature = "jsonschema")]
     pub module_name: String,
+}
+
+/// The walk over a parsed `pattern` that collects the rewrites its JavaScript spelling needs and
+/// the first construct that has no JavaScript spelling at all.
+///
+/// The AST walked is the one `regex::Regex::new` is itself built on, so the guard's reading of a
+/// pattern is the crate's own reading of it. A second grammar written here would answer for the
+/// crate's while drifting from it, and it would have to tell `[--/]`, three ordinary class members,
+/// from `[+--]`, a set difference — which the bytes alone do not say.
+#[derive(Default)]
+struct JsSpelling {
+    /// Byte offsets of the `P` in each `(?P<name>` the pattern opens.
+    ///
+    /// This is the only rewrite the guard makes, and it is safe because it is local: the bytes
+    /// around a group's opening are fixed, so dropping the `P` cannot change how anything else in
+    /// the pattern parses. Escaping a class-opening `]` looks like the same kind of fix and is
+    /// not — `[]-a]` is three members and `[\]-a]` is a range — which is why that one is refused
+    /// rather than rewritten.
+    named_group_markers: Vec<usize>,
+    refusal: Option<Unportable>,
+}
+
+/// A construct the `regex` crate reads that a JavaScript regex literal has no reading for.
+struct Unportable {
+    /// What the same bytes are inside a JavaScript regex literal instead.
+    read_as: &'static str,
+    /// The construct, as the rejection names it.
+    written: &'static str,
+}
+
+impl JsSpelling {
+    fn assertion(&mut self, assertion: &Assertion) {
+        let (written, read_as) = match assertion.kind {
+            AssertionKind::StartLine
+            | AssertionKind::EndLine
+            | AssertionKind::WordBoundary
+            | AssertionKind::NotWordBoundary => return,
+            AssertionKind::StartText => (
+                "the `\\A` anchor",
+                "an escaped `A`, matching that letter; a flagless literal spells the same anchor \
+                 `^`",
+            ),
+            AssertionKind::EndText => (
+                "the `\\z` anchor",
+                "an escaped `z`, matching that letter; a flagless literal spells the same anchor \
+                 `$`",
+            ),
+            AssertionKind::WordBoundaryStart | AssertionKind::WordBoundaryEnd => (
+                "a `\\b{start}` or `\\b{end}` word boundary",
+                "a plain word boundary followed by a literal `{start}` or `{end}`",
+            ),
+            AssertionKind::WordBoundaryStartHalf | AssertionKind::WordBoundaryEndHalf => (
+                "a `\\b{start-half}` or `\\b{end-half}` word boundary",
+                "a plain word boundary followed by a literal `{start-half}` or `{end-half}`",
+            ),
+            AssertionKind::WordBoundaryStartAngle | AssertionKind::WordBoundaryEndAngle => (
+                "a `\\<` or `\\>` word boundary",
+                "an escaped `<` or `>`, matching that character",
+            ),
+        };
+        self.refuse(written, read_as);
+    }
+
+    fn ast(&mut self, ast: &Ast) {
+        match ast {
+            // `.`, `\d` and `\w` are in both grammars and differ only in whether they are
+            // Unicode-aware, which divides what they match rather than what they are.
+            Ast::Empty(_) | Ast::Dot(_) | Ast::ClassPerl(_) => {}
+            Ast::Flags(_) => self.refuse(
+                "an inline flag directive `(?...)`",
+                "a group opening no JavaScript regex parses",
+            ),
+            Ast::Literal(literal) => self.literal(literal, false),
+            Ast::Assertion(assertion) => self.assertion(assertion),
+            Ast::ClassUnicode(_) => self.refuse(UNICODE_CLASS_WRITTEN, UNICODE_CLASS_READ_AS),
+            Ast::ClassBracketed(class) => self.class_set(&class.kind),
+            Ast::Repetition(repetition) => self.ast(&repetition.ast),
+            Ast::Group(group) => self.group(group),
+            Ast::Alternation(alternation) => self.asts(&alternation.asts),
+            Ast::Concat(concat) => self.asts(&concat.asts),
+        }
+    }
+
+    fn asts(&mut self, asts: &[Ast]) {
+        for ast in asts {
+            self.ast(ast);
+        }
+    }
+
+    fn class_item(&mut self, item: &ClassSetItem) {
+        match item {
+            ClassSetItem::Empty(_) | ClassSetItem::Perl(_) => {}
+            ClassSetItem::Literal(literal) => self.literal(literal, true),
+            ClassSetItem::Range(range) => {
+                self.literal(&range.start, true);
+                self.literal(&range.end, true);
+            }
+            ClassSetItem::Ascii(_) => self.refuse(
+                "a POSIX class `[:name:]`",
+                "the characters `[`, `:` and the name, listed as members of the class",
+            ),
+            ClassSetItem::Unicode(_) => self.refuse(UNICODE_CLASS_WRITTEN, UNICODE_CLASS_READ_AS),
+            ClassSetItem::Bracketed(class) => {
+                self.refuse(
+                    "a class nested inside another class",
+                    "a literal `[` listed as a member of the outer class",
+                );
+                self.class_set(&class.kind);
+            }
+            ClassSetItem::Union(union) => {
+                for member in &union.items {
+                    self.class_item(member);
+                }
+            }
+        }
+    }
+
+    fn class_set(&mut self, set: &ClassSet) {
+        match set {
+            ClassSet::Item(item) => self.class_item(item),
+            ClassSet::BinaryOp(op) => {
+                let written = match op.kind {
+                    ClassSetBinaryOpKind::Intersection => "the `&&` class intersection",
+                    ClassSetBinaryOpKind::Difference => "the `--` class difference",
+                    ClassSetBinaryOpKind::SymmetricDifference => {
+                        "the `~~` class symmetric difference"
+                    }
+                };
+                self.refuse(
+                    written,
+                    "the operator's own characters, listed as members of the class",
+                );
+                self.class_set(&op.lhs);
+                self.class_set(&op.rhs);
+            }
+        }
+    }
+
+    fn group(&mut self, group: &Group) {
+        match &group.kind {
+            GroupKind::CaptureIndex(_) => {}
+            GroupKind::CaptureName { starts_with_p, .. } => {
+                if *starts_with_p {
+                    // `(?P<name>` and `(?<name>` are one construct under two spellings, and the
+                    // `P` that tells them apart sits two bytes into the group's span.
+                    self.named_group_markers.push(group.span.start.offset + 2);
+                }
+            }
+            GroupKind::NonCapturing(flags) => {
+                for item in &flags.items {
+                    let FlagsItemKind::Flag(flag) = &item.kind else {
+                        continue;
+                    };
+                    let written = match flag {
+                        Flag::CaseInsensitive | Flag::MultiLine | Flag::DotMatchesNewLine => {
+                            continue;
+                        }
+                        Flag::SwapGreed => "the swap-greed flag on a `(?U:...)` group",
+                        Flag::Unicode => "the Unicode flag on a `(?u:...)` group",
+                        Flag::CRLF => "the CRLF flag on a `(?R:...)` group",
+                        Flag::IgnoreWhitespace => {
+                            "the ignore-whitespace flag on a `(?x:...)` group"
+                        }
+                    };
+                    self.refuse(written, MODIFIER_GROUP_READ_AS);
+                }
+            }
+        }
+        self.ast(&group.ast);
+    }
+
+    fn literal(&mut self, literal: &Literal, in_class: bool) {
+        if in_class && literal.c == ']' && matches!(literal.kind, LiteralKind::Verbatim) {
+            self.refuse(
+                "an unescaped `]` opening a character class",
+                "the empty class `[]`, which matches nothing, followed by the rest of the class as \
+                 ordinary text; the member both grammars read is `\\]`",
+            );
+        }
+        let (written, read_as) = match literal.kind {
+            LiteralKind::Verbatim
+            | LiteralKind::Meta
+            | LiteralKind::Superfluous
+            | LiteralKind::HexFixed(HexLiteralKind::X | HexLiteralKind::UnicodeShort)
+            | LiteralKind::Special(
+                SpecialLiteralKind::FormFeed
+                | SpecialLiteralKind::Tab
+                | SpecialLiteralKind::LineFeed
+                | SpecialLiteralKind::CarriageReturn
+                | SpecialLiteralKind::VerticalTab
+                | SpecialLiteralKind::Space,
+            ) => return,
+            LiteralKind::Octal => (
+                "an octal escape",
+                "a legacy escape a JavaScript regex reads by its own rules and refuses outright \
+                 under a Unicode flag",
+            ),
+            LiteralKind::HexBrace(_) => (
+                "a braced code point escape -- `\\x{...}`, `\\u{...}` or `\\U{...}`",
+                "an escaped `x`, `u` or `U` followed by a literal `{...}`, since the one braced \
+                 form JavaScript has needs the `u` flag and a spliced literal carries no flags",
+            ),
+            LiteralKind::HexFixed(HexLiteralKind::UnicodeLong) => (
+                "the eight-digit `\\U...` code point escape",
+                "an escaped `U` followed by the digits themselves",
+            ),
+            LiteralKind::Special(SpecialLiteralKind::Bell) => (
+                "the `\\a` bell escape",
+                "an escaped `a`, matching that letter",
+            ),
+        };
+        self.refuse(written, read_as);
+    }
+
+    /// Records `written` as the pattern's refusal, keeping the first construct the walk reached.
+    fn refuse(&mut self, written: &'static str, read_as: &'static str) {
+        self.refusal.get_or_insert(Unportable { read_as, written });
+    }
+
+    /// `pattern` with every `(?P<name>` it opens rewritten to `(?<name>`.
+    fn rewritten(mut self, pattern: &str) -> String {
+        if self.named_group_markers.is_empty() {
+            return pattern.to_owned();
+        }
+        self.named_group_markers.sort_unstable();
+        let mut result = String::with_capacity(pattern.len());
+        let mut cut = 0;
+        for marker in self.named_group_markers {
+            result.push_str(&pattern[cut..marker]);
+            cut = marker + 1;
+        }
+        result.push_str(&pattern[cut..]);
+        result
+    }
 }
 
 thread_local! {
@@ -336,16 +589,61 @@ const fn js_line_terminator_escape(ch: char) -> Option<&'static str> {
     }
 }
 
-/// The `regex` crate's own rejection of a `pattern` attribute value, spanned on the literal the
-/// author wrote, or `None` when the pattern parses.
+/// A `pattern` attribute value in the spelling every surface it is spliced into reads the same
+/// way, or the rejection that keeps it off them, spanned on the literal the author wrote.
 ///
-/// Both splice points hand the string to `regex::Regex::new(...).unwrap()` inside the generated
-/// validator, so a pattern that does not parse here is a panic at the first validation there. The
-/// macro holds the string and links `regex`, so the parse happens at expansion instead.
-pub fn regex_rejection(lit: &LitStr) -> Option<syn::Error> {
-    regex::Regex::new(&lit.value())
-        .err()
-        .map(|err| syn::Error::new_spanned(lit, err))
+/// One string reaches three surfaces: the Rust validator's `regex::Regex::new(...).unwrap()`, the
+/// Zod schema's JavaScript regex literal, and the JSON Schema `pattern` keyword, which ECMA-262
+/// defines as a JavaScript regex. A pattern the `regex` crate cannot parse is a panic at the first
+/// validated value. A pattern only the `regex` crate can parse is quieter and worse: the derive
+/// expands clean and the generated JavaScript either throws where it loads or, where the two
+/// grammars disagree rather than collide, matches a different set of strings than the Rust
+/// validator it was written beside. Both verdicts are reached here, at expansion.
+///
+/// Where the grammars merely spell one construct differently the spelling is rewritten instead of
+/// refused: `(?P<name>...)` becomes `(?<name>...)`. That rewrite is the only one, and it is a
+/// spelling the `regex` crate reads too, so the one string that goes to all three surfaces still
+/// means to the validator exactly what it meant before. A `]` opening a character class looks like
+/// the same kind of fix and is not — `[]-a]` is three members and `[\]-a]` is a range — so it is
+/// refused rather than escaped.
+pub fn portable_pattern(lit: &LitStr) -> Result<String, syn::Error> {
+    let pattern = lit.value();
+    if let Err(err) = regex::Regex::new(&pattern) {
+        return Err(syn::Error::new_spanned(
+            lit,
+            format!(
+                "`pattern` is not a regex the `regex` crate can parse. The generated validator \
+                 builds it with `regex::Regex::new(...).unwrap()`, so accepting it here would turn \
+                 the first validated value into a panic. {err}"
+            ),
+        ));
+    }
+    js_spelling(&pattern).map_err(|message| syn::Error::new_spanned(lit, message))
+}
+
+/// The pattern rewritten to the spelling a JavaScript regex literal reads the same way, or the
+/// first construct in it that a JavaScript regex literal has no reading for.
+fn js_spelling(pattern: &str) -> Result<String, String> {
+    let ast = PatternParser::new().parse(pattern).map_err(|err| {
+        format!(
+            "`pattern` parses for `regex::Regex::new` but not for the grammar this guard reads it \
+             back with, so what the Zod and JSON Schema surfaces would be handed cannot be \
+             decided. {err}"
+        )
+    })?;
+    let mut walk = JsSpelling::default();
+    walk.ast(&ast);
+    if let Some(refusal) = walk.refusal.as_ref() {
+        return Err(format!(
+            "`pattern` uses {}, which the `regex` crate reads and a JavaScript regex literal does \
+             not: there the same bytes are {}. The Zod schema splices this string between `/` \
+             delimiters and the JSON Schema `pattern` keyword is an ECMA-262 regex, so the \
+             constraint would say one thing in the Rust validator and another -- or nothing at all \
+             -- on the surfaces generated beside it.",
+            refusal.written, refusal.read_as
+        ));
+    }
+    Ok(walk.rewritten(pattern))
 }
 
 /// Escapes a regex pattern for splicing between the `/` delimiters of a JavaScript regex literal.

--- a/src/utils/tests.rs
+++ b/src/utils/tests.rs
@@ -1,5 +1,58 @@
 use super::*;
 
+/// The pattern shapes the shipped tests write, none of which the two grammars spell differently.
+/// Every one of them has to come back byte for byte: the guard is there to stop a pattern only one
+/// grammar reads, not to touch the ones both already read the same way.
+const PORTABLE_PATTERNS: [&str; 10] = [
+    "^[a-z]+$",
+    "^[0-9a-fA-F]{24}$",
+    r"^\d{3}\.\d{3}\.\d{3}-\d{2}$",
+    r"^\/[a-z]+$",
+    "^/[a-z]+$",
+    r"^a\n[a-z]+$",
+    "(?<word>[a-z]+)",
+    // `(?P<` inside a class is four ordinary members, and the rename must not reach into one.
+    "[(?P<]",
+    "[--/]",
+    r"[a\]b]",
+];
+
+/// Every construct the guard refuses, beside the words the refusal has to name it by.
+///
+/// The list is the inventory of what `regex::Regex::new` accepts and a JavaScript regex literal
+/// either fails to parse or reads as something else, so it doubles as the record of what was
+/// checked against both grammars.
+const UNPORTABLE_PATTERNS: [(&str, &str); 22] = [
+    ("(?i)abc", "inline flag directive"),
+    ("abc(?i)def", "inline flag directive"),
+    ("(?x:a b)", "ignore-whitespace flag"),
+    ("(?U:a+)", "swap-greed flag"),
+    ("(?u:a)", "Unicode flag"),
+    ("(?R:a)", "CRLF flag"),
+    (r"\Aabc", r"`\A` anchor"),
+    (r"abc\z", r"`\z` anchor"),
+    (r"\b{start}a", "word boundary"),
+    (r"\<a", "word boundary"),
+    (r"\p{L}", "Unicode class"),
+    (r"\pL", "Unicode class"),
+    (r"[\p{L}]", "Unicode class"),
+    ("[[:alpha:]]", "POSIX class"),
+    (r"[\w&&\d]", "`&&` class intersection"),
+    ("[+--]", "`--` class difference"),
+    (r"[\d~~\w]", "`~~` class symmetric difference"),
+    ("[a[b]]", "class nested inside another class"),
+    (r"\x{41}", "braced code point escape"),
+    ("[]]", "unescaped `]` opening a character class"),
+    ("[^]]", "unescaped `]` opening a character class"),
+    ("[]-a]", "unescaped `]` opening a character class"),
+];
+
+/// The haystacks a rewritten pattern is held to: whatever the original matched among them, the
+/// rewrite has to match too.
+const REWRITE_HAYSTACKS: [&str; 12] = [
+    "", "a", "abc", "]", "]]", "a]", "-", "/", "a-b", "word-42", "AB", "[",
+];
+
 #[cfg(feature = "zod")]
 #[test]
 fn test_extract_example_simple() {
@@ -250,4 +303,115 @@ fn test_escape_js_regex_literal_leaves_an_authored_line_terminator_escape_alone(
 fn test_escape_js_regex_literal_rewrites_an_identity_escaped_line_terminator() {
     assert_eq!(escape_js_regex_literal("^a\\\nb$"), r"^a\nb$");
     assert_eq!(escape_js_regex_literal("^a\\\\\nb$"), r"^a\\\nb$");
+}
+
+/// Runs the `pattern` guard over `pattern` written as the literal an author would have written,
+/// which is what the guard spans its refusals on.
+fn portable(pattern: &str) -> Result<String, String> {
+    let lit = LitStr::new(pattern, proc_macro2::Span::call_site());
+    portable_pattern(&lit).map_err(|rejection| rejection.to_string())
+}
+
+/// `(?P<name>` is Rust's and Python's spelling of the group JavaScript spells `(?<name>`, and the
+/// `regex` crate reads both, so the one spelling that reaches every surface is the shared one.
+#[test]
+fn test_portable_pattern_translates_the_rust_named_group_spelling() {
+    assert_eq!(portable("(?P<w>[a-z]+)").unwrap(), "(?<w>[a-z]+)");
+    assert_eq!(
+        portable("^(?P<w>[a-z]+)-(?P<n>[0-9]+)$").unwrap(),
+        "^(?<w>[a-z]+)-(?<n>[0-9]+)$"
+    );
+    assert_eq!(
+        portable("(?P<outer>(?P<inner>a))").unwrap(),
+        "(?<outer>(?<inner>a))"
+    );
+    // The group's span is a byte offset, so a multi-byte character ahead of it must not shift the
+    // `P` the rewrite drops.
+    assert_eq!(portable("\u{e9}(?P<w>a)").unwrap(), "\u{e9}(?<w>a)");
+}
+
+/// A class-opening `]` is refused rather than escaped because escaping it is not local: `[]-a]` is
+/// the three members `]`, `-` and `a`, and `[\]-a]` is the range `]` to `a`. Pinned here so a
+/// later attempt to "just escape it" fails instead of quietly widening the constraint.
+#[test]
+fn test_portable_pattern_does_not_escape_a_class_opening_bracket() {
+    let escaped = regex::Regex::new(r"[\]-a]").unwrap();
+    let written = regex::Regex::new("[]-a]").unwrap();
+    assert!(escaped.is_match("_"));
+    assert!(!written.is_match("_"));
+    portable("[]-a]").unwrap_err();
+}
+
+/// A pattern both grammars already read the same way comes back untouched, byte for byte.
+#[test]
+fn test_portable_pattern_leaves_a_shared_pattern_byte_identical() {
+    for pattern in PORTABLE_PATTERNS {
+        assert_eq!(portable(pattern).as_deref(), Ok(pattern), "for {pattern}");
+    }
+}
+
+/// `.`, `\d`, `\w`, `\s` and `\b` are in both grammars and part ways only over what counts as a
+/// digit, a word character or a boundary. That is a divergence in what they match, not in what
+/// they are, and the guard deliberately leaves it alone.
+#[test]
+fn test_portable_pattern_admits_the_classes_both_grammars_spell() {
+    for pattern in [r"^\d+$", r"^\w+$", r"^\s+$", "^.$", r"\ba", r"\Ba"] {
+        assert_eq!(portable(pattern).as_deref(), Ok(pattern), "for {pattern}");
+    }
+}
+
+/// Every refusal names the construct that earned it and the surface that cannot carry it.
+#[test]
+fn test_portable_pattern_names_the_construct_javascript_cannot_carry() {
+    for (pattern, construct) in UNPORTABLE_PATTERNS {
+        assert!(
+            regex::Regex::new(pattern).is_ok(),
+            "{pattern} is not a pattern the `regex` crate accepts, so it probes nothing"
+        );
+        let rejection = portable(pattern).unwrap_err();
+        for needle in [construct, "JavaScript regex literal", "Zod", "JSON Schema"] {
+            assert!(
+                rejection.contains(needle),
+                "{needle} missing for {pattern}: {rejection}"
+            );
+        }
+    }
+}
+
+/// A rewrite is a change of spelling, not of meaning: what the pattern matched before it, it
+/// matches after — read off `regex::Regex` itself rather than restated here.
+#[test]
+fn test_portable_pattern_rewrite_keeps_what_the_pattern_matched() {
+    for pattern in [
+        "(?P<w>[a-z]+)",
+        "^(?P<w>[a-z]+)-(?P<n>[0-9]+)$",
+        "(?P<outer>(?P<inner>a))",
+        r"(?P<w>[a-z]+)|(?P<n>\d+)",
+    ] {
+        let rewritten = portable(pattern).unwrap();
+        let before = regex::Regex::new(pattern).unwrap();
+        let after = regex::Regex::new(&rewritten).unwrap();
+        for haystack in REWRITE_HAYSTACKS {
+            assert_eq!(
+                before.is_match(haystack),
+                after.is_match(haystack),
+                "{pattern} and {rewritten} part ways over {haystack:?}"
+            );
+        }
+    }
+}
+
+/// A pattern the `regex` crate cannot parse is still refused with the crate's own words, ahead of
+/// any question of what JavaScript would make of it.
+#[test]
+fn test_portable_pattern_quotes_the_regex_crate_on_a_pattern_it_refuses() {
+    let rejection = portable(r"^ab\").unwrap_err();
+    for needle in [
+        "pattern",
+        "regex parse error",
+        "incomplete escape sequence",
+        "panic",
+    ] {
+        assert!(rejection.contains(needle), "{needle} missing: {rejection}");
+    }
 }

--- a/tests/pattern_preprocess_tests/tests.rs
+++ b/tests/pattern_preprocess_tests/tests.rs
@@ -715,3 +715,70 @@ fn test_the_escaped_newline_literal_matches_the_value_set_the_validator_enforces
         );
     }
 }
+
+// A pattern whose named group is spelled Rust's way
+
+#[cfg(feature = "zod")]
+#[test]
+fn test_a_rust_named_group_reaches_the_zod_literal_as_javascript_spells_it() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize)]
+    pub struct RustNamedGroup {
+        #[model_schema_prop(pattern = r"^(?P<word>[a-z]+)-(?P<number>[0-9]+)$")]
+        pub tag: String,
+    }
+
+    let schema = RustNamedGroup::zod_schema();
+    assert!(
+        schema.contains("z.regex(/^(?<word>[a-z]+)-(?<number>[0-9]+)$/)"),
+        "Schema: {schema}"
+    );
+    assert!(
+        !schema.contains("(?P<"),
+        "The Rust-only spelling must not reach the literal: {schema}"
+    );
+}
+
+#[cfg(feature = "jsonschema")]
+#[test]
+fn test_a_rust_named_group_reaches_the_json_schema_as_ecma_262_spells_it() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize)]
+    pub struct RustNamedGroupJson {
+        #[model_schema_prop(pattern = "^(?P<word>[a-z]+)$")]
+        pub tag: String,
+    }
+
+    let schema_str = serde_json::to_string(&RustNamedGroupJson::json_schema()).unwrap();
+    assert!(
+        schema_str.contains(r#""pattern":"^(?<word>[a-z]+)$""#),
+        "JSON Schema `pattern` is an ECMA-262 regex: {schema_str}"
+    );
+}
+
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn test_the_rewritten_named_group_matches_the_value_set_the_validator_enforces() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug)]
+    pub struct RustNamedGroupValidated {
+        #[model_schema_prop(pattern = r"^(?P<word>[a-z]+)-(?P<number>[0-9]+)$")]
+        pub tag: String,
+    }
+
+    serde_json::from_str::<RustNamedGroupValidated>(r#"{"tag": "abc-42"}"#).unwrap();
+    for rejected in [
+        r#"{"tag": "abc"}"#,
+        r#"{"tag": "ABC-42"}"#,
+        r#"{"tag": "-42"}"#,
+    ] {
+        let err = serde_json::from_str::<RustNamedGroupValidated>(rejected).unwrap_err();
+        assert!(
+            err.to_string().contains("does not match pattern"),
+            "Expected a pattern rejection for {rejected}: {err}"
+        );
+    }
+}


### PR DESCRIPTION
One pattern string reaches three engines — the Rust validator's regex::Regex, the Zod literal, and the JSON Schema pattern keyword (ECMA-262 by definition) — but the guard only validated with Rust semantics, so a pattern valid only in the Rust grammar expanded clean and produced JavaScript that throws at load time (or, where the grammars disagree rather than collide, silently matches a different set).

regex_rejection is replaced by portable_pattern: Regex::new runs first (verdict and message unchanged), then a walk over the regex-syntax AST — the parser Regex::new is itself built on, so the guard's reading is the crate's own; a hand-rolled second grammar could not tell [--/] (three ordinary members) from [+--] (a set difference). Twenty-two Rust-only constructs are refused with a spanned error naming the construct and what JavaScript makes of the same bytes; one is translated: (?P<name>) becomes the (?<name>) both grammars read, by a byte-local drop that cannot change how anything else parses. A class-opening ] looks like the same kind of fix and is not — []-a] is three members while [\]-a] is a range — so it is refused rather than silently widened; a red test pins that trap. Both splice points (field constraint and brand argument) go through the one channel, so all three surfaces get the same string.

The rewrite is execution-verified: node parses the emitted literal and its verdicts agree with regex::Regex over the haystack matrix, zero mismatches. All ten shipped pattern shapes come back byte-identical, and every pre-existing pattern test passes untouched. regex-syntax 0.8 becomes a direct dependency (already in the tree under regex), capped below 0.9 on purpose: the AST is matched exhaustively, so a grammar that grows a construct must be classified rather than waved through. Full powerset tests and lint-all green locally.