### PR TITLE
drop the rust example block from field and variant JSDoc through the one shared body

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -25,7 +25,7 @@ use crate::{
     field_type::{
         FieldDef, FieldDefType, VariantKind, classify_variant, get_field_def, is_plain_enum,
     },
-    utils::{get_field_docs, get_variant_docs},
+    utils::{get_field_docs, get_variant_docs, strip_examples_from_docs},
 };
 
 // The item paths take their exported name from `compute_item_export_name` and their module name
@@ -74,7 +74,7 @@ use crate::features::jsonschema::{
 use crate::features::jsonschema::{MergeDiagnostic, merged_object_value};
 
 #[cfg(any(feature = "typescript", feature = "zod"))]
-use crate::utils::{get_enum_docs, get_struct_docs, strip_examples_from_docs};
+use crate::utils::{get_enum_docs, get_struct_docs};
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 use crate::utils::{compute_alias_export_name, ident_schema_module_name};
@@ -758,21 +758,20 @@ fn has_serde_transparent(attrs: &[syn::Attribute]) -> bool {
 }
 
 /// Builds the `JSDoc` comment body (lines prefixed with ` * `) that precedes an item's
-/// `export type`. Serves the shapes that publish no zod `description` of their own — structs,
-/// tuple structs, and the tagged and untagged enums; the shapes that publish both surfaces spell
-/// them from the same lines in `build_item_docs_and_description`.
+/// `export type`, and the one each field and enum variant inside it is emitted under. The item
+/// shapes that publish a zod `description` alongside spell both from the same lines in
+/// `build_item_docs_and_description`; a member publishes no second surface.
 ///
-/// The no-docs fallback names the item as it is exported, not as it is declared in Rust, so a
-/// `JSDoc` header never contradicts the `export type` one line under it.
+/// The no-docs fallback names what is documented as it is exported, not as it is declared in Rust,
+/// so a `JSDoc` header never contradicts the line under it.
 ///
-/// An item's ` ```rust example ` block is dropped before its lines reach the body, the way
+/// A ` ```rust example ` block is dropped before its lines reach the body, the way
 /// `item_plain_doc_lines` drops it: the block is Rust source, and nothing reads it as such once it
 /// is sitting in a `TypeScript` comment. A consumer after the example reads the Rust docs.
-#[cfg(feature = "typescript")]
-fn build_item_jsdoc(docs_vec: Option<&[String]>, item_name: &str) -> String {
+fn build_jsdoc_body(docs_vec: Option<&[String]>, fallback_name: &str) -> String {
     docs_vec.map_or_else(
         || {
-            [item_name.to_owned(), String::new()]
+            [fallback_name.to_owned(), String::new()]
                 .into_iter()
                 .map(|l| format!(" * {l}"))
                 .collect::<Vec<_>>()
@@ -1582,7 +1581,7 @@ fn process_struct(mut item_struct: syn::ItemStruct, args: &ModelSchemaArgs) -> T
     }
 
     #[cfg(feature = "typescript")]
-    let docs = build_item_jsdoc(docs_and_example.0.as_deref(), &item_name);
+    let docs = build_jsdoc_body(docs_and_example.0.as_deref(), &item_name);
     #[cfg(all(
         not(feature = "typescript"),
         any(feature = "zod", feature = "jsonschema")
@@ -1805,7 +1804,7 @@ fn process_tuple_struct(
         json_schema_methods(&item_name, &tuple_struct_json_body(&item_name, &slots)),
         #[cfg(feature = "typescript")]
         build_tuple_struct_ts_definition_method(
-            &build_item_jsdoc(docs_and_example.0.as_deref(), &item_name),
+            &build_jsdoc_body(docs_and_example.0.as_deref(), &item_name),
             &item_name,
             &tuple_struct_ts_body(&slots),
         ),
@@ -3012,8 +3011,12 @@ fn collect_plain_enum_options(
 
         #[cfg(feature = "typescript")]
         {
-            let variant_docs =
-                get_variant_docs(item).map_or_else(String::new, |doc_lines| doc_lines.join("\n"));
+            // The one member body not written as ` * ` lines: a plain enum's variants are commented
+            // inside the union rather than over a property. The example is dropped the same way,
+            // and a variant documented with nothing else is left as an undocumented one.
+            let variant_docs = get_variant_docs(item).map_or_else(String::new, |doc_lines| {
+                strip_examples_from_docs(&doc_lines).join("\n")
+            });
             enum_variant_docs.push(variant_docs);
         }
     }
@@ -3231,24 +3234,7 @@ fn collect_discriminated_variants(
             field_defs.push(f_def);
         }
 
-        let discriminator_docs = get_variant_docs(item).map_or_else(
-            || {
-                [final_name.clone(), String::new()]
-                    .into_iter()
-                    .map(|l| format!(" * {l}"))
-                    .collect::<Vec<_>>()
-                    .join("\n")
-            },
-            |doc_lines| {
-                doc_lines
-                    .into_iter()
-                    .flat_map(|v| v.lines().map(ToOwned::to_owned).collect::<Vec<_>>())
-                    .chain(vec![String::new()])
-                    .map(|l| format!(" * {l}"))
-                    .collect::<Vec<_>>()
-                    .join("\n")
-            },
-        );
+        let discriminator_docs = build_jsdoc_body(get_variant_docs(item).as_deref(), &final_name);
         variants.push(DiscriminatedVariant {
             discriminator_value: final_name,
             docs: discriminator_docs,
@@ -3370,7 +3356,7 @@ fn process_discriminated_enum(
     );
 
     #[cfg(feature = "typescript")]
-    let docs = build_item_jsdoc(docs_vec.as_deref(), item_name);
+    let docs = build_jsdoc_body(docs_vec.as_deref(), item_name);
 
     // Generate schema module methods
     #[cfg(feature = "jsonschema")]
@@ -3768,7 +3754,7 @@ fn process_externally_tagged_enum(
     let _: &_ = &name;
 
     #[cfg(feature = "typescript")]
-    let docs = build_item_jsdoc(docs_vec.as_deref(), item_name);
+    let docs = build_jsdoc_body(docs_vec.as_deref(), item_name);
 
     #[cfg(feature = "jsonschema")]
     let json_schema_method =
@@ -4163,7 +4149,7 @@ fn process_internally_tagged_enum(
     let _: &_ = &name;
 
     #[cfg(feature = "typescript")]
-    let docs = build_item_jsdoc(docs_vec.as_deref(), item_name);
+    let docs = build_jsdoc_body(docs_vec.as_deref(), item_name);
 
     #[cfg(feature = "jsonschema")]
     let json_schema_method =
@@ -4620,7 +4606,7 @@ fn process_untagged_enum(
     let schema_code = format!("z.union([{}])", zod_parts.join(", "));
 
     #[cfg(feature = "typescript")]
-    let docs = build_item_jsdoc(docs_vec.as_deref(), item_name);
+    let docs = build_jsdoc_body(docs_vec.as_deref(), item_name);
 
     // Generate schema module methods
     #[cfg(feature = "jsonschema")]
@@ -6945,7 +6931,7 @@ fn process_field(
     let field_type: &syn::Type = &field.ty;
 
     let final_name = get_final_field_name(&raw_field_ident, field_rename.as_deref(), rename_all);
-    let field_docs = build_field_docs(field, &final_name);
+    let field_docs = build_jsdoc_body(get_field_docs(field).as_deref(), &final_name);
 
     // Create the field definition and apply any model_schema_prop overrides
     let mut field_def = get_field_def(&final_name, field_type, &field_docs);
@@ -7141,28 +7127,6 @@ fn generate_field_validation(
         Some(validation_code.module_items),
         Some(validation_code.validate_body),
         None,
-    )
-}
-
-/// Builds the JSDoc-style doc string for a field from its doc comments (or a fallback).
-fn build_field_docs(field: &Field, final_name: &str) -> String {
-    get_field_docs(field).map_or_else(
-        || {
-            [final_name.to_owned(), String::new()]
-                .into_iter()
-                .map(|l| format!(" * {l}"))
-                .collect::<Vec<_>>()
-                .join("\n")
-        },
-        |doc_lines| {
-            doc_lines
-                .into_iter()
-                .flat_map(|v| v.lines().map(ToOwned::to_owned).collect::<Vec<_>>())
-                .chain(vec![String::new()])
-                .map(|l| format!(" * {l}"))
-                .collect::<Vec<_>>()
-                .join("\n")
-        },
     )
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -363,9 +363,9 @@ pub fn compute_item_export_name(rust_ident: &str, override_name: Option<&str>) -
 }
 
 /// Builds the `JSDoc` comment body an alias's `export type` is emitted under, which is what
-/// `build_item_jsdoc` builds for a declared item. Between them they are every `JSDoc` body an
-/// exported type carries, so the rule below holds wherever one is written rather than at the call
-/// sites that reach for one.
+/// `build_jsdoc_body` builds for a declared item and for the members inside it. Between them they
+/// are every `JSDoc` body the crate writes, so the rule below holds wherever one is written rather
+/// than at the call sites that reach for one.
 ///
 /// An alias's ` ```rust example ` block is dropped before its lines reach the body, the way every
 /// item shape drops it: the block is Rust source, and nothing reads it as such once it is sitting in
@@ -567,8 +567,9 @@ fn transform_example_code(code: &str) -> String {
 
 /// Strips example code blocks from documentation lines.
 ///
-/// This is used for descriptions to avoid including example code in the description field.
-#[cfg(any(feature = "typescript", feature = "zod"))]
+/// Every doc body the crate writes — an item's, an alias's, a field's, an enum variant's, and the
+/// descriptions spelled from the same lines — passes through here, so the block is dropped once
+/// rather than at each surface.
 pub fn strip_examples_from_docs(docs: &[String]) -> Vec<String> {
     let mut result = Vec::new();
     let mut in_example_block = false;

--- a/tests/item_jsdoc_example_tests/tests.rs
+++ b/tests/item_jsdoc_example_tests/tests.rs
@@ -94,6 +94,65 @@ pub enum DocumentedSlot {
 #[model_schema()]
 pub type DocumentedAlias = u32;
 
+/// A struct whose documented member is a field.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug)]
+pub struct DocumentedFieldHolder {
+    /// A documented field.
+    /// ```rust example
+    /// let item = DocumentedFieldHolder {
+    ///     label: "alpha".to_string(),
+    /// };
+    /// println!("Item: {:?}", item);
+    /// ```
+    pub label: String,
+}
+
+/// An internally tagged enum whose documented member is a variant.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "kind")]
+pub enum DocumentedInternalVariant {
+    /// A documented variant.
+    /// ```rust example
+    /// let item = DocumentedInternalVariant::Unit;
+    /// println!("Item: {:?}", item);
+    /// ```
+    Named {
+        side: u8,
+    },
+    Unit,
+}
+
+/// An externally tagged enum whose documented member is a variant.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug)]
+pub enum DocumentedExternalVariant {
+    /// A documented variant.
+    /// ```rust example
+    /// let item = DocumentedExternalVariant::Unit;
+    /// println!("Item: {:?}", item);
+    /// ```
+    Named {
+        side: u8,
+    },
+    Unit,
+}
+
+/// A plain enum whose documented member is a variant, commented inside the union rather than over
+/// a property — the one member body not written as ` * ` lines.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+pub enum DocumentedSlotVariant {
+    /// A documented slot.
+    /// ```rust example
+    /// let item = DocumentedSlotVariant::Primary;
+    /// println!("Item: {:?}", item);
+    /// ```
+    Primary,
+    Secondary,
+}
+
 /// Every documented shape above, paired with the description its `JSDoc` is left with once the
 /// example is dropped. The plain enum rides along as the shape that already dropped it.
 fn documented_shapes() -> Vec<(String, &'static str)> {
@@ -127,6 +186,26 @@ fn documented_shapes() -> Vec<(String, &'static str)> {
     ]
 }
 
+/// Every shape whose example is written on a member rather than on the type, paired with the
+/// description that member's `JSDoc` is left with once the example is dropped.
+fn documented_members() -> Vec<(String, &'static str)> {
+    vec![
+        (
+            DocumentedFieldHolder::ts_definition(),
+            "A documented field.",
+        ),
+        (
+            DocumentedInternalVariant::ts_definition(),
+            "A documented variant.",
+        ),
+        (
+            DocumentedExternalVariant::ts_definition(),
+            "A documented variant.",
+        ),
+        (DocumentedSlotVariant::ts_definition(), "A documented slot."),
+    ]
+}
+
 /// The reported failure: a struct's `JSDoc` opened with the fence and the Rust body under it, so
 /// neither the fence nor anything written inside it may reach the emitted `TypeScript`.
 #[test]
@@ -137,6 +216,19 @@ fn a_documented_item_never_carries_its_rust_example_into_the_emitted_typescript(
     assert_eq!(aliased, 3);
 
     for (ts, description) in documented_shapes() {
+        for leaked in ["```", "let item", "println!"] {
+            assert!(!ts.contains(leaked), "{leaked} reached: {ts}");
+        }
+        assert!(ts.contains(description), "docs dropped from: {ts}");
+    }
+}
+
+/// The rule is the doc body's, not the type's: a field's and a variant's `JSDoc` are written from
+/// the same lines an item's is, so an example written on a member is dropped where an example
+/// written on the type is, and the description under it is what survives.
+#[test]
+fn a_documented_member_never_carries_its_rust_example_into_the_emitted_typescript() {
+    for (ts, description) in documented_members() {
         for leaked in ["```", "let item", "println!"] {
             assert!(!ts.contains(leaked), "{leaked} reached: {ts}");
         }


### PR DESCRIPTION
Member-level JSDoc still leaked the rust example fence: the field-docs builder and the discriminated-variant closure were byte-for-byte copies of the item builder minus the strip, and a plain enum's variant docs — the one member body written inside a /* */ comment rather than over a property — leaked it through a third spelling the report that found the others had missed.

Rather than minting a member-side copy, the item builder became the single JSDoc-body builder for both levels: generalized name and fallback parameter, gate dropped because the member call sites read docs whatever features are on, and both member paths hand their lines straight to it; the field-docs builder is deleted. The plain-enum variant path strips at its own read point with the reason commented. This landing also carries the merge with the description-refactor that reshaped the same function on master — the resolution keeps the generalized ungated surface over the refactor's shared bodies, with the helpers ungated to match. Four member fixtures join the example suite so the rule is asserted across items, alias, fields, and variants together; a before/after dump shows the only change is the example blocks disappearing. The example-only-docs fallback hole found on the way is tracked separately. Full powerset tests and lint-all green on the merged tree with the exit value read before landing.