### PR TITLE
spell the $oid object one way in every position, closed and patterned

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -108,6 +108,11 @@ const KNOWN_ARGS: &[&str] = &["name", "pattern", "minLength", "maxLength", "no_d
 const FLATTENED_PLAIN_ENUM_SCOPE: &str = "Only a type the registry has already classified reaches this guard; one it has not keeps its \
      TypeScript and Zod intersection, and is refused by the JSON surface when the merge runs.";
 
+/// The 24-character hex an `ObjectId`'s `$oid` member holds, as a JSON-schema `pattern`. Written
+/// once so no position can describe the same string a different way.
+#[cfg(all(feature = "jsonschema", feature = "object_id"))]
+const OBJECT_ID_HEX_PATTERN: &str = r"^[a-f\d]{24}$";
+
 /// One variant of a discriminated enum, carrying everything its union member is rendered from.
 struct DiscriminatedVariant {
     discriminator_value: String,
@@ -1995,12 +2000,14 @@ fn branded_checked_value(
     }
 }
 
-/// Builds the string schema a branded newtype's constraints are written into: `type_name` as the
-/// `"type"`, then one insert per constraint the brand declares.
+/// Builds the schema a branded newtype's constraints are written into: `base_inserts` first — what
+/// the inner type describes as before the brand narrows it — then one insert per constraint the
+/// brand declares. A keyword the base already states is written over rather than beside it, one
+/// string carrying one `pattern`.
 #[cfg(feature = "jsonschema")]
-fn branded_constrained_schema_obj(
+fn branded_schema_obj_over(
     args: &ModelSchemaArgs,
-    type_name: &str,
+    base_inserts: &proc_macro2::TokenStream,
 ) -> proc_macro2::TokenStream {
     let mut constraint_inserts: Vec<proc_macro2::TokenStream> = Vec::new();
 
@@ -2023,11 +2030,40 @@ fn branded_constrained_schema_obj(
     quote! {
         {
             let mut schema_obj = serde_json::Map::new();
-            schema_obj.insert("type".to_string(), serde_json::Value::String(#type_name.to_string()));
+            #base_inserts
             #(#constraint_inserts)*
             serde_json::Value::Object(schema_obj)
         }
     }
+}
+
+/// Builds the string schema a branded newtype's constraints are written into: `type_name` as the
+/// `"type"`, then one insert per constraint the brand declares.
+#[cfg(feature = "jsonschema")]
+fn branded_constrained_schema_obj(
+    args: &ModelSchemaArgs,
+    type_name: &str,
+) -> proc_macro2::TokenStream {
+    branded_schema_obj_over(
+        args,
+        &quote! {
+            schema_obj.insert("type".to_string(), serde_json::Value::String(#type_name.to_string()));
+        },
+    )
+}
+
+/// The `$oid` member an `ObjectId` brand carries: the hex string the type always holds, narrowed by
+/// the brand's own constraints, so a brand that declares none still describes the hex the type it
+/// wraps describes wherever else it is written.
+#[cfg(all(feature = "jsonschema", feature = "object_id"))]
+fn branded_object_id_hex_schema(args: &ModelSchemaArgs) -> proc_macro2::TokenStream {
+    branded_schema_obj_over(
+        args,
+        &quote! {
+            schema_obj.insert("type".to_string(), serde_json::Value::String("string".to_string()));
+            schema_obj.insert("pattern".to_string(), serde_json::Value::String(#OBJECT_ID_HEX_PATTERN.to_string()));
+        },
+    )
 }
 
 /// The description a brand carries for an inner no `"type"` keyword names: the one the slot
@@ -2062,7 +2098,7 @@ fn build_branded_json_schema_method(
         BrandedJsonInner::Scalar(type_name) => branded_constrained_schema_obj(args, type_name),
         #[cfg(feature = "object_id")]
         BrandedJsonInner::ObjectId => {
-            object_id_json_schema_value(&branded_constrained_schema_obj(args, "string"))
+            object_id_json_schema_value(&branded_object_id_hex_schema(args))
         }
         BrandedJsonInner::Slot(inner) => branded_slot_json_schema(inner, def_name),
     };
@@ -4465,15 +4501,7 @@ fn field_json_schema_value(fld: &FieldDef) -> proc_macro2::TokenStream {
         }
         FieldDefType::Boolean => quote! { serde_json::json!({ "type": "boolean" }) },
         #[cfg(feature = "object_id")]
-        FieldDefType::ObjectId => quote! {
-            serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "$oid": { "type": "string", "pattern": "^[a-f\\d]{24}$" }
-                },
-                "required": ["$oid"]
-            })
-        },
+        FieldDefType::ObjectId => object_id_json_schema_value(&object_id_hex_json_schema()),
         #[cfg(feature = "chrono")]
         FieldDefType::NaiveDate => {
             quote! { serde_json::json!({ "type": "string", "format": "date" }) }
@@ -5158,13 +5186,7 @@ fn scalar_field_json_schema_item(fld: &FieldDef) -> Option<proc_macro2::TokenStr
             quote! { { "type": "string", "format": "date-time" } }
         }
         #[cfg(feature = "object_id")]
-        FieldDefType::ObjectId => quote! { {
-            "type": "object",
-            "properties": {
-                "$oid": { "type": "string", "pattern": "^[a-f\\d]{24}$" }
-            },
-            "required": ["$oid"]
-        } },
+        FieldDefType::ObjectId => object_id_json_schema_item(&object_id_hex_json_schema()),
         FieldDefType::Unknown
         | FieldDefType::SiblingType(..)
         | FieldDefType::Map(..)
@@ -5173,23 +5195,15 @@ fn scalar_field_json_schema_item(fld: &FieldDef) -> Option<proc_macro2::TokenStr
     Some(item_schema)
 }
 
-/// [`build_map_member_item`] for a tuple element, which differs for exactly two value types.
-///
-/// An `ObjectId` here carries the field-position `$oid` object — patterned, and open — where a
-/// `String`-keyed map member carries the closed, unpatterned one; which of the two a slot should
-/// carry is unsettled, so this position keeps the rendering it has. A tuple renders as the
-/// fixed-arity array its own field position renders, which is the one value the map path has no
-/// renderer for: an element is dispatched by the tuple builder itself, so the nesting costs
-/// nothing but the recursion.
+/// [`build_map_member_item`] for a tuple element, which differs for exactly one value type: a tuple
+/// renders as the fixed-arity array its own field position renders, which is the one value the map
+/// path has no renderer for. An element is dispatched by the tuple builder itself, so the nesting
+/// costs nothing but the recursion.
 ///
 /// Every other value is the member the map path renders, at every depth, so a type describes the
 /// same in either slot.
 #[cfg(feature = "jsonschema")]
 fn build_tuple_element_item(value: &FieldDef) -> Result<MapMemberItem, MapMemberRejection> {
-    #[cfg(feature = "object_id")]
-    if matches!(value.field_type, FieldDefType::ObjectId) {
-        return Ok(MapMemberItem::Fragment(scalar_slot_item(value)?));
-    }
     if let FieldDefType::Tuple(elements) = &value.field_type {
         return Ok(MapMemberItem::Value(tuple_json_schema_value(elements)?));
     }
@@ -5682,15 +5696,11 @@ fn build_map_member_item(value: &FieldDef) -> Result<MapMemberItem, MapMemberRej
             );
             MapMemberItem::Value(sibling_json_schema_value(value_type_name, value.type_span))
         }
-        // A map member's `$oid` object is closed and unpatterned, where the shared mapping's
-        // field-position rendering carries the hex pattern and leaves the object open.
+        // The one `$oid` object every position spells, which a member carries as written.
         #[cfg(feature = "object_id")]
-        FieldDefType::ObjectId => MapMemberItem::Fragment(quote! { {
-            "type": "object",
-            "properties": { "$oid": { "type": "string" } },
-            "required": ["$oid"],
-            "additionalProperties": false
-        } }),
+        FieldDefType::ObjectId => {
+            MapMemberItem::Fragment(object_id_json_schema_item(&object_id_hex_json_schema()))
+        }
         // An opaque value carries no type name to narrow with, so a member admits any value: the
         // permissive empty schema, as in field position.
         FieldDefType::Unknown => MapMemberItem::Fragment(quote! { {} }),
@@ -5790,19 +5800,6 @@ fn string_key_map_json_schema_value(
     })
 }
 
-/// [`build_map_member_item`] for a member of an enum-keyed map, which differs for exactly one value
-/// type: an `ObjectId` member here carries the field-position `$oid` object — patterned, and open —
-/// where a `String`-keyed member carries the closed, unpatterned one. Which of the two a map member
-/// should carry is unsettled, so each key path keeps the rendering it has.
-#[cfg(feature = "jsonschema")]
-fn build_enum_key_map_member_item(value: &FieldDef) -> Result<MapMemberItem, MapMemberRejection> {
-    #[cfg(feature = "object_id")]
-    if matches!(value.field_type, FieldDefType::ObjectId) {
-        return Ok(MapMemberItem::Fragment(scalar_slot_item(value)?));
-    }
-    build_map_member_item(value)
-}
-
 /// The object an enum-keyed map describes as, as a standalone `serde_json::Value` expression: one
 /// property per member the key enumerates, each carrying the value type's own rendering, and closed
 /// to every other key. `Err` when the value has no rendering here, or when the registry proves the
@@ -5837,7 +5834,7 @@ fn enum_key_map_json_schema_value(
     }
 
     let normalized = normalized_slot_value(value);
-    let member_value = build_enum_key_map_member_item(&normalized)?.into_member_value(&normalized);
+    let member_value = build_map_member_item(&normalized)?.into_member_value(&normalized);
     let key_type_name_ident = Ident::new(key_type_name, key_span);
     let key_members = quote_spanned! {key_span=> #key_type_name_ident::enum_members() };
     Ok(quote! {
@@ -6021,23 +6018,41 @@ fn build_sibling_type_field_schema(
     }
 }
 
-/// The JSON schema an `ObjectId` describes — the closed `$oid` object serde writes — with
+/// The `json!` literal an `ObjectId` describes as — the closed `$oid` object serde writes — with
 /// `hex_schema` as the schema of the hex string it holds.
 ///
-/// Field position and the branded path read this one spelling, so the transparent brand and the
-/// inner it wraps cannot drift apart. The map-member positions still carry their own renderings.
+/// Every position reads this one spelling: a field, a slot (a tuple element, a tuple struct, a
+/// brand over a container), a member of a map on either key path, and an untagged member. So the
+/// same `ObjectId` cannot describe two ways depending on where it is written, and a brand cannot
+/// drift from the inner it wraps.
+///
+/// The object is closed because serde writes that one member and every other object this crate
+/// emits is closed, and the hex member is patterned because that is what the string always holds —
+/// both are true of every payload serde writes, so neither turns one away.
+#[cfg(all(feature = "jsonschema", feature = "object_id"))]
+fn object_id_json_schema_item(hex_schema: &proc_macro2::TokenStream) -> proc_macro2::TokenStream {
+    quote! { {
+        "type": "object",
+        "properties": {
+            "$oid": (#hex_schema)
+        },
+        "required": ["$oid"],
+        "additionalProperties": false
+    } }
+}
+
+/// [`object_id_json_schema_item`] as a standalone `serde_json::Value` expression, for the positions
+/// that hold the `$oid` object as a value rather than writing it into a literal.
 #[cfg(all(feature = "jsonschema", feature = "object_id"))]
 fn object_id_json_schema_value(hex_schema: &proc_macro2::TokenStream) -> proc_macro2::TokenStream {
-    quote! {
-        serde_json::json!({
-            "type": "object",
-            "properties": {
-                "$oid": (#hex_schema)
-            },
-            "required": ["$oid"],
-            "additionalProperties": false
-        })
-    }
+    let item = object_id_json_schema_item(hex_schema);
+    quote! { serde_json::json!(#item) }
+}
+
+/// The hex string an `ObjectId`'s `$oid` member holds, where no brand narrows it further.
+#[cfg(all(feature = "jsonschema", feature = "object_id"))]
+fn object_id_hex_json_schema() -> proc_macro2::TokenStream {
+    quote! { serde_json::json!({ "type": "string", "pattern": #OBJECT_ID_HEX_PATTERN }) }
 }
 
 /// Builds the JSON schema for a `MongoDB` `ObjectId` field (`{ "$oid": string }`).
@@ -6045,7 +6060,7 @@ fn object_id_json_schema_value(hex_schema: &proc_macro2::TokenStream) -> proc_ma
 fn build_object_id_field_schema(fld: &FieldDef, field_name_str: &str) -> proc_macro2::TokenStream {
     let schema = arrayed_json_schema_value(
         fld,
-        object_id_json_schema_value(&quote! { serde_json::json!({ "type": "string" }) }),
+        object_id_json_schema_value(&object_id_hex_json_schema()),
     );
     quote! {
         properties.insert(#field_name_str.to_string(), { #schema });

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -2239,16 +2239,15 @@ fn a_chrono_enum_keyed_map_value_keeps_its_format() {
     }
 }
 
-/// An `ObjectId` is the one value the two key paths spell differently: a `String`-keyed member
-/// carries a closed, unpatterned `$oid` object where an enum-keyed member carries the field-position
-/// form. Pinned so the divergence stays a decision rather than a drift.
+/// An enum-keyed member binds the one `$oid` object every position spells — the same one a
+/// `String`-keyed member carries. Pinned so neither key path can grow a spelling of its own.
 #[cfg(all(feature = "object_id", feature = "jsonschema"))]
 #[test]
-fn an_object_id_enum_keyed_map_value_keeps_the_field_position_oid_object() {
+fn an_object_id_enum_keyed_map_value_binds_the_one_oid_object() {
     let tokens = enum_key_map_value_binding(FieldDefType::ObjectId);
     assert!(
         tokens.contains(
-            r#"let value_schema = serde_json :: json ! ({ "type" : "object" , "properties" : { "$oid" : { "type" : "string" , "pattern" : "^[a-f\\d]{24}$" } } , "required" : ["$oid"] }) ;"#
+            r#"let value_schema = serde_json :: json ! ({ "type" : "object" , "properties" : { "$oid" : (serde_json :: json ! ({ "type" : "string" , "pattern" : "^[a-f\\d]{24}$" })) } , "required" : ["$oid"] , "additionalProperties" : false }) ;"#
         ),
         "got: {tokens}"
     );
@@ -2648,11 +2647,11 @@ fn a_nested_string_literal_map_value_keeps_its_const() {
     );
 }
 
-/// A nested `ObjectId` member carries the closed `$oid` object the outer member carries.
+/// A nested `ObjectId` member carries the `$oid` object the outer member carries.
 #[cfg(all(feature = "object_id", feature = "jsonschema"))]
 #[test]
 fn a_nested_object_id_map_value_keeps_its_oid_object() {
-    let inner_member = r#"{ "type" : "object" , "additionalProperties" : { "type" : "object" , "properties" : { "$oid" : { "type" : "string" } } , "required" : ["$oid"] , "additionalProperties" : false } }"#;
+    let inner_member = r#"{ "type" : "object" , "additionalProperties" : { "type" : "object" , "properties" : { "$oid" : (serde_json :: json ! ({ "type" : "string" , "pattern" : "^[a-f\\d]{24}$" })) } , "required" : ["$oid"] , "additionalProperties" : false } }"#;
     let bare = nested_string_key_map_value_schema(FieldDefType::ObjectId, 0);
     assert!(
         bare.contains(&format!(r#""additionalProperties" : {inner_member}"#)),
@@ -3320,18 +3319,17 @@ fn an_unwrapped_map_field_keeps_the_object_it_has_always_described_as() {
     );
 }
 
-/// The `ObjectId` divergence is frozen by position, so routing the tuple element through the map
-/// path's dispatch must not migrate it onto the `String`-keyed member's closed, unpatterned `$oid`
-/// object: the element keeps the patterned, open field-position form it has always carried.
+/// A tuple element is a slot, and a slot spells the `$oid` object the way every other position
+/// spells it. Pinned so the element cannot be handed a rendering of its own again.
 #[cfg(all(feature = "object_id", feature = "jsonschema"))]
 #[test]
-fn an_object_id_tuple_element_keeps_the_field_position_oid_object() {
+fn an_object_id_tuple_element_spells_the_one_oid_object() {
     let parsed = super::get_field_def("id", &syn::parse_quote!(ObjectId), "");
     assert_eq!(
         super::build_tuple_element_json_schema(&parsed)
             .unwrap()
             .to_string(),
-        r#"serde_json :: json ! ({ "type" : "object" , "properties" : { "$oid" : { "type" : "string" , "pattern" : "^[a-f\\d]{24}$" } } , "required" : ["$oid"] })"#
+        r#"serde_json :: json ! ({ "type" : "object" , "properties" : { "$oid" : (serde_json :: json ! ({ "type" : "string" , "pattern" : "^[a-f\\d]{24}$" })) } , "required" : ["$oid"] , "additionalProperties" : false })"#
     );
 }
 

--- a/tests/branded_newtype_tests/tests.rs
+++ b/tests/branded_newtype_tests/tests.rs
@@ -434,7 +434,7 @@ mod objectid_branded_surface_tests {
             PlainObjectId::json_schema(),
             serde_json::json!({
                 "type": "object",
-                "properties": { "$oid": { "type": "string" } },
+                "properties": { "$oid": { "type": "string", "pattern": r"^[a-f\d]{24}$" } },
                 "required": ["$oid"],
                 "additionalProperties": false
             })
@@ -486,9 +486,8 @@ mod objectid_branded_surface_tests {
 
     /// An arrayed `ObjectId` writes the array around the `$oid` object, which is a container and
     /// so is described by the slot dispatch — the same rendering the unbranded tuple struct over
-    /// the same `Vec` publishes, hex pattern and open object included. Slot position and field
-    /// position spell the `$oid` object differently; the brand follows the slot it is
-    /// rendered through.
+    /// the same `Vec` publishes. Every position reads one builder, so the item here is the object
+    /// field position carries too.
     #[test]
     fn an_arrayed_objectid_brand_describes_the_array_of_oid_objects() {
         let zod = ObjectIdList::zod_schema();
@@ -508,10 +507,15 @@ mod objectid_branded_surface_tests {
                 "type": "array",
                 "items": {
                     "type": "object",
-                    "properties": { "$oid": { "type": "string", "pattern": "^[a-f\\d]{24}$" } },
-                    "required": ["$oid"]
+                    "properties": { "$oid": { "type": "string", "pattern": r"^[a-f\d]{24}$" } },
+                    "required": ["$oid"],
+                    "additionalProperties": false
                 }
             })
+        );
+        assert_eq!(
+            ObjectIdList::json_schema()["items"],
+            PlainObjectId::json_schema()
         );
     }
 }

--- a/tests/mongodb_real_tests/tests.rs
+++ b/tests/mongodb_real_tests/tests.rs
@@ -47,6 +47,26 @@ struct NestedRefMaps {
     run_batches: HashMap<String, Vec<HashMap<String, ObjectId>>>,
 }
 
+// Every position an `ObjectId` can be written in, gathered into one item: a field, an array item, a
+// tuple element, and a member of a map on each key path.
+#[cfg(feature = "jsonschema")]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct EveryOidPosition {
+    by_name: HashMap<String, ObjectId>,
+    by_slot: HashMap<RefSlot, ObjectId>,
+    many: Vec<ObjectId>,
+    nested: HashMap<String, HashMap<String, ObjectId>>,
+    one: ObjectId,
+    pair: (ObjectId, String),
+}
+
+// A tuple struct's lone element is a slot, not a field.
+#[cfg(feature = "jsonschema")]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct OidSlot(ObjectId);
+
 // Basic struct with real ObjectId
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -268,32 +288,22 @@ fn test_enum_keyed_objectid_map_json_schema() {
         "in: {by_slot}"
     );
     for member in members {
-        let value = &by_slot["properties"][&member];
-        assert_eq!(value["type"], "object", "member {member} in: {by_slot}");
         assert_eq!(
-            value["properties"]["$oid"]["type"], "string",
-            "member {member} in: {by_slot}"
-        );
-        assert_eq!(
-            value["required"][0], "$oid",
+            by_slot["properties"][&member],
+            unified_oid_object(),
             "member {member} in: {by_slot}"
         );
     }
 }
 
-/// The member schema a nested map carries is the value type's own — for an `ObjectId` the closed
-/// `$oid` object, at whatever depth the map nests.
+/// The member schema a nested map carries is the value type's own — for an `ObjectId` the one
+/// `$oid` object every position spells, at whatever depth the map nests.
 #[test]
 #[cfg(all(feature = "object_id", feature = "jsonschema"))]
 fn test_nested_objectid_map_json_schema() {
     let schema = NestedRefMaps::json_schema();
     let properties = schema["properties"].as_object().unwrap();
-    let oid_member = serde_json::json!({
-        "type": "object",
-        "properties": { "$oid": { "type": "string" } },
-        "required": ["$oid"],
-        "additionalProperties": false
-    });
+    let oid_member = unified_oid_object();
 
     for (field_name, expected_value_schema) in [
         (
@@ -319,6 +329,124 @@ fn test_nested_objectid_map_json_schema() {
         assert_eq!(
             field["additionalProperties"], expected_value_schema,
             "in: {field}"
+        );
+    }
+}
+
+/// The one `$oid` object every position spells: closed, because that is the object serde writes and
+/// every other object this crate emits is closed, and carrying the hex pattern, because that is what
+/// the string inside it always holds.
+#[cfg(all(feature = "object_id", feature = "jsonschema"))]
+fn unified_oid_object() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "properties": { "$oid": { "type": "string", "pattern": r"^[a-f\d]{24}$" } },
+        "required": ["$oid"],
+        "additionalProperties": false
+    })
+}
+
+/// An `ObjectId` describes the same wherever it is written — a field, an array item, a tuple
+/// element, a tuple struct's own slot, and a map member on either key path all read one builder, so
+/// no position can spell the `$oid` object its own way.
+#[test]
+#[cfg(all(feature = "object_id", feature = "jsonschema"))]
+fn every_position_spells_the_same_oid_object() {
+    let unified = unified_oid_object();
+    let schema = EveryOidPosition::json_schema();
+    let properties = &schema["properties"];
+
+    for (position, spelled) in [
+        ("field", &properties["one"]),
+        ("array item", &properties["many"]["items"]),
+        ("tuple element", &properties["pair"]["prefixItems"][0]),
+        (
+            "String-keyed map member",
+            &properties["by_name"]["additionalProperties"],
+        ),
+        (
+            "enum-keyed map member",
+            &properties["by_slot"]["properties"]["Author"],
+        ),
+        (
+            "nested map member",
+            &properties["nested"]["additionalProperties"]["additionalProperties"],
+        ),
+    ] {
+        assert_eq!(*spelled, unified, "{position} in: {schema}");
+    }
+
+    assert_eq!(OidSlot::json_schema(), unified);
+}
+
+/// Every object carrying a `$oid` member anywhere in `value`, at any depth.
+#[cfg(all(feature = "object_id", feature = "jsonschema"))]
+fn collect_oid_objects(value: &serde_json::Value, found: &mut Vec<serde_json::Value>) {
+    match value {
+        serde_json::Value::Object(members) => {
+            if members.contains_key("$oid") {
+                found.push(value.clone());
+            }
+            for member in members.values() {
+                collect_oid_objects(member, found);
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                collect_oid_objects(item, found);
+            }
+        }
+        serde_json::Value::Null
+        | serde_json::Value::Bool(_)
+        | serde_json::Value::Number(_)
+        | serde_json::Value::String(_) => {}
+    }
+}
+
+/// The closure and the pattern are only true information if serde never writes anything else: every
+/// `$oid` object it writes, in every position, holds that one member and a hex the pattern matches.
+#[test]
+#[cfg(all(feature = "object_id", feature = "jsonschema"))]
+fn every_serde_written_oid_payload_satisfies_the_unified_spelling() {
+    let unified = unified_oid_object();
+    let hex_pattern =
+        regex::Regex::new(unified["properties"]["$oid"]["pattern"].as_str().unwrap()).unwrap();
+
+    let mut written = Vec::new();
+    for _ in 0_u32..64_u32 {
+        let payload = EveryOidPosition {
+            by_name: HashMap::from([("a".to_owned(), ObjectId::new())]),
+            by_slot: HashMap::from([
+                (RefSlot::Author, ObjectId::new()),
+                (RefSlot::Reviewer, ObjectId::new()),
+            ]),
+            many: vec![ObjectId::new(), ObjectId::new()],
+            nested: HashMap::from([(
+                "group".to_owned(),
+                HashMap::from([("a".to_owned(), ObjectId::new())]),
+            )]),
+            one: ObjectId::new(),
+            pair: (ObjectId::new(), "x".to_owned()),
+        };
+        collect_oid_objects(&serde_json::to_value(&payload).unwrap(), &mut written);
+        collect_oid_objects(
+            &serde_json::to_value(OidSlot(ObjectId::new())).unwrap(),
+            &mut written,
+        );
+    }
+    assert!(!written.is_empty());
+
+    for oid_object in written {
+        let members = oid_object.as_object().unwrap();
+        assert_eq!(
+            members.keys().collect::<Vec<_>>(),
+            vec!["$oid"],
+            "a closed schema admits no other member: {oid_object}"
+        );
+        let hex = members["$oid"].as_str().unwrap();
+        assert!(
+            hex_pattern.is_match(hex),
+            "the pattern rejects a hex serde wrote: {hex}"
         );
     }
 }

--- a/tests/untagged_tests/tests.rs
+++ b/tests/untagged_tests/tests.rs
@@ -2,6 +2,9 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use tixschema::model_schema;
 
+#[cfg(feature = "object_id")]
+use mongodb::bson::oid::ObjectId;
+
 // ISO-8601 date string. Branded newtype carries the regex pattern.
 #[model_schema(pattern = r"^\d{4}-\d{2}-\d{2}$")]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -85,6 +88,16 @@ enum Bucket {
 enum KeyedUnion {
     Counts { counts: HashMap<Bucket, u32> },
     Labels { labels: HashMap<String, String> },
+}
+
+// An untagged member is written by a dispatch of its own, so it is a position an `ObjectId` can be
+// spelled in.
+#[cfg(feature = "object_id")]
+#[model_schema()]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+enum OidUnion {
+    One { one: ObjectId },
 }
 
 #[test]
@@ -417,4 +430,22 @@ fn test_untagged_map_member_keys_json_schema() {
         assert_eq!(branch["properties"][member], serde_json::json!({}));
         assert_eq!(branch["required"], serde_json::json!([member]));
     }
+}
+
+/// An untagged member spells the `$oid` object the way every other position spells it — a member is
+/// written by its own dispatch, which is one more place the object could have drifted.
+#[test]
+#[cfg(all(feature = "jsonschema", feature = "object_id"))]
+fn test_untagged_objectid_member_spells_the_one_oid_object() {
+    let schema = OidUnion::json_schema();
+    assert_eq!(
+        schema["anyOf"][0]["properties"]["one"],
+        serde_json::json!({
+            "type": "object",
+            "properties": { "$oid": { "type": "string", "pattern": r"^[a-f\d]{24}$" } },
+            "required": ["$oid"],
+            "additionalProperties": false
+        }),
+        "Got:\n{schema}"
+    );
 }

--- a/tests/untagged_tests/tests.rs
+++ b/tests/untagged_tests/tests.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use tixschema::model_schema;
 
-#[cfg(feature = "object_id")]
+#[cfg(all(feature = "jsonschema", feature = "object_id"))]
 use mongodb::bson::oid::ObjectId;
 
 // ISO-8601 date string. Branded newtype carries the regex pattern.
@@ -92,7 +92,7 @@ enum KeyedUnion {
 
 // An untagged member is written by a dispatch of its own, so it is a position an `ObjectId` can be
 // spelled in.
-#[cfg(feature = "object_id")]
+#[cfg(all(feature = "jsonschema", feature = "object_id"))]
 #[model_schema()]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]


### PR DESCRIPTION
The $oid object was spelled four ways by position: field and String-keyed map members wrote it closed and unpatterned, the slot dispatch and untagged members wrote it open and patterned, and the enum-keyed map path held an override existing only to preserve the divergence. The same Rust type described differently depending on where it was written, and a brand could drift from the inner it wraps.

Every position now reads one builder emitting the closed, patterned union of the live forms: closed because serde writes exactly that one member and every other object the crate emits is closed, patterned because the hex is what the string always holds. The hex pattern is a single constant; the builder splits into a literal fragment and a standalone value so inlining and value positions share it instead of one lifting the other through a conversion; both divergence-holding overrides are deleted; and the brand path seeds the hex member with the shared pattern before writing the brand's own constraints over it. That the union turns nothing away is proven by execution: sixty-four rounds of fresh ObjectIds across every position, each written payload's $oid object checked against the pattern read out of the generated schema — green before and after, which is exactly the claim. A parity test pins all seven positions to the one spelling; the freeze pins from the map-value unification are updated to guard it rather than deleted; the workspace consumers have zero hits for the open form. This also settles the String-key vs enum-key ObjectId-value divergence — the override whose sole reason was that split is gone, both paths hit one arm, before/after capture on record. The composed-vs-replaced brand-pattern split on the JSON surface is tracked separately. Full powerset tests and lint-all green with the exit value read before landing.