### PR TITLE
drop the rust example block from an alias's emitted JSDoc too

### DIFF
--- a/README.md
+++ b/README.md
@@ -1220,7 +1220,7 @@ Key points:
 - Use the exact syntax: ` ```rust example` (note the space and `example` keyword).
 - If multiple examples are present, only the **first one** is used.
 - Examples respect Serde attributes (field renaming, etc.).
-- On a struct or an enum, the example block reaches the Zod `example` field only. Being Rust source, it is dropped from the JSDoc comment above the generated `export type`.
+- Being Rust source, the example block is dropped from the JSDoc comment above the generated `export type`, whatever the type is declared as. On a struct or an enum it reaches the Zod `example` field; on a type alias, which publishes no `example` field, it reaches no generated surface at all.
 - The example code is executed at compile time and serialized to JSON.
 - Wrong types produce compile errors, ensuring examples stay in sync with your types.
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -361,12 +361,23 @@ pub fn compute_item_export_name(rust_ident: &str, override_name: Option<&str>) -
     override_name.map_or_else(|| safe_type_name(rust_ident), ToOwned::to_owned)
 }
 
+/// Builds the `JSDoc` comment body an alias's `export type` is emitted under, which is what
+/// `build_item_jsdoc` builds for a declared item. Between them they are every `JSDoc` body an
+/// exported type carries, so the rule below holds wherever one is written rather than at the call
+/// sites that reach for one.
+///
+/// An alias's ` ```rust example ` block is dropped before its lines reach the body, the way every
+/// item shape drops it: the block is Rust source, and nothing reads it as such once it is sitting in
+/// a `TypeScript` comment. An alias documented with nothing but an example is left naming itself,
+/// as an undocumented one is.
 #[cfg(feature = "typescript")]
 pub fn format_docs_for_ts(docs: &[String], fallback_name: &str) -> String {
-    if docs.is_empty() {
+    let described = strip_examples_from_docs(docs);
+    if described.is_empty() {
         format!(" * {fallback_name}\n * ")
     } else {
-        docs.iter()
+        described
+            .iter()
             .map(|line| format!(" * {line}"))
             .chain(iter::once(" * ".to_owned()))
             .collect::<Vec<_>>()

--- a/tests/item_jsdoc_example_tests.rs
+++ b/tests/item_jsdoc_example_tests.rs
@@ -1,8 +1,8 @@
 //! Tests for what an item's ` ```rust example ` block reaches in the emitted `TypeScript`.
 //!
 //! The example is Rust source. It does not compile, render, or mean anything inside a `TypeScript`
-//! `JSDoc` comment, so no item shape carries it there — the fence and its body are dropped from
-//! every `JSDoc` body, whatever the item is declared as.
+//! `JSDoc` comment, so nothing carries it there — the fence and its body are dropped from every
+//! `JSDoc` body, whatever the type is declared as, a type alias included.
 
 #[cfg(feature = "typescript")]
 #[cfg(test)]

--- a/tests/item_jsdoc_example_tests/tests.rs
+++ b/tests/item_jsdoc_example_tests/tests.rs
@@ -86,6 +86,14 @@ pub enum DocumentedSlot {
     Secondary,
 }
 
+/// A documented alias.
+/// ```rust example
+/// let item: DocumentedAlias = 3;
+/// println!("Item: {:?}", item);
+/// ```
+#[model_schema()]
+pub type DocumentedAlias = u32;
+
 /// Every documented shape above, paired with the description its `JSDoc` is left with once the
 /// example is dropped. The plain enum rides along as the shape that already dropped it.
 fn documented_shapes() -> Vec<(String, &'static str)> {
@@ -112,6 +120,10 @@ fn documented_shapes() -> Vec<(String, &'static str)> {
             "A documented untagged enum.",
         ),
         (DocumentedSlot::ts_definition(), "A documented plain enum."),
+        (
+            documented_alias_schema::Schema::ts_definition(),
+            "A documented alias.",
+        ),
     ]
 }
 
@@ -119,11 +131,27 @@ fn documented_shapes() -> Vec<(String, &'static str)> {
 /// neither the fence nor anything written inside it may reach the emitted `TypeScript`.
 #[test]
 fn a_documented_item_never_carries_its_rust_example_into_the_emitted_typescript() {
+    // The alias publishes `ts_definition` from its own module rather than from the alias, so naming
+    // the type here is what keeps the fixture from being pruned as unused.
+    let aliased: DocumentedAlias = 3;
+    assert_eq!(aliased, 3);
+
     for (ts, description) in documented_shapes() {
-        for leaked in ["```", "let item =", "println!"] {
+        for leaked in ["```", "let item", "println!"] {
             assert!(!ts.contains(leaked), "{leaked} reached: {ts}");
         }
         assert!(ts.contains(description), "docs dropped from: {ts}");
+    }
+}
+
+/// Only the `JSDoc` side of an alias changed. What its example reaches on the Zod side is what it
+/// always reached: nothing — an alias publishes no `example` field to drop it into.
+#[cfg(feature = "zod")]
+#[test]
+fn a_documented_alias_publishes_the_same_zod_schema_it_always_did() {
+    let zod = documented_alias_schema::Schema::zod_schema();
+    for leaked in ["```", "let item", "println!", "example"] {
+        assert!(!zod.contains(leaked), "{leaked} reached: {zod}");
     }
 }
 


### PR DESCRIPTION
The type-alias TypeScript path was a seventh, separately-built JSDoc emission: it handed raw doc lines to its formatter with no example stripping, so a documented alias's ```rust example fence and Rust body reached the emitted TS JSDoc while all six item shapes had just been unified onto the strip helper.

The strip now lives inside the alias formatter itself, chosen over the call site on a complete caller audit: the formatter has exactly one caller in the crate and, this being a proc-macro crate, no outside caller can exist — so the formatter and the item builder together are every JSDoc body an exported type carries, and the rule holds where a body is written rather than by convention at call sites. An alias documented with nothing but an example falls back to naming itself, exactly as an undocumented one does. The alias joins the example-suite so all seven documented shapes are asserted together; a documented no-example alias and an undocumented alias are diffed byte-identical against the pre-fix emission, and a zod-gated test pins that an alias's Zod schema carries no example surface at all. The README rule widens from structs-and-enums to every type declaration, stating where the example does land per shape. Member-level (field and variant) JSDoc has the same leak through separate builders; tracked separately. Full powerset tests and lint-all green locally with the exit value read before landing.