### PR TITLE
defer an internally tagged newtype variant's content read the way flattened bases defer

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,9 +393,11 @@ Generated Zod -- a flattened member is an intersection, which has no shape of it
 export const Internal$Schema: ZodType<Internal> = z.union([
   z.strictObject({ type: z.literal("Bare") }),
   z.strictObject({ type: z.literal("Fields"), a: z.string(), b: z.boolean() }),
-  z.strictObject({ type: z.literal("Wrapped") }).and(TagPayload$Schema),
+  z.strictObject({ type: z.literal("Wrapped") }).and(z.lazy(() => TagPayload$Schema)),
 ]);
 ```
+
+The content joins the member under `z.lazy` for the reason a flattened base does: the inner type is a `const` of its own and nothing orders one type's schema against another's, so reading the name while the union's `const` initializes would fail for any inner type declared below -- and a cycle running through a variant's content and a `#[serde(flatten)]` base has no order that puts each above the other. Deferred, every module loads whatever order it is assembled in.
 
 Only a value Serde writes as an object has members to put beside the tag. A newtype variant wrapping a string, a number, a boolean, a sequence, an `Option` or a tuple is one Serde refuses to serialize at run time (`cannot serialize tagged newtype variant ... containing a string`), and a multi-element tuple variant is one Serde's own derive refuses outright. `#[model_schema()]` rejects all of those at expansion rather than describing a value that cannot reach the wire; name a `content` key so the value gets an object of its own, or wrap it in a struct whose fields can sit beside the tag.
 

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -4029,11 +4029,13 @@ fn render_internal_variant(
     #[cfg(not(feature = "jsonschema"))]
     let json = quote! {};
 
+    // The content joins the member through [`deferred_zod_operand`] for the reason a flattened
+    // base does: it names a `const` of its own, and one macro invocation sees one type.
     #[cfg(feature = "zod")]
     let zod = format!(
         "z.strictObject({}).and({})",
         parts.schema_code,
-        inner.zod_type()
+        deferred_zod_operand(&inner.zod_type())
     );
     #[cfg(not(feature = "zod"))]
     let zod = String::new();

--- a/tests/flatten_tests/tests.rs
+++ b/tests/flatten_tests/tests.rs
@@ -73,6 +73,26 @@ enum CycleUnionEither {
     Only(Box<CycleUnionNode>),
 }
 
+/// A cycle spanning both places an intersection operand is written: a struct's `#[serde(flatten)]`
+/// base on one side, an internally tagged newtype variant's content on the other. Each names the
+/// other's `const`, so neither declaration order puts both above the other.
+#[cfg(feature = "zod")]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct CycleVariantContent {
+    #[serde(flatten)]
+    back: CycleVariantHost,
+    own: String,
+}
+
+#[cfg(feature = "zod")]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(tag = "type")]
+enum CycleVariantHost {
+    Wrapped(Box<CycleVariantContent>),
+}
+
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct ExtraPart {
@@ -599,6 +619,34 @@ fn test_a_flatten_cycle_defers_both_sides_of_the_pair() {
     assert!(
         !second.contains(".and(CycleFirst$Schema)"),
         "`CycleFirst$Schema` is read eagerly in: {second}"
+    );
+}
+
+/// An intersection operand is written in two places — a struct's flattened base and an internally
+/// tagged newtype variant's content — and a cycle can run through both. Deferring one side alone
+/// leaves the other reading a name that a module declared below has not bound yet, so both sides
+/// carry the same deferral and the pair loads whichever order the modules are assembled in.
+#[test]
+#[cfg(feature = "zod")]
+fn test_a_flatten_cycle_through_a_variants_content_defers_both_sides() {
+    let content = CycleVariantContent::zod_schema();
+    let host = CycleVariantHost::zod_schema();
+
+    assert!(
+        content.contains("}).and(z.lazy(() => CycleVariantHost$Schema));"),
+        "expected a deferred base, got: {content}"
+    );
+    assert!(
+        host.contains("}).and(z.lazy(() => CycleVariantContent$Schema))"),
+        "expected a deferred content, got: {host}"
+    );
+    assert!(
+        !content.contains(".and(CycleVariantHost$Schema)"),
+        "`CycleVariantHost$Schema` is read eagerly in: {content}"
+    );
+    assert!(
+        !host.contains(".and(CycleVariantContent$Schema)"),
+        "`CycleVariantContent$Schema` is read eagerly in: {host}"
     );
 }
 

--- a/tests/tuple_variant_tests/tests.rs
+++ b/tests/tuple_variant_tests/tests.rs
@@ -1626,7 +1626,7 @@ fn test_bare_tag_zod_intersects_the_inner_schema() {
 
     assert!(
         zod.contains(
-            "z.strictObject({\n  type: z.literal(\"Wrapped\"),\n}).and(TagPayload$Schema)"
+            "z.strictObject({\n  type: z.literal(\"Wrapped\"),\n}).and(z.lazy(() => TagPayload$Schema))"
         ),
         "Got: {zod}"
     );
@@ -1636,6 +1636,29 @@ fn test_bare_tag_zod_intersects_the_inner_schema() {
         "An intersection member cannot be discriminated on. Got: {zod}"
     );
     assert!(!zod.contains("value:"), "Got: {zod}");
+}
+
+/// Test 22c2: the inner type is a `const` of its own and nothing orders one type's emitted module
+/// against another's, so naming it straight into the member would read it while the enum's own
+/// `const` initializes — which fails for any inner type declared below. The read is deferred to
+/// whenever something validates, the same way a `#[serde(flatten)]` base's is.
+#[cfg(feature = "zod")]
+#[test]
+fn test_a_newtype_variants_content_is_never_read_while_the_const_initializes() {
+    for (zod, inner) in [
+        (Internal::zod_schema(), "TagPayload"),
+        (InternalOverBrand::zod_schema(), "InternalSlug"),
+        (InternalOverUntagged::zod_schema(), "InternalEither"),
+    ] {
+        assert!(
+            zod.contains(&format!(".and(z.lazy(() => {inner}$Schema))")),
+            "expected a deferred content, got: {zod}"
+        );
+        assert!(
+            !zod.contains(&format!(".and({inner}$Schema)")),
+            "`{inner}$Schema` is read eagerly in: {zod}"
+        );
+    }
 }
 
 /// Test 22d: with no newtype variant every member is an object carrying the tag, so the union still


### PR DESCRIPTION
The internally tagged newtype variant's flattened content was the second of the crate's two intersection-operand emission sites, and it still spliced the content's exported const name straight into the enum's own const initializer — so a cycle running through a variant's content and a struct flatten was only half deferred, and one of the two declaration orders threw at import.

The operand now routes through the same deferral helper the struct fold uses; the crate's two .and( emission sites share one spelling. Execution-verified in node against modules taken verbatim from the crate's own emission: before, host-declared-first failed at load with a ReferenceError; after, both declaration orders import and a genuinely cyclic pair resolves on demand. A before/after dump of all seventeen tuple-variant fixtures shows exactly three lines moved, all of them a flattened newtype variant's content; every other fixture is byte-identical. The moved goldens are the literal deferral spelling plus the matching README example and note. Full powerset tests and lint-all green locally with the exit value read before landing.