### PR TITLE
narrow the to_snake_case import to its one remaining serde-gated caller

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -87,12 +87,7 @@ use crate::utils::{format_docs_for_ts, get_item_docs};
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 use crate::utils::register_alias_info;
 
-#[cfg(any(
-    feature = "typescript",
-    feature = "zod",
-    feature = "jsonschema",
-    feature = "serde"
-))]
+#[cfg(feature = "serde")]
 use crate::utils::to_snake_case;
 
 use crate::rename_rule::resolve_rename_rule;


### PR DESCRIPTION
The module-naming unification removed the last non-serde uses of to_snake_case in model_schema.rs but left its import gated on any schema feature, so every combo without serde fails clippy -D warnings on unused-imports — lint-all and CI red on master. The sole remaining caller (the per-field helper-name stem) is serde-gated; the import now is too. Full powerset tests and lint-all green locally with the exit value verified before this PR was opened.