### PR TITLE
name every item's schema module from its Rust ident so forward references to renamed items resolve

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -1458,10 +1458,13 @@ fn is_branded_newtype(item_struct: &syn::ItemStruct) -> bool {
 /// The registration carries the exported name, so a `name = "…"` override reaches every reference
 /// to the struct as well as its own surfaces — a sibling names it in Rust and resolves to the name
 /// it is exported under.
+///
+/// The module is named from the Rust ident, not from the export name, so that a type naming the
+/// struct before it has expanded assumes the module the struct goes on to publish.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn struct_module_idents(name: &syn::Ident, name_override: Option<&str>) -> (String, String, Ident) {
     let item_name = compute_item_export_name(&name.to_string(), name_override);
-    let module_name = format!("{}_schema", to_snake_case(&item_name));
+    let module_name = ident_schema_module_name(&name.to_string());
     let module_ident = Ident::new(&module_name, name.span());
     register_alias_info(
         &name.to_string(),
@@ -1472,11 +1475,12 @@ fn struct_module_idents(name: &syn::Ident, name_override: Option<&str>) -> (Stri
     (item_name, module_name, module_ident)
 }
 
-/// The enum counterpart of [`struct_module_idents`]. `kind` differs per enum shape: only a plain
-/// unit enum is given an `enum_members()`, so only it can back an enum-keyed map.
+/// The enum counterpart of [`struct_module_idents`], down to naming the module from the Rust ident.
+/// `kind` differs per enum shape: only a plain unit enum is given an `enum_members()`, so only it
+/// can back an enum-keyed map.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn enum_module_idents(name: &syn::Ident, item_name: &str, kind: AliasKind) -> (String, Ident) {
-    let module_name = format!("{}_schema", to_snake_case(item_name));
+    let module_name = ident_schema_module_name(&name.to_string());
     let module_ident = Ident::new(&module_name, name.span());
     register_alias_info(&name.to_string(), item_name, &module_name, kind);
     (module_name, module_ident)
@@ -2674,7 +2678,7 @@ fn process_branded_newtype(item_struct: syn::ItemStruct, args: &ModelSchemaArgs)
 
     let name = item_struct.ident.clone();
     let item_name = compute_item_export_name(&name.to_string(), args.name_override.as_deref());
-    let module_name = format!("{}_schema", to_snake_case(&item_name));
+    let module_name = ident_schema_module_name(&name.to_string());
     let module_ident = Ident::new(&module_name, name.span());
 
     register_alias_info(
@@ -5242,11 +5246,11 @@ fn nullable_slot_json_schema_value(
 
 /// The schema module a sibling type's `Schema::json_schema()` lives in.
 ///
-/// A declared item's module is named after its exported name, which a `name = "…"` override moves
-/// away from the raw ident, so the registry answers first. A name it does not hold is one this
-/// expansion has not seen — a type expanded later, or one from another crate — and takes the
-/// ident-derived naming, which is all a reference standing before the type has to go on. That
-/// naming is what a type alias publishes under, so an alias resolves in either declaration order.
+/// The registry answers first, for a name this expansion has already seen. A name it does not hold
+/// is one expanded later, or one from another crate, and takes the ident-derived naming — all a
+/// reference standing before the type has to go on. That naming is what every `#[model_schema()]`
+/// item publishes under, so a reference resolves in either declaration order however the item is
+/// renamed.
 ///
 /// The ident is spanned on where the sibling was named rather than on the attribute. Nothing the
 /// macro can read tells it whether the module will be in scope — a generated module reaches its

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -323,14 +323,15 @@ pub fn safe_type_name(key: &str) -> String {
     }
 }
 
-/// The schema module a `#[model_schema()]` type alias publishes, which is also the module a
-/// reference assumes for a name the registry does not hold.
+/// The schema module a `#[model_schema()]` item publishes — an alias, a struct, an enum, a branded
+/// newtype alike — which is also the module a reference assumes for a name the registry does not
+/// hold.
 ///
-/// A reference written *before* the alias expands has nothing but the Rust ident to name a module
-/// from — the registry is empty of the alias, and the exported name is not recoverable from the
+/// A reference written *before* the item expands has nothing but the Rust ident to name a module
+/// from — the registry is empty of the item, and the exported name is not recoverable from the
 /// ident once a `name = "…"` override is in play. So the module is named from the ident on both
-/// sides, and the two spellings agree in either declaration order. A rename moves what the alias
-/// is exported as; it does not move where the alias's schema lives.
+/// sides, and the two spellings agree in either declaration order. A rename moves what the item is
+/// exported as; it does not move where the item's schema lives.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 pub fn ident_schema_module_name(rust_ident: &str) -> String {
     format!("{}_schema", to_snake_case(&safe_type_name(rust_ident)))

--- a/src/utils/tests.rs
+++ b/src/utils/tests.rs
@@ -327,6 +327,31 @@ fn ident_schema_module_name_is_derived_from_the_ident_alone() {
     );
 }
 
+/// A declared item's module used to be named from its export name, so the move is a move only for
+/// an item carrying an override: without one the export name *is* the ident, and both spellings
+/// land on the same module. That is what keeps every unrenamed item's published path unchanged.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn an_unrenamed_item_publishes_the_same_module_under_either_derivation() {
+    for ident in ["LaterItem", "LaterItemJson", "HTTPHeader", "A"] {
+        assert_eq!(
+            ident_schema_module_name(ident),
+            format!(
+                "{}_schema",
+                to_snake_case(&compute_item_export_name(ident, None))
+            ),
+            "for: {ident}"
+        );
+    }
+    assert_ne!(
+        ident_schema_module_name("LaterItem"),
+        format!(
+            "{}_schema",
+            to_snake_case(&compute_item_export_name("LaterItem", Some("RenamedLater")))
+        ),
+    );
+}
+
 /// Runs the `pattern` guard over `pattern` written as the literal an author would have written,
 /// which is what the guard spans its refusals on.
 fn portable(pattern: &str) -> Result<String, String> {

--- a/tests/item_rename_tests/tests.rs
+++ b/tests/item_rename_tests/tests.rs
@@ -51,6 +51,41 @@ pub struct ReferencesRenamedItems {
     pub tree: TreeUnderRustName,
 }
 
+/// Declaration order, taken both ways round. This struct names a renamed struct and a renamed enum
+/// that have not expanded yet, so the module each reference resolves to is derived from the item's
+/// Rust ident and nothing else; [`NamesRenamedItemsDeclaredEarlier`] names the same two once they
+/// are registered. Both have to reach the same modules, or one of the two orders names a module
+/// that was never emitted.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct NamesRenamedItemsDeclaredLater {
+    pub gauge: LaterRenamedGauge,
+    pub grades: Vec<LaterRenamedGrade>,
+}
+
+/// A rename moves what the item is *exported* as. It does not move the module its schema is
+/// published in — an override is not recoverable from the Rust ident, so a module named after the
+/// override would be one no forward reference could ever name.
+#[model_schema(name = "RenamedLaterGauge")]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct LaterRenamedGauge {
+    pub reading: u32,
+}
+
+#[model_schema(name = "RenamedLaterGrade")]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum LaterRenamedGrade {
+    High,
+    Low,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct NamesRenamedItemsDeclaredEarlier {
+    pub gauge: LaterRenamedGauge,
+    pub grades: Vec<LaterRenamedGrade>,
+}
+
 #[test]
 fn every_renamed_shape_expands_in_this_feature_combination() {
     let value = ReferencesRenamedItems {
@@ -221,23 +256,109 @@ fn a_renamed_item_names_its_json_definition_by_the_override() {
     );
 }
 
-/// The JSON reference is a Rust path to the renamed item's schema module, so this is the one
-/// surface where the override has to reach the module name as well as the exported name.
+/// The JSON reference is a Rust path to the renamed item's schema module, and that module is named
+/// after the Rust ident the reference had to go on — the override never reaches it.
 #[cfg(feature = "jsonschema")]
 #[test]
-fn the_module_a_json_reference_resolves_to_is_the_one_the_override_named() {
+fn the_module_a_json_reference_resolves_to_is_the_one_named_for_the_rust_ident() {
     let referencing = ReferencesRenamedItems::json_schema();
     let properties = referencing.get("properties").unwrap();
     assert_eq!(
         properties.get("item").unwrap(),
-        &renamed_item_schema::Schema::json_schema()
+        &item_under_rust_name_schema::Schema::json_schema()
     );
     assert_eq!(
         properties.get("slot").unwrap(),
-        &renamed_slot_schema::Schema::json_schema()
+        &slot_under_rust_name_schema::Schema::json_schema()
     );
     assert_eq!(
         properties.get("brand").unwrap(),
-        &renamed_brand_schema::Schema::json_schema()
+        &brand_under_rust_name_schema::Schema::json_schema()
     );
+}
+
+#[test]
+fn renamed_items_declared_under_their_reference_expand_in_this_feature_combination() {
+    let later = NamesRenamedItemsDeclaredLater {
+        gauge: LaterRenamedGauge { reading: 7 },
+        grades: vec![LaterRenamedGrade::High],
+    };
+    assert_eq!(later.gauge.reading, 7);
+    assert_eq!(later.grades, vec![LaterRenamedGrade::High]);
+
+    let earlier = NamesRenamedItemsDeclaredEarlier {
+        gauge: LaterRenamedGauge { reading: 8 },
+        grades: vec![LaterRenamedGrade::Low],
+    };
+    assert_eq!(earlier.gauge.reading, 8);
+    assert_eq!(earlier.grades, vec![LaterRenamedGrade::Low]);
+}
+
+/// A struct naming a renamed struct or enum declared under it used to refuse the whole crate: the
+/// reference assumed `later_renamed_gauge_schema` while the item published
+/// `renamed_later_gauge_schema`, and rustc reported an `E0433` for a module the author never
+/// wrote. One spelling now answers on both sides, so which side of the item the reference is
+/// written on changes nothing.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn an_item_reference_describes_the_same_on_either_side_of_the_item() {
+    assert_eq!(
+        NamesRenamedItemsDeclaredLater::json_schema(),
+        NamesRenamedItemsDeclaredEarlier::json_schema()
+    );
+}
+
+/// And what it resolves to is the renamed item's own module rather than something that merely
+/// exists: each member carries exactly what the item publishes.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_forward_item_reference_carries_what_the_item_publishes() {
+    let schema = NamesRenamedItemsDeclaredLater::json_schema();
+    let properties = schema.get("properties").unwrap();
+    assert_eq!(
+        properties.get("gauge").unwrap(),
+        &later_renamed_gauge_schema::Schema::json_schema(),
+        "in: {schema}"
+    );
+    assert_eq!(
+        properties.get("grades").unwrap().get("items").unwrap(),
+        &later_renamed_grade_schema::Schema::json_schema(),
+        "in: {schema}"
+    );
+}
+
+/// The override and the module name come apart: a forward-referenced item is exported under the
+/// name the author wrote, from the module named after its Rust ident.
+#[cfg(feature = "typescript")]
+#[test]
+fn a_forward_referenced_renamed_item_exports_under_the_override() {
+    for (ts, declared) in [
+        (
+            LaterRenamedGauge::ts_definition(),
+            "export type RenamedLaterGauge",
+        ),
+        (
+            LaterRenamedGrade::ts_definition(),
+            "export type RenamedLaterGrade",
+        ),
+    ] {
+        assert!(ts.contains(declared), "{declared} missing from: {ts}");
+    }
+}
+
+#[cfg(feature = "zod")]
+#[test]
+fn a_forward_referenced_renamed_item_publishes_its_zod_schema_under_the_override() {
+    for (zod, declared) in [
+        (
+            LaterRenamedGauge::zod_schema(),
+            "export const RenamedLaterGauge$Schema",
+        ),
+        (
+            LaterRenamedGrade::zod_schema(),
+            "export const RenamedLaterGrade$Schema",
+        ),
+    ] {
+        assert!(zod.contains(declared), "{declared} missing from: {zod}");
+    }
 }


### PR DESCRIPTION
The alias-module fix established the rule: a rename moves what an item exports as, never where its schema module lives, because the raw ident is the only spelling a forward reference can derive. Structs, enums, and branded newtypes still named their modules from the export name, so a type referencing a renamed item declared below it failed with E0433 for a module the author never wrote — the same divergence in the same declaration order, captured for both a renamed struct and a renamed enum before the fix.

The three item-side naming sites (the struct helper, the enum helper covering all five enum shapes, and the branded newtype's inline naming) now call the same ident-derived seam the reference fallback uses. Registration still carries the export name, so overrides reach every surface untouched — pinned by the pre-existing override tests plus new forward-pair TS and zod assertions. A both-orders parity test pins forward == backward schemas, and each member resolves against the item's own module rather than something that merely exists. Unrenamed items move nowhere by construction (the two derivations collapse to the same string without an override), pinned as a unit test; the workspace consumer references six generated modules and none of them moves. Renamed items' module paths move from the override-derived to the ident-derived spelling; the crate's one affected test is repointed. Full powerset tests and lint-all green locally on the merged tree.