### PR TITLE
give every model_schema_prop placement one verdict: rendered, refused with a span, or a verified no-op

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,6 +524,8 @@ z.union([z.strictObject({ x: z.string(), }), z.strictObject({ y: z.number().int(
 
 Untagged enums compose with `#[serde(flatten)]`: a flattened variant carrying `Vec<DateValue>` renders `sampleValues: z.array(DateValue$Schema)` (TypeScript `Array<DateValue>`), and the JSON-schema `items` for that field is the `DateValue` `anyOf`.
 
+A member of an untagged variant carries `#[model_schema_prop(...)]` exactly as the same field written in a tagged variant does: the constraint reaches the Zod schema and the JSON Schema, and every guard the attribute earns is reported at the member. The one difference is the Rust side -- an untagged enum generates no per-field validators, so a constrained member has no `validate()` contribution and no deserialization check.
+
 **Unsupported variants:** unit variants and multi-field tuple variants in an untagged enum produce a compile-time error.
 
 ### Nested Types
@@ -941,6 +943,12 @@ Generated JSON Schema for `username`: `{ "type": "string", "minLength": 3, "maxL
 
 The TypeScript type is unchanged -- still just `string`.
 
+A type whose schema this crate writes whole carries none of the five constraints, and writing one on
+such a field is a compile error naming the keys and the type: `ObjectId` writes a `{"$oid": "..."}`
+object rather than a string, and the chrono types (`NaiveDate`, `NaiveTime`, `NaiveDateTime`,
+`DateTime<Tz>`) write their own ISO spellings, which no surface reads a length, a pattern or a range
+beside. Carry the value in a `String` field if it needs one.
+
 A `PathBuf` field carries the same three constraints, as does the `Path` borrow behind a wrapper (`Box<Path>`, `Cow<'_, Path>`, `Arc<Path>`, `Rc<Path>`): serde writes a path as a JSON string, which is what the three surfaces render a constrained string for. The checks measure that string -- the path's `to_string_lossy` rendering, which is the exact wire value for every path serde can write, a path that is not UTF-8 being one serde refuses to serialize at all.
 
 ### Numeric Constraints (minimum, maximum)
@@ -1084,9 +1092,11 @@ Both approaches produce identical TypeScript and Zod output. The single-value en
 - **Pattern matching** -- match on `DocumentLiteralValue::Document` instead of checking string equality
 - **Naming convention**: Use the `<Something>LiteralValue` naming pattern (e.g., `DocumentLiteralValue`)
 
-### Type Overrides (`as`)
+### Type Names (`as`)
 
-Use `as` to override the TypeScript/Zod type for a field, keeping the Rust type unchanged:
+Use `as` to name the type a field renders. The target must be the type the field already renders --
+either the field's own type, or the value under its wrappers, so `as = String` is written on a
+`String`, an `Option<String>` and a `Vec<String>` alike:
 
 ```rust
 #[model_schema()]
@@ -1095,9 +1105,17 @@ pub struct ApiConfig {
     pub id: String,
     #[model_schema_prop(as = String)]
     pub metric_type: String,
+    #[model_schema_prop(as = String, minLength = 1)]
+    pub tags: Vec<String>,
     pub enabled: bool,
 }
 ```
+
+Naming any other type is a compile error. The key cannot override the emitted type: all three
+surfaces are written from the field's declared type because that is the type serde reads and writes,
+and a `serialize_with` names a function whose output the expansion cannot see -- so a target that
+rendered differently would describe a payload serde never produces. `as` also cannot be written
+beside `preprocess`; the two have no defined order.
 
 ### Zod Preprocessing
 
@@ -1121,7 +1139,7 @@ pub struct Event {
 
 By default an `Option<T>` field renders as a required key carrying `| undefined` (`field: T | undefined`). Add the bare `ts_optional` flag to render it as an optional key instead (`field?: T`).
 
-This is a TypeScript-only knob -- the Zod schema and JSON Schema are unchanged (the field is already optional in both). The flag is only valid on `Option<T>` fields; applying it to a non-`Option` field is a compile error. It composes with `as = Type`.
+This is a TypeScript-only knob -- the Zod schema and JSON Schema are unchanged (the field is already optional in both). The flag is only valid on `Option<T>` fields; applying it to a non-`Option` field is a compile error. It composes with `as = Type`, which names the type the field already renders.
 
 ```rust
 #[model_schema()]

--- a/src/features/model_schema_prop.rs
+++ b/src/features/model_schema_prop.rs
@@ -31,6 +31,11 @@ const KNOWN_KEYS: &[&str] = &[
 ///
 /// ## String constraints
 ///
+/// Each applies to a field that renders a plain string — `String`, `str`, `PathBuf`, `Path`, and
+/// those under any number of `Option`, sequence and transparent wrappers. A type whose schema this
+/// crate writes whole (`ObjectId`, the chrono types) renders no bound and reading one is a compile
+/// error rather than a silent drop.
+///
 /// - `pattern = "regex"` — validates the string matches the regex pattern. Must be a regex all
 ///   three engines read the same way; see [`crate::utils::portable_pattern`] for what that rules
 ///   out and what it rewrites.
@@ -62,7 +67,9 @@ const KNOWN_KEYS: &[&str] = &[
 ///
 /// ## Type overrides
 ///
-/// - `as = Type` — override the TypeScript/Zod type emitted for this field.
+/// - `as = Type` — name the type emitted for this field. The target must be the field's own type
+///   or the value under its wrappers (`as = String` on a `Vec<String>`); any other target is a
+///   compile error. Cannot be written beside `preprocess`.
 /// - `literal = "value"` — emit as a string literal type instead of `string`.
 /// - `ts_optional` — for an `Option<T>` field, emit `field?: T` instead of `field: T | undefined` (TypeScript only; a non-`Option` field is a compile error).
 ///
@@ -93,7 +100,9 @@ const KNOWN_KEYS: &[&str] = &[
 #[derive(Clone, Debug, Default)]
 pub struct ModelSchemaPropMeta {
     pub as_number: bool, // DateTime<Tz>: epoch-number + codegen coercer instead of the native Date default
-    pub as_type: Option<String>, // e.g., "String" from as = String
+    /// The type named by `as`, kept as written so the guard that answers for it can build the field
+    /// the target would render and compare that against the field's own.
+    pub as_type: Option<Type>, // e.g., `String` from as = String
     /// The parser's refusal of the attribute — a key it does not read, or a value it cannot read —
     /// spanned on the tokens that earned it.
     pub attr_rejection: Option<syn::Error>,
@@ -137,8 +146,7 @@ pub fn parse_model_schema_prop_attributes(attrs: &[Attribute]) -> ModelSchemaPro
 /// Reads one `key` or `key = value` of a `model_schema_prop` attribute into `meta`.
 fn parse_prop_key(nested: &ParseNestedMeta, meta: &mut ModelSchemaPropMeta) -> syn::Result<()> {
     if nested.path.is_ident("as") {
-        let ty: Type = nested.value()?.parse()?;
-        meta.as_type = Some(quote::quote!(#ty).to_string());
+        meta.as_type = Some(nested.value()?.parse::<Type>()?);
     } else if nested.path.is_ident("literal") {
         let lit: LitStr = nested.value()?.parse()?;
         meta.literal = Some(lit.value());

--- a/src/features/model_schema_prop/tests.rs
+++ b/src/features/model_schema_prop/tests.rs
@@ -15,7 +15,7 @@ fn test_parse_as_type() {
     let attr: Attribute = parse_quote! { #[model_schema_prop(as = String)] };
     let meta = parse_model_schema_prop_attributes(&[attr]);
     assert!(meta.as_type.is_some());
-    assert_eq!(meta.as_type.unwrap(), "String");
+    assert_eq!(meta.as_type.unwrap(), parse_quote!(String));
     assert!(meta.literal.is_none());
     assert!(meta.min_length.is_none());
 }
@@ -35,7 +35,7 @@ fn test_parse_both_as_and_literal() {
     let attr: Attribute = parse_quote! { #[model_schema_prop(as = String, literal = "Tixena")] };
     let meta = parse_model_schema_prop_attributes(&[attr]);
     assert!(meta.as_type.is_some());
-    assert_eq!(meta.as_type.unwrap(), "String");
+    assert_eq!(meta.as_type.unwrap(), parse_quote!(String));
     assert!(meta.literal.is_some());
     assert_eq!(meta.literal.unwrap(), "Tixena");
     assert!(meta.min_length.is_none());
@@ -56,7 +56,7 @@ fn test_parse_as_and_min_length() {
     let attr: Attribute = parse_quote! { #[model_schema_prop(as = String, minLength = 5)] };
     let meta = parse_model_schema_prop_attributes(&[attr]);
     assert!(meta.as_type.is_some());
-    assert_eq!(meta.as_type.unwrap(), "String");
+    assert_eq!(meta.as_type.unwrap(), parse_quote!(String));
     assert!(meta.literal.is_none());
     assert!(meta.min_length.is_some());
     assert_eq!(meta.min_length.unwrap(), 5);
@@ -76,7 +76,7 @@ fn test_parse_both_as_and_ts_optional() {
     let attr: Attribute = parse_quote! { #[model_schema_prop(as = SomeBrand, ts_optional)] };
     let meta = parse_model_schema_prop_attributes(&[attr]);
     assert!(meta.as_type.is_some());
-    assert_eq!(meta.as_type.unwrap(), "SomeBrand");
+    assert_eq!(meta.as_type.unwrap(), parse_quote!(SomeBrand));
     assert!(meta.ts_optional);
 }
 
@@ -93,7 +93,7 @@ fn test_parse_all_attributes() {
         parse_quote! { #[model_schema_prop(as = String, literal = "test", minLength = 3)] };
     let meta = parse_model_schema_prop_attributes(&[attr]);
     assert!(meta.as_type.is_some());
-    assert_eq!(meta.as_type.unwrap(), "String");
+    assert_eq!(meta.as_type.unwrap(), parse_quote!(String));
     assert!(meta.literal.is_some());
     assert_eq!(meta.literal.unwrap(), "test");
     assert!(meta.min_length.is_some());

--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -64,7 +64,11 @@ pub enum VariantKind {
 /// Feature dependencies:
 /// - "`object_id"`: Enables `ObjectId` variant for `MongoDB` support
 /// - Without features, falls back to basic mappings
-#[derive(Clone, Debug)]
+///
+/// Equality is the question `as = Type` asks: do two written types describe the same value on every
+/// surface? The variants a spelling collapses onto answer it — `Path` reaching `String` is the same
+/// type here as `PathBuf` is — and the nested defs answer it through [`FieldDef`]'s own `PartialEq`.
+#[derive(Clone, Debug, PartialEq)]
 pub enum FieldDefType {
     /// Boolean primitive - maps to boolean.
     Boolean,
@@ -187,6 +191,21 @@ pub struct FieldDef {
     pub nullable_levels: Vec<u8>,
     #[cfg(feature = "jsonschema")]
     pub type_span: Span,
+}
+
+/// Two field defs are equal when they describe the same value on every surface: the same type, the
+/// same array levels, the same fixed lengths and the same nullable levels.
+///
+/// What the author wrote *around* the value is left out. A name, a doc comment and a
+/// `model_schema_prop` are the field's, not the type's, and two fields differing only in those
+/// render the same schema — which is exactly the question `as = Type` asks of its target.
+impl PartialEq for FieldDef {
+    fn eq(&self, other: &Self) -> bool {
+        self.array_depth == other.array_depth
+            && self.array_lengths == other.array_lengths
+            && self.nullable_levels == other.nullable_levels
+            && self.field_type == other.field_type
+    }
 }
 
 impl FieldDef {
@@ -345,6 +364,51 @@ impl FieldDef {
             .iter()
             .find(|&&(at, _)| at == level)
             .map(|&(_, length)| length)
+    }
+
+    /// The name of the type this field renders as, when that type's schema is one the crate writes
+    /// whole and a `model_schema_prop` bound has no place in.
+    ///
+    /// Each of these renders a shape fixed here rather than the plain string or number a length, a
+    /// pattern or a range is spelled against: a chrono value as its own ISO spelling, an `ObjectId`
+    /// as the `{"$oid": …}` object serde writes it as. None of the three surfaces reads a bound for
+    /// them and neither does the Rust validator, so a bound written on one reaches nothing; the
+    /// caller turns that into a guard error naming the field instead of dropping it.
+    ///
+    /// Only the field's own rendering is asked about. A map or a tuple holding one of these
+    /// describes its members separately, and a bound on the field around them was never theirs.
+    pub const fn fixed_shape_name(&self) -> Option<&'static str> {
+        match &self.field_type {
+            #[cfg(feature = "object_id")]
+            FieldDefType::ObjectId => Some("ObjectId"),
+            #[cfg(feature = "chrono")]
+            FieldDefType::NaiveDate => Some("chrono::NaiveDate"),
+            #[cfg(feature = "chrono")]
+            FieldDefType::NaiveTime => Some("chrono::NaiveTime"),
+            #[cfg(feature = "chrono")]
+            FieldDefType::NaiveDateTime => Some("chrono::NaiveDateTime"),
+            #[cfg(feature = "chrono")]
+            FieldDefType::DateTime => Some("chrono::DateTime"),
+            FieldDefType::SiblingType(_, _)
+            | FieldDefType::Map(_, _)
+            | FieldDefType::Tuple(_)
+            | FieldDefType::Unknown
+            | FieldDefType::StringLiteral(_)
+            | FieldDefType::Boolean
+            | FieldDefType::String
+            | FieldDefType::U8
+            | FieldDefType::U16
+            | FieldDefType::U32
+            | FieldDefType::U64
+            | FieldDefType::I8
+            | FieldDefType::I16
+            | FieldDefType::I32
+            | FieldDefType::I64
+            | FieldDefType::Usize
+            | FieldDefType::Isize
+            | FieldDefType::F32
+            | FieldDefType::F64 => None,
+        }
     }
 
     #[cfg(feature = "chrono")]
@@ -649,6 +713,20 @@ impl FieldDef {
         } else {
             pre_result
         }
+    }
+
+    /// The value this field's wrappers hold, as a field of its own: the same type with the
+    /// `Option`s and the array levels dropped.
+    ///
+    /// The wrappers are the field's to declare and the value under them is what a type name stands
+    /// for, so this is what an `as = Type` is compared against when the target names a bare type —
+    /// the spelling `as = String` on a `Vec<String>` uses.
+    pub fn value_under_wrappers(&self) -> Self {
+        let mut value = self.clone();
+        value.array_depth = 0;
+        value.array_lengths.clear();
+        value.nullable_levels.clear();
+        value
     }
 
     /// The type match plus one `z.array(…)` per array level, each carrying the `z.nullable(…)` of

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,7 +336,9 @@ pub fn model_schema(args: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// ## Type Overrides
 ///
-/// - `as = Type` — override the TypeScript/Zod type for this field
+/// - `as = Type` — name the type this field renders. The target must be the field's own type or
+///   the value under its wrappers; naming any other type is a compile error, since every surface
+///   is written from the declared type and the expansion has no second reading of the wire.
 /// - `literal = "value"` — emit as a string literal type in TypeScript and Zod
 ///
 /// ```rust

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -4504,8 +4504,14 @@ fn field_json_schema_value(fld: &FieldDef) -> proc_macro2::TokenStream {
 ///
 /// This path builds its field defs directly rather than through [`process_field`], so it runs the
 /// field guards itself. A member renders exactly as a struct field of the same written type does —
-/// a named `Option` in the absent form, a map from its key's members — so each guard it escapes
-/// would be a rendering this position alone is allowed to write.
+/// a named `Option` in the absent form, a map from its key's members, the constraint its
+/// `model_schema_prop` carries — so each guard it escapes would be a rendering this position alone
+/// is allowed to write.
+///
+/// The `model_schema_prop` attribute is read off each member and then stripped, as
+/// [`process_field`] strips it: it is this crate's own and inert to every derive, so a copy left on
+/// the emitted item is one rustc reports as an attribute that does not exist, pointing at the
+/// user's line with a diagnostic naming the wrong macro.
 #[cfg(feature = "serde")]
 fn collect_untagged_members(item_enum: &mut syn::ItemEnum) -> UntaggedMemberData {
     let enum_type_name = item_enum.ident.to_string();
@@ -4525,27 +4531,30 @@ fn collect_untagged_members(item_enum: &mut syn::ItemEnum) -> UntaggedMemberData
                 .as_ref()
                 .map(ToString::to_string)
                 .unwrap_or_default();
+            let prop_meta = parse_model_schema_prop_attributes(&field.attrs);
+            field
+                .attrs
+                .retain(|attr| !attr.path().is_ident("model_schema_prop"));
+
             let mut field_def = get_field_def(&field_name, &field.ty, "");
-            if let Err(err) = check_os_string_field(field, &field_def, &field_label(&field_name)) {
-                guard_errors.push(err.to_compile_error());
-            }
-            #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-            if let Err(err) = check_map_key(field, &field_def, &field_label(&field_name)) {
-                guard_errors.push(err.to_compile_error());
-            }
             let serde_field_meta = parse_serde_field_attributes(&field.attrs);
-            if let Some(rejection) = serde_field_meta.cfg_attr_rejection.as_ref() {
-                guard_errors.push(cfg_attr_guard_error(rejection, &field_label(&field_name)));
-            } else if let Err(err) = check_optional_field_serialization(
+            let serde_guard_errors = field_guard_errors(
                 field,
+                &field_name,
                 field_def.is_optional(),
                 &serde_field_meta,
-            ) {
-                guard_errors.push(err.to_compile_error());
-            } else {
-                // No guard violated by this field.
-            }
+                None,
+            );
+            guard_errors.extend(collect_field_guard_errors(
+                field,
+                &field_def,
+                &field_name,
+                &prop_meta,
+                serde_guard_errors,
+            ));
+
             field_def.resolve_self_references(&enum_type_name);
+            apply_model_schema_prop_meta(&mut field_def, prop_meta, &field_name);
             field_defs.push(field_def);
         }
 
@@ -6807,13 +6816,11 @@ fn field_guard_errors(
 }
 
 /// Every guard error the field violates: the two the written type earns — the `OsString` guard and
-/// the map-key guard, neither of which any attribute can hide — then what the `model_schema_prop`
-/// parser refused, then the unparseable `pattern`, then the serde-side guards when any fired.
+/// the map-key guard, neither of which any attribute can hide — then everything the
+/// `model_schema_prop` attribute earned, then the serde-side guards when any fired.
 ///
-/// Both `model_schema_prop` guards stand under every feature subset: an unread key and an
-/// unparseable `pattern` alike reach the Rust validator, the Zod literal and the JSON schema, and
-/// no toggle makes either one mean anything. The map-key guard stands under every subset that
-/// emits a schema at all, which is the same set the registry it reads is populated under.
+/// The map-key guard stands under every subset that emits a schema at all, which is the same set
+/// the registry it reads is populated under.
 fn collect_field_guard_errors(
     field: &Field,
     field_def: &FieldDef,
@@ -6835,20 +6842,183 @@ fn collect_field_guard_errors(
         .map(|err| err.to_compile_error())
         .into_iter()
         .chain(map_key_error)
-        .chain(
-            prop_meta
-                .attr_rejection
-                .as_ref()
-                .map(|rejection| attr_guard_error(rejection, &label)),
-        )
+        .chain(model_schema_prop_guard_errors(
+            field, field_def, &label, prop_meta,
+        ))
+        .chain(serde_guard_errors)
+        .collect()
+}
+
+/// Every guard the field's `model_schema_prop` attribute earns: what the parser refused, then an
+/// unparseable `pattern`, then a bound written where the type renders none, an `as` naming a type
+/// the field is not written as, and the three misuses the flag validators answer for.
+///
+/// All of them stand under every feature subset. The attribute is read in one place and acted on
+/// nowhere else, so a key that stops at any of these reaches no emitter under any toggle — the
+/// field would be emitted as though the key had been left off, which is the loss each of these
+/// exists to report instead of taking.
+fn model_schema_prop_guard_errors(
+    field: &Field,
+    field_def: &FieldDef,
+    label: &str,
+    prop_meta: &ModelSchemaPropMeta,
+) -> Vec<proc_macro2::TokenStream> {
+    let refusals = [
+        check_fixed_shape_constraints(field, field_def, prop_meta, label).err(),
+        check_as_type_override(field, field_def, prop_meta, label).err(),
+        check_as_preprocess_conflict(field, prop_meta, label).err(),
+        flag_guard_error(
+            field,
+            label,
+            validate_ts_optional_flag(field_def.is_optional(), prop_meta.ts_optional),
+        ),
+        flag_guard_error(
+            field,
+            label,
+            validate_as_number_flag(&field_def.field_type, prop_meta.as_number),
+        ),
+    ];
+
+    prop_meta
+        .attr_rejection
+        .as_ref()
+        .map(|rejection| attr_guard_error(rejection, label))
+        .into_iter()
         .chain(
             prop_meta
                 .pattern_rejection
                 .as_ref()
-                .map(|rejection| pattern_guard_error(rejection, &label)),
+                .map(|rejection| pattern_guard_error(rejection, label)),
         )
-        .chain(serde_guard_errors)
+        .chain(
+            refusals
+                .into_iter()
+                .flatten()
+                .map(|err| err.to_compile_error()),
+        )
         .collect()
+}
+
+/// Turns a flag validator's refusal into a spanned error at the field that carries the flag.
+///
+/// The validator keeps its message: it is the one place the misuse is spelled, and a caller that
+/// re-spells it maintains the same sentence twice.
+fn flag_guard_error(field: &Field, label: &str, result: Result<(), String>) -> Option<syn::Error> {
+    result
+        .err()
+        .map(|message| syn::Error::new_spanned(field, format!("model_schema: {label}: {message}")))
+}
+
+/// The bound keys a `model_schema_prop` meta carries, named as they were written.
+///
+/// A guard that answers for where a bound may sit names the ones it found, so the author is pointed
+/// at the keys to remove rather than at the attribute as a whole.
+fn written_constraint_keys(prop_meta: &ModelSchemaPropMeta) -> Vec<&'static str> {
+    [
+        ("minLength", prop_meta.min_length.is_some()),
+        ("maxLength", prop_meta.max_length.is_some()),
+        ("pattern", prop_meta.pattern.is_some()),
+        ("minimum", prop_meta.minimum.is_some()),
+        ("maximum", prop_meta.maximum.is_some()),
+    ]
+    .into_iter()
+    .filter_map(|(key, written)| written.then_some(key))
+    .collect()
+}
+
+/// Rejects a length, pattern or range written on a field whose schema this crate writes whole.
+///
+/// The types [`FieldDef::fixed_shape_name`] answers for render a shape fixed in this crate rather
+/// than the plain string or number a bound is spelled against, and every surface writes that shape
+/// without ever reading the meta — so the bound is accepted at expansion and reaches nothing, which
+/// leaves the author holding a contract that says the value is checked when nothing checks it.
+fn check_fixed_shape_constraints(
+    field: &Field,
+    field_def: &FieldDef,
+    prop_meta: &ModelSchemaPropMeta,
+    label: &str,
+) -> Result<(), syn::Error> {
+    let Some(name) = field_def.fixed_shape_name() else {
+        return Ok(());
+    };
+    let keys = written_constraint_keys(prop_meta);
+    if keys.is_empty() {
+        return Ok(());
+    }
+    Err(syn::Error::new_spanned(
+        field,
+        format!(
+            "model_schema: {label}: `{}` cannot apply to `{name}` — this crate writes that type's \
+             schema whole, not as the plain string or number a bound is spelled against, and no \
+             surface reads a bound beside it: the constraint would reach neither Zod, nor the JSON \
+             schema, nor the generated validator. Drop it, or carry the value in a `String` field \
+             the bound can measure.",
+            keys.join("`, `")
+        ),
+    ))
+}
+
+/// Rejects an `as = Type` naming anything but the type the field already renders.
+///
+/// Every surface is written from the field's declared type because that is the type serde reads and
+/// writes, and the expansion has no second source for the wire: a `serialize_with` names a function
+/// whose output type a proc macro cannot see. So a target that renders differently asks the schemas
+/// to describe a payload nothing produces, while one that renders the same is already what every
+/// surface emits — the only reading of the key the expansion can stand behind.
+///
+/// The target may name the field itself or the value under its wrappers, an `Option<T>` and a
+/// `Vec<T>` both rendering the `T` the parser collapsed them onto.
+fn check_as_type_override(
+    field: &Field,
+    field_def: &FieldDef,
+    prop_meta: &ModelSchemaPropMeta,
+    label: &str,
+) -> Result<(), syn::Error> {
+    let Some(as_type) = prop_meta.as_type.as_ref() else {
+        return Ok(());
+    };
+    let target = get_field_def(&field_def.name, as_type, "");
+    if *field_def == target || field_def.value_under_wrappers() == target {
+        return Ok(());
+    }
+    let written = quote!(#as_type).to_string();
+    let field_type = &field.ty;
+    let declared = quote!(#field_type).to_string();
+    Err(syn::Error::new_spanned(
+        field,
+        format!(
+            "model_schema: {label}: `as = {written}` names a type the field does not render — it is \
+             written as `{declared}`. The difference cannot be honored: every surface is written \
+             from the declared type, which is the one serde reads and writes, and a \
+             `serialize_with` names a function whose output the expansion cannot see, so emitting \
+             `{written}` here would describe a payload serde never writes. Declare the field as the \
+             type the wire carries, or drop the `as`."
+        ),
+    ))
+}
+
+/// Rejects `as` and `preprocess` written on the same field.
+///
+/// `as` names the type the surfaces render and `preprocess` wraps the schema that rendering
+/// produced; this crate defines no order between them, so a field carrying both says nothing
+/// either surface can act on.
+fn check_as_preprocess_conflict(
+    field: &Field,
+    prop_meta: &ModelSchemaPropMeta,
+    label: &str,
+) -> Result<(), syn::Error> {
+    if prop_meta.as_type.is_none() || prop_meta.preprocess.is_empty() {
+        return Ok(());
+    }
+    Err(syn::Error::new_spanned(
+        field,
+        format!(
+            "model_schema: {label}: `as` and `preprocess` cannot be written on the same field — \
+             `as` names the type the surfaces render and `preprocess` wraps the schema that \
+             rendering produced, and this crate defines no order between the two. Write one or the \
+             other."
+        ),
+    ))
 }
 
 /// Rejects a field that reaches an `OsString`/`OsStr`, at any depth.
@@ -6908,12 +7078,6 @@ fn process_field(
 
     // Parse model_schema_prop attributes before filtering them out
     let model_schema_prop_meta = parse_model_schema_prop_attributes(&field.attrs);
-
-    // Validate: cannot use both `as` and `preprocess` on the same field
-    assert!(
-        model_schema_prop_meta.as_type.is_none() || model_schema_prop_meta.preprocess.is_empty(),
-        "Cannot use both `as` and `preprocess` on the same field in model_schema_prop"
-    );
 
     // Filter out model_schema_prop attributes, and optionally inject serde deserialize_with
     for attr in &field.attrs {
@@ -6975,48 +7139,7 @@ fn process_field(
         serde_guard_errors,
     );
 
-    field_def.model_schema_prop_meta = (model_schema_prop_meta.as_type.is_some()
-        || model_schema_prop_meta.literal.is_some()
-        || model_schema_prop_meta.min_length.is_some()
-        || model_schema_prop_meta.max_length.is_some()
-        || model_schema_prop_meta.pattern.is_some()
-        || model_schema_prop_meta.minimum.is_some()
-        || model_schema_prop_meta.maximum.is_some()
-        || model_schema_prop_meta.ts_optional
-        || model_schema_prop_meta.as_number
-        || !model_schema_prop_meta.preprocess.is_empty())
-    .then_some(model_schema_prop_meta);
-
-    let ts_optional_flag = field_def
-        .model_schema_prop_meta
-        .as_ref()
-        .is_some_and(|m| m.ts_optional);
-    // A failed assert here surfaces as a compile error at macro-expansion time.
-    assert!(
-        validate_ts_optional_flag(field_def.is_optional(), ts_optional_flag).is_ok(),
-        "#[model_schema_prop(ts_optional)] requires an Option<T> field on field `{final_name}`"
-    );
-
-    let as_number_flag = field_def
-        .model_schema_prop_meta
-        .as_ref()
-        .is_some_and(|m| m.as_number);
-    assert!(
-        validate_as_number_flag(&field_def.field_type, as_number_flag).is_ok(),
-        "#[model_schema_prop(as_number)] requires a chrono DateTime<Tz> field on field `{final_name}`"
-    );
-
-    // Apply type overrides based on model_schema_prop attributes
-    if let Some(meta) = &field_def.model_schema_prop_meta
-        && let Some(literal) = &meta.literal
-    {
-        // If literal is specified, override the field type to StringLiteral
-        field_def.field_type = FieldDefType::StringLiteral(literal.clone());
-    }
-    // TODO: Handle `as` parameter for type overrides in future implementation
-
-    // Update field docs to include length/range constraint information
-    apply_constraint_docs(&mut field_def, &final_name);
+    apply_model_schema_prop_meta(&mut field_def, model_schema_prop_meta, &final_name);
 
     (field_def, validation_fn, validate_body, guard_errors)
 }
@@ -7143,6 +7266,42 @@ fn generate_field_validation(
         Some(validation_code.validate_body),
         None,
     )
+}
+
+/// Hands the field the `model_schema_prop` metadata the surfaces read it back off, and applies the
+/// one key that names the type rather than constrains it.
+///
+/// A meta carrying nothing is not attached at all: the surfaces ask whether the field has one
+/// before reading it, so an empty meta and no meta would have to render the same, and only one of
+/// the two can be checked. `literal` is applied here rather than in a renderer because all three
+/// surfaces render the literal type, not the written one.
+///
+/// Every path that builds a field def runs this, so a member of an untagged variant carries its
+/// attribute exactly as the same field written in a tagged one does.
+fn apply_model_schema_prop_meta(
+    field_def: &mut FieldDef,
+    prop_meta: ModelSchemaPropMeta,
+    final_name: &str,
+) {
+    field_def.model_schema_prop_meta = (prop_meta.as_type.is_some()
+        || prop_meta.literal.is_some()
+        || prop_meta.min_length.is_some()
+        || prop_meta.max_length.is_some()
+        || prop_meta.pattern.is_some()
+        || prop_meta.minimum.is_some()
+        || prop_meta.maximum.is_some()
+        || prop_meta.ts_optional
+        || prop_meta.as_number
+        || !prop_meta.preprocess.is_empty())
+    .then_some(prop_meta);
+
+    if let Some(meta) = &field_def.model_schema_prop_meta
+        && let Some(literal) = &meta.literal
+    {
+        field_def.field_type = FieldDefType::StringLiteral(literal.clone());
+    }
+
+    apply_constraint_docs(field_def, final_name);
 }
 
 /// Appends length/range constraint information to a field's generated docs.

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -388,6 +388,92 @@ fn untagged_member_reaching_a_map_key_with_no_members_is_refused() {
     }
 }
 
+/// A member's `model_schema_prop` reaches the surfaces exactly as the same field written in a
+/// tagged variant does — the constraint was previously refused by rustc as an attribute that does
+/// not exist, the untagged walk never having read or stripped it.
+#[cfg(all(feature = "serde", feature = "zod"))]
+#[test]
+fn untagged_member_carries_its_constraint_to_the_surfaces() {
+    let mut item: syn::ItemEnum = syn::parse_quote! {
+        enum Choice {
+            Named {
+                #[model_schema_prop(minLength = 2, pattern = "^[a-z]+$")]
+                name: String,
+            },
+        }
+    };
+    let (_, zod_parts, _, errors) = collect_untagged_members(&mut item);
+    assert!(errors.is_empty(), "got: {errors:?}");
+    assert!(
+        zod_parts[0].contains("z.string().min(2).check(z.regex(/^[a-z]+$/))"),
+        "got: {}",
+        zod_parts[0]
+    );
+}
+
+/// The attribute is stripped off the member the way [`super::process_field`] strips it off a struct
+/// field: it is this crate's own and inert to every derive, so a copy left on the emitted item is
+/// one rustc reports as an attribute that does not exist.
+#[cfg(feature = "serde")]
+#[test]
+fn untagged_member_prop_attribute_is_stripped_from_the_emitted_item() {
+    let mut item: syn::ItemEnum = syn::parse_quote! {
+        enum Choice {
+            Named {
+                #[model_schema_prop(minLength = 2)]
+                #[serde(rename = "label")]
+                name: String,
+            },
+        }
+    };
+    collect_untagged_members(&mut item);
+    let attrs = &item.variants[0].fields.iter().next().unwrap().attrs;
+    assert!(
+        !attrs
+            .iter()
+            .any(|attr| attr.path().is_ident("model_schema_prop")),
+        "got: {}",
+        quote::quote!(#(#attrs)*)
+    );
+    assert!(
+        attrs.iter().any(|attr| attr.path().is_ident("serde")),
+        "the serde attribute must survive the strip"
+    );
+}
+
+/// The whole `model_schema_prop` guard chain reaches this position too, so a member's misspelled
+/// key is named where it was written instead of emitting an unconstrained member.
+#[cfg(feature = "serde")]
+#[test]
+fn untagged_member_prop_guards_apply() {
+    for (member, needle) in [
+        (
+            quote::quote! { #[model_schema_prop(patern = "^[a-z]+$")] name: String },
+            "patern",
+        ),
+        (
+            quote::quote! { #[model_schema_prop(ts_optional)] name: String },
+            "requires an Option<T> field",
+        ),
+        (
+            quote::quote! { #[model_schema_prop(as = String)] name: u64 },
+            "as = String",
+        ),
+    ] {
+        let errors = untagged_guard_errors(syn::parse_quote! {
+            enum Choice {
+                Named { #member },
+            }
+        });
+        assert_eq!(errors.len(), 1, "for {member}: {errors:?}");
+        assert!(
+            errors[0].contains(needle),
+            "{needle} missing for {member}: {}",
+            errors[0]
+        );
+    }
+}
+
 /// The guard turns away only what the registry proves has no members: a member keyed by a plain
 /// enum, or by a `String`, keeps the variant it had.
 #[cfg(all(
@@ -1064,6 +1150,181 @@ fn a_refused_key_and_an_unparseable_pattern_are_both_reported() {
         "got: {}",
         errors[1]
     );
+}
+
+/// The types whose schema this crate writes whole read no bound off the meta, on any surface, so a
+/// bound written on one is refused where it is written instead of accepted and dropped.
+#[cfg(feature = "chrono")]
+#[test]
+fn a_bound_on_a_chrono_field_is_refused() {
+    for (constraint, key) in [
+        (quote::quote! { minLength = 30 }, "minLength"),
+        (quote::quote! { maxLength = 30 }, "maxLength"),
+        (quote::quote! { pattern = "^[0-9-]+$" }, "pattern"),
+        (quote::quote! { minimum = 5 }, "minimum"),
+        (quote::quote! { maximum = 5 }, "maximum"),
+    ] {
+        for field_type in [
+            quote::quote! { chrono::NaiveDate },
+            quote::quote! { Option<chrono::NaiveTime> },
+            quote::quote! { Vec<chrono::NaiveDateTime> },
+            quote::quote! { chrono::DateTime<chrono::Utc> },
+        ] {
+            let errors = field_prop_guard_errors(&syn::parse_quote! {
+                struct Report {
+                    #[model_schema_prop(#constraint)]
+                    when: #field_type,
+                }
+            });
+            assert_eq!(errors.len(), 1, "for {key} on {field_type}: {errors:?}");
+            for needle in ["compile_error", "field `when`", key, "chrono::"] {
+                assert!(
+                    errors[0].contains(needle),
+                    "{needle} missing for {key} on {field_type}: {}",
+                    errors[0]
+                );
+            }
+        }
+    }
+}
+
+/// An `ObjectId` writes an object, not the string a length or a pattern measures, so it answers as
+/// the chrono types do.
+#[cfg(feature = "object_id")]
+#[test]
+fn a_bound_on_an_object_id_field_is_refused() {
+    let errors = field_prop_guard_errors(&syn::parse_quote! {
+        struct Report {
+            #[model_schema_prop(minLength = 30, pattern = "^[a-f]+$")]
+            id: ObjectId,
+        }
+    });
+    assert_eq!(errors.len(), 1, "got: {errors:?}");
+    for needle in [
+        "compile_error",
+        "field `id`",
+        "minLength",
+        "pattern",
+        "ObjectId",
+    ] {
+        assert!(
+            errors[0].contains(needle),
+            "{needle} missing: {}",
+            errors[0]
+        );
+    }
+}
+
+/// A chrono or `ObjectId` field carrying no bound must not acquire one of these errors, and neither
+/// must the keys that name the type rather than constrain the value.
+#[cfg(all(feature = "chrono", feature = "object_id"))]
+#[test]
+fn a_fixed_shape_field_without_a_bound_is_left_alone() {
+    for field in [
+        quote::quote! { when: chrono::NaiveDate },
+        quote::quote! { #[model_schema_prop(as_number)] when: chrono::DateTime<chrono::Utc> },
+        quote::quote! { #[model_schema_prop(preprocess = ["trim"])] when: chrono::NaiveDate },
+        quote::quote! { id: ObjectId },
+    ] {
+        let errors = field_prop_guard_errors(&syn::parse_quote! {
+            struct Report {
+                #field
+            }
+        });
+        assert!(errors.is_empty(), "for {field}: {errors:?}");
+    }
+}
+
+/// `as` names the type the field already renders or it names nothing the expansion can honor: the
+/// surfaces are written from the declared type, and no second reading of the wire exists here.
+#[test]
+fn an_as_naming_another_type_is_refused() {
+    let errors = field_prop_guard_errors(&syn::parse_quote! {
+        struct Report {
+            #[model_schema_prop(as = String)]
+            id: u64,
+        }
+    });
+    assert_eq!(errors.len(), 1, "got: {errors:?}");
+    for needle in ["compile_error", "field `id`", "as = String", "u64"] {
+        assert!(
+            errors[0].contains(needle),
+            "{needle} missing: {}",
+            errors[0]
+        );
+    }
+}
+
+/// The target may name the field itself or the value under its wrappers — the two readings the
+/// shipped uses of the key are written in — and neither is an override of anything.
+#[test]
+fn an_as_naming_the_rendered_type_is_accepted() {
+    for field in [
+        quote::quote! { #[model_schema_prop(as = String)] name: String },
+        quote::quote! { #[model_schema_prop(as = String)] name: Option<String> },
+        quote::quote! { #[model_schema_prop(as = String)] name: Vec<String> },
+        quote::quote! { #[model_schema_prop(as = Vec<String>)] name: Vec<String> },
+        quote::quote! { #[model_schema_prop(as = Inner)] name: Option<Inner> },
+        quote::quote! { #[model_schema_prop(as = String)] name: PathBuf },
+    ] {
+        let errors = field_prop_guard_errors(&syn::parse_quote! {
+            struct Report {
+                #field
+            }
+        });
+        assert!(errors.is_empty(), "for {field}: {errors:?}");
+    }
+}
+
+/// The three misuses that aborted expansion with `custom attribute panicked`, spanned on the field
+/// that carries them and carrying the message their validator already spelled.
+#[test]
+fn the_field_prop_misuses_leave_by_the_guard_channel() {
+    for (field, needle) in [
+        (
+            quote::quote! { #[model_schema_prop(ts_optional)] name: String },
+            "requires an Option<T> field",
+        ),
+        (
+            quote::quote! { #[model_schema_prop(as_number)] name: u32 },
+            "requires a chrono DateTime<Tz> field",
+        ),
+        (
+            quote::quote! { #[model_schema_prop(as = String, preprocess = ["trim"])] name: String },
+            "cannot be written on the same field",
+        ),
+    ] {
+        let errors = field_prop_guard_errors(&syn::parse_quote! {
+            struct Report {
+                #field
+            }
+        });
+        assert_eq!(errors.len(), 1, "for {field}: {errors:?}");
+        for expected in ["compile_error", "field `name`", needle] {
+            assert!(
+                errors[0].contains(expected),
+                "{expected} missing for {field}: {}",
+                errors[0]
+            );
+        }
+    }
+}
+
+/// The valid spellings of the same three keys stay valid.
+#[test]
+fn the_field_prop_flags_on_the_shapes_they_fit_are_accepted() {
+    for field in [
+        quote::quote! { #[model_schema_prop(ts_optional)] name: Option<String> },
+        quote::quote! { #[model_schema_prop(preprocess = ["trim"])] name: String },
+        quote::quote! { #[model_schema_prop(as = String, minLength = 1)] name: String },
+    ] {
+        let errors = field_prop_guard_errors(&syn::parse_quote! {
+            struct Report {
+                #field
+            }
+        });
+        assert!(errors.is_empty(), "for {field}: {errors:?}");
+    }
 }
 
 #[cfg(feature = "serde")]

--- a/tests/untagged_tests/tests.rs
+++ b/tests/untagged_tests/tests.rs
@@ -92,6 +92,7 @@ enum KeyedUnion {
 
 // An untagged struct variant carrying a constrained member, beside the same member written in a
 // tagged enum. The two must render the same constrained value.
+#[cfg(any(feature = "zod", feature = "jsonschema"))]
 #[model_schema()]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -102,6 +103,7 @@ enum ConstrainedUnion {
     },
 }
 
+#[cfg(any(feature = "zod", feature = "jsonschema"))]
 #[model_schema()]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "kind")]

--- a/tests/untagged_tests/tests.rs
+++ b/tests/untagged_tests/tests.rs
@@ -87,6 +87,28 @@ enum KeyedUnion {
     Labels { labels: HashMap<String, String> },
 }
 
+// An untagged struct variant carrying a constrained member, beside the same member written in a
+// tagged enum. The two must render the same constrained value.
+#[model_schema()]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+enum ConstrainedUnion {
+    Slug {
+        #[model_schema_prop(minLength = 2, pattern = "^[a-z]+$")]
+        slug: String,
+    },
+}
+
+#[model_schema()]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind")]
+enum ConstrainedTagged {
+    Slug {
+        #[model_schema_prop(minLength = 2, pattern = "^[a-z]+$")]
+        slug: String,
+    },
+}
+
 #[test]
 fn test_untagged_entry_constructible() {
     let entry = DataElementSampleValueEntry {
@@ -417,4 +439,37 @@ fn test_untagged_map_member_keys_json_schema() {
         assert_eq!(branch["properties"][member], serde_json::json!({}));
         assert_eq!(branch["required"], serde_json::json!([member]));
     }
+}
+
+/// The member's constraint reaches Zod in the spelling the tagged twin's does. Before this, the
+/// attribute never reached the macro at all: the untagged walk left it on the emitted item and
+/// rustc refused it as an attribute that does not exist.
+#[test]
+#[cfg(feature = "zod")]
+fn test_untagged_member_constraint_zod() {
+    let expected = "slug: z.string().min(2).check(z.regex(/^[a-z]+$/)),";
+    let untagged = ConstrainedUnion::zod_schema();
+    assert!(untagged.contains(expected), "Got:\n{untagged}");
+    assert!(
+        ConstrainedTagged::zod_schema().contains(expected),
+        "the tagged twin must render the same member"
+    );
+}
+
+/// The same constraint in the JSON schema, keyword for keyword with the tagged twin's.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_untagged_member_constraint_json_schema() {
+    let untagged = ConstrainedUnion::json_schema();
+    let member = &untagged["anyOf"][0]["properties"]["slug"];
+    assert_eq!(
+        *member,
+        serde_json::json!({ "type": "string", "minLength": 2_i32, "pattern": "^[a-z]+$" }),
+        "Got:\n{untagged}"
+    );
+    let tagged = ConstrainedTagged::json_schema();
+    assert_eq!(
+        tagged["oneOf"][0]["properties"]["slug"], *member,
+        "the tagged twin must render the same member"
+    );
 }


### PR DESCRIPTION
Four constraint-handling defects, one contract: every accepted constraint reaches every surface it is meaningful on, every meaningless placement is a spanned refusal, and nothing is silently dropped or panics.

A bound on a chrono or ObjectId field was accepted at expansion and dropped by every surface — those types' schemas are written whole, so the constraint reached neither Zod nor the JSON schema nor the validator while the author held a contract claiming otherwise; such a bound is now refused naming the keys and the type, with the guard reading the field's own classification so it stands in zod-only builds too. Three misuses (ts_optional off an Option, as_number off a DateTime, as beside preprocess) aborted expansion with assert! panics; they now leave by the spanned guard channel, every violating field reported in one expansion. The documented as = Type override never overrode anything — measurement shows serde writes the declared type and a serialize_with names a function whose output the expansion cannot read, so the override is unimplementable without describing payloads nothing writes; as now verifies its target names the type the field already renders (the field itself or the value under its wrappers, the two readings shipped uses employ, compared as built field definitions) and refuses anything else. And an untagged variant's member rejected the attribute outright — the walk never read or stripped it, so rustc refused it as an unknown attribute; the member now runs the full guard chain and renders its constraint exactly as the tagged twin does, pinned keyword-for-keyword on both schema surfaces.

Byte-identity for every untouched placement is proven by a real A/B: both trees built over one probe carrying every untouched placement, 701 lines of output diffed identical. The Rust-side validation gap for untagged members, the three remaining untagged-shape panics, and the still-dropped bounds on map and tuple fields are tracked separately. Full powerset tests and lint-all green on the merged tree with the exit value read before landing.