### PR TITLE
one JSDoc fallback rule at one seam, the merge documented on its entry point, and hasher arguments truncated at the parse

### DIFF
--- a/src/features/jsonschema.rs
+++ b/src/features/jsonschema.rs
@@ -150,24 +150,6 @@ fn closed_object_body(json_schema_fields: &[proc_macro2::TokenStream]) -> proc_m
     }
 }
 
-/// A base object's members with the members of every schema merged beside them.
-///
-/// serde writes a `#[serde(flatten)]` base and an internally tagged variant's newtype content the
-/// same way — what is merged contributes its members to the object the base is writing — so both
-/// describe through this one merge rather than each spelling its own. `base` is a
-/// `serde_json::Map` expression and every entry of `merged` a `serde_json::Value` one; the result
-/// is a `serde_json::Value`.
-///
-/// A merged schema that is itself a union multiplies out rather than collapsing, so each branch
-/// stays a closed object naming exactly the members that branch writes. Both spellings of a union
-/// are read: a discriminated enum's `oneOf` and an untagged one's `anyOf` alike name what serde
-/// picked one of, and the merged schema is the union of the merges.
-///
-/// Only a value serde writes as an object has members to contribute, and the expansion cannot
-/// always tell which types those are — a name reaches the merge without saying what it writes. The
-/// schema it produces does say, so the merge reads it there: a description naming any type but
-/// `object` is refused rather than merged, which is the last point at which the wrong schema can
-/// still be stopped.
 /// The four things the merge asks of a schema it is handed, as the tokens the merging block opens
 /// with: how two objects join, whether a schema is a deferred name, what type it commits its value
 /// to, and which branches it offers under which spelling.
@@ -495,6 +477,31 @@ fn branch_expansion() -> proc_macro2::TokenStream {
     }
 }
 
+/// A base object's members with the members of every schema merged beside them.
+///
+/// serde writes a `#[serde(flatten)]` base and an internally tagged variant's newtype content the
+/// same way — what is merged contributes its members to the object the base is writing — so both
+/// describe through this one merge rather than each spelling its own. `base` is a
+/// `serde_json::Map` expression and every entry of `merged` a `serde_json::Value` one; the result
+/// is a `serde_json::Value`.
+///
+/// A merged schema that is itself a union multiplies out rather than collapsing, so each branch
+/// stays a closed object naming exactly the members that branch writes. Both spellings of a union
+/// are read: a discriminated enum's `oneOf` and an untagged one's `anyOf` alike name what serde
+/// picked one of, and the merged schema is the union of the merges. A source reached through an
+/// `Option` offers its own absence beside whatever it described as, the two key sets being what the
+/// field actually writes.
+///
+/// Only a value serde writes as an object has members to contribute, and the expansion cannot
+/// always tell which types those are — a name reaches the merge without saying what it writes. The
+/// schema it produces does say, so the merge reads it there: a description naming any type but
+/// `object` is refused rather than merged, which is the last point at which the wrong schema can
+/// still be stopped. A flatten edge that closes a cycle is refused on the same terms, named for the
+/// frame that read it.
+///
+/// The reading itself is the tokens [`merge_readers`] emits, and what the multiplication is carried
+/// in is [`merged_tree`]; both are written into the block this returns, so the whole merge is one
+/// expression the caller can place wherever a `serde_json::Value` is wanted.
 pub fn merged_object_value(
     base: &proc_macro2::TokenStream,
     merged: &[MergedSource],

--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -865,6 +865,29 @@ pub fn is_sequence_wrapper(name: &str) -> bool {
     )
 }
 
+/// The number of leading type arguments a std container's wire form is written from, or `None` for
+/// a name that is not one of them.
+///
+/// std's hashed maps and sets carry a hasher past the types they write, and each of these
+/// containers takes an allocator beside it. Neither reaches the wire — serde writes the same bytes
+/// whichever is named — so neither is part of what the container describes as, and an argument past
+/// this count is dropped rather than read as a type of its own.
+///
+/// The count is what the container is claimed on, not what it is written with: a spelling carrying
+/// fewer arguments than this is not the container at all, and is left to fall through as the
+/// sibling it was written as, where the schema module it names is reported unresolvable against the
+/// author's own type. The one-argument list is the surfaces' shared answer for what writes a JSON
+/// array, so a wrapper cannot be read here as a container and there as a name of its own.
+fn container_wire_arity(name: &str) -> Option<usize> {
+    if name == "HashMap" || name == "BTreeMap" {
+        Some(2)
+    } else if is_sequence_wrapper(name) {
+        Some(1)
+    } else {
+        None
+    }
+}
+
 /// The one list of std wrappers the crate reads straight through to what they hold.
 ///
 /// Membership is decided on the wire and nothing else: serde writes each of these as its inner
@@ -996,7 +1019,7 @@ fn get_field_def_from_generic_type(
 ) -> FieldDef {
     let ident_name = type_ident.to_string();
     let ident = ident_name.as_str();
-    let arg_types: Vec<FieldDef> = args
+    let mut arg_types: Vec<FieldDef> = args
         .args
         .iter()
         .filter_map(|arg| {
@@ -1007,6 +1030,13 @@ fn get_field_def_from_generic_type(
             }
         })
         .collect();
+    // A container is claimed by its own name, so what it is written with past its wire form is
+    // dropped before the arms below count arguments.
+    if let Some(arity) = container_wire_arity(ident)
+        && arg_types.len() > arity
+    {
+        arg_types.truncate(arity);
+    }
     if arg_types.is_empty() {
         FieldDef {
             name: safe_name,

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -82,7 +82,7 @@ use crate::utils::{compute_alias_export_name, ident_schema_module_name};
 use crate::utils::compute_item_export_name;
 
 #[cfg(feature = "typescript")]
-use crate::utils::{format_docs_for_ts, get_item_docs};
+use crate::utils::get_item_docs;
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 use crate::utils::register_alias_info;
@@ -2969,9 +2969,14 @@ fn item_plain_doc_lines(doc_lines: &[String]) -> Vec<String> {
 }
 
 /// An item's doc lines, flattened the way the calling surface reads them, or the one line it falls
-/// back to when it carries no docs: the name it is exported under, not the one it is declared
-/// under, so a `JSDoc` header never contradicts the `export type` one line beneath it and a
-/// description never names an item something no surface exports.
+/// back to when it says nothing: the name it is exported under, not the one it is declared under,
+/// so a `JSDoc` header never contradicts the `export type` one line beneath it and a description
+/// never names an item something no surface exports.
+///
+/// Whether anything was said is read off the flattened lines rather than off the attribute, because
+/// the flattening is what decides: a ` ```rust example ` block is Rust source and is dropped, so an
+/// item documented with nothing else has an attribute and still says nothing, and is left naming
+/// itself the way an undocumented one is.
 ///
 /// Every item shape and member reaches that fallback through here, so no path can drift from the
 /// rest by spelling it separately. What a caller brings of its own is `flatten` — how its docs
@@ -2982,7 +2987,28 @@ fn item_lines_or_name(
     item_name: &str,
     flatten: impl FnOnce(&[String]) -> Vec<String>,
 ) -> Vec<String> {
-    docs_vec.map_or_else(|| vec![item_name.to_owned()], flatten)
+    let lines = docs_vec.map(flatten).unwrap_or_default();
+    if lines.is_empty() {
+        vec![item_name.to_owned()]
+    } else {
+        lines
+    }
+}
+
+/// The `JSDoc` body an alias's `export type` is emitted under.
+///
+/// An alias has no surface name of its own and is given the `Type` suffix, which is the name it
+/// falls back to. Everything else is the body every declared item is written from — the same
+/// fallback, over the same lines, closed the same way — so an alias with nothing to say opens
+/// exactly as a struct with nothing to say does. What it keeps of its own is the flattening: an
+/// alias publishes its doc lines as they were written, blank ones included.
+#[cfg(feature = "typescript")]
+fn alias_jsdoc_body(docs_vec: Option<&[String]>, export_name: &str) -> String {
+    item_jsdoc_body(&item_lines_or_name(
+        docs_vec,
+        export_name,
+        strip_examples_from_docs,
+    ))
 }
 
 /// The `JSDoc` body a set of lines is written as: each prefixed with ` * `, the block closed by a
@@ -7600,9 +7626,7 @@ fn generate_alias_ts_definition_method(
 ) -> proc_macro2::TokenStream {
     #[cfg(feature = "typescript")]
     {
-        let docs_vec = get_item_docs(&alias.attrs)
-            .unwrap_or_else(|| vec![export_name.to_owned(), String::new()]);
-        let docs_formatted = format_docs_for_ts(&docs_vec, export_name);
+        let docs_formatted = alias_jsdoc_body(get_item_docs(&alias.attrs).as_deref(), export_name);
 
         let generics: Vec<String> = alias
             .generics

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -894,6 +894,62 @@ fn an_alias_targeting_a_map_key_with_no_members_is_refused() {
     assert!(error.contains("Doc"), "got: {error}");
 }
 
+/// The type the parser reads a field's written spelling as, rendered the way every surface receives
+/// it: one `FieldDef`, so a spelling that parses alike describes alike wherever it is dispatched.
+fn parsed_field_type(field_type: &proc_macro2::TokenStream) -> String {
+    let item: syn::ItemStruct = syn::parse_quote! {
+        struct Report {
+            counts: #field_type,
+        }
+    };
+    let field = item.fields.iter().next().unwrap();
+    format!("{:?}", get_field_def("counts", &field.ty, "").field_type)
+}
+
+/// The reported failure: std's `HashMap<K, V, S>` and `HashSet<T, S>` carry a hasher past the types
+/// they write, and the arity-keyed arms read that argument as a type of its own — demoting the
+/// container to a sibling naming a schema module the expansion never writes. serde writes the same
+/// bytes whichever hasher is named, so a container is read by its own name and the arguments past
+/// its wire form are dropped before any arm is consulted.
+#[test]
+fn a_container_written_with_a_hasher_parses_as_the_container_without_one() {
+    for (written, implied) in [
+        (
+            quote::quote! { HashMap<String, u32, FxBuildHasher> },
+            quote::quote! { HashMap<String, u32> },
+        ),
+        (
+            quote::quote! { HashSet<String, FxBuildHasher> },
+            quote::quote! { HashSet<String> },
+        ),
+        (
+            quote::quote! { HashMap<String, HashSet<u32, FxBuildHasher>> },
+            quote::quote! { HashMap<String, HashSet<u32>> },
+        ),
+        (
+            quote::quote! { Option<HashSet<u32, FxBuildHasher>> },
+            quote::quote! { Option<HashSet<u32>> },
+        ),
+    ] {
+        assert_eq!(
+            parsed_field_type(&written),
+            parsed_field_type(&implied),
+            "for {written}"
+        );
+    }
+}
+
+/// A container named with fewer arguments than its wire form is written from is not that container,
+/// and is left to fall through as the sibling it was written as — where the schema module it names
+/// is reported unresolvable against the type the author wrote, rather than quietly read as a map.
+#[test]
+fn a_container_short_of_its_wire_arity_still_falls_through_as_a_sibling() {
+    assert_eq!(
+        parsed_field_type(&quote::quote! { HashMap<String> }),
+        parsed_field_type(&quote::quote! { Wrapper<String> }).replace("Wrapper", "HashMap"),
+    );
+}
+
 /// Runs the field walk the way [`super::process_field`] does and renders the guard failures its
 /// `model_schema_prop` attributes earn, so a refused key and an unparseable `pattern` are read off
 /// the same channel that carries them to the emitted item.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,4 @@
 use core::cell::RefCell;
-#[cfg(feature = "typescript")]
-use core::iter;
 use regex_syntax::ast::parse::Parser as PatternParser;
 use regex_syntax::ast::{
     Assertion, AssertionKind, Ast, ClassSet, ClassSetBinaryOpKind, ClassSetItem, Flag,
@@ -360,30 +358,6 @@ pub fn compute_alias_export_name(rust_ident: &str, override_name: Option<&str>) 
 /// it is exported as.
 pub fn compute_item_export_name(rust_ident: &str, override_name: Option<&str>) -> String {
     override_name.map_or_else(|| safe_type_name(rust_ident), ToOwned::to_owned)
-}
-
-/// Builds the `JSDoc` comment body an alias's `export type` is emitted under, which is what
-/// `build_jsdoc_body` builds for a declared item and for the members inside it. Between them they
-/// are every `JSDoc` body the crate writes, so the rule below holds wherever one is written rather
-/// than at the call sites that reach for one.
-///
-/// An alias's ` ```rust example ` block is dropped before its lines reach the body, the way every
-/// item shape drops it: the block is Rust source, and nothing reads it as such once it is sitting in
-/// a `TypeScript` comment. An alias documented with nothing but an example is left naming itself,
-/// as an undocumented one is.
-#[cfg(feature = "typescript")]
-pub fn format_docs_for_ts(docs: &[String], fallback_name: &str) -> String {
-    let described = strip_examples_from_docs(docs);
-    if described.is_empty() {
-        format!(" * {fallback_name}\n * ")
-    } else {
-        described
-            .iter()
-            .map(|line| format!(" * {line}"))
-            .chain(iter::once(" * ".to_owned()))
-            .collect::<Vec<_>>()
-            .join("\n")
-    }
 }
 
 #[cfg(any(feature = "typescript", feature = "zod"))]

--- a/tests/collection_tests/tests.rs
+++ b/tests/collection_tests/tests.rs
@@ -1,7 +1,9 @@
 use alloc::collections::{BTreeSet, BinaryHeap, VecDeque};
+use core::hash::BuildHasher;
 use core::iter::once;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
+use std::hash::DefaultHasher;
 use tixschema::model_schema;
 
 /// The covered wrappers by the name a generated surface could leak. `Vec` is covered too but
@@ -271,6 +273,44 @@ struct VecElementFields {
     preprocessed_labels: Vec<String>,
     sibling_tags: Vec<MetricTag>,
     small_ids: Vec<u32>,
+}
+
+/// A `BuildHasher` written where std implies one, so a field can name the hasher parameter both
+/// `HashMap` and `HashSet` carry past the types they write. What it hashes with is beside the
+/// point — serde writes the same bytes whichever hasher a container is built with, which is why the
+/// argument is not part of the wire form the surfaces render.
+#[derive(Clone, Default)]
+struct NamedHasher;
+
+impl BuildHasher for NamedHasher {
+    type Hasher = DefaultHasher;
+
+    fn build_hasher(&self) -> Self::Hasher {
+        DefaultHasher::new()
+    }
+}
+
+// The twin pair the hasher is read through: the same containers at the same element and key types,
+// one spelling naming the hasher parameter and one leaving it implied. Every surface holds the two
+// against each other, the way the sequence wrappers are held against their `Vec` spelling.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct HasherNamedFields {
+    counts: HashMap<String, u32, NamedHasher>,
+    enum_keyed_counts: HashMap<MetricSlot, u32, NamedHasher>,
+    nested_ids: HashMap<String, HashSet<u32, NamedHasher>>,
+    small_ids: HashSet<u32, NamedHasher>,
+    tags: HashSet<MetricTag, NamedHasher>,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct HasherImpliedFields {
+    counts: HashMap<String, u32>,
+    enum_keyed_counts: HashMap<MetricSlot, u32>,
+    nested_ids: HashMap<String, HashSet<u32>>,
+    small_ids: HashSet<u32>,
+    tags: HashSet<MetricTag>,
 }
 
 // A slot — a map member, a tuple element — cannot be dropped the way an object key can, so it
@@ -1767,6 +1807,89 @@ fn test_set_element_json_schema() {
         MetricTag::json_schema(),
         "in: {}",
         properties["sibling_tags"]
+    );
+}
+
+/// The twin values the hasher pair is read off: the same members holding the same things, one built
+/// with the hasher named and one with it implied.
+fn hasher_named_fields() -> HasherNamedFields {
+    HasherNamedFields {
+        counts: once(("alpha".to_owned(), 1)).collect(),
+        enum_keyed_counts: once((MetricSlot::Daily, 2)).collect(),
+        nested_ids: once(("beta".to_owned(), once(3).collect())).collect(),
+        small_ids: once(4).collect(),
+        tags: once(MetricTag {
+            label: "gamma".to_owned(),
+        })
+        .collect(),
+    }
+}
+
+fn hasher_implied_fields() -> HasherImpliedFields {
+    HasherImpliedFields {
+        counts: once(("alpha".to_owned(), 1)).collect(),
+        enum_keyed_counts: once((MetricSlot::Daily, 2)).collect(),
+        nested_ids: once(("beta".to_owned(), once(3).collect())).collect(),
+        small_ids: once(4).collect(),
+        tags: once(MetricTag {
+            label: "gamma".to_owned(),
+        })
+        .collect(),
+    }
+}
+
+/// The whole reason a named hasher may be held against the implied one: serde writes the same bytes
+/// either way, the hasher deciding only the order of a bucket the wire form never exposes. Read off
+/// what serde actually produces, so the claim answers to the wire rather than to a name.
+#[test]
+fn test_a_named_hasher_writes_what_the_implied_hasher_writes() {
+    assert_eq!(
+        serde_json::to_value(hasher_named_fields()).unwrap(),
+        serde_json::to_value(hasher_implied_fields()).unwrap()
+    );
+}
+
+/// The reported failure: naming the hasher carried an argument more than the container arms claimed,
+/// so the type fell through to the sibling rendering and each surface published a name nothing
+/// emits — a `HashMap<…>` TypeScript type, the same string as a Zod schema, and a schema module the
+/// expansion never writes. Writing the same bytes, the two spellings describe the same.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_hasher_named_fields_describe_as_the_implied_spelling() {
+    let named = HasherNamedFields::json_schema();
+    let implied = HasherImpliedFields::json_schema();
+
+    assert_eq!(named["properties"], implied["properties"]);
+    assert_eq!(named["required"], implied["required"]);
+}
+
+/// The same holding on the TypeScript surface, with the fixture's own name set aside: no container
+/// name and no hasher name reached the output.
+#[test]
+#[cfg(feature = "typescript")]
+fn test_hasher_named_fields_type_as_the_implied_spelling() {
+    let named = HasherNamedFields::ts_definition();
+    for leaked in ["NamedHasher", "HashMap<", "HashSet<"] {
+        assert!(!named.contains(leaked), "{leaked} reached: {named}");
+    }
+    assert_eq!(
+        named.replace("HasherNamedFields", "HasherImpliedFields"),
+        HasherImpliedFields::ts_definition()
+    );
+}
+
+/// And on the Zod surface, where the sibling rendering published a bare type name that is not a
+/// schema expression at all.
+#[test]
+#[cfg(feature = "zod")]
+fn test_hasher_named_fields_validate_as_the_implied_spelling() {
+    let named = HasherNamedFields::zod_schema();
+    for leaked in ["NamedHasher", "HashMap<", "HashSet<"] {
+        assert!(!named.contains(leaked), "{leaked} reached: {named}");
+    }
+    assert_eq!(
+        named.replace("HasherNamedFields", "HasherImpliedFields"),
+        HasherImpliedFields::zod_schema()
     );
 }
 

--- a/tests/item_description_tests/tests.rs
+++ b/tests/item_description_tests/tests.rs
@@ -165,10 +165,37 @@ pub struct SuffixedBrandJson(pub String);
 #[serde(transparent)]
 pub struct BrandUnderRustName(pub String);
 
+// The one shape with no surface name of its own: an alias is exported under the `Type` suffix, and
+// falls back to that exported name the way every declared item falls back to its own. Commented
+// with `//`, since a `///` line here would be the fixture's docs and the fallback would not fire.
+#[cfg(feature = "typescript")]
+#[model_schema()]
+pub type PlainAlias = u32;
+
 #[cfg(feature = "typescript")]
 fn assert_jsdoc_opens_with(ts: &str, expected: &str) {
     let header = format!("/**\n * {expected}\n");
     assert!(ts.starts_with(&header), "expected {expected} to open: {ts}");
+}
+
+/// The ` * ` lines a definition's `JSDoc` block is written from, with the block's own delimiters and
+/// the surrounding indentation set aside — what every shape spells from one body, and the one part
+/// of the emitted `TypeScript` the shapes may be held against each other over.
+///
+/// The rendered JSON schema an item publishes under `jsonschema` is appended after that body rather
+/// than written from it, so it is read as the end of the body and not as part of it.
+#[cfg(feature = "typescript")]
+fn jsdoc_body_lines(ts: &str) -> Vec<String> {
+    let (block, _) = ts
+        .strip_prefix("/**\n")
+        .and_then(|rest| rest.split_once("**/"))
+        .unwrap();
+    block
+        .lines()
+        .map(|line| line.trim().to_owned())
+        .take_while(|line| line != "* JSON Schema:")
+        .filter(|line| line.starts_with('*'))
+        .collect()
 }
 
 #[cfg(feature = "typescript")]
@@ -240,6 +267,37 @@ fn an_item_exported_under_its_rust_ident_keeps_the_header_it_had() {
         (PlainEither::ts_definition(), "PlainEither"),
     ] {
         assert_jsdoc_opens_with(&ts, declared);
+    }
+}
+
+/// The reported failure: an undocumented alias closed its `JSDoc` on a second blank ` * ` line,
+/// where every declared item closes on the first. Nothing about a shape decides how a name is
+/// written under `/**`, so the seven shapes that publish a header write the same two lines.
+#[cfg(feature = "typescript")]
+#[test]
+fn every_undocumented_shape_writes_the_same_two_jsdoc_lines() {
+    // The alias publishes `ts_definition` from its own module rather than from the alias, so naming
+    // the type here is what keeps the fixture from being pruned as unused.
+    let aliased: PlainAlias = 3;
+    assert_eq!(aliased, 3);
+
+    for (ts, exported) in [
+        (PlainStruct::ts_definition(), "PlainStruct"),
+        (PlainTuple::ts_definition(), "PlainTuple"),
+        (PlainSlot::ts_definition(), "PlainSlot"),
+        (PlainShape::ts_definition(), "PlainShape"),
+        (PlainAdjacent::ts_definition(), "PlainAdjacent"),
+        (PlainEither::ts_definition(), "PlainEither"),
+        (
+            plain_alias_schema::Schema::ts_definition(),
+            "PlainAliasType",
+        ),
+    ] {
+        assert_eq!(
+            jsdoc_body_lines(&ts),
+            vec![format!("* {exported}"), "*".to_owned()],
+            "for {exported}: {ts}"
+        );
     }
 }
 

--- a/tests/item_jsdoc_example_tests/tests.rs
+++ b/tests/item_jsdoc_example_tests/tests.rs
@@ -153,6 +153,101 @@ pub enum DocumentedSlotVariant {
     Secondary,
 }
 
+/// ```rust example
+/// let item = ExampleOnlyStruct {
+///     label: "alpha".to_string(),
+/// };
+/// println!("Item: {:?}", item);
+/// ```
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ExampleOnlyStruct {
+    /// ```rust example
+    /// let label = "alpha".to_string();
+    /// println!("Label: {}", label);
+    /// ```
+    pub label: String,
+}
+
+// An internally tagged enum whose one documented member says nothing but an example. Commented with
+// `//`, so the item itself is held against its twin as the undocumented one it is.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "kind")]
+pub enum ExampleOnlyVariantHolder {
+    /// ```rust example
+    /// let item = ExampleOnlyVariantHolder::Unit;
+    /// println!("Item: {:?}", item);
+    /// ```
+    Named {
+        side: u8,
+    },
+    Unit,
+}
+
+/// ```rust example
+/// let item: ExampleOnlyAlias = 3;
+/// println!("Item: {:?}", item);
+/// ```
+#[model_schema()]
+pub type ExampleOnlyAlias = u32;
+
+/// ```rust example
+/// let item = ExampleOnlySlot::Primary;
+/// println!("Item: {:?}", item);
+/// ```
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+pub enum ExampleOnlySlot {
+    Primary,
+    Secondary,
+}
+
+/// ```rust example
+/// let item = ExampleOnlyBrand("alpha".to_string());
+/// println!("Item: {:?}", item);
+/// ```
+// A brand publishes a description and no `JSDoc` header of its own, so it is read on the Zod
+// surface alone and is gated on the feature that surface is.
+#[cfg(feature = "zod")]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(transparent)]
+pub struct ExampleOnlyBrand(pub String);
+
+// The undocumented twins of the shapes above. Dropping an example is the whole of what the strip
+// does, so a shape documented with nothing else is left exactly where a shape documented with
+// nothing at all already stands — which is what the twins below are held against.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug)]
+pub struct UndocumentedStruct {
+    pub label: String,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "kind")]
+pub enum UndocumentedVariantHolder {
+    Named { side: u8 },
+    Unit,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+pub enum UndocumentedSlot {
+    Primary,
+    Secondary,
+}
+
+#[cfg(feature = "zod")]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(transparent)]
+pub struct UndocumentedBrand(pub String);
+
+#[model_schema()]
+pub type UndocumentedAlias = u32;
+
 /// Every documented shape above, paired with the description its `JSDoc` is left with once the
 /// example is dropped. The plain enum rides along as the shape that already dropped it.
 fn documented_shapes() -> Vec<(String, &'static str)> {
@@ -244,6 +339,101 @@ fn a_documented_alias_publishes_the_same_zod_schema_it_always_did() {
     let zod = documented_alias_schema::Schema::zod_schema();
     for leaked in ["```", "let item", "println!", "example"] {
         assert!(!zod.contains(leaked), "{leaked} reached: {zod}");
+    }
+}
+
+/// Every shape documented with nothing but an example, paired with the undocumented twin it is
+/// held against: the `TypeScript` one writes is the other's with the fixture's own name in it.
+fn example_only_twins() -> Vec<(String, String, &'static str, &'static str)> {
+    vec![
+        (
+            ExampleOnlyStruct::ts_definition(),
+            UndocumentedStruct::ts_definition(),
+            "ExampleOnlyStruct",
+            "UndocumentedStruct",
+        ),
+        (
+            ExampleOnlyVariantHolder::ts_definition(),
+            UndocumentedVariantHolder::ts_definition(),
+            "ExampleOnlyVariantHolder",
+            "UndocumentedVariantHolder",
+        ),
+        (
+            ExampleOnlySlot::ts_definition(),
+            UndocumentedSlot::ts_definition(),
+            "ExampleOnlySlot",
+            "UndocumentedSlot",
+        ),
+        (
+            example_only_alias_schema::Schema::ts_definition(),
+            undocumented_alias_schema::Schema::ts_definition(),
+            "ExampleOnlyAlias",
+            "UndocumentedAlias",
+        ),
+    ]
+}
+
+/// The reported failure: an item and a member documented with nothing but an example emitted an
+/// empty `JSDoc` body, where an undocumented one names what it is documenting. The strip is what
+/// decides whether anything was said, so what it leaves empty is what falls back to the name — and
+/// the shape is then the undocumented one, byte for byte.
+#[test]
+fn an_example_only_shape_writes_what_its_undocumented_twin_writes() {
+    // The aliases publish `ts_definition` from their own modules rather than from the alias, so
+    // naming the types here is what keeps the fixtures from being pruned as unused.
+    let aliased: ExampleOnlyAlias = 3;
+    let aliased_twin: UndocumentedAlias = 3;
+    assert_eq!(aliased, aliased_twin);
+
+    for (example_only, twin, named, twin_named) in example_only_twins() {
+        assert_eq!(example_only.replace(named, twin_named), twin, "for {named}");
+    }
+}
+
+/// What the fallback writes, read off the emitted `TypeScript` rather than off the twin: the item
+/// names itself as it is exported, and each member names itself as it is serialized.
+#[test]
+fn an_example_only_item_and_member_name_themselves() {
+    let ts = ExampleOnlyStruct::ts_definition();
+    assert!(
+        ts.starts_with("/**\n * ExampleOnlyStruct\n * \n"),
+        "item did not name itself: {ts}"
+    );
+    assert!(ts.contains("/**\n * label\n * \n"), "field unnamed: {ts}");
+
+    let variants = ExampleOnlyVariantHolder::ts_definition();
+    assert!(
+        variants.contains("/**\n * Named\n * \n"),
+        "variant unnamed: {variants}"
+    );
+
+    let alias = example_only_alias_schema::Schema::ts_definition();
+    assert!(
+        alias.starts_with("/**\n * ExampleOnlyAliasType\n * \n"),
+        "alias did not name itself: {alias}"
+    );
+}
+
+/// The `description` a shape publishes is spelled from the lines its `JSDoc` body is spelled from,
+/// so the fallback fires on the same reading at both. The two shapes that publish one are covered:
+/// a plain enum writes it beside a header of its own, and a brand writes it instead of one.
+///
+/// Only the description is held against the twin's. The Zod surface is where an example is *kept* —
+/// it is published as the schema's own `example`, which is the one thing an example-only shape has
+/// that an undocumented one does not.
+#[cfg(feature = "zod")]
+#[test]
+fn an_example_only_shape_describes_itself_as_its_undocumented_twin_does() {
+    for (zod, exported) in [
+        (ExampleOnlySlot::zod_schema(), "ExampleOnlySlot"),
+        (UndocumentedSlot::zod_schema(), "UndocumentedSlot"),
+        (ExampleOnlyBrand::zod_schema(), "ExampleOnlyBrand"),
+        (UndocumentedBrand::zod_schema(), "UndocumentedBrand"),
+    ] {
+        assert!(
+            zod.contains(&format!("description: \"{exported}\"")),
+            "{exported} did not describe itself: {zod}"
+        );
     }
 }
 


### PR DESCRIPTION
Four consistency defects, landed together.

An undocumented alias wrote a three-line JSDoc header where every declared item writes two — its call site spelled its own fallback; it now spells through the same two seams every item uses, keeping only its own flattening, because an alias publishes blank doc lines the item flatten drops (folding wholesale would have moved documented aliases' bytes, which the capture forbade; a full cargo-expand diff shows exactly the seven undocumented-alias headers changing and nothing else, and the now-unreferenced formatter is deleted). Docs consisting of nothing but a rust example emitted an empty JSDoc body and an empty description — the fallback now fires on the stripped lines being empty rather than on the attribute being absent, at the one seam every path already crosses, with example-only shapes pinned byte-for-byte against their undocumented twins across items, fields, variants, aliases, and brands (the Zod example field keeps the example, which is its actual home). The merge machinery's own documentation sat on a helper, leaving the public entry point undocumented — moved and extended to cover what the earlier split left unstated. And a HashMap or HashSet written with an explicit hasher fell through to the sibling rendering, publishing a type name nothing emits on all three surfaces plus an unresolvable schema module — containers are now claimed by name at the parse seam and their arguments truncated to the wire arity (serde writes the same bytes whichever hasher is named, proven on the wire against a named-hasher twin), while a container short of its arity still falls through loudly.

Full powerset tests and lint-all green on the merged tree with the exit value read before landing.