### PR TITLE
drop the rust example block from every item's emitted JSDoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1219,6 +1219,7 @@ Key points:
 - Use the exact syntax: ` ```rust example` (note the space and `example` keyword).
 - If multiple examples are present, only the **first one** is used.
 - Examples respect Serde attributes (field renaming, etc.).
+- On a struct or an enum, the example block reaches the Zod `example` field only. Being Rust source, it is dropped from the JSDoc comment above the generated `export type`.
 - The example code is executed at compile time and serialized to JSON.
 - Wrong types produce compile errors, ensuring examples stay in sync with your types.
 

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -767,8 +767,9 @@ fn has_serde_transparent(attrs: &[syn::Attribute]) -> bool {
 /// The no-docs fallback names the item as it is exported, not as it is declared in Rust, so a
 /// `JSDoc` header never contradicts the `export type` one line under it.
 ///
-/// Doc lines reach the body as written: unlike the `item_plain_doc_lines` path, this one strips no
-/// ` ```rust example ` block.
+/// An item's ` ```rust example ` block is dropped before its lines reach the body, the way
+/// `item_plain_doc_lines` drops it: the block is Rust source, and nothing reads it as such once it
+/// is sitting in a `TypeScript` comment. A consumer after the example reads the Rust docs.
 #[cfg(feature = "typescript")]
 fn build_item_jsdoc(docs_vec: Option<&[String]>, item_name: &str) -> String {
     docs_vec.map_or_else(
@@ -780,7 +781,7 @@ fn build_item_jsdoc(docs_vec: Option<&[String]>, item_name: &str) -> String {
                 .join("\n")
         },
         |doc_lines| {
-            doc_lines
+            strip_examples_from_docs(doc_lines)
                 .iter()
                 .flat_map(|v| v.lines().map(ToOwned::to_owned).collect::<Vec<_>>())
                 .chain(vec![String::new()])

--- a/tests/item_jsdoc_example_tests.rs
+++ b/tests/item_jsdoc_example_tests.rs
@@ -1,0 +1,10 @@
+//! Tests for what an item's ` ```rust example ` block reaches in the emitted `TypeScript`.
+//!
+//! The example is Rust source. It does not compile, render, or mean anything inside a `TypeScript`
+//! `JSDoc` comment, so no item shape carries it there — the fence and its body are dropped from
+//! every `JSDoc` body, whatever the item is declared as.
+
+#[cfg(feature = "typescript")]
+#[cfg(test)]
+#[path = "item_jsdoc_example_tests/tests.rs"]
+mod tests;

--- a/tests/item_jsdoc_example_tests/tests.rs
+++ b/tests/item_jsdoc_example_tests/tests.rs
@@ -1,0 +1,141 @@
+use serde::{Deserialize, Serialize};
+use tixschema::model_schema;
+
+/// A documented struct.
+/// ```rust example
+/// let item = DocumentedStruct {
+///     label: "alpha".to_string(),
+/// };
+/// println!("Item: {:?}", item);
+/// ```
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug)]
+pub struct DocumentedStruct {
+    pub label: String,
+}
+
+/// A documented tuple struct.
+/// ```rust example
+/// let item = DocumentedTuple("alpha".to_string(), 7);
+/// println!("Item: {:?}", item);
+/// ```
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug)]
+pub struct DocumentedTuple(pub String, pub u32);
+
+/// A documented adjacently tagged enum.
+/// ```rust example
+/// let item = DocumentedAdjacent::Unit;
+/// println!("Item: {:?}", item);
+/// ```
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "kind", content = "payload")]
+pub enum DocumentedAdjacent {
+    Named { side: u8 },
+    Unit,
+}
+
+/// A documented externally tagged enum.
+/// ```rust example
+/// let item = DocumentedExternal::Unit;
+/// println!("Item: {:?}", item);
+/// ```
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug)]
+pub enum DocumentedExternal {
+    Named { side: u8 },
+    Unit,
+}
+
+/// A documented internally tagged enum.
+/// ```rust example
+/// let item = DocumentedInternal::Unit;
+/// println!("Item: {:?}", item);
+/// ```
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "kind")]
+pub enum DocumentedInternal {
+    Named { side: u8 },
+    Unit,
+}
+
+/// A documented untagged enum.
+/// ```rust example
+/// let item = DocumentedUntagged::Count(3);
+/// println!("Item: {:?}", item);
+/// ```
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(untagged)]
+pub enum DocumentedUntagged {
+    Count(u32),
+    Label(String),
+}
+
+/// A documented plain enum.
+/// ```rust example
+/// let item = DocumentedSlot::Primary;
+/// println!("Item: {:?}", item);
+/// ```
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+pub enum DocumentedSlot {
+    Primary,
+    Secondary,
+}
+
+/// Every documented shape above, paired with the description its `JSDoc` is left with once the
+/// example is dropped. The plain enum rides along as the shape that already dropped it.
+fn documented_shapes() -> Vec<(String, &'static str)> {
+    vec![
+        (DocumentedStruct::ts_definition(), "A documented struct."),
+        (
+            DocumentedTuple::ts_definition(),
+            "A documented tuple struct.",
+        ),
+        (
+            DocumentedAdjacent::ts_definition(),
+            "A documented adjacently tagged enum.",
+        ),
+        (
+            DocumentedExternal::ts_definition(),
+            "A documented externally tagged enum.",
+        ),
+        (
+            DocumentedInternal::ts_definition(),
+            "A documented internally tagged enum.",
+        ),
+        (
+            DocumentedUntagged::ts_definition(),
+            "A documented untagged enum.",
+        ),
+        (DocumentedSlot::ts_definition(), "A documented plain enum."),
+    ]
+}
+
+/// The reported failure: a struct's `JSDoc` opened with the fence and the Rust body under it, so
+/// neither the fence nor anything written inside it may reach the emitted `TypeScript`.
+#[test]
+fn a_documented_item_never_carries_its_rust_example_into_the_emitted_typescript() {
+    for (ts, description) in documented_shapes() {
+        for leaked in ["```", "let item =", "println!"] {
+            assert!(!ts.contains(leaked), "{leaked} reached: {ts}");
+        }
+        assert!(ts.contains(description), "docs dropped from: {ts}");
+    }
+}
+
+/// The example was the only thing separating the shapes, so with it gone every one of them opens
+/// its `JSDoc` the same way: the description, then the blank continuation line.
+#[test]
+fn every_documented_shape_opens_its_jsdoc_identically() {
+    for (ts, description) in documented_shapes() {
+        let header = format!("/**\n * {description}\n * \n");
+        assert!(
+            ts.starts_with(&header),
+            "expected {description} to open: {ts}"
+        );
+    }
+}


### PR DESCRIPTION
A documented item's ```rust example fence and its Rust body landed verbatim inside the emitted TypeScript JSDoc — the capture proved this for all six shapes served by the shared JSDoc builder (struct, tuple struct, and the four tagged/untagged enum families), while the plain-enum path already stripped them. The example is Rust source; it does not compile, render, or mean anything sitting in a TypeScript comment, and it still reaches the Zod example field, which is its actual consumer.

The builder now runs its doc lines through the same strip helper the plain-enum path uses — one stripping implementation, all six call sites inheriting it — and its rustdoc, which asserted the opposite behavior in prose, is rewritten. A new test suite documents one shape per family plus the plain enum and asserts every JSDoc opens identically with no fence and no example body. The plain-enum output is diffed byte-identical before and after. The type-alias TS path is a seventh, separately-built JSDoc emission that still carries the fence; tracked separately. README documents the rule, scoped to structs and enums. Full powerset tests and lint-all green locally.