### PR TITLE
defer a flattened base's Zod schema read so emitted modules load in any declaration order

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,12 +444,13 @@ Generated Zod:
 export const DataElementSampleValueEntry$Schema: ZodType<DataElementSampleValueEntry> =
   z.strictObject({
     dataElementId: z.string(),
-  }).and(DataElementSampleValueVariant$Schema);
+  }).and(z.lazy(() => DataElementSampleValueVariant$Schema));
 ```
 
 Notes:
 
-- Multiple `#[serde(flatten)]` fields chain: `{ ... } & BasePart & ExtraPart` in TypeScript and `z.strictObject({ ... }).and(BasePart$Schema).and(ExtraPart$Schema)` in Zod.
+- The flattened base joins the intersection under `z.lazy`. A base is a `const` of its own and nothing orders one type's schema against another's, so reading the name while the intersection's `const` initializes would fail for any base declared below -- and for two bases that flatten each other, no order puts each above the other. Deferred, every module loads whatever order it is assembled in, and a pair that does flatten each other fails when asked to validate rather than at import.
+- Multiple `#[serde(flatten)]` fields chain: `{ ... } & BasePart & ExtraPart` in TypeScript and `z.strictObject({ ... }).and(z.lazy(() => BasePart$Schema)).and(z.lazy(() => ExtraPart$Schema))` in Zod.
 - A struct whose only field is flattened becomes a plain alias (e.g. `export type FlattenOnly = DataElementSampleValueVariant;`).
 - **JSON Schema** stays strict: rather than `allOf` (which cannot faithfully compose a tagged union under `additionalProperties: false`), the base properties are distributed into each branch of the flattened union, keeping every branch closed. Both spellings of a union are distributed into: a discriminated enum's `oneOf` and an untagged enum's `anyOf`. Plain-struct flattens merge into a single closed object; multiple flattened unions form a cross-product.
 - Each flattened union keeps the spelling it was written under. A discriminated enum's members are exclusive, so its branches stay a `oneOf`; an untagged enum is first-match-wins and its members may overlap (one member's keys a subset of another's, the difference optional), so its branches are an `anyOf` -- under `oneOf` the document would reject exactly what Serde writes for the narrower member, which matches both branches. An object flattening one of each nests the wrappers, the untagged `anyOf` sitting inside each branch of the discriminated `oneOf`.

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -7295,8 +7295,26 @@ fn generate_ts_definition_method(
     }
 }
 
+/// A schema an intersection is built from, written so the name it carries is read when the
+/// intersection is used rather than while the `const` holding it is being initialized.
+///
+/// A flattened base is rendered as the base's own exported `const`. Spliced in as it stands, that
+/// name is read the moment the containing `const`'s initializer runs — which fails outright when
+/// the base is declared below, and no declaration order puts each of two bases that flatten each
+/// other above the other. Deferring the read is what makes every emitted module load whatever
+/// order they are assembled in; a pair that does flatten each other then fails when something asks
+/// it to validate, rather than at the import of everything declared alongside it.
+#[cfg(feature = "zod")]
+fn deferred_zod_operand(schema: &str) -> String {
+    format!("z.lazy(() => {schema})")
+}
+
 #[cfg(feature = "zod")]
 /// Generates the Zod schema method (Zod schemas only, no TypeScript types).
+///
+/// Each flattened base joins the intersection through [`deferred_zod_operand`]: a base names a
+/// `const` of its own, and one macro invocation sees one type, so nothing here can know whether
+/// that `const` is declared above the module this writes or below it.
 fn generate_zod_schema_method(
     item_name: &str,
     schema_code: &str,
@@ -7305,7 +7323,7 @@ fn generate_zod_schema_method(
 ) -> proc_macro2::TokenStream {
     #[cfg_attr(not(feature = "zod"), allow(unused_variables))]
     let and_suffix: String = flatten_schemas.iter().fold(String::new(), |mut acc, s| {
-        let _ = write!(acc, ".and({s})");
+        let _ = write!(acc, ".and({})", deferred_zod_operand(s));
         acc
     });
 

--- a/tests/flatten_tests/tests.rs
+++ b/tests/flatten_tests/tests.rs
@@ -36,7 +36,7 @@ enum DataElementSampleValueVariant {
 
 /// Two bases that flatten each other: neither body exists when the other's merge asks for it, and
 /// no finite value inhabits either type.
-#[cfg(feature = "jsonschema")]
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct CycleFirst {
@@ -45,7 +45,7 @@ struct CycleFirst {
     second: CycleSecond,
 }
 
-#[cfg(feature = "jsonschema")]
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct CycleSecond {
@@ -533,7 +533,7 @@ fn test_flatten_zod_intersection() {
     let zod = DataElementSampleValueEntry::zod_schema();
     assert!(zod.contains("z.strictObject({"));
     assert!(zod.contains("dataElementId:"));
-    assert!(zod.contains("}).and(DataElementSampleValueVariant$Schema);"));
+    assert!(zod.contains("}).and(z.lazy(() => DataElementSampleValueVariant$Schema));"));
     assert!(!zod.contains("variant:"));
 }
 
@@ -541,7 +541,9 @@ fn test_flatten_zod_intersection() {
 #[cfg(feature = "zod")]
 fn test_flatten_zod_multiple_chained() {
     let zod = MultiFlatten::zod_schema();
-    assert!(zod.contains("}).and(BasePart$Schema).and(ExtraPart$Schema);"));
+    assert!(
+        zod.contains("}).and(z.lazy(() => BasePart$Schema)).and(z.lazy(() => ExtraPart$Schema));")
+    );
 }
 
 #[test]
@@ -550,6 +552,54 @@ fn test_no_flatten_zod_unchanged() {
     let zod = NoFlatten::zod_schema();
     assert!(zod.contains("z.strictObject({"));
     assert!(!zod.contains(".and("));
+}
+
+/// A base's schema is a `const` the emitted module reads, and nothing orders one type's module
+/// against another's. A flattened base named straight into the intersection would be read while
+/// the const initializer runs, which fails outright for any base declared below the type that
+/// flattens it — so the operand is the deferred form and the read happens when something validates.
+#[test]
+#[cfg(feature = "zod")]
+fn test_a_flattened_base_is_never_read_while_the_const_initializes() {
+    for zod in [
+        DataElementSampleValueEntry::zod_schema(),
+        MultiFlatten::zod_schema(),
+        FlattenOnly::zod_schema(),
+    ] {
+        for name in ["DataElementSampleValueVariant", "BasePart", "ExtraPart"] {
+            assert!(
+                !zod.contains(&format!(".and({name}$Schema)")),
+                "`{name}$Schema` is read eagerly in: {zod}"
+            );
+        }
+    }
+}
+
+/// Two bases that flatten each other name each other's `const`, and no declaration order puts both
+/// above the other. Deferring each read is what makes the pair's modules load at all; the cycle is
+/// then reached only by asking the schema to validate, never by importing it.
+#[test]
+#[cfg(feature = "zod")]
+fn test_a_flatten_cycle_defers_both_sides_of_the_pair() {
+    let first = CycleFirst::zod_schema();
+    let second = CycleSecond::zod_schema();
+
+    assert!(
+        first.contains("}).and(z.lazy(() => CycleSecond$Schema));"),
+        "expected a deferred base, got: {first}"
+    );
+    assert!(
+        second.contains("}).and(z.lazy(() => CycleFirst$Schema));"),
+        "expected a deferred base, got: {second}"
+    );
+    assert!(
+        !first.contains(".and(CycleSecond$Schema)"),
+        "`CycleSecond$Schema` is read eagerly in: {first}"
+    );
+    assert!(
+        !second.contains(".and(CycleFirst$Schema)"),
+        "`CycleFirst$Schema` is read eagerly in: {second}"
+    );
 }
 
 // ========================================================================


### PR DESCRIPTION
The flatten fold spliced a base's exported const name straight into the intersection's own const initializer, so the name was read while that initializer ran: any base declared below its host failed at import, and two bases flattening each other could never load in any order — the emitted module was the only surface producing output for a flatten cycle, and it produced one that cannot load (serde itself writes nothing for such a value: the Box-flattened pair has no finite inhabitant, and the Option-flattened spelling does not even compile, overflowing trait resolution).

Each flattened base now joins through z.lazy(() => Base$Schema), via one small helper. Applied unconditionally rather than cycle-only: a macro invocation sees one type and cannot know whether a base's const sits above or below the module it writes, and the failure never needed a cycle — declaration order alone triggered it. Execution-verified in node against a stub z with bases declared below their hosts: the eager emission fails at load with a ReferenceError; the deferred one loads in any order, validates acyclic payloads, and a genuinely cyclic pair fails only when asked to validate, never at import.

Four goldens move, all of them the deferral spelling itself (the intersection and chained-flatten pins, plus the README examples); everything else is byte-identical, and the jsonschema and TypeScript surfaces are untouched. The second, variant-content splice site is tracked separately. Full powerset tests and lint-all green locally.