### PR TITLE
describe a brand's inner honestly on every surface

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -108,6 +108,11 @@ const KNOWN_ARGS: &[&str] = &["name", "pattern", "minLength", "maxLength", "no_d
 const FLATTENED_PLAIN_ENUM_SCOPE: &str = "Only a type the registry has already classified reaches this guard; one it has not keeps its \
      TypeScript and Zod intersection, and is refused by the JSON surface when the merge runs.";
 
+/// The 24-character hex an `ObjectId`'s `$oid` member holds, as a JSON-schema `pattern`. Written
+/// once so no position can describe the same string a different way.
+#[cfg(all(feature = "jsonschema", feature = "object_id"))]
+const OBJECT_ID_HEX_PATTERN: &str = r"^[a-f\d]{24}$";
+
 /// One variant of a discriminated enum, carrying everything its union member is rendered from.
 struct DiscriminatedVariant {
     discriminator_value: String,
@@ -209,6 +214,10 @@ enum BrandedComposite {
 /// The JSON schema shape a branded newtype's inner field describes.
 #[cfg(feature = "jsonschema")]
 enum BrandedJsonInner {
+    /// The string a chrono type writes, named by the `"format"` keyword that says which instant it
+    /// spells — the one field position carries for the same type.
+    #[cfg(feature = "chrono")]
+    Chrono(&'static str),
     /// The `$oid` object an `ObjectId` writes, whose hex member carries the brand's string
     /// constraints.
     #[cfg(feature = "object_id")]
@@ -219,6 +228,25 @@ enum BrandedJsonInner {
     /// wherever else it is written. Boxed so the whole field def does not set the size of an enum
     /// whose other shapes are a type name and a unit.
     Slot(Box<FieldDef>),
+}
+
+/// Whether the schema a brand narrows already states a `pattern` of its own.
+///
+/// One JSON Schema string carries one `pattern` keyword, so where the inner type states the one
+/// every payload it writes already satisfies, the brand's cannot be written over it — the type's
+/// own would be gone, and the surface would admit strings the value can never hold. The brand's
+/// narrows from inside an `allOf` beside it instead, where a payload has to match both. That is
+/// what the Zod side already does: the type's own check runs, and the brand's runs after it.
+///
+/// The `$oid` object's hex member is the one base that states a pattern, so without the type that
+/// writes it there is no such base to narrow — which is what the gate on `Stated` says.
+#[cfg(feature = "jsonschema")]
+#[derive(Clone, Copy)]
+enum BasePattern {
+    /// The base states none, so the brand's is the schema's own `pattern` keyword.
+    Absent,
+    #[cfg(feature = "object_id")]
+    Stated,
 }
 
 /// What a field bottoms out in, under the wrappers it was written beneath.
@@ -1180,6 +1208,8 @@ fn branded_option_inner_error(
 /// A `SiblingType` inner — another brand, an unresolved user type, or a bare generic parameter —
 /// is admitted, because expansion cannot know its shape. That is why the constrained path asserts
 /// `Display` separately: the guard bounds the schema surfaces, the assertion bounds the Rust one.
+/// A sequence wrapper is the one `SiblingType` spelling that says its shape outright, and is
+/// refused as the array it is.
 ///
 /// Resolved through the same `get_field_def` call the renderers make, so the guard and the
 /// contract cannot disagree about what a shape is.
@@ -1216,9 +1246,16 @@ fn branded_constraint_inner_error(
 /// An `ObjectId` answers `None` on that reading rather than on its schema's shape: it writes the
 /// `$oid` object, whose single hex member is both what `Display` renders and where every surface
 /// puts the checks.
+///
+/// A sequence is asked for through the two spellings it reaches here as — the array levels the
+/// parser collapses a `Vec` or a `[T; N]` onto, and the wrapper name it keeps for a `BTreeSet` and
+/// its siblings — because both write the same JSON array, and every renderer already reads them as
+/// one. Reading only the first would let the second escape with the constraints reinterpreted: the
+/// JSON schema drops `minLength` outside a string, while Zod's `.min` on an array is a bound on
+/// how many items it holds rather than on how long any string is.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-const fn non_string_inner_shape(inner: &FieldDef) -> Option<&'static str> {
-    if inner.is_array() {
+fn non_string_inner_shape(inner: &FieldDef) -> Option<&'static str> {
+    if inner.is_array() || sequence_wrapper_element(inner).is_some() {
         return Some("container");
     }
     match &inner.field_type {
@@ -1982,12 +2019,18 @@ fn branded_checked_value(
     }
 }
 
-/// Builds the string schema a branded newtype's constraints are written into: `type_name` as the
-/// `"type"`, then one insert per constraint the brand declares.
+/// Builds the schema a branded newtype's constraints are written into: `base_inserts` first — what
+/// the inner type describes as before the brand narrows it — then one insert per constraint the
+/// brand declares.
+///
+/// A length keyword is the brand's alone, so it is written beside the base. A `pattern` is only the
+/// brand's where the base states none; `base_pattern` is what says which, and where the base states
+/// one the brand's is layered rather than written over it.
 #[cfg(feature = "jsonschema")]
-fn branded_constrained_schema_obj(
+fn branded_schema_obj_over(
     args: &ModelSchemaArgs,
-    type_name: &str,
+    base_inserts: &proc_macro2::TokenStream,
+    base_pattern: BasePattern,
 ) -> proc_macro2::TokenStream {
     let mut constraint_inserts: Vec<proc_macro2::TokenStream> = Vec::new();
 
@@ -2002,19 +2045,74 @@ fn branded_constrained_schema_obj(
         });
     }
     if let Some(pattern) = &args.pattern {
-        constraint_inserts.push(quote! {
-            schema_obj.insert("pattern".to_string(), serde_json::Value::String(#pattern.to_string()));
+        constraint_inserts.push(match base_pattern {
+            BasePattern::Absent => quote! {
+                schema_obj.insert("pattern".to_string(), serde_json::Value::String(#pattern.to_string()));
+            },
+            #[cfg(feature = "object_id")]
+            BasePattern::Stated => quote! {
+                schema_obj.insert("allOf".to_string(), serde_json::json!([{ "pattern": #pattern }]));
+            },
         });
     }
 
     quote! {
         {
             let mut schema_obj = serde_json::Map::new();
-            schema_obj.insert("type".to_string(), serde_json::Value::String(#type_name.to_string()));
+            #base_inserts
             #(#constraint_inserts)*
             serde_json::Value::Object(schema_obj)
         }
     }
+}
+
+/// Builds the string schema a branded newtype's constraints are written into: `type_name` as the
+/// `"type"`, then one insert per constraint the brand declares.
+#[cfg(feature = "jsonschema")]
+fn branded_constrained_schema_obj(
+    args: &ModelSchemaArgs,
+    type_name: &str,
+) -> proc_macro2::TokenStream {
+    branded_schema_obj_over(
+        args,
+        &quote! {
+            schema_obj.insert("type".to_string(), serde_json::Value::String(#type_name.to_string()));
+        },
+        BasePattern::Absent,
+    )
+}
+
+/// The string a chrono-typed inner writes, carrying the `"format"` keyword [`chrono_json_schema_format`]
+/// gives that type — the one field position carries for it — and narrowed by the brand's own
+/// constraints, which sit beside `type` and `format` the way they sit beside `type` alone.
+#[cfg(all(feature = "jsonschema", feature = "chrono"))]
+fn branded_chrono_schema(args: &ModelSchemaArgs, format: &str) -> proc_macro2::TokenStream {
+    branded_schema_obj_over(
+        args,
+        &quote! {
+            schema_obj.insert("type".to_string(), serde_json::Value::String("string".to_string()));
+            schema_obj.insert("format".to_string(), serde_json::Value::String(#format.to_string()));
+        },
+        BasePattern::Absent,
+    )
+}
+
+/// The `$oid` member an `ObjectId` brand carries: the hex string the type always holds, narrowed by
+/// the brand's own constraints, so a brand that declares none still describes the hex the type it
+/// wraps describes wherever else it is written.
+///
+/// The hex is the base's own `pattern`, which is why the brand's is layered beside it rather than
+/// written over it — see [`BasePattern`].
+#[cfg(all(feature = "jsonschema", feature = "object_id"))]
+fn branded_object_id_hex_schema(args: &ModelSchemaArgs) -> proc_macro2::TokenStream {
+    branded_schema_obj_over(
+        args,
+        &quote! {
+            schema_obj.insert("type".to_string(), serde_json::Value::String("string".to_string()));
+            schema_obj.insert("pattern".to_string(), serde_json::Value::String(#OBJECT_ID_HEX_PATTERN.to_string()));
+        },
+        BasePattern::Stated,
+    )
 }
 
 /// The description a brand carries for an inner no `"type"` keyword names: the one the slot
@@ -2022,19 +2120,52 @@ fn branded_constrained_schema_obj(
 /// it is written. An inner the dispatch cannot render replaces the body with the single diagnostic
 /// naming the brand, as an unrenderable slot does in every other position.
 ///
-/// The brand's own constraints are not written beside it. [`branded_constraint_inner_error`]
-/// refuses them over an array, a map, a tuple, and an opaque inner, so there is nothing to write —
-/// except through the one spelling that guard reads as a name rather than as the array it writes,
-/// a sequence wrapper, where they were being written onto a `"type": "string"` describing no value
-/// the type can hold.
+/// The brand's own constraints are layered around that description rather than written into it.
+/// [`branded_constraint_inner_error`] refuses them over an array, a sequence wrapper, a map, a
+/// tuple, and an opaque inner, so the one inner reaching here with any is a named type — whose
+/// description is an expression this expansion cannot read, and may be a reference into the
+/// document's definitions, which carries no keyword beside it. An `allOf` narrows either without
+/// touching it, and is what the Zod value already writes: the named schema, then the brand's own
+/// checks after it.
 #[cfg(feature = "jsonschema")]
-fn branded_slot_json_schema(inner: &FieldDef, def_name: &str) -> proc_macro2::TokenStream {
+fn branded_slot_json_schema(
+    args: &ModelSchemaArgs,
+    inner: &FieldDef,
+    def_name: &str,
+) -> proc_macro2::TokenStream {
     match build_tuple_element_json_schema(inner) {
-        Ok(value) => value,
+        Ok(value) => branded_layered_over(args, &value),
         Err(rejection) => {
             let message = map_member_rejection_message(&format!("`{def_name}`"), &rejection);
             quote! { compile_error!(#message) }
         }
+    }
+}
+
+/// `described` narrowed by the brand's own constraints from inside an `allOf`, or `described` alone
+/// when the brand declares none.
+#[cfg(feature = "jsonschema")]
+fn branded_layered_over(
+    args: &ModelSchemaArgs,
+    described: &proc_macro2::TokenStream,
+) -> proc_macro2::TokenStream {
+    let mut narrowing: Vec<proc_macro2::TokenStream> = Vec::new();
+    if let Some(min_len) = args.min_length {
+        let len = min_len as u64;
+        narrowing.push(quote! { "minLength": #len });
+    }
+    if let Some(max_len) = args.max_length {
+        let len = max_len as u64;
+        narrowing.push(quote! { "maxLength": #len });
+    }
+    if let Some(pattern) = &args.pattern {
+        narrowing.push(quote! { "pattern": #pattern });
+    }
+    if narrowing.is_empty() {
+        return described.clone();
+    }
+    quote! {
+        serde_json::json!({ "allOf": [#described, { #(#narrowing),* }] })
     }
 }
 
@@ -2046,12 +2177,14 @@ fn build_branded_json_schema_method(
     def_name: &str,
 ) -> proc_macro2::TokenStream {
     let body = match json_inner {
+        #[cfg(feature = "chrono")]
+        BrandedJsonInner::Chrono(format) => branded_chrono_schema(args, format),
         BrandedJsonInner::Scalar(type_name) => branded_constrained_schema_obj(args, type_name),
         #[cfg(feature = "object_id")]
         BrandedJsonInner::ObjectId => {
-            object_id_json_schema_value(&branded_constrained_schema_obj(args, "string"))
+            object_id_json_schema_value(&branded_object_id_hex_schema(args))
         }
-        BrandedJsonInner::Slot(inner) => branded_slot_json_schema(inner, def_name),
+        BrandedJsonInner::Slot(inner) => branded_slot_json_schema(args, inner, def_name),
     };
     json_schema_methods(def_name, &body)
 }
@@ -2094,10 +2227,15 @@ fn branded_ts_type_and_generics(
 
 /// Resolves the JSON schema shape for a branded newtype's inner field.
 ///
-/// For generic newtypes this is always `"string"` (mirrors the Zod logic). An `ObjectId` and a
-/// composite are read off their own `FieldDef`, because neither writes a value one `"type"`
-/// keyword describes; every remaining non-generic inner maps from the resolved TypeScript type
-/// name.
+/// For generic newtypes this is always `"string"` (mirrors the Zod logic). An `ObjectId`, a
+/// composite and a named type are read off their own `FieldDef`, because none of them writes a
+/// value one `"type"` keyword describes; a chrono type writes a string one keyword names but not
+/// the only one it carries. Every remaining non-generic inner maps from the resolved TypeScript
+/// type name.
+///
+/// The composite question is asked before the other two, so an inner written under array levels
+/// answers for the array around whatever it holds — which is what `#[serde(transparent)]` puts on
+/// the wire — rather than for the item.
 #[cfg(feature = "jsonschema")]
 fn branded_json_inner(is_generic: bool, inner_ty: &syn::Type) -> BrandedJsonInner {
     if is_generic {
@@ -2109,6 +2247,16 @@ fn branded_json_inner(is_generic: bool, inner_ty: &syn::Type) -> BrandedJsonInne
         return BrandedJsonInner::ObjectId;
     }
     if branded_inner_composite(&inner).is_some() {
+        return BrandedJsonInner::Slot(Box::new(inner));
+    }
+    #[cfg(feature = "chrono")]
+    if let Some(format) = chrono_json_schema_format(&inner.field_type) {
+        return BrandedJsonInner::Chrono(format);
+    }
+    // A name is not a shape, so it is not described here at all: it is deferred to the type it
+    // names, through the reference every other position defers it through — which is what makes a
+    // forward declaration and a cycle behave for a brand as they behave for a field.
+    if matches!(inner.field_type, FieldDefType::SiblingType(..)) {
         return BrandedJsonInner::Slot(Box::new(inner));
     }
     BrandedJsonInner::Scalar(match inner.typescript_typename().as_str() {
@@ -2226,6 +2374,12 @@ fn branded_zod_inner(args: &ModelSchemaArgs, is_generic: bool, inner_ty: &syn::T
 ///
 /// Each name is the class bare, as `ZodObject` is: every one of them defaults its type parameters,
 /// so the annotation widens the raw schema rather than restating its element types.
+///
+/// A named inner has no class of its own to name — the type it names publishes one, and this
+/// expansion cannot resolve it — so the annotation is the type of the very binding the value is
+/// composed from, read back off that same rendering. A check the brand adds returns the schema it
+/// was called on, so the binding's type is the base schema's type whether or not the brand
+/// constrains it.
 #[cfg(all(feature = "zod", feature = "typescript"))]
 fn branded_zod_type_name(is_generic: bool, inner_ty: &syn::Type) -> String {
     if is_generic {
@@ -2243,6 +2397,11 @@ fn branded_zod_type_name(is_generic: bool, inner_ty: &syn::Type) -> String {
             BrandedComposite::Opaque => "ZodUnknown".to_owned(),
             BrandedComposite::Tuple => "ZodTuple".to_owned(),
         };
+    }
+    if let FieldDefType::SiblingType(_, args) = &inner.field_type
+        && args.is_empty()
+    {
+        return format!("typeof {}", inner.zod_type());
     }
     match inner.typescript_typename().as_str() {
         "number" => "ZodNumber".to_owned(),
@@ -4489,16 +4648,13 @@ fn field_json_schema_value(fld: &FieldDef) -> proc_macro2::TokenStream {
             })
         },
         #[cfg(feature = "chrono")]
-        FieldDefType::NaiveDate => {
-            quote! { serde_json::json!({ "type": "string", "format": "date" }) }
-        }
-        #[cfg(feature = "chrono")]
-        FieldDefType::NaiveTime => {
-            quote! { serde_json::json!({ "type": "string", "format": "time" }) }
-        }
-        #[cfg(feature = "chrono")]
-        FieldDefType::NaiveDateTime | FieldDefType::DateTime => {
-            quote! { serde_json::json!({ "type": "string", "format": "date-time" }) }
+        FieldDefType::NaiveDate
+        | FieldDefType::NaiveTime
+        | FieldDefType::NaiveDateTime
+        | FieldDefType::DateTime => {
+            // The arm has matched exactly the types the mapping answers for.
+            let item = chrono_json_schema_item(&fld.field_type).unwrap();
+            quote! { serde_json::json!(#item) }
         }
         // Map / Tuple / Unknown inner shapes are out of scope for v1 untagged members;
         // emit a permissive empty schema rather than silently mis-typing.
@@ -5133,6 +5289,55 @@ fn fixed_length_json_schema_bounds(fld: &FieldDef, level: u8) -> proc_macro2::To
     )
 }
 
+/// Which instant a chrono type's string spells, as the JSON-schema `"format"` keyword that names
+/// it, and `None` for every type that writes no such string.
+///
+/// Written once so no position can name the same instant a different way: the field, the slot and
+/// the branded path all read this one mapping, where each of them used to spell the keyword itself
+/// — and the branded path, reaching the string through the TypeScript name every chrono type
+/// shares with `String`, spelled nothing at all.
+///
+/// Named exhaustively rather than caught by a wildcard: a new variant must be classified, not
+/// silently answered for.
+#[cfg(all(feature = "jsonschema", feature = "chrono"))]
+const fn chrono_json_schema_format(field_type: &FieldDefType) -> Option<&'static str> {
+    match *field_type {
+        FieldDefType::NaiveDate => Some("date"),
+        FieldDefType::NaiveTime => Some("time"),
+        FieldDefType::NaiveDateTime | FieldDefType::DateTime => Some("date-time"),
+        FieldDefType::Boolean
+        | FieldDefType::F32
+        | FieldDefType::F64
+        | FieldDefType::I8
+        | FieldDefType::I16
+        | FieldDefType::I32
+        | FieldDefType::I64
+        | FieldDefType::Isize
+        | FieldDefType::Map(..)
+        | FieldDefType::SiblingType(..)
+        | FieldDefType::String
+        | FieldDefType::StringLiteral(_)
+        | FieldDefType::Tuple(..)
+        | FieldDefType::U8
+        | FieldDefType::U16
+        | FieldDefType::U32
+        | FieldDefType::U64
+        | FieldDefType::Unknown
+        | FieldDefType::Usize => None,
+        #[cfg(feature = "object_id")]
+        FieldDefType::ObjectId => None,
+    }
+}
+
+/// The JSON schema literal a chrono type describes as — the string it writes, carrying the
+/// `"format"` keyword that says which instant it spells — and `None` for every type that writes no
+/// such string.
+#[cfg(all(feature = "jsonschema", feature = "chrono"))]
+fn chrono_json_schema_item(field_type: &FieldDefType) -> Option<proc_macro2::TokenStream> {
+    let format = chrono_json_schema_format(field_type)?;
+    Some(quote! { { "type": "string", "format": #format } })
+}
+
 /// The JSON schema literal for a type that renders inline as a scalar — the object body itself,
 /// which a caller writing inside a `serde_json::json!` inlines and one needing a standalone
 /// `serde_json::Value` wraps — or `None` for the composite types (sibling references, maps,
@@ -5160,17 +5365,10 @@ fn scalar_field_json_schema_item(fld: &FieldDef) -> Option<proc_macro2::TokenStr
         FieldDefType::F32 | FieldDefType::F64 => quote! { { "type": "number" } },
         FieldDefType::Boolean => quote! { { "type": "boolean" } },
         #[cfg(feature = "chrono")]
-        FieldDefType::NaiveDate => {
-            quote! { { "type": "string", "format": "date" } }
-        }
-        #[cfg(feature = "chrono")]
-        FieldDefType::NaiveTime => {
-            quote! { { "type": "string", "format": "time" } }
-        }
-        #[cfg(feature = "chrono")]
-        FieldDefType::NaiveDateTime | FieldDefType::DateTime => {
-            quote! { { "type": "string", "format": "date-time" } }
-        }
+        FieldDefType::NaiveDate
+        | FieldDefType::NaiveTime
+        | FieldDefType::NaiveDateTime
+        | FieldDefType::DateTime => chrono_json_schema_item(&fld.field_type)?,
         #[cfg(feature = "object_id")]
         FieldDefType::ObjectId => quote! { {
             "type": "object",
@@ -6054,12 +6252,18 @@ fn object_id_json_schema_value(hex_schema: &proc_macro2::TokenStream) -> proc_ma
     }
 }
 
+/// The hex string an `ObjectId`'s `$oid` member holds, where no brand narrows it further.
+#[cfg(all(feature = "jsonschema", feature = "object_id"))]
+fn object_id_hex_json_schema() -> proc_macro2::TokenStream {
+    quote! { serde_json::json!({ "type": "string", "pattern": #OBJECT_ID_HEX_PATTERN }) }
+}
+
 /// Builds the JSON schema for a `MongoDB` `ObjectId` field (`{ "$oid": string }`).
 #[cfg(all(feature = "jsonschema", feature = "object_id"))]
 fn build_object_id_field_schema(fld: &FieldDef, field_name_str: &str) -> proc_macro2::TokenStream {
     let schema = arrayed_json_schema_value(
         fld,
-        object_id_json_schema_value(&quote! { serde_json::json!({ "type": "string" }) }),
+        object_id_json_schema_value(&object_id_hex_json_schema()),
     );
     quote! {
         properties.insert(#field_name_str.to_string(), { #schema });
@@ -6152,16 +6356,13 @@ fn build_field_type_schema(fld: &FieldDef, field_name_str: &str) -> proc_macro2:
         #[cfg(feature = "object_id")]
         FieldDefType::ObjectId => build_object_id_field_schema(fld, field_name_str),
         #[cfg(feature = "chrono")]
-        FieldDefType::NaiveDate => build_string_format_field_schema(fld, field_name_str, "date"),
-        #[cfg(feature = "chrono")]
-        FieldDefType::NaiveTime => build_string_format_field_schema(fld, field_name_str, "time"),
-        #[cfg(feature = "chrono")]
-        FieldDefType::NaiveDateTime => {
-            build_string_format_field_schema(fld, field_name_str, "date-time")
-        }
-        #[cfg(feature = "chrono")]
-        FieldDefType::DateTime => {
-            build_string_format_field_schema(fld, field_name_str, "date-time")
+        FieldDefType::NaiveDate
+        | FieldDefType::NaiveTime
+        | FieldDefType::NaiveDateTime
+        | FieldDefType::DateTime => {
+            // The arm has matched exactly the types the mapping answers for.
+            let format = chrono_json_schema_format(&fld.field_type).unwrap();
+            build_string_format_field_schema(fld, field_name_str, format)
         }
         FieldDefType::SiblingType(name, lst) => {
             build_sibling_type_field_schema(fld, field_name_str, name, lst)

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -6361,12 +6361,6 @@ fn object_id_hex_json_schema() -> proc_macro2::TokenStream {
     quote! { serde_json::json!({ "type": "string", "pattern": #OBJECT_ID_HEX_PATTERN }) }
 }
 
-/// The hex string an `ObjectId`'s `$oid` member holds, where no brand narrows it further.
-#[cfg(all(feature = "jsonschema", feature = "object_id"))]
-fn object_id_hex_json_schema() -> proc_macro2::TokenStream {
-    quote! { serde_json::json!({ "type": "string", "pattern": #OBJECT_ID_HEX_PATTERN }) }
-}
-
 /// Builds the JSON schema for a `MongoDB` `ObjectId` field (`{ "$oid": string }`).
 #[cfg(all(feature = "jsonschema", feature = "object_id"))]
 fn build_object_id_field_schema(fld: &FieldDef, field_name_str: &str) -> proc_macro2::TokenStream {

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -1427,6 +1427,11 @@ fn each_string_constraint_alone_rejects_a_numeric_inner() {
 }
 
 /// The shapes whose surfaces read the string constraints as something other than a string check.
+///
+/// Every sequence spelling stands beside the `Vec` it writes the same array as. A wrapper name is
+/// what the parser leaves for all but `Vec` and `[T; N]`, and reading it as a name rather than as
+/// the array it writes is what let a set through: the JSON schema then dropped `minLength` outside
+/// a string, while Zod read `.min` as a bound on how many items the array holds.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
 fn string_constraints_over_a_non_string_inner_are_rejected() {
@@ -1437,6 +1442,11 @@ fn string_constraints_over_a_non_string_inner_are_rejected() {
         ("bool", "boolean"),
         ("Vec<String>", "container"),
         ("[u8; 4]", "container"),
+        ("BTreeSet<String>", "container"),
+        ("BinaryHeap<String>", "container"),
+        ("HashSet<String>", "container"),
+        ("LinkedList<String>", "container"),
+        ("VecDeque<String>", "container"),
         ("HashMap<String, String>", "container"),
         ("(String, String)", "container"),
         ("serde_json::Value", "opaque"),
@@ -1458,11 +1468,19 @@ fn string_constraints_over_a_non_string_inner_are_rejected() {
 
 /// The inners that carry the constraints faithfully. A `SiblingType` — another brand, an
 /// unresolved user type, or a bare generic parameter — is admitted because expansion cannot know
-/// its shape; the constrained path's `Display` assertion is what covers it.
+/// its shape; the constrained path's `Display` assertion is what covers it. A name carrying one
+/// argument that is not a sequence wrapper is such a name too, and stays admitted.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
 fn string_constraints_over_a_string_shaped_inner_pass() {
-    for inner in ["String", "PathBuf", "ObjectId", "SomeOtherBrand", "T"] {
+    for inner in [
+        "String",
+        "PathBuf",
+        "ObjectId",
+        "SomeOtherBrand",
+        "T",
+        "SomeWrapper<String>",
+    ] {
         let ty: syn::Type = syn::parse_str(inner).unwrap();
         let errors = branded_errors_with(
             &syn::parse_quote! {
@@ -1476,11 +1494,19 @@ fn string_constraints_over_a_string_shaped_inner_pass() {
 }
 
 /// The guard reads the constraints, not the inner type: an unconstrained brand over any of the
-/// rejected shapes is the shipped `no_display` contract and stays accepted.
+/// rejected shapes is the shipped `no_display` contract and stays accepted — a sequence wrapper
+/// included, which describes the array it writes on every surface and needs no refusal.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
 fn an_unconstrained_brand_over_a_non_string_inner_passes() {
-    for inner in ["u64", "bool", "Vec<String>", "serde_json::Value"] {
+    for inner in [
+        "u64",
+        "bool",
+        "Vec<String>",
+        "BTreeSet<String>",
+        "VecDeque<String>",
+        "serde_json::Value",
+    ] {
         let ty: syn::Type = syn::parse_str(inner).unwrap();
         let errors = branded_errors(&syn::parse_quote! {
             #[serde(transparent)]

--- a/tests/branded_newtype_tests/tests.rs
+++ b/tests/branded_newtype_tests/tests.rs
@@ -402,6 +402,14 @@ mod objectid_branded_surface_tests {
     #[serde(transparent)]
     pub struct HexObjectId(pub ObjectId);
 
+    /// A brand whose pattern is wider than the hex the type holds — the shape that tells layering
+    /// from replacement, since a surface holding only the brand's admits strings no `ObjectId` can
+    /// ever be.
+    #[model_schema(pattern = "^.{24}$")]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct WideObjectId(pub ObjectId);
+
     #[model_schema(no_display)]
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     #[serde(transparent)]
@@ -434,7 +442,7 @@ mod objectid_branded_surface_tests {
             PlainObjectId::json_schema(),
             serde_json::json!({
                 "type": "object",
-                "properties": { "$oid": { "type": "string" } },
+                "properties": { "$oid": { "type": "string", "pattern": r"^[a-f\d]{24}$" } },
                 "required": ["$oid"],
                 "additionalProperties": false
             })
@@ -444,6 +452,11 @@ mod objectid_branded_surface_tests {
     /// A brand's string constraints measure the inner's `Display` — the bare hex — which on the
     /// wire is the `$oid` member, so both schema surfaces carry them there. Zod has no string
     /// check to apply to the object itself.
+    ///
+    /// The brand's own `pattern` is layered rather than written over the hex the type always
+    /// holds: one JSON Schema string carries one `pattern`, and writing the brand's into that slot
+    /// dropped the type's — which is how a brand wider than the hex came to admit, on this surface
+    /// alone, strings an `ObjectId` can never hold.
     #[test]
     fn a_constrained_objectid_brand_carries_its_constraints_on_the_oid_member() {
         let zod = HexObjectId::zod_schema();
@@ -466,7 +479,11 @@ mod objectid_branded_surface_tests {
             serde_json::json!({
                 "type": "object",
                 "properties": {
-                    "$oid": { "type": "string", "pattern": "^[0-9a-fA-F]{24}$" }
+                    "$oid": {
+                        "type": "string",
+                        "pattern": r"^[a-f\d]{24}$",
+                        "allOf": [{ "pattern": "^[0-9a-fA-F]{24}$" }]
+                    }
                 },
                 "required": ["$oid"],
                 "additionalProperties": false
@@ -482,6 +499,47 @@ mod objectid_branded_surface_tests {
             PlainObjectId::json_schema(),
             HoldsObjectId::json_schema()["properties"]["id"]
         );
+    }
+
+    /// Every `pattern` the `$oid` member states, applied: the member's own and the one each `allOf`
+    /// branch adds. A payload has to match all of them, which is what a single `pattern` keyword
+    /// cannot say and so what tells a layered brand pattern from one written over the type's.
+    fn admits_oid(schema: &serde_json::Value, hex: &str) -> bool {
+        let member = &schema["properties"]["$oid"];
+        member["pattern"]
+            .as_str()
+            .into_iter()
+            .chain(
+                member["allOf"]
+                    .as_array()
+                    .into_iter()
+                    .flatten()
+                    .filter_map(|branch| branch["pattern"].as_str()),
+            )
+            .all(|pattern| regex::Regex::new(pattern).unwrap().is_match(hex))
+    }
+
+    /// The two surfaces read the same probe payloads the same way. A brand pattern wider than the
+    /// hex is where they came apart: Zod ran the type's own regex before the brand's check, while
+    /// the JSON schema had only the brand's left and admitted a `$oid` of 24 arbitrary characters.
+    #[test]
+    fn a_brand_pattern_wider_than_the_hex_still_narrows_to_the_hex_on_both_surfaces() {
+        let zod = WideObjectId::zod_schema();
+        assert!(zod.contains(OID_ZOD_BASE), "Got:\n{zod}");
+        assert!(zod.contains(".check(z.regex(/^.{24}$/))"), "Got:\n{zod}");
+
+        let schema = WideObjectId::json_schema();
+        for (hex, admitted) in [
+            ("507f1f77bcf86cd799439011", true),
+            ("zzzzzzzzzzzzzzzzzzzzzzzz", false),
+            ("507f1f77bcf86cd79943901", false),
+        ] {
+            assert_eq!(
+                admits_oid(&schema, hex),
+                admitted,
+                "for {hex}, schema: {schema}"
+            );
+        }
     }
 
     /// An arrayed `ObjectId` writes the array around the `$oid` object, which is a container and
@@ -1166,6 +1224,307 @@ mod branded_composite_inner_tests {
         assert_eq!(LabelList::json_schema(), holder["properties"]["labels"]);
         assert_eq!(LabelPair::json_schema(), holder["properties"]["pair"]);
         assert_eq!(WeightMap::json_schema(), holder["properties"]["weights"]);
+    }
+}
+
+/// The four surfaces of a brand whose inner names another type, pinned against what serde writes
+/// for it.
+///
+/// `#[serde(transparent)]` puts the named type on the wire by itself, so an object inner writes
+/// that object — never a string. The TypeScript type and the Zod value already deferred to the
+/// name; the JSON schema and the Zod type annotation are pinned here beside them, so a consumer
+/// type-checking the exported binding and one validating a payload read the same shape.
+#[cfg(all(
+    feature = "jsonschema",
+    feature = "serde",
+    feature = "typescript",
+    feature = "zod"
+))]
+mod branded_sibling_inner_tests {
+    use super::*;
+
+    #[model_schema()]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    pub struct Part {
+        pub a: String,
+        pub b: u32,
+    }
+
+    #[model_schema(no_display)]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct WrappedPart(pub Part);
+
+    #[model_schema()]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    pub struct HoldsPart {
+        pub part: Part,
+    }
+
+    // Written before the type it names, which is what a reference has to survive.
+    #[model_schema(no_display)]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct WrappedTail(pub Tail);
+
+    #[model_schema()]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    pub struct Tail {
+        pub z: String,
+    }
+
+    #[model_schema()]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    pub struct Chain {
+        pub name: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub next: Option<Box<ChainRef>>,
+    }
+
+    #[model_schema(no_display)]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct ChainRef(pub Chain);
+
+    // A string-shaped sibling: the one a constrained brand can be written over, the constrained
+    // path asserting `Display` on the inner.
+    #[model_schema(maxLength = 10)]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct Slug(pub String);
+
+    #[model_schema(minLength = 3)]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct ShortSlug(pub Slug);
+
+    #[test]
+    fn a_sibling_brand_writes_the_object_its_inner_writes() {
+        let part = Part {
+            a: "a".to_owned(),
+            b: 1,
+        };
+        assert_eq!(
+            serde_json::to_string(&WrappedPart(part.clone())).unwrap(),
+            r#"{"a":"a","b":1}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&part).unwrap(),
+            serde_json::to_string(&WrappedPart(part)).unwrap()
+        );
+    }
+
+    #[test]
+    fn a_sibling_brand_describes_the_named_type_on_every_surface() {
+        assert_eq!(
+            WrappedPart::ts_definition(),
+            r#"export type WrappedPart = Part & $brand<"WrappedPart">;"#
+        );
+        let zod = WrappedPart::zod_schema();
+        assert!(
+            zod.contains(r#"const WrappedPart$RawSchema = Part$Schema.brand<"WrappedPart">()"#),
+            "Got:\n{zod}"
+        );
+        assert!(
+            zod.contains(r#"WrappedPart$Schema: $ZodBranded<typeof Part$Schema, "WrappedPart">"#),
+            "Got:\n{zod}"
+        );
+        assert_eq!(WrappedPart::json_schema(), Part::json_schema());
+    }
+
+    /// A transparent brand is nothing on the wire, so it describes exactly what its inner
+    /// describes where that inner is named directly.
+    #[test]
+    fn a_sibling_brand_describes_what_the_field_position_describes() {
+        assert_eq!(
+            WrappedPart::json_schema(),
+            HoldsPart::json_schema()["properties"]["part"]
+        );
+    }
+
+    /// A reference resolves in either declaration order, so a brand standing before the type it
+    /// names carries that type's own schema all the same.
+    #[test]
+    fn a_forward_declared_sibling_brand_carries_the_named_types_schema() {
+        assert_eq!(WrappedTail::json_schema(), Tail::json_schema());
+        assert!(
+            WrappedTail::zod_schema()
+                .contains(r#"WrappedTail$Schema: $ZodBranded<typeof Tail$Schema, "WrappedTail">"#),
+            "Got:\n{}",
+            WrappedTail::zod_schema()
+        );
+    }
+
+    /// A cycle closed through a brand defers exactly as one closed through a field does: the name
+    /// re-entered while still being written becomes a reference, and its body is hoisted to the
+    /// root that reference resolves against.
+    #[test]
+    fn a_recursive_sibling_brand_defers_rather_than_inlining() {
+        assert_eq!(
+            ChainRef::json_schema(),
+            serde_json::json!({
+                "$defs": {
+                    "ChainRef": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "name": { "type": "string" },
+                            "next": { "$ref": "#/$defs/ChainRef" }
+                        },
+                        "required": ["name"]
+                    }
+                },
+                "$ref": "#/$defs/ChainRef"
+            })
+        );
+    }
+
+    /// A brand over a string-shaped sibling keeps its own constraints, layered around the named
+    /// type's schema rather than written in place of it — which is how the Zod value already
+    /// composes them, the named schema first and the brand's checks after it.
+    #[test]
+    fn a_constrained_sibling_brand_layers_its_constraints_over_the_named_schema() {
+        assert_eq!(
+            ShortSlug::json_schema(),
+            serde_json::json!({
+                "allOf": [{ "type": "string", "maxLength": 10_u32 }, { "minLength": 3_u32 }]
+            })
+        );
+        let zod = ShortSlug::zod_schema();
+        assert!(
+            zod.contains(r#"const ShortSlug$RawSchema = Slug$Schema.min(3).brand<"ShortSlug">()"#),
+            "Got:\n{zod}"
+        );
+        assert!(
+            zod.contains(r#"ShortSlug$Schema: $ZodBranded<typeof Slug$Schema, "ShortSlug">"#),
+            "Got:\n{zod}"
+        );
+    }
+}
+
+/// The surfaces of a brand whose inner is a chrono type, pinned against what serde writes for it.
+///
+/// `#[serde(transparent)]` puts the chrono value on the wire by itself, so the brand writes the
+/// same string a field of that type writes — and carries the same `"format"` keyword saying which
+/// instant the string spells. Reaching the string through the TypeScript name every chrono type
+/// shares with `String` is what dropped the keyword.
+#[cfg(all(feature = "chrono", feature = "jsonschema", feature = "serde"))]
+mod branded_chrono_inner_tests {
+    use super::*;
+    use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
+
+    #[model_schema()]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct Stamp(pub NaiveDate);
+
+    #[model_schema()]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct Clock(pub NaiveTime);
+
+    #[model_schema()]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct Moment(pub NaiveDateTime);
+
+    #[model_schema()]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct Instant(pub DateTime<Utc>);
+
+    #[model_schema(minLength = 10, maxLength = 10, pattern = r"^\d{4}-\d{2}-\d{2}$")]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct IsoStamp(pub NaiveDate);
+
+    #[model_schema()]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    pub struct HoldsChrono {
+        pub clock: NaiveTime,
+        pub instant: DateTime<Utc>,
+        pub moment: NaiveDateTime,
+        pub stamp: NaiveDate,
+    }
+
+    #[test]
+    fn a_chrono_brand_writes_the_string_its_inner_writes() {
+        let date = NaiveDate::from_ymd_opt(2020, 1, 2).unwrap();
+        assert_eq!(
+            serde_json::to_string(&Stamp(date)).unwrap(),
+            r#""2020-01-02""#
+        );
+        assert_eq!(
+            serde_json::to_string(&date).unwrap(),
+            serde_json::to_string(&Stamp(date)).unwrap()
+        );
+    }
+
+    #[test]
+    fn a_chrono_brand_carries_the_format_keyword() {
+        assert_eq!(
+            Stamp::json_schema(),
+            serde_json::json!({ "type": "string", "format": "date" })
+        );
+        assert_eq!(
+            Clock::json_schema(),
+            serde_json::json!({ "type": "string", "format": "time" })
+        );
+        assert_eq!(
+            Moment::json_schema(),
+            serde_json::json!({ "type": "string", "format": "date-time" })
+        );
+        assert_eq!(
+            Instant::json_schema(),
+            serde_json::json!({ "type": "string", "format": "date-time" })
+        );
+    }
+
+    /// A transparent brand is nothing on the wire, so it describes exactly what its inner
+    /// describes where that inner is named directly.
+    #[test]
+    fn a_chrono_brand_describes_what_the_field_position_describes() {
+        let holder = HoldsChrono::json_schema();
+        assert_eq!(Stamp::json_schema(), holder["properties"]["stamp"]);
+        assert_eq!(Clock::json_schema(), holder["properties"]["clock"]);
+        assert_eq!(Moment::json_schema(), holder["properties"]["moment"]);
+        assert_eq!(Instant::json_schema(), holder["properties"]["instant"]);
+    }
+
+    /// The wire is a string, so the brand's own constraints stay legal — and sit beside `type` and
+    /// `format` the way they sit beside `type` alone.
+    #[test]
+    fn a_constrained_chrono_brand_carries_its_constraints_beside_the_format() {
+        assert_eq!(
+            IsoStamp::json_schema(),
+            serde_json::json!({
+                "type": "string",
+                "format": "date",
+                "minLength": 10_u32,
+                "maxLength": 10_u32,
+                "pattern": r"^\d{4}-\d{2}-\d{2}$"
+            })
+        );
+    }
+
+    /// The Zod value already emitted the same `z.iso.*` schema field position emits, and the
+    /// annotation is the class zod gives it; only the JSON schema moved.
+    #[cfg(all(feature = "typescript", feature = "zod"))]
+    #[test]
+    fn the_zod_surfaces_of_a_chrono_brand_are_unchanged() {
+        let zod = Stamp::zod_schema();
+        assert!(
+            zod.contains(r#"const Stamp$RawSchema = z.iso.date().brand<"Stamp">()"#),
+            "Got:\n{zod}"
+        );
+        assert!(
+            zod.contains(r#"Stamp$Schema: $ZodBranded<ZodString, "Stamp">"#),
+            "Got:\n{zod}"
+        );
+        assert_eq!(
+            Stamp::ts_definition(),
+            r#"export type Stamp = string & $brand<"Stamp">;"#
+        );
     }
 }
 


### PR DESCRIPTION
Four branded-newtype surface defects, one principle: the brand describes exactly what its inner writes, and its own constraints narrow that description rather than replace it.

A brand over a sibling type claimed {"type":"string"} on the JSON surface and ZodString in the annotation while TS and the Zod value already deferred to the name — the JSON side now defers through the same reference and hoisted-definitions machinery a field naming the type uses (forward declarations and cycles behave identically, pinned), and the annotation is typeof the very binding the value composes. A chrono-inner brand dropped the format keyword — which instant a chrono string spells is now said once, in one exhaustively-matched mapping that the field, slot, and branded paths all read, with brand constraints legal beside type and format. The constraint guard read a sequence wrapper as a name, so a BTreeSet brand slipped past the container refusal a Vec gets — with its constraints silently reinterpreted (the JSON schema dropped minLength outside a string; Zod's .min became an item-count bound); every sequence spelling now earns the identical refusal through the shared wrapper helper. And a constrained ObjectId brand's pattern replaced the hex pattern the type always holds — one string carries one pattern keyword — so a brand wider than the hex admitted, on that surface alone, strings no ObjectId can be; the brand's pattern now layers from inside an allOf beside the type's own, exactly how the Zod side already composes them, with a wide-pattern probe pinning that both surfaces reject what the hex rejects.

Constrained sibling brands layer the same way (the named schema may be a reference carrying no keyword beside it, so allOf narrows without touching it). Each fix was verified red by mechanical reversion; scalar brands, unconstrained brands, and every non-brand path are byte-identical. The Zod/JSON case-sensitivity split on the hex and the now-surfaced E0433 for brands over unannotated types are tracked separately. Full powerset tests and lint-all green on the merged tree with the exit value read before landing.