### PR TITLE
classify every map key by what serde writes for it

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,9 +144,36 @@ pub struct Schedule {
 }
 ```
 
-A key path is the one spelling that can name an enum, so a key path the expansion can prove is *not* a plain enum — a struct, a branded newtype, a tagged or untagged enum, or a `#[model_schema()]` alias of any of them — is refused where it is written, at whatever depth the map sits at, naming the type as the author spelled it. A key path the expansion has not seen yet, one declared after the type that writes the map or one from another crate, cannot be ruled out and is emitted as an enumerating key; a key that turns out to have no members surfaces as an `E0599` at the key type instead. A sequence-wrapped key — a `Vec`, a `[T; N]`, one of the sets — is refused outright, serde writing no object at all for a map keyed by one. All three are covered under [Compilation Errors](#compilation-errors), with the exact diagnostic each produces.
+A `#[serde(transparent)]` branded newtype over a string — a brand over `String` or `PathBuf`, or over another such brand — is the open case wearing a name. serde writes the brand as the bare string its inner is, which is exactly what a JSON object key is, so the map is an object keyed by arbitrary strings. TypeScript and Zod keep the brand's own spelling as the key type the way they keep an enum's — `Partial<Record<CorrelationId, V>>` and `z.record(CorrelationId$Schema, V)` — while the JSON schema is the open object, having no brand to say. A brand over anything else is refused as a key.
 
-Every other key is neither open nor enumerable, and none of them is refused. The JSON schema describes such a map as an object and says nothing about its members — `{"type": "object", "additionalProperties": true}` — while TypeScript and Zod keep the key's own type, so a `HashMap<u32, String>` is `Partial<Record<number, string>>` and `z.record(z.number().int(), z.string())`. serde writes the object with the key's string form for its keys: `7` becomes `"7"`, `true` becomes `"true"`, a chrono `NaiveDate` its ISO rendering. Only the narrowing is missing, not the object.
+```rust
+use std::collections::HashMap;
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(transparent)]
+pub struct CorrelationId(String);
+
+#[model_schema()]
+#[derive(Serialize, Deserialize)]
+pub struct Traces {
+    // {"type": "object", "additionalProperties": {"type": "string"}}, serialized {"abc": "..."}
+    pub spans: HashMap<CorrelationId, String>,
+}
+```
+
+A key path is the one spelling that can name an enum or a brand, so a key path the expansion can prove is *neither* a plain enum nor a string-shaped brand — a struct, a brand over a non-string inner, a tagged or untagged enum, or a `#[model_schema()]` alias of any of them — is refused where it is written, at whatever depth the map sits at, naming the type as the author spelled it. A key path the expansion has not seen yet, one declared after the type that writes the map or one from another crate, cannot be ruled out and is emitted as an enumerating key; a key that turns out to have no members surfaces as an `E0599` at the key type instead.
+
+The remaining refusals are all one rule: a JSON object key is a string, and `serde_json` raises `key must be a string` — refusing the whole map at serialization, with no fallback form — for every key whose own wire form is not one. Each of these is therefore refused rather than described, there being no object to describe:
+
+- a **sequence-wrapped** key — a `Vec`, a `[T; N]`, one of the sets — which writes a JSON array;
+- a **tuple** key, which writes a JSON array;
+- a **nested map** key and an **`ObjectId`** key, which write JSON objects;
+- an **`Option`** key, whose `Some` writes what its inner writes but whose `None` writes nothing a key can be — so a single `None` fails the whole map at runtime, and a schema for the `Some` half alone would describe a contract the type does not keep.
+
+All of them are covered under [Compilation Errors](#compilation-errors), with the exact diagnostic each produces.
+
+Every other key is neither open nor enumerable, and none of them is refused: serde stringifies each one into a key for you. The JSON schema describes such a map as an object and says nothing about its members — `{"type": "object", "additionalProperties": true}` — while TypeScript and Zod keep the key's own type, so a `HashMap<u32, String>` is `Partial<Record<number, string>>` and `z.record(z.number().int(), z.string())`. serde writes the object with the key's string form for its keys: `7` becomes `"7"`, `true` becomes `"true"`, a chrono `NaiveDate` its ISO rendering. Only the narrowing is missing, not the object. The rule the refusals apply is refuse-what-serde-refuses, never refuse-what-is-not-a-`String`.
 
 ### Pointers and Borrowed Values
 
@@ -1588,9 +1615,9 @@ tixschema = { features = ["serde"] }
 
 **Error:** *a map key must be a plain `#[model_schema()]` enum, whose members become the object's keys — `<type>` resolves to a type with no `enum_members()`*, reported at the field; or `no associated function or constant named enum_members found for <type>` (`E0599`), reported at the map's key type.
 
-A map key written as a type path must be a plain `#[model_schema()]` enum, whose members become the object's keys. A `String` key is the other supported spelling, and every key that is neither is covered under [Collections and Maps](#collections-and-maps) — this entry is about the two diagnostics a type path earns.
+A map key written as a type path must be a plain `#[model_schema()]` enum, whose members become the object's keys, or a `#[serde(transparent)]` brand over a string, which keys the map the way a `String` does. A `String` key is the third supported spelling, and every key that is none of them is covered under [Collections and Maps](#collections-and-maps) — this entry is about the two diagnostics a type path earns.
 
-A key the expansion has already seen and knows is not a plain enum — a struct, a branded newtype, a tagged or untagged enum, or a `#[model_schema()]` alias of one of those — is named directly, at the field that writes the map:
+A key the expansion has already seen and knows is neither — a struct, a brand over a non-string inner, a tagged or untagged enum, or a `#[model_schema()]` alias of one of those — is named directly, at the field that writes the map:
 
 ```rust
 #[model_schema()]
@@ -1655,6 +1682,53 @@ pub struct Counts {
 ```
 
 Every sequence spelling earns this — `Vec`, `[T; N]`, and the sets — the wrapper being what serde writes as an array. The message names the element rather than the wrapper, the parser having already collapsed those spellings onto their array levels. A sequence in the map's *value* is untouched: only the key has to be a string.
+
+#### Map Keys serde Refuses to Write
+
+**Error:** *a map key must be a value serde writes as a string ... serde writes `<type>` as a JSON array | a JSON object, and refuses to serialize a map keyed by one at all*, reported at the field.
+
+The same rule as above, reached by the key's own type rather than by a wrapper around it. A tuple writes a JSON array; a nested map and an `ObjectId` write JSON objects. `serde_json` uses none of them as an object key — it raises `key must be a string` and refuses the whole map — so there is no wire form for a schema to describe:
+
+```rust
+// Wrong: each key writes an array or an object, which serde will not use as an object key
+#[model_schema()]
+pub struct BadCounts {
+    pub by_pair: HashMap<(Slot, Slot), u32>,
+    pub by_map: HashMap<BTreeMap<String, u32>, u32>,
+    pub by_oid: HashMap<ObjectId, u32>,
+}
+
+// Correct: key by a value serde writes as a string
+#[model_schema()]
+pub struct Counts {
+    pub by_slot: HashMap<Slot, u32>,
+    pub by_id: HashMap<String, u32>,
+}
+```
+
+The keys serde *does* stringify for you are untouched and stay open — numbers, `bool`, and the chrono types all describe as `{"type": "object", "additionalProperties": true}`, as [Collections and Maps](#collections-and-maps) sets out. The rule is refuse-what-serde-refuses, never refuse-what-is-not-a-`String`. A tuple or a map in the map's *value* is untouched too: only the key has to be a string.
+
+#### `Option`-Wrapped Map Keys
+
+**Error:** *a map key must be a value serde writes as a string ... this key is an `Option<T>`, whose `Some` serde writes as the bare `T` while a `None` has no string form at all and makes serde refuse the whole map; key it by `T`*, reported at the field.
+
+An `Option` key is transparent for a `Some` — `HashMap<Option<Slot>, u32>` writes `{"Daily": 1}`, exactly what the bare-keyed map writes — and has no form at all for a `None`, which fails serialization with `key must be a string`. A schema describing only the `Some` half would validate documents the type can raise a runtime error on and say nothing about the half it cannot write, so the spelling is refused and the inner is named as the remedy:
+
+```rust
+// Wrong: a `None` key has no wire form, and one is enough to fail the whole map
+#[model_schema()]
+pub struct BadCounts {
+    pub counts: HashMap<Option<Slot>, u32>,
+}
+
+// Correct: key by the inner, which is what every `Some` was already writing
+#[model_schema()]
+pub struct Counts {
+    pub counts: HashMap<Slot, u32>,
+}
+```
+
+An `Option` in the map's *value* is untouched: a map entry cannot be dropped the way an object key can, so a `None` value is written as `null` and described as such.
 
 #### Function-Local Types
 

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -108,6 +108,13 @@ const KNOWN_ARGS: &[&str] = &["name", "pattern", "minLength", "maxLength", "no_d
 const FLATTENED_PLAIN_ENUM_SCOPE: &str = "Only a type the registry has already classified reaches this guard; one it has not keeps its \
      TypeScript and Zod intersection, and is refused by the JSON surface when the merge runs.";
 
+/// The two shapes a map key can write that `serde_json` will not use as an object key, as
+/// [`MapKeyRejection::Unwritable`] names them.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+const WRITTEN_AS_ARRAY: &str = "a JSON array";
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+const WRITTEN_AS_OBJECT: &str = "a JSON object";
+
 /// One variant of a discriminated enum, carrying everything its union member is rendered from.
 struct DiscriminatedVariant {
     discriminator_value: String,
@@ -299,10 +306,10 @@ enum MapMemberItem {
 #[cfg(feature = "jsonschema")]
 #[derive(Debug)]
 enum MapMemberRejection {
-    /// A map key the registry proves carries no `enum_members()`, named so the author can act on it.
-    NonEnumKey(String),
-    /// A map key written under a sequence wrapper, named by the element it holds.
-    SequencedKey(String),
+    /// A map key with no rendering, whatever reason it has and at whatever depth the value walk
+    /// reached it. The reason is the same value the field guard refuses on, so a key is worded
+    /// once however the expansion arrives at it.
+    Key(MapKeyRejection),
     Tuple,
 }
 
@@ -315,24 +322,41 @@ enum MapMemberRejection {
 enum MapKeyPath<'key> {
     /// A key named by a type path, whose `enum_members()` become the object's keys.
     Enumerated(&'key str),
-    /// A `String` key, which enumerates nothing — one schema stands for every member.
+    /// A key serde writes as a bare string, which enumerates nothing — one schema stands for every
+    /// member. `String` is one, and so is a brand the registry proves serde writes as a string.
     Open,
-    /// A key written under a sequence wrapper, which serde writes as a JSON array. A JSON object
-    /// key is a string, so serde refuses such a map outright rather than writing an object — there
-    /// is no wire form here for any surface to describe.
-    Sequenced,
+    /// A key with no object for any surface to describe, carrying the reason.
+    Refused(MapKeyRejection),
     /// A key this expansion cannot narrow, leaving the members unconstrained.
     Unnarrowed,
 }
 
-/// Why a map key a field reaches has no rendering. Both reasons carry the name the author can act
-/// on, and both stand on every surface, the key being read off the field all three render from.
+/// Why a map key a field reaches has no rendering. Every reason carries the name the author can act
+/// on, and every one stands on every surface, the key being read off the field all three render
+/// from.
+///
+/// Below the first, they are all one fact wearing different spellings: a JSON object key is a
+/// string, and serde raises `key must be a string` — refusing the whole map at serialization rather
+/// than falling back to any other form — for every key whose own wire form is not one. So the
+/// spelling is refused rather than described: there is no wire here to describe badly.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[derive(Debug)]
 enum MapKeyRejection {
     /// The registry proves the key type carries no `enum_members()`.
     NoEnumMembers(String),
+    /// The key is written as an `Option`, named by the inner it holds. A `Some` writes what the
+    /// inner writes; a `None` writes nothing a key can be.
+    Optional(String),
     /// The key is written under a sequence wrapper, named by the element it holds.
     Sequenced(String),
+    /// The key's own type is one serde writes as neither a string nor anything it will stringify.
+    Unwritable {
+        /// The key as it was written, by its own name where it has one and by its shape where it
+        /// has none.
+        key_name: String,
+        /// What serde writes for it instead, as the message names it.
+        written_as: &'static str,
+    },
 }
 
 /// What a newtype variant's inner value is when the tag is written beside it rather than around
@@ -1299,9 +1323,48 @@ fn branded_pattern_error(name: &Ident, args: &ModelSchemaArgs) -> Option<proc_ma
         .map(|rejection| pattern_guard_error(rejection, &format!("type `{name}`")))
 }
 
+/// What the registry records for a brand.
+///
+/// A brand is `#[serde(transparent)]`, so its wire form is its inner's: a brand over a string is
+/// written as that bare string, which is exactly what a JSON object key is, and so it keys a map the
+/// way `String` does — under its own name on the nominal surfaces, and as the open object on the
+/// structural one, which has no brand to say. The inner is asked through the very dispatch a map key
+/// is read by, so only an inner that opens a map opens the brand: a brand over a number, a chrono
+/// value, an `ObjectId`, or a container answers `NoEnumMembers` and stays refused as a key, which is
+/// what it was before this question was asked at all.
+///
+/// It is never `EnumMembers`: the brand publishes no `enum_members()` of its own, whatever it wraps.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn branded_alias_kind(inner_field: &Field) -> AliasKind {
+    let inner = get_field_def("", &inner_field.ty, "");
+    if matches!(map_key_path(&inner), MapKeyPath::Open) {
+        AliasKind::StringWire
+    } else {
+        AliasKind::NoEnumMembers
+    }
+}
+
+/// The `compile_error!` tokens for a branded newtype whose inner reaches a map key no surface can
+/// write, or `None` when it reaches none.
+///
+/// The brand renders its inner straight into the brand rather than walking it as a field, so the
+/// guard every field position runs never sees it — leaving a brand over a map with an unwritable key
+/// to emit a `Record` keyed by a type that supplies no keys, on every feature set that builds no
+/// JSON schema to catch it. The key is the same value read through the same walk, so the brand earns
+/// the diagnostic a field of that map type earns, spanned on the inner type, which is where the map
+/// was written.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn branded_map_key_error(name: &Ident, inner_field: &Field) -> Option<proc_macro2::TokenStream> {
+    let inner = get_field_def("", &inner_field.ty, "");
+    let rejection = map_key_rejection(&inner)?;
+    let message = map_key_rejection_message(&format!("type `{name}`"), &rejection);
+    Some(syn::Error::new_spanned(&inner_field.ty, message).to_compile_error())
+}
+
 /// The `compile_error!` tokens for every guard a branded newtype violates: a `cfg_attr`-wrapped
 /// serde attribute on the type or on its inner slot, an `Option` inner type, string constraints
-/// over an inner type that cannot carry them, and a `pattern` that is not a regex.
+/// over an inner type that cannot carry them, a `pattern` that is not a regex, and a map key the
+/// inner reaches that no surface can write.
 ///
 /// The branded path renders the inner type straight into the brand instead of walking fields, so
 /// it has to collect these itself; the ordinary struct walk never sees a transparent newtype.
@@ -1320,6 +1383,7 @@ fn branded_guard_errors(
             args,
         ))
         .chain(branded_pattern_error(&item_struct.ident, args))
+        .chain(branded_map_key_error(&item_struct.ident, inner_field))
         .collect()
 }
 
@@ -2668,7 +2732,7 @@ fn process_branded_newtype(item_struct: syn::ItemStruct, args: &ModelSchemaArgs)
         &name.to_string(),
         &item_name,
         &module_name,
-        AliasKind::NoEnumMembers,
+        branded_alias_kind(item_struct.fields.iter().next().unwrap()),
     );
 
     // Extract docs and example
@@ -5364,26 +5428,43 @@ fn sequence_wrapper_element(fld: &FieldDef) -> Option<&FieldDef> {
 
 /// The classification every position reads a map key through.
 ///
-/// The sequence spellings come first: they are the key as written, and what they write is a JSON
-/// array, which serde never puts in an object key. Reading past one would answer for the element
-/// instead — enumerating an enum's members as keys the map cannot hold.
+/// The rule it applies is serde's own: a JSON object key is a string, so a key serde writes as a
+/// string keys a map and a key it writes as anything else refuses the map outright at serialization
+/// (`key must be a string`, with no fallback form). What the expansion refuses is therefore what
+/// serde refuses — never what merely is not a `String`. The keys serde stringifies for the author,
+/// the numbers and the `bool` and the chrono renderings, keep the open object they have always
+/// described as.
 ///
-/// Below them, only a bare type path can name an enum: a generic spelling is a type this expansion
-/// has no `enum_members()` for, and every other type names keys the schema cannot enumerate.
+/// The wrapper spellings come first, in the order they were written: they are the key as written,
+/// and reading past one would answer for the inner instead — enumerating an enum's members as keys
+/// the map cannot hold. A sequence writes an array; an `Option` writes its inner or nothing at all.
+///
+/// Below them, only a bare type path can name an enum or a brand, and the registry says which: a
+/// generic spelling is a type this expansion has no `enum_members()` for, and every other type
+/// names keys the schema cannot enumerate.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn map_key_path(key: &FieldDef) -> MapKeyPath<'_> {
     if key.array_depth > 0 || sequence_wrapper_element(key).is_some() {
-        return MapKeyPath::Sequenced;
+        return MapKeyPath::Refused(MapKeyRejection::Sequenced(map_key_element_name(key)));
+    }
+    if key.is_optional() {
+        return MapKeyPath::Refused(MapKeyRejection::Optional(map_key_element_name(key)));
     }
     match &key.field_type {
         FieldDefType::String => MapKeyPath::Open,
         FieldDefType::SiblingType(key_type_name, args) if args.is_empty() => {
-            MapKeyPath::Enumerated(key_type_name.as_str())
+            if writes_string_wire(key_type_name) {
+                MapKeyPath::Open
+            } else {
+                MapKeyPath::Enumerated(key_type_name.as_str())
+            }
         }
+        FieldDefType::Tuple(..) => MapKeyPath::Refused(unwritable_key(key, WRITTEN_AS_ARRAY)),
+        FieldDefType::Map(..) => MapKeyPath::Refused(unwritable_key(key, WRITTEN_AS_OBJECT)),
+        #[cfg(feature = "object_id")]
+        FieldDefType::ObjectId => MapKeyPath::Refused(unwritable_key(key, WRITTEN_AS_OBJECT)),
         FieldDefType::SiblingType(..)
         | FieldDefType::Unknown
-        | FieldDefType::Map(..)
-        | FieldDefType::Tuple(..)
         | FieldDefType::Boolean
         | FieldDefType::StringLiteral(_)
         | FieldDefType::U8
@@ -5398,8 +5479,6 @@ fn map_key_path(key: &FieldDef) -> MapKeyPath<'_> {
         | FieldDefType::Isize
         | FieldDefType::F32
         | FieldDefType::F64 => MapKeyPath::Unnarrowed,
-        #[cfg(feature = "object_id")]
-        FieldDefType::ObjectId => MapKeyPath::Unnarrowed,
         #[cfg(feature = "chrono")]
         FieldDefType::DateTime
         | FieldDefType::NaiveDate
@@ -5408,16 +5487,26 @@ fn map_key_path(key: &FieldDef) -> MapKeyPath<'_> {
     }
 }
 
+/// The rejection a key earns for its own wire form, naming the key as written and what serde writes
+/// for it instead.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn unwritable_key(key: &FieldDef, written_as: &'static str) -> MapKeyRejection {
+    MapKeyRejection::Unwritable {
+        key_name: map_key_element_name(key),
+        written_as,
+    }
+}
+
 /// Why this key has no rendering, and `None` for every key that may still have one.
 ///
-/// A sequence-wrapped key is ruled out by its own spelling: serde writes it as a JSON array, which
-/// is no object key at all. Below that, only a target the registry positively rules out is named —
-/// an unregistered name, a foreign type or one expanded after the type that writes the map, cannot
-/// be ruled out at this expansion and is left alone.
+/// A key the dispatch already refuses is ruled out by its own spelling. Below that, only a target
+/// the registry positively rules out is named — an unregistered name, a foreign type or one
+/// expanded after the type that writes the map, cannot be ruled out at this expansion and is left
+/// alone.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn key_rejection(key: &FieldDef) -> Option<MapKeyRejection> {
     match map_key_path(key) {
-        MapKeyPath::Sequenced => Some(MapKeyRejection::Sequenced(map_key_element_name(key))),
+        MapKeyPath::Refused(rejection) => Some(rejection),
         MapKeyPath::Enumerated(key_type_name) => proves_no_enum_members(key_type_name)
             .then(|| MapKeyRejection::NoEnumMembers(key_type_name.to_owned())),
         MapKeyPath::Open | MapKeyPath::Unnarrowed => None,
@@ -5472,8 +5561,24 @@ fn map_key_element_name(key: &FieldDef) -> String {
 /// both the plain enums that have them and the names this expansion never saw registered.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn proves_no_enum_members(key_type_name: &str) -> bool {
+    lookup_alias_info(key_type_name).is_some_and(|key_alias| {
+        matches!(
+            key_alias.kind,
+            AliasKind::NoEnumMembers | AliasKind::StringWire
+        )
+    })
+}
+
+/// Whether the registry proves serde writes the named type as a bare string — the wire form a JSON
+/// object key has, so such a key opens the map the way a `String` key does, under its own name.
+///
+/// Only a `#[serde(transparent)]` brand over a string-shaped inner earns this, and an alias chain
+/// ending in one inherits it. An unregistered name earns nothing: the expansion cannot tell it from
+/// a plain enum declared later.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn writes_string_wire(key_type_name: &str) -> bool {
     lookup_alias_info(key_type_name)
-        .is_some_and(|key_alias| key_alias.kind == AliasKind::NoEnumMembers)
+        .is_some_and(|key_alias| key_alias.kind == AliasKind::StringWire)
 }
 
 /// Why the first map key this field reaches, at any depth, has no rendering.
@@ -5543,6 +5648,37 @@ fn sequenced_map_key_message(subject: &str, element_name: &str) -> String {
     )
 }
 
+/// What an `Option`-wrapped key is reported as, worded like its siblings above and carrying the same
+/// `subject`.
+///
+/// The `Some` half writes exactly what the inner writes — a transparent wrapper on the wire — so the
+/// schema the expansion would emit is the bare-keyed map's, byte for byte. It is the `None` half
+/// that has no wire form: serde raises `key must be a string` for it and refuses the whole map, so a
+/// schema describing only the `Some` half would validate documents the type cannot produce and stay
+/// silent about the ones it errors on. The inner is named because it is also the remedy.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn optional_map_key_message(subject: &str, inner_name: &str) -> String {
+    format!(
+        "{subject}: a map key must be a value serde writes as a string, which is what a JSON object key is — this key is an `Option<{inner_name}>`, whose `Some` serde writes as the bare `{inner_name}` while a `None` has no string form at all and makes serde refuse the whole map; key it by `{inner_name}`"
+    )
+}
+
+/// What a key serde writes as neither a string nor anything it stringifies for the author is
+/// reported as, worded like its siblings above and carrying the same `subject`.
+///
+/// This is the same refusal the sequence spelling earns, reached by the key's own type rather than
+/// by a wrapper around it: a tuple writes a JSON array, a nested map and an `ObjectId` write JSON
+/// objects, and serde will not use any of them as an object key. What is written is named beside
+/// the key so the diagnostic says why, and the numbers, the `bool` and the chrono renderings are
+/// deliberately absent — serde stringifies those into keys, so they describe as the open object
+/// they always have.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn unwritable_map_key_message(subject: &str, key_name: &str, written_as: &str) -> String {
+    format!(
+        "{subject}: a map key must be a value serde writes as a string, which is what a JSON object key is — serde writes `{key_name}` as {written_as}, and refuses to serialize a map keyed by one at all"
+    )
+}
+
 /// What a map key with no rendering is reported as, whichever reason it has.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn map_key_rejection_message(subject: &str, rejection: &MapKeyRejection) -> String {
@@ -5553,6 +5689,11 @@ fn map_key_rejection_message(subject: &str, rejection: &MapKeyRejection) -> Stri
         MapKeyRejection::Sequenced(element_name) => {
             sequenced_map_key_message(subject, element_name)
         }
+        MapKeyRejection::Optional(inner_name) => optional_map_key_message(subject, inner_name),
+        MapKeyRejection::Unwritable {
+            key_name,
+            written_as,
+        } => unwritable_map_key_message(subject, key_name, written_as),
     }
 }
 
@@ -5616,11 +5757,7 @@ fn build_nested_map_member_item(
             )
         }
         MapKeyPath::Unnarrowed => MapMemberItem::Fragment(unnarrowed_key_map_json_schema_item()),
-        MapKeyPath::Sequenced => {
-            return Err(MapMemberRejection::SequencedKey(map_key_element_name(
-                inner_key,
-            )));
-        }
+        MapKeyPath::Refused(rejection) => return Err(MapMemberRejection::Key(rejection)),
     })
 }
 
@@ -5758,12 +5895,7 @@ fn build_map_member_schema(
 #[cfg(feature = "jsonschema")]
 fn map_member_rejection_message(subject: &str, rejection: &MapMemberRejection) -> String {
     match rejection {
-        MapMemberRejection::NonEnumKey(key_type_name) => {
-            non_enum_map_key_message(subject, key_type_name)
-        }
-        MapMemberRejection::SequencedKey(element_name) => {
-            sequenced_map_key_message(subject, element_name)
-        }
+        MapMemberRejection::Key(key_rejection) => map_key_rejection_message(subject, key_rejection),
         MapMemberRejection::Tuple => format!(
             "{subject}: a tuple is not supported as a map value — give the value a `#[model_schema()]` struct instead"
         ),
@@ -5847,7 +5979,9 @@ fn enum_key_map_json_schema_value(
     value: &FieldDef,
 ) -> Result<proc_macro2::TokenStream, MapMemberRejection> {
     if proves_no_enum_members(key_type_name) {
-        return Err(MapMemberRejection::NonEnumKey(key_type_name.to_owned()));
+        return Err(MapMemberRejection::Key(MapKeyRejection::NoEnumMembers(
+            key_type_name.to_owned(),
+        )));
     }
 
     let normalized = normalized_slot_value(value);
@@ -5893,7 +6027,7 @@ fn build_map_field_schema(
         }
         MapKeyPath::Open => string_key_map_json_schema_value(value),
         MapKeyPath::Unnarrowed => Ok(unnarrowed_key_map_json_schema_value(key)),
-        MapKeyPath::Sequenced => Err(MapMemberRejection::SequencedKey(map_key_element_name(key))),
+        MapKeyPath::Refused(rejection) => Err(MapMemberRejection::Key(rejection)),
     };
     match rendered {
         Ok(map_schema) => {

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -849,9 +849,194 @@ fn a_sequence_wrapped_map_key_is_refused_wherever_it_is_written() {
     }
 }
 
+/// A key whose own type writes a JSON array or a JSON object earns the same refusal a
+/// sequence-wrapped one does, and for the same reason: serde raises `key must be a string` and
+/// refuses the whole map, so there is no object for any surface to describe. The key is named by the
+/// shape it was written as, and what serde writes for it is named beside it.
+///
+/// Every depth is covered, the position a map sits in not being what decides whether its key can be
+/// written.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn assert_unwritable_map_key(field_type: &proc_macro2::TokenStream, key_name: &str) {
+    let error = field_map_key_error(field_type);
+    assert!(error.contains("compile_error"), "for {field_type}: {error}");
+    assert!(
+        error.contains("field `counts`"),
+        "for {field_type}: {error}"
+    );
+    assert!(
+        error.contains("a map key must be a value serde writes as a string"),
+        "for {field_type}: {error}"
+    );
+    assert!(error.contains(key_name), "for {field_type}: {error}");
+    assert!(
+        error.contains("refuses to serialize a map keyed by one"),
+        "for {field_type}: {error}"
+    );
+}
+
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn a_map_key_serde_refuses_to_write_is_refused_wherever_it_is_written() {
+    register_alias_info("Slot", "Slot", "slot_schema", AliasKind::EnumMembers);
+    for (field_type, key_name) in [
+        (quote::quote! { HashMap<(Slot, Slot), u32> }, "(_, _)"),
+        (quote::quote! { HashMap<(String, u32), u32> }, "(_, _)"),
+        (
+            quote::quote! { HashMap<HashMap<String, u32>, u32> },
+            "HashMap<_, _>",
+        ),
+        (
+            quote::quote! { HashMap<BTreeMap<String, u32>, u32> },
+            "HashMap<_, _>",
+        ),
+        (
+            quote::quote! { HashMap<String, HashMap<(Slot, Slot), u32>> },
+            "(_, _)",
+        ),
+        (
+            quote::quote! { HashMap<Slot, HashMap<(Slot, Slot), u32>> },
+            "(_, _)",
+        ),
+        (quote::quote! { Vec<HashMap<(Slot, Slot), u32>> }, "(_, _)"),
+        (
+            quote::quote! { Option<HashMap<(Slot, Slot), u32>> },
+            "(_, _)",
+        ),
+        (
+            quote::quote! { (String, HashMap<(Slot, Slot), u32>) },
+            "(_, _)",
+        ),
+        (
+            quote::quote! { Wrapper<HashMap<(Slot, Slot), u32>> },
+            "(_, _)",
+        ),
+    ] {
+        assert_unwritable_map_key(&field_type, key_name);
+    }
+}
+
+/// An `ObjectId` writes a `{"$oid": ...}` object, so it joins the tuple and the nested map: serde
+/// refuses a map keyed by one exactly as it refuses those.
+#[cfg(all(
+    feature = "object_id",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn an_object_id_map_key_is_refused_wherever_it_is_written() {
+    register_alias_info("Slot", "Slot", "slot_schema", AliasKind::EnumMembers);
+    for field_type in [
+        quote::quote! { HashMap<ObjectId, u32> },
+        quote::quote! { HashMap<String, HashMap<ObjectId, u32>> },
+        quote::quote! { HashMap<Slot, HashMap<ObjectId, u32>> },
+        quote::quote! { Vec<HashMap<ObjectId, u32>> },
+        quote::quote! { (String, HashMap<ObjectId, u32>) },
+        quote::quote! { Wrapper<HashMap<ObjectId, u32>> },
+    ] {
+        assert_unwritable_map_key(&field_type, "ObjectId");
+    }
+}
+
+/// An `Option`-wrapped key writes what its inner writes for a `Some` and nothing a key can be for a
+/// `None` — serde refuses the whole map the moment one is present — so the map is refused rather
+/// than described by the half that serializes. The inner is named, that being the remedy.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn an_optional_map_key_is_refused_wherever_it_is_written() {
+    register_alias_info("Slot", "Slot", "slot_schema", AliasKind::EnumMembers);
+    for (field_type, inner) in [
+        (quote::quote! { HashMap<Option<Slot>, u32> }, "Slot"),
+        (quote::quote! { HashMap<Option<String>, u32> }, "String"),
+        (quote::quote! { HashMap<Option<u32>, u64> }, "u32"),
+        (
+            quote::quote! { HashMap<String, HashMap<Option<Slot>, u32>> },
+            "Slot",
+        ),
+        (
+            quote::quote! { HashMap<Slot, HashMap<Option<Slot>, u32>> },
+            "Slot",
+        ),
+        (quote::quote! { Vec<HashMap<Option<Slot>, u32>> }, "Slot"),
+        (quote::quote! { Option<HashMap<Option<Slot>, u32>> }, "Slot"),
+        (
+            quote::quote! { (String, HashMap<Option<Slot>, u32>) },
+            "Slot",
+        ),
+        (
+            quote::quote! { Wrapper<HashMap<Option<Slot>, u32>> },
+            "Slot",
+        ),
+    ] {
+        let error = field_map_key_error(&field_type);
+        assert!(error.contains("compile_error"), "for {field_type}: {error}");
+        assert!(
+            error.contains("field `counts`"),
+            "for {field_type}: {error}"
+        );
+        assert!(
+            error.contains("a map key must be a value serde writes as a string"),
+            "for {field_type}: {error}"
+        );
+        assert!(
+            error.contains(&format!("Option<{inner}>")),
+            "for {field_type}: {error}"
+        );
+    }
+}
+
+/// The wrapper spellings answer in the order they were written, so a key wearing both keeps the
+/// diagnostic of its outermost one: an optional sequence is still refused as the sequence its array
+/// levels make it, and only a key whose outermost wrapper is the `Option` earns the `None`-key
+/// wording.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn a_key_wrapped_twice_is_named_by_its_outermost_wrapper() {
+    register_alias_info("Slot", "Slot", "slot_schema", AliasKind::EnumMembers);
+    let sequenced = field_map_key_error(&quote::quote! { HashMap<Option<Vec<Slot>>, u32> });
+    assert!(sequenced.contains("is a sequence of"), "got: {sequenced}");
+    let optional = field_map_key_error(&quote::quote! { HashMap<Option<(Slot, Slot)>, u32> });
+    assert!(optional.contains("Option<(_, _)>"), "got: {optional}");
+}
+
+/// A brand is `#[serde(transparent)]`, so a brand over a string writes the bare string a JSON object
+/// key is — it keys a map exactly as `String` does and is left alone, at every depth. A brand over
+/// anything else keeps the refusal it had: its wire is no key.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn a_string_wire_brand_keys_a_map_the_way_a_string_does() {
+    register_alias_info("Slot", "Slot", "slot_schema", AliasKind::EnumMembers);
+    register_alias_info(
+        "CorrelationId",
+        "CorrelationId",
+        "correlation_id_schema",
+        AliasKind::StringWire,
+    );
+    register_alias_info("Tick", "Tick", "tick_schema", AliasKind::NoEnumMembers);
+    for field_type in [
+        quote::quote! { HashMap<CorrelationId, u32> },
+        quote::quote! { HashMap<String, HashMap<CorrelationId, u32>> },
+        quote::quote! { HashMap<Slot, HashMap<CorrelationId, u32>> },
+        quote::quote! { HashMap<CorrelationId, HashMap<CorrelationId, u32>> },
+        quote::quote! { Vec<HashMap<CorrelationId, u32>> },
+        quote::quote! { (String, HashMap<CorrelationId, u32>) },
+        quote::quote! { Wrapper<HashMap<CorrelationId, u32>> },
+    ] {
+        let error = field_map_key_error(&field_type);
+        assert!(error.is_empty(), "for {field_type}, got: {error}");
+    }
+
+    let refused = field_map_key_error(&quote::quote! { HashMap<Tick, u32> });
+    assert!(
+        refused.contains("a map key must be a plain"),
+        "got: {refused}"
+    );
+    assert!(refused.contains("Tick"), "got: {refused}");
+}
+
 /// The guard is a filter, never a rewrite: a key the registry names as a plain enum, one it never
 /// saw registered, and one no position enumerates all keep the field they had. A sequence in the
-/// *value* is no key at all, so the sequence refusal does not reach across the map to it.
+/// *value* is no key at all, so the sequence refusal does not reach across the map to it — nor does
+/// any of its siblings, an `Option` value and a tuple value being ordinary members.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
 fn a_map_key_that_may_have_enum_members_is_left_alone() {
@@ -861,10 +1046,33 @@ fn a_map_key_that_may_have_enum_members_is_left_alone() {
         quote::quote! { HashMap<String, u32> },
         quote::quote! { HashMap<Ghost, u32> },
         quote::quote! { HashMap<u32, u64> },
+        quote::quote! { HashMap<bool, u64> },
         quote::quote! { HashMap<String, HashMap<Slot, u32>> },
         quote::quote! { HashMap<Slot, Vec<u32>> },
         quote::quote! { HashMap<String, Vec<Slot>> },
+        quote::quote! { HashMap<String, Option<Slot>> },
+        quote::quote! { HashMap<String, (Slot, Slot)> },
+        quote::quote! { HashMap<String, HashMap<String, u32>> },
         quote::quote! { Vec<HashMap<Slot, u32>> },
+    ] {
+        let error = field_map_key_error(&field_type);
+        assert!(error.is_empty(), "for {field_type}, got: {error}");
+    }
+}
+
+/// Every key serde stringifies for the author keeps the open object it has always described as: the
+/// rule is refuse-what-serde-refuses, never refuse-what-is-not-a-`String`.
+#[cfg(all(
+    feature = "chrono",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn a_chrono_map_key_is_left_alone() {
+    for field_type in [
+        quote::quote! { HashMap<NaiveDate, u32> },
+        quote::quote! { HashMap<NaiveTime, u32> },
+        quote::quote! { HashMap<NaiveDateTime, u32> },
+        quote::quote! { HashMap<DateTime<Utc>, u32> },
     ] {
         let error = field_map_key_error(&field_type);
         assert!(error.is_empty(), "for {field_type}, got: {error}");
@@ -1400,6 +1608,69 @@ fn a_brand_pattern_javascript_cannot_carry_names_the_type_and_the_construct() {
 fn a_brand_pattern_naming_a_group_the_rust_way_clears_the_guard() {
     let errors = brand_pattern_errors("^(?P<word>[a-z]+)$");
     assert!(errors.is_empty(), "got: {errors:?}");
+}
+
+/// The brand renders its inner into the brand rather than walking it as a field, so the map-key
+/// guard has to be run here or the inner escapes it entirely — leaving TypeScript to write a
+/// `Record` keyed by a type that supplies no keys. The brand earns the same diagnostic a field of
+/// the inner's type earns, whichever reason the key has.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn a_brand_over_a_map_with_an_unwritable_key_is_refused() {
+    register_alias_info("Doc", "Doc", "doc_schema", AliasKind::NoEnumMembers);
+    for (inner, needle) in [
+        (
+            quote::quote! { HashMap<Doc, u32> },
+            "a map key must be a plain",
+        ),
+        (quote::quote! { HashMap<Vec<Doc>, u32> }, "is a sequence of"),
+        (
+            quote::quote! { HashMap<(String, u32), u32> },
+            "serde writes `(_, _)`",
+        ),
+        (quote::quote! { HashMap<Option<Doc>, u32> }, "Option<Doc>"),
+        (
+            quote::quote! { Vec<HashMap<Doc, u32>> },
+            "a map key must be a plain",
+        ),
+    ] {
+        let errors = branded_errors(&syn::parse_quote! {
+            #[serde(transparent)]
+            struct Wrap(pub #inner);
+        });
+        assert_eq!(errors.len(), 1, "for {inner}, got: {errors:?}");
+        assert!(
+            errors[0].contains("compile_error"),
+            "for {inner}: {}",
+            errors[0]
+        );
+        assert!(
+            errors[0].contains("type `Wrap`"),
+            "for {inner}: {}",
+            errors[0]
+        );
+        assert!(errors[0].contains(needle), "for {inner}: {}", errors[0]);
+    }
+}
+
+/// The guard is a filter here too: a brand over a map whose key can be written, and a brand over no
+/// map at all, keep the brand they had.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn a_brand_over_a_writable_map_key_clears_the_guard() {
+    register_alias_info("Slot", "Slot", "slot_schema", AliasKind::EnumMembers);
+    for inner in [
+        quote::quote! { String },
+        quote::quote! { HashMap<String, u32> },
+        quote::quote! { HashMap<Slot, u32> },
+        quote::quote! { Vec<HashMap<String, u32>> },
+    ] {
+        let errors = branded_errors(&syn::parse_quote! {
+            #[serde(transparent)]
+            struct Wrap(pub #inner);
+        });
+        assert!(errors.is_empty(), "for {inner}, got: {errors:?}");
+    }
 }
 
 /// Every constraint the guard reacts to, applied one at a time: `has_string_constraints` is an

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -26,18 +26,23 @@ const UNICODE_CLASS_READ_AS: &str = "an escaped `p` or `P` followed by a literal
 /// A Unicode class, in the three spellings the `regex` crate reads one by.
 const UNICODE_CLASS_WRITTEN: &str = "a Unicode class -- `\\p{...}`, `\\pL` or `\\P{...}`";
 
-/// Whether a registered Rust ident, *written as a type path*, resolves to something carrying an
-/// inherent `enum_members()` — the enumeration the JSON-schema map-key expansion calls. Only a
-/// plain unit enum gets that method, and a type path sees straight through an alias, so an alias
-/// answers for whatever it targets rather than for itself.
+/// What a registered Rust ident, *written as a type path*, resolves to — the two facts a map key
+/// asks of it: whether it carries an inherent `enum_members()`, the enumeration the JSON-schema
+/// map-key expansion calls, and whether serde writes it as a bare string, which is what a JSON
+/// object key is. Only a plain unit enum gets that method, and a type path sees straight through an
+/// alias, so an alias answers for whatever it targets rather than for itself.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum AliasKind {
     /// A plain unit enum, or an alias chain ending in one.
     EnumMembers,
-    /// Provably has none: a struct, a branded newtype, a non-plain enum, or an alias whose target
-    /// is a primitive, a collection, or one of those.
+    /// Provably has neither: a struct, a brand over a non-string inner, a non-plain enum, or an
+    /// alias whose target is a primitive, a collection, or one of those.
     NoEnumMembers,
+    /// No `enum_members()`, but serde writes it as a bare string: a `#[serde(transparent)]` brand
+    /// whose inner is itself string-shaped, or an alias chain ending in one. Such a type keys a map
+    /// exactly as `String` does, under its own name.
+    StringWire,
     /// Undecidable at this expansion — an alias naming a type that was not registered before it.
     Unknown,
 }

--- a/tests/collection_tests/tests.rs
+++ b/tests/collection_tests/tests.rs
@@ -126,6 +126,40 @@ struct NestedEnumKeyedMapValues {
     string_keyed_outer: HashMap<String, HashMap<MetricBucket, u64>>,
 }
 
+/// A `#[serde(transparent)]` brand over a `String`: serde writes it as the bare string its inner
+/// is, which is exactly what a JSON object key is.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[serde(transparent)]
+struct CorrelationId(String);
+
+/// A brand over such a brand. The wire form is the same bare string at every link of the chain.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[serde(transparent)]
+struct TraceId(CorrelationId);
+
+// A brand key is the open case wearing a name: serde writes the brand as the bare string its inner
+// is, so the map is an object keyed by arbitrary strings — held below against the `String`-keyed
+// twin, which is what the map describes as once the brand's name is spent.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct BrandKeyedMaps {
+    chained: HashMap<TraceId, u64>,
+    counts: HashMap<CorrelationId, u64>,
+    nested: HashMap<CorrelationId, HashMap<CorrelationId, u64>>,
+    samples: HashMap<CorrelationId, MetricSample>,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct StringKeyedBrandTwin {
+    chained: HashMap<String, u64>,
+    counts: HashMap<String, u64>,
+    nested: HashMap<String, HashMap<String, u64>>,
+    samples: HashMap<String, MetricSample>,
+}
+
 // A String key enumerates nothing, so one `additionalProperties` schema stands for every member —
 // and it is the value type's own, which is what the enum-keyed twin above spells out per key.
 #[model_schema()]
@@ -1375,6 +1409,119 @@ fn test_string_keyed_sibling_value_maps_typescript_generation() {
             .contains("optional_sample: z.record(z.string(), z.nullable(MetricSample$Schema))"),
         "Got: {zod_schema}"
     );
+}
+
+/// A brand key clears the derive under every feature set that reads one, none of them excepted:
+/// the key is read off the field all three surfaces render from, so the same source cannot be a
+/// schema under one toggle and a refusal under another.
+#[test]
+fn test_brand_keyed_maps_constructible() {
+    let key = CorrelationId("abc".to_owned());
+    let maps = BrandKeyedMaps {
+        chained: HashMap::from([(TraceId(key.clone()), 2)]),
+        counts: HashMap::from([(key.clone(), 1)]),
+        nested: HashMap::from([(key.clone(), HashMap::from([(key.clone(), 3)]))]),
+        samples: HashMap::from([(
+            key.clone(),
+            MetricSample {
+                label: "s".to_owned(),
+            },
+        )]),
+    };
+    assert_eq!(maps.counts[&key], 1);
+    assert_eq!(maps.nested[&key][&key], 3);
+
+    let twin = StringKeyedBrandTwin {
+        chained: HashMap::from([("abc".to_owned(), 2)]),
+        counts: HashMap::from([("abc".to_owned(), 1)]),
+        nested: HashMap::from([("abc".to_owned(), HashMap::from([("abc".to_owned(), 3)]))]),
+        samples: HashMap::new(),
+    };
+    assert_eq!(twin.counts["abc"], maps.counts[&key]);
+}
+
+/// A brand key builds the same object a `String` key builds. The JSON schema is the structural
+/// surface and has no brand to say, so it describes the open object outright — field for field the
+/// `String`-keyed twin's.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_brand_keyed_maps_describe_as_their_string_keyed_twin() {
+    assert_eq!(
+        BrandKeyedMaps::json_schema()["properties"],
+        StringKeyedBrandTwin::json_schema()["properties"]
+    );
+}
+
+/// The nominal surfaces keep the brand's own spelling as the key type, the way the enum-key path
+/// keeps the enum's — a `Record` and a `z.record` keyed by the brand, not by bare `string`.
+#[test]
+#[cfg(all(feature = "typescript", feature = "zod"))]
+fn test_brand_keyed_maps_name_the_brand_as_the_key_type() {
+    let ts_definition = BrandKeyedMaps::ts_definition();
+    for expected in [
+        "counts: Partial<Record<CorrelationId, number>>;",
+        "chained: Partial<Record<TraceId, number>>;",
+        "samples: Partial<Record<CorrelationId, MetricSample>>;",
+        "nested: Partial<Record<CorrelationId, Partial<Record<CorrelationId, number>>>>;",
+    ] {
+        assert!(
+            ts_definition.contains(expected),
+            "{expected} missing: {ts_definition}"
+        );
+    }
+
+    let zod_schema = BrandKeyedMaps::zod_schema();
+    for expected in [
+        "counts: z.record(CorrelationId$Schema, z.number().int())",
+        "chained: z.record(TraceId$Schema, z.number().int())",
+        "samples: z.record(CorrelationId$Schema, MetricSample$Schema)",
+        "nested: z.record(CorrelationId$Schema, z.record(CorrelationId$Schema, z.number().int()))",
+    ] {
+        assert!(
+            zod_schema.contains(expected),
+            "{expected} missing: {zod_schema}"
+        );
+    }
+}
+
+/// The whole reason the brand keys a map: serde writes it as the bare string, so what the schema
+/// describes as an open object is the object the value actually writes — and reads back.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_brand_keyed_maps_match_the_serialized_form() {
+    let key = CorrelationId("abc".to_owned());
+    let maps = BrandKeyedMaps {
+        chained: HashMap::from([(TraceId(key.clone()), 2)]),
+        counts: HashMap::from([(key.clone(), 1)]),
+        nested: HashMap::from([(key.clone(), HashMap::from([(key.clone(), 3)]))]),
+        samples: HashMap::from([(
+            key,
+            MetricSample {
+                label: "s".to_owned(),
+            },
+        )]),
+    };
+    let payload = serde_json::to_value(&maps).unwrap();
+    assert_eq!(payload["counts"], serde_json::json!({ "abc": 1_u64 }));
+    assert_eq!(payload["chained"], serde_json::json!({ "abc": 2_u64 }));
+    assert_eq!(
+        payload["nested"],
+        serde_json::json!({ "abc": { "abc": 3_u64 } })
+    );
+
+    let schema = BrandKeyedMaps::json_schema();
+    for field_name in ["counts", "chained", "nested", "samples"] {
+        let field = &schema["properties"][field_name];
+        assert_eq!(field["type"], json_type_name(&payload[field_name]));
+        assert!(field["additionalProperties"].is_object(), "in: {field}");
+    }
+    assert_eq!(
+        schema["properties"]["samples"]["additionalProperties"],
+        MetricSample::json_schema()
+    );
+
+    let read_back: BrandKeyedMaps = serde_json::from_value(payload).unwrap();
+    assert_eq!(read_back, maps);
 }
 
 #[test]


### PR DESCRIPTION
Four map-key defects, one rule: refuse what serde refuses, never what merely is not a String.

Keys whose own wire form serde will not use as an object key — tuples and nested maps and ObjectId (key must be a string, no fallback), and Option-wrapped keys (a Some writes the bare inner, a None has no string form and one is enough to fail the whole map) — compiled silently as open objects describing shapes no value can write. Each is now a spanned refusal naming the key as written and what serde writes for it instead; the Option wording names the inner as the remedy. Meanwhile a serde(transparent) brand over a string was refused as a key even though its wire is exactly the bare string an object key is: the registry now records string-wire brands (brand-over-brand chains included), and such a key opens the map the way String does — the nominal surfaces keep the brand's own name as the key type while the JSON schema writes the open object, pinned field-for-field against a String-keyed twin plus a wire round-trip. And a brand whose inner reaches an unwritable map key escaped every guard (the brand path renders its inner without walking it as a field), emitting a Record keyed by a type that supplies no keys on feature sets with no JSON schema to catch it — the brand now earns exactly the diagnostic a field of that type earns, spanned on the inner.

The machinery consolidates as one typed channel: the bespoke sequence arm folds into a general Refused(reason) classification, the member-side rejection carries the same reason value, and each reason is worded once however the expansion reaches the key. Keys serde stringifies (numbers, bool, chrono) stay open and byte-identical, pinned. The README's key contract is rewritten to match. Capture-first per bead; a two-wrapper test pins which diagnostic a doubly-wrapped key earns. Full powerset tests and lint-all green on the merged tree with the exit value read before landing.