### PR TITLE
name an alias's schema module from its Rust ident so forward references resolve

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -28,10 +28,10 @@ use crate::{
     utils::{get_field_docs, get_variant_docs},
 };
 
-// The item paths take their exported name from `compute_item_export_name`, which applies this
-// itself; what is left is the naming a reference falls back to for a type this expansion never saw,
-// and the parameter list a generic alias writes.
-#[cfg(any(feature = "typescript", feature = "jsonschema"))]
+// The item paths take their exported name from `compute_item_export_name` and their module name
+// from `ident_schema_module_name`, both of which apply this themselves; what is left is the
+// parameter list a generic alias writes.
+#[cfg(feature = "typescript")]
 use crate::utils::safe_type_name;
 
 #[cfg(feature = "zod")]
@@ -77,7 +77,7 @@ use crate::features::jsonschema::{MergeDiagnostic, merged_object_value};
 use crate::utils::{get_enum_docs, get_struct_docs, strip_examples_from_docs};
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-use crate::utils::compute_alias_export_name;
+use crate::utils::{compute_alias_export_name, ident_schema_module_name};
 
 use crate::utils::compute_item_export_name;
 
@@ -663,6 +663,9 @@ fn flattened_plain_enum(inner: &FieldDef) -> Option<&str> {
 /// `#module_ident::Schema::json_schema()`. So the module and its `register_alias_info` call are
 /// driven by the union: gating them on `typescript` alone left the jsonschema references
 /// dangling. The module's *contents* are chosen per feature while building the tokens.
+///
+/// The module is named from the Rust ident, not from the export name, so that a type naming the
+/// alias before it has expanded assumes the module the alias goes on to publish.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn process_type_alias(item_type: ItemType, args: &ModelSchemaArgs) -> TokenStream {
     let mut alias = item_type;
@@ -673,7 +676,7 @@ fn process_type_alias(item_type: ItemType, args: &ModelSchemaArgs) -> TokenStrea
     let rust_ident = alias.ident.clone();
     let rust_ident_str = rust_ident.to_string();
     let export_name = compute_alias_export_name(&rust_ident_str, args.name_override.as_deref());
-    let module_name = format!("{}_schema", to_snake_case(&export_name));
+    let module_name = ident_schema_module_name(&rust_ident_str);
     let module_ident = Ident::new(&module_name, rust_ident.span());
 
     // Registered only once the target has been classified: the alias's own expansion is the only
@@ -5228,10 +5231,11 @@ fn nullable_slot_json_schema_value(
 
 /// The schema module a sibling type's `Schema::json_schema()` lives in.
 ///
-/// An alias's module is named after its registered export name, which the raw ident does not
-/// reproduce, so the registry answers first. A name it does not hold is one this expansion has not
-/// seen — a type expanded later, or one from another crate — and takes the naming every
-/// `#[model_schema()]` type follows.
+/// A declared item's module is named after its exported name, which a `name = "…"` override moves
+/// away from the raw ident, so the registry answers first. A name it does not hold is one this
+/// expansion has not seen — a type expanded later, or one from another crate — and takes the
+/// ident-derived naming, which is all a reference standing before the type has to go on. That
+/// naming is what a type alias publishes under, so an alias resolves in either declaration order.
 ///
 /// The ident is spanned on where the sibling was named rather than on the attribute. Nothing the
 /// macro can read tells it whether the module will be in scope — a generated module reaches its
@@ -5242,7 +5246,7 @@ fn nullable_slot_json_schema_value(
 fn sibling_schema_module_ident(name: &str, span: proc_macro2::Span) -> Ident {
     let module_name = match lookup_alias_info(name) {
         Some(alias) => alias.module_name,
-        None => format!("{}_schema", to_snake_case(&safe_type_name(name))),
+        None => ident_schema_module_name(name),
     };
     Ident::new(module_name.as_str(), span)
 }

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -2916,8 +2916,8 @@ fn a_map_never_parses_as_a_sibling_named_after_its_container() {
     }
 }
 
-/// An alias's schema module is named after its registered export name, which the raw ident does
-/// not reproduce — the reference has to come from the registry or it names a module that was never
+/// A renamed item's schema module is named after its exported name, which the raw ident does not
+/// reproduce — the reference has to come from the registry or it names a module that was never
 /// emitted.
 #[cfg(feature = "jsonschema")]
 #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -70,8 +70,22 @@ pub fn safe_type_name(key: &str) -> String {
     }
 }
 
-/// The export name is what `register_alias_info` stores and what the alias schema module is
-/// named after, so every feature that references an alias needs it — not just `typescript`.
+/// The schema module a `#[model_schema()]` type alias publishes, which is also the module a
+/// reference assumes for a name the registry does not hold.
+///
+/// A reference written *before* the alias expands has nothing but the Rust ident to name a module
+/// from — the registry is empty of the alias, and the exported name is not recoverable from the
+/// ident once a `name = "…"` override is in play. So the module is named from the ident on both
+/// sides, and the two spellings agree in either declaration order. A rename moves what the alias
+/// is exported as; it does not move where the alias's schema lives.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+pub fn ident_schema_module_name(rust_ident: &str) -> String {
+    format!("{}_schema", to_snake_case(&safe_type_name(rust_ident)))
+}
+
+/// The export name is what `register_alias_info` stores and what the alias's TypeScript, zod, and
+/// JSON-schema surfaces are written under, so every feature that references an alias needs it —
+/// not just `typescript`.
 ///
 /// An override is taken verbatim: the parser has already refused a value no surface can carry, so
 /// what arrives here is the name the author wrote.

--- a/src/utils/tests.rs
+++ b/src/utils/tests.rs
@@ -251,3 +251,25 @@ fn test_escape_js_regex_literal_rewrites_an_identity_escaped_line_terminator() {
     assert_eq!(escape_js_regex_literal("^a\\\nb$"), r"^a\nb$");
     assert_eq!(escape_js_regex_literal("^a\\\\\nb$"), r"^a\\\nb$");
 }
+
+/// The module name a reference assumes for a name it has not seen and the one an alias goes on to
+/// publish are the same call, so nothing the alias is written with can pull them apart: the `Type`
+/// suffix an alias exports under and a `name = "…"` override both land on the export name only.
+/// The `Json` suffix is still read through, that being what every reference already spells.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn ident_schema_module_name_is_derived_from_the_ident_alone() {
+    assert_eq!(ident_schema_module_name("LaterAlias"), "later_alias_schema");
+    assert_eq!(
+        ident_schema_module_name("LaterAliasJson"),
+        "later_alias_schema"
+    );
+    assert_eq!(
+        compute_alias_export_name("LaterAlias", None),
+        "LaterAliasType"
+    );
+    assert_eq!(
+        compute_alias_export_name("LaterAlias", Some("Renamed")),
+        "Renamed"
+    );
+}

--- a/tests/alias_reference_tests/tests.rs
+++ b/tests/alias_reference_tests/tests.rs
@@ -57,6 +57,33 @@ pub type DocumentIdsByName = HashMap<String, ReferencedDocumentId>;
 #[model_schema()]
 pub type DocumentIdsBySlot = HashMap<DocumentSlot, ReferencedDocumentId>;
 
+/// Declaration order, taken both ways round. This struct names aliases that have not expanded yet,
+/// so the module each reference resolves to is derived from the alias's Rust ident and nothing
+/// else; [`NamesAliasesDeclaredEarlier`] names the same two once they are registered. Both have to
+/// reach the same modules, or one of the two orders names a module that was never emitted.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct NamesAliasesDeclaredLater {
+    pub counts: Vec<LaterDeclaredCount>,
+    pub ids: HashMap<String, LaterDeclaredId>,
+}
+
+#[model_schema()]
+pub type LaterDeclaredId = String;
+
+/// A rename moves what the alias is *exported* as. It does not move the module its schema is
+/// published in — an override is not recoverable from the Rust ident, so a module named after the
+/// override would be one no forward reference could ever name.
+#[model_schema(name = "RenamedLaterDeclaredCount")]
+pub type LaterDeclaredCount = u64;
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct NamesAliasesDeclaredEarlier {
+    pub counts: Vec<LaterDeclaredCount>,
+    pub ids: HashMap<String, LaterDeclaredId>,
+}
+
 #[test]
 fn struct_referencing_an_alias_expands_in_this_feature_combination() {
     let value = UsesAliasByValue {
@@ -117,7 +144,7 @@ fn alias_module_backs_the_reference_emitted_by_the_referencing_struct() {
     assert!(properties.get("id").is_some());
     assert_eq!(
         properties.get("id").unwrap(),
-        &referenced_document_id_type_schema::Schema::json_schema()
+        &referenced_document_id_schema::Schema::json_schema()
     );
 }
 
@@ -126,7 +153,7 @@ fn alias_module_backs_the_reference_emitted_by_the_referencing_struct() {
 fn alias_module_backs_the_map_value_reference() {
     let schema = UsesAliasAsMapValue::json_schema();
     let by_slot = schema.get("properties").unwrap().get("by_slot").unwrap();
-    let alias_schema = referenced_document_id_type_schema::Schema::json_schema();
+    let alias_schema = referenced_document_id_schema::Schema::json_schema();
     for slot in DocumentSlot::enum_members() {
         assert_eq!(
             by_slot.get("properties").unwrap().get(&slot).unwrap(),
@@ -143,7 +170,7 @@ fn alias_module_backs_the_map_value_reference() {
 fn alias_keyed_map_enumerates_the_members_of_the_aliased_enum() {
     let schema = UsesAliasAsMapKey::json_schema();
     let properties = schema.get("properties").unwrap();
-    let alias_schema = referenced_document_id_type_schema::Schema::json_schema();
+    let alias_schema = referenced_document_id_schema::Schema::json_schema();
     for field in ["by_slot", "by_chained_slot"] {
         let keyed = properties.get(field).unwrap().get("properties").unwrap();
         for slot in DocumentSlot::enum_members() {
@@ -163,7 +190,7 @@ fn alias_keyed_map_enumerates_the_members_of_the_aliased_enum() {
 #[test]
 fn an_aliased_scalar_publishes_the_targets_schema() {
     assert_eq!(
-        referenced_document_id_type_schema::Schema::json_schema(),
+        referenced_document_id_schema::Schema::json_schema(),
         serde_json::json!({ "type": "string" })
     );
 }
@@ -174,7 +201,7 @@ fn an_aliased_scalar_publishes_the_targets_schema() {
 #[test]
 fn an_aliased_sibling_publishes_the_siblings_own_schema() {
     assert_eq!(
-        document_slot_alias_type_schema::Schema::json_schema(),
+        document_slot_alias_schema::Schema::json_schema(),
         document_slot_schema::Schema::json_schema()
     );
 }
@@ -185,7 +212,7 @@ fn an_aliased_sibling_publishes_the_siblings_own_schema() {
 #[test]
 fn an_alias_of_an_alias_resolves_to_the_type_at_the_end_of_the_chain() {
     assert_eq!(
-        document_slot_alias_chain_type_schema::Schema::json_schema(),
+        document_slot_alias_chain_schema::Schema::json_schema(),
         document_slot_schema::Schema::json_schema()
     );
 }
@@ -194,10 +221,10 @@ fn an_alias_of_an_alias_resolves_to_the_type_at_the_end_of_the_chain() {
 #[test]
 fn an_aliased_sequence_publishes_the_array_of_its_element() {
     assert_eq!(
-        referenced_document_ids_type_schema::Schema::json_schema(),
+        referenced_document_ids_schema::Schema::json_schema(),
         serde_json::json!({
             "type": "array",
-            "items": referenced_document_id_type_schema::Schema::json_schema()
+            "items": referenced_document_id_schema::Schema::json_schema()
         })
     );
 }
@@ -207,13 +234,13 @@ fn an_aliased_sequence_publishes_the_array_of_its_element() {
 #[cfg(feature = "jsonschema")]
 #[test]
 fn an_aliased_map_publishes_the_object_its_key_and_value_describe() {
-    let member = referenced_document_id_type_schema::Schema::json_schema();
+    let member = referenced_document_id_schema::Schema::json_schema();
     assert_eq!(
-        document_ids_by_name_type_schema::Schema::json_schema(),
+        document_ids_by_name_schema::Schema::json_schema(),
         serde_json::json!({ "type": "object", "additionalProperties": member })
     );
 
-    let by_slot = document_ids_by_slot_type_schema::Schema::json_schema();
+    let by_slot = document_ids_by_slot_schema::Schema::json_schema();
     let properties = by_slot.get("properties").unwrap();
     for slot in DocumentSlot::enum_members() {
         assert_eq!(properties.get(&slot).unwrap(), &member, "in: {by_slot}");
@@ -232,12 +259,12 @@ fn an_aliased_map_publishes_the_object_its_key_and_value_describe() {
 #[test]
 fn no_alias_publishes_a_schema_that_validates_nothing() {
     for schema in [
-        referenced_document_id_type_schema::Schema::json_schema(),
-        referenced_document_ids_type_schema::Schema::json_schema(),
-        document_slot_alias_type_schema::Schema::json_schema(),
-        document_slot_alias_chain_type_schema::Schema::json_schema(),
-        document_ids_by_name_type_schema::Schema::json_schema(),
-        document_ids_by_slot_type_schema::Schema::json_schema(),
+        referenced_document_id_schema::Schema::json_schema(),
+        referenced_document_ids_schema::Schema::json_schema(),
+        document_slot_alias_schema::Schema::json_schema(),
+        document_slot_alias_chain_schema::Schema::json_schema(),
+        document_ids_by_name_schema::Schema::json_schema(),
+        document_ids_by_slot_schema::Schema::json_schema(),
     ] {
         assert!(schema.get("warning").is_none(), "got: {schema}");
         assert!(schema.get("type").is_some(), "got: {schema}");
@@ -274,7 +301,7 @@ fn alias_map_value_zod_schema_name_matches_the_registered_export() {
 #[cfg(feature = "zod")]
 #[test]
 fn alias_zod_schema_name_matches_the_reference_emitted_by_the_struct() {
-    let alias_zod = referenced_document_id_type_schema::Schema::zod_schema();
+    let alias_zod = referenced_document_id_schema::Schema::zod_schema();
     assert!(
         alias_zod.contains("ReferencedDocumentIdType$Schema"),
         "got: {alias_zod}"
@@ -283,5 +310,77 @@ fn alias_zod_schema_name_matches_the_reference_emitted_by_the_struct() {
     assert!(
         struct_zod.contains("ReferencedDocumentIdType$Schema"),
         "got: {struct_zod}"
+    );
+}
+
+#[test]
+fn aliases_declared_under_their_reference_expand_in_this_feature_combination() {
+    let later = NamesAliasesDeclaredLater {
+        counts: vec![9_u64],
+        ids: HashMap::from([("n".to_owned(), "doc-8".to_owned())]),
+    };
+    assert_eq!(later.ids.get("n"), Some(&"doc-8".to_owned()));
+    assert_eq!(later.counts, vec![9_u64]);
+
+    let earlier = NamesAliasesDeclaredEarlier {
+        counts: vec![10_u64],
+        ids: HashMap::new(),
+    };
+    assert!(earlier.ids.is_empty());
+    assert_eq!(earlier.counts, vec![10_u64]);
+}
+
+/// A struct naming an alias declared under it used to refuse the whole crate: the reference
+/// assumed `later_declared_id_schema` while the alias published `later_declared_id_type_schema`,
+/// and rustc reported an `E0433` for a module the author never wrote. One spelling now answers on
+/// both sides, so which side of the alias the reference is written on changes nothing.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn an_alias_reference_describes_the_same_on_either_side_of_the_alias() {
+    assert_eq!(
+        NamesAliasesDeclaredLater::json_schema(),
+        NamesAliasesDeclaredEarlier::json_schema()
+    );
+}
+
+/// And what it resolves to is the alias's own module rather than something that merely exists:
+/// each member carries exactly what the alias publishes, the renamed one included.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_forward_alias_reference_carries_what_the_alias_publishes() {
+    let schema = NamesAliasesDeclaredLater::json_schema();
+    let properties = schema.get("properties").unwrap();
+    assert_eq!(
+        properties
+            .get("ids")
+            .unwrap()
+            .get("additionalProperties")
+            .unwrap(),
+        &later_declared_id_schema::Schema::json_schema(),
+        "in: {schema}"
+    );
+    assert_eq!(
+        properties.get("counts").unwrap().get("items").unwrap(),
+        &later_declared_count_schema::Schema::json_schema(),
+        "in: {schema}"
+    );
+}
+
+/// The override and the module name come apart: the alias is exported under the name the author
+/// wrote, from the module named after the Rust ident.
+#[cfg(feature = "typescript")]
+#[test]
+fn a_renamed_alias_exports_under_the_override_from_the_module_named_for_its_ident() {
+    let ts = later_declared_count_schema::Schema::ts_definition();
+    assert!(ts.contains("RenamedLaterDeclaredCount"), "got: {ts}");
+}
+
+#[cfg(feature = "zod")]
+#[test]
+fn a_renamed_alias_publishes_its_zod_schema_from_the_module_named_for_its_ident() {
+    let zod = later_declared_count_schema::Schema::zod_schema();
+    assert!(
+        zod.contains("RenamedLaterDeclaredCount$Schema"),
+        "got: {zod}"
     );
 }

--- a/tests/collection_tests/tests.rs
+++ b/tests/collection_tests/tests.rs
@@ -1397,7 +1397,7 @@ fn test_string_keyed_alias_value_maps_constructible() {
 #[test]
 #[cfg(feature = "jsonschema")]
 fn test_string_keyed_alias_value_maps_resolve_the_registered_module() {
-    let alias_schema = metric_sample_ref_type_schema::Schema::json_schema();
+    let alias_schema = metric_sample_ref_schema::Schema::json_schema();
     let schema = StringKeyedAliasValueMaps::json_schema();
     let properties = schema["properties"].as_object().unwrap();
 
@@ -2356,20 +2356,19 @@ fn test_an_alias_of_a_nested_sequence_publishes_its_depth() {
 
     #[cfg(feature = "typescript")]
     assert!(
-        metric_grid_type_schema::Schema::ts_definition().contains("Array<Array<number>>"),
+        metric_grid_schema::Schema::ts_definition().contains("Array<Array<number>>"),
         "Got: {}",
-        metric_grid_type_schema::Schema::ts_definition()
+        metric_grid_schema::Schema::ts_definition()
     );
     #[cfg(feature = "zod")]
     assert!(
-        metric_grid_type_schema::Schema::zod_schema()
-            .contains("z.array(z.array(z.number().int()))"),
+        metric_grid_schema::Schema::zod_schema().contains("z.array(z.array(z.number().int()))"),
         "Got: {}",
-        metric_grid_type_schema::Schema::zod_schema()
+        metric_grid_schema::Schema::zod_schema()
     );
     #[cfg(feature = "jsonschema")]
     assert_eq!(
-        metric_grid_type_schema::Schema::json_schema(),
+        metric_grid_schema::Schema::json_schema(),
         serde_json::json!({
             "type": "array",
             "items": { "type": "array", "items": { "type": "integer" } }

--- a/tests/semantic_types_tests/tests.rs
+++ b/tests/semantic_types_tests/tests.rs
@@ -660,7 +660,7 @@ fn test_complex_alias_usage() {
 fn test_name_override() {
     let some: SomeType = String::new();
     assert!(some.is_empty());
-    let ts = custom_name_schema::Schema::ts_definition();
+    let ts = some_type_schema::Schema::ts_definition();
 
     assert!(
         ts.contains("export type CustomName = string;"),


### PR DESCRIPTION
A struct naming a #[model_schema()] type alias declared below it failed with E0433 for a module the author never wrote: the alias published its schema module from its export name ({snake(export)}_schema, where the default export is the ident plus the Type suffix, or a name override), while the reference-side fallback — which is all a forward reference has before the alias registers — derives from the raw ident. The two spellings could never meet in that declaration order.

Both sides now call one seam, ident_schema_module_name, deriving from the Rust ident alone: the ident is the only thing a forward reference can know, so it is where the module lives. A rename moves what the alias is exported as; it does not move its module — a module named after an override would sit where no forward reference could name it (the split is pinned on both nominal surfaces). The registry still answers first for names it holds. Alias module paths therefore move from the export-derived to the ident-derived spelling; the crate's own call sites are repointed.

Capture pins the exact divergent pair before the fix; a both-orders parity test asserts a forward- and a backward-referencing struct emit identical schemas. Structs and enums are untouched — the same divergence for renamed items, and the raw-ident leak on the nominal surfaces, are tracked separately. Full powerset tests and lint-all green locally on the merged tree.