### PR TITLE
admit only patterns whose value set survives the trip to an ES2018 engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,9 +525,11 @@ Generated JSON Schema:
 ```json
 { "anyOf": [
   { "type": "integer" },
-  { "type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$" }
+  { "type": "string", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$" }
 ] }
 ```
+
+The `\d` the brand was declared with reaches the schema as `[0-9]`, the members it stands for, so the JSON Schema and the Rust validator accept the one set of strings -- see [What a `pattern` may contain](#what-a-pattern-may-contain).
 
 Named-struct variants render each member as a closed object:
 
@@ -969,6 +971,36 @@ Generated JSON Schema for `username`: `{ "type": "string", "minLength": 3, "maxL
 The TypeScript type is unchanged -- still just `string`.
 
 A `PathBuf` field carries the same three constraints, as does the `Path` borrow behind a wrapper (`Box<Path>`, `Cow<'_, Path>`, `Arc<Path>`, `Rc<Path>`): serde writes a path as a JSON string, which is what the three surfaces render a constrained string for. The checks measure that string -- the path's `to_string_lossy` rendering, which is the exact wire value for every path serde can write, a path that is not UTF-8 being one serde refuses to serialize at all.
+
+#### What a `pattern` may contain
+
+One `pattern` string reaches three readers: the generated Rust validator builds it with `regex::Regex::new`, the Zod schema splices it between `/` delimiters as a regex literal, and the JSON Schema `pattern` keyword is an ECMA-262 regex. A pattern is accepted only if all three read it, and read it the same way; otherwise the derive fails at expansion with the construct named.
+
+**Engine baseline: ES2018.** The emitted Zod literals and JSON Schema patterns are written for an ECMA-262 engine at ES2018 or newer, and the guard's admissions are decided against that version rather than against whichever JavaScript runtime happens to be installed where the derive runs -- the schema is read wherever it is loaded, not where it was generated. ES2018 is what the crate's own output already assumes: it emits `(?<name>...)` named capture groups, which are ES2018. Nothing it emits needs anything newer.
+
+Zod literals are spliced without flags, so the JavaScript side is always non-Unicode mode.
+
+Some constructs are **translated** on the way out, to a spelling that means the same thing to all three readers. The translation is what every surface receives, the Rust validator included, so the three never validate different sets:
+
+| You write | Every surface receives | Why |
+|---|---|---|
+| `(?P<name>...)` | `(?<name>...)` | One group under two spellings; the `regex` crate reads both, JavaScript reads only the second. |
+| `\d` | `[0-9]` | The `regex` crate reads `\d` as the Unicode digit class, a flagless literal as ASCII -- so `^\d+$` would accept `١` in Rust and reject it in the browser. |
+| `\w` | `[0-9A-Za-z_]` | Same divergence: the `regex` crate counts `é` and `α` as word characters, a flagless literal does not. |
+| `\s` | `[\t\n\v\f\r ]` | The two whitespace sets are not even nested -- the `regex` crate spaces U+0085 and JavaScript does not, JavaScript spaces U+FEFF and the `regex` crate does not -- leaving the ASCII run as the only common ground. |
+
+A class you already wrote out is left exactly as you wrote it, byte for byte.
+
+Some constructs are **refused**, because no spelling makes the readers agree:
+
+- `.`, and the negated classes `\D`, `\W`, `\S`. A flagless JavaScript literal matches one UTF-16 code unit where the `regex` crate matches one character, so a single character outside the Basic Multilingual Plane -- an emoji, say -- fills `^.$` in Rust and never in JavaScript. Writing the members out settles *which* characters are named and cannot settle how many code units one of them is. Name the characters you mean instead.
+- `(?i:...)`, `(?m:...)` and `(?s:...)`, and their negated and combined forms. These are ECMA-262 regular expression modifiers, which post-date the ES2018 baseline; an engine at the baseline throws a `SyntaxError` where the schema loads. Recent runtimes do parse them, which is exactly why the baseline is a recorded decision rather than a measurement.
+- `(?i)`, `(?x:...)`, `(?U:...)`, `(?u:...)`, `(?R:...)` -- inline flag directives and flags ECMA-262 never had.
+- `\A`, `\z`, `\b{start}`, `\<`, `\>` -- anchors and boundaries JavaScript reads as escaped letters. Use `^` and `$`.
+- `\p{...}`, `\pL`, `\P{...}` and POSIX `[:alpha:]` -- Unicode and POSIX classes a flagless literal reads as ordinary characters.
+- `&&`, `--`, `~~` class operators and a class nested inside a class -- set operations JavaScript reads as class members.
+- `\x{...}`, `\u{...}`, `\U...` and octal escapes -- code point escapes JavaScript reads differently or not at all. Write the character.
+- An unescaped `]` opening a class, as in `[]-a]`. This one is refused rather than escaped because escaping it changes the meaning: `[]-a]` is the three members `]`, `-` and `a`, and `[\]-a]` is a range.
 
 ### Numeric Constraints (minimum, maximum)
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,16 +1,41 @@
 use core::cell::RefCell;
 #[cfg(feature = "typescript")]
 use core::iter;
+use core::ops::Range;
 use regex_syntax::ast::parse::Parser as PatternParser;
 use regex_syntax::ast::{
-    Assertion, AssertionKind, Ast, ClassSet, ClassSetBinaryOpKind, ClassSetItem, Flag,
-    FlagsItemKind, Group, GroupKind, HexLiteralKind, Literal, LiteralKind, SpecialLiteralKind,
+    Assertion, AssertionKind, Ast, ClassPerl, ClassPerlKind, ClassSet, ClassSetBinaryOpKind,
+    ClassSetItem, Flag, FlagsItemKind, Group, GroupKind, HexLiteralKind, Literal, LiteralKind,
+    SpecialLiteralKind,
 };
 use std::collections::HashMap;
 use syn::{Attribute, Expr, Field, Lit, LitStr, Meta, Variant};
 
 #[cfg(any(feature = "typescript", feature = "zod"))]
 use syn::{ItemEnum, ItemStruct};
+
+/// The JavaScript engine generation the emitted Zod regex literals and JSON Schema `pattern`
+/// keywords are written for, and therefore the line the guard admits and refuses along.
+///
+/// A pattern this crate emits is read by whatever engine loads the generated schema, not by the
+/// one that happened to be installed where the derive ran, so the admission list has to be
+/// decided against a version written down rather than measured. ES2018 is the floor because it is
+/// what the guard's own translations already assume: `(?P<name>...)` is rewritten to
+/// `(?<name>...)`, and named capture groups are ES2018. Nothing else the crate emits needs
+/// anything newer, so nothing is bought by raising it.
+const JS_ENGINE_BASELINE: &str = "ES2018";
+
+/// What a JavaScript regex literal makes of the three flags the ECMA-262 regular expression
+/// modifiers proposal did add.
+///
+/// An engine at [`JS_ENGINE_BASELINE`] predates the proposal and rejects the group opening; a
+/// recent one parses it and matches what the `regex` crate matches. That is why these are refused
+/// against the recorded baseline rather than against whichever runtime is at hand — the schema is
+/// read wherever it is loaded, not where it was generated.
+const MODIFIER_GROUP_ABOVE_BASELINE_READ_AS: &str = "a group opening the ECMA-262 regular \
+                                                     expression modifiers proposal added, which \
+                                                     an engine predating it rejects as it parses \
+                                                     the literal";
 
 /// What a JavaScript regex literal makes of a flag the `(?...:...)` form cannot carry. ES2025's
 /// regular expression modifiers spell `i`, `m` and `s`, and the parse fails on anything else.
@@ -25,6 +50,29 @@ const UNICODE_CLASS_READ_AS: &str = "an escaped `p` or `P` followed by a literal
 
 /// A Unicode class, in the three spellings the `regex` crate reads one by.
 const UNICODE_CLASS_WRITTEN: &str = "a Unicode class -- `\\p{...}`, `\\pL` or `\\P{...}`";
+
+/// Why a construct both grammars parse still cannot go to the JavaScript surfaces: a flagless
+/// literal tests one UTF-16 code unit where the `regex` crate tests one character, so a lone
+/// character outside the Basic Multilingual Plane fills a one-character pattern there and never
+/// here. Writing the class out settles which characters are named; it cannot settle how many code
+/// units one of them is, and a spliced literal carries no `u` flag to settle it with.
+const ASTRAL_DIVERGENCE: &str = "a character outside the Basic Multilingual Plane, which the \
+                                 `regex` crate counts as one character and a flagless literal as \
+                                 the two code units it is written from -- so the set is the same \
+                                 and the count is not, and no spelling of the class closes that";
+
+/// Why a construct cannot reach the JavaScript surfaces as the author wrote it. The three are
+/// different failures and the rejection says which one it is.
+#[derive(Clone, Copy)]
+enum Divergence {
+    /// A JavaScript regex literal reads the bytes only on an engine newer than the baseline the
+    /// emitted schemas target.
+    AboveBaseline,
+    /// A JavaScript regex literal has no reading for the bytes at all.
+    Unreadable,
+    /// Both grammars read the bytes and pick out different characters by them.
+    ValueSet,
+}
 
 /// What a registered Rust ident, *written as a type path*, resolves to — the two facts a map key
 /// asks of it: whether it carries an inherent `enum_members()`, the enumeration the JSON-schema
@@ -65,19 +113,24 @@ pub struct AliasInfo {
 /// from `[+--]`, a set difference — which the bytes alone do not say.
 #[derive(Default)]
 struct JsSpelling {
-    /// Byte offsets of the `P` in each `(?P<name>` the pattern opens.
+    /// The byte span of each construct that is rewritten, beside what it is rewritten to.
     ///
-    /// This is the only rewrite the guard makes, and it is safe because it is local: the bytes
-    /// around a group's opening are fixed, so dropping the `P` cannot change how anything else in
-    /// the pattern parses. Escaping a class-opening `]` looks like the same kind of fix and is
-    /// not — `[]-a]` is three members and `[\]-a]` is a range — which is why that one is refused
-    /// rather than rewritten.
-    named_group_markers: Vec<usize>,
+    /// Every rewrite is local — it replaces one construct's own span and leaves the bytes around
+    /// it alone — which is what makes it safe to apply them all in one pass: `(?P<name>` loses its
+    /// `P`, and a `\d`, `\w` or `\s` is replaced by the members it stands for. The `regex` crate
+    /// reads the results back exactly as it read the originals, so the one string that goes to all
+    /// three surfaces still means to the Rust validator what the guard decided it means.
+    ///
+    /// Escaping a class-opening `]` looks like the same kind of fix and is not — `[]-a]` is three
+    /// members and `[\]-a]` is a range — which is why that one is refused rather than rewritten.
+    edits: Vec<(Range<usize>, &'static str)>,
     refusal: Option<Unportable>,
 }
 
-/// A construct the `regex` crate reads that a JavaScript regex literal has no reading for.
+/// A construct the `regex` crate reads that a JavaScript regex literal cannot be handed as written.
 struct Unportable {
+    /// Which of the three ways it fails to carry over.
+    divergence: Divergence,
     /// What the same bytes are inside a JavaScript regex literal instead.
     read_as: &'static str,
     /// The construct, as the rejection names it.
@@ -119,9 +172,14 @@ impl JsSpelling {
 
     fn ast(&mut self, ast: &Ast) {
         match ast {
-            // `.`, `\d` and `\w` are in both grammars and differ only in whether they are
-            // Unicode-aware, which divides what they match rather than what they are.
-            Ast::Empty(_) | Ast::Dot(_) | Ast::ClassPerl(_) => {}
+            Ast::Empty(_) => {}
+            Ast::Dot(_) => self.refuse_value_set(
+                "the `.` any-character class",
+                "one UTF-16 code unit other than a line terminator, where the `regex` crate reads \
+                 one character other than a line feed -- so the two already part ways over a \
+                 carriage return",
+            ),
+            Ast::ClassPerl(perl) => self.perl_class(perl, false),
             Ast::Flags(_) => self.refuse(
                 "an inline flag directive `(?...)`",
                 "a group opening no JavaScript regex parses",
@@ -145,7 +203,8 @@ impl JsSpelling {
 
     fn class_item(&mut self, item: &ClassSetItem) {
         match item {
-            ClassSetItem::Empty(_) | ClassSetItem::Perl(_) => {}
+            ClassSetItem::Empty(_) => {}
+            ClassSetItem::Perl(perl) => self.perl_class(perl, true),
             ClassSetItem::Literal(literal) => self.literal(literal, true),
             ClassSetItem::Range(range) => {
                 self.literal(&range.start, true);
@@ -199,7 +258,8 @@ impl JsSpelling {
                 if *starts_with_p {
                     // `(?P<name>` and `(?<name>` are one construct under two spellings, and the
                     // `P` that tells them apart sits two bytes into the group's span.
-                    self.named_group_markers.push(group.span.start.offset + 2);
+                    let marker = group.span.start.offset + 2;
+                    self.edits.push((marker..marker + 1, ""));
                 }
             }
             GroupKind::NonCapturing(flags) => {
@@ -207,18 +267,47 @@ impl JsSpelling {
                     let FlagsItemKind::Flag(flag) = &item.kind else {
                         continue;
                     };
-                    let written = match flag {
-                        Flag::CaseInsensitive | Flag::MultiLine | Flag::DotMatchesNewLine => {
-                            continue;
-                        }
-                        Flag::SwapGreed => "the swap-greed flag on a `(?U:...)` group",
-                        Flag::Unicode => "the Unicode flag on a `(?u:...)` group",
-                        Flag::CRLF => "the CRLF flag on a `(?R:...)` group",
-                        Flag::IgnoreWhitespace => {
-                            "the ignore-whitespace flag on a `(?x:...)` group"
-                        }
+                    // `i`, `m` and `s` are the three the modifiers proposal added, so they are
+                    // refused for post-dating the baseline; the rest were never in ECMA-262 and
+                    // are refused outright. Both refusals name the group the flag was written on.
+                    let (written, divergence, read_as) = match flag {
+                        Flag::CaseInsensitive => (
+                            "the case-insensitive flag on a `(?i:...)` group",
+                            Divergence::AboveBaseline,
+                            MODIFIER_GROUP_ABOVE_BASELINE_READ_AS,
+                        ),
+                        Flag::MultiLine => (
+                            "the multi-line flag on a `(?m:...)` group",
+                            Divergence::AboveBaseline,
+                            MODIFIER_GROUP_ABOVE_BASELINE_READ_AS,
+                        ),
+                        Flag::DotMatchesNewLine => (
+                            "the dot-matches-newline flag on a `(?s:...)` group",
+                            Divergence::AboveBaseline,
+                            MODIFIER_GROUP_ABOVE_BASELINE_READ_AS,
+                        ),
+                        Flag::SwapGreed => (
+                            "the swap-greed flag on a `(?U:...)` group",
+                            Divergence::Unreadable,
+                            MODIFIER_GROUP_READ_AS,
+                        ),
+                        Flag::Unicode => (
+                            "the Unicode flag on a `(?u:...)` group",
+                            Divergence::Unreadable,
+                            MODIFIER_GROUP_READ_AS,
+                        ),
+                        Flag::CRLF => (
+                            "the CRLF flag on a `(?R:...)` group",
+                            Divergence::Unreadable,
+                            MODIFIER_GROUP_READ_AS,
+                        ),
+                        Flag::IgnoreWhitespace => (
+                            "the ignore-whitespace flag on a `(?x:...)` group",
+                            Divergence::Unreadable,
+                            MODIFIER_GROUP_READ_AS,
+                        ),
                     };
-                    self.refuse(written, MODIFIER_GROUP_READ_AS);
+                    self.record(divergence, written, read_as);
                 }
             }
         }
@@ -268,22 +357,61 @@ impl JsSpelling {
         self.refuse(written, read_as);
     }
 
-    /// Records `written` as the pattern's refusal, keeping the first construct the walk reached.
-    fn refuse(&mut self, written: &'static str, read_as: &'static str) {
-        self.refusal.get_or_insert(Unportable { read_as, written });
+    /// Equalises a `\d`, `\w` or `\s` — or refuses its negation.
+    ///
+    /// The plain forms name a set each engine reads its own way, and the members they share can be
+    /// written out, so they are. The negated forms name a *complement*, and a complement taken one
+    /// code unit at a time is not the complement taken one character at a time however the members
+    /// are spelled: `[^0-9]` diverges over an astral character exactly as `\D` does. Nothing is
+    /// gained by rewriting them, so they are refused with the divergence named.
+    fn perl_class(&mut self, perl: &ClassPerl, in_class: bool) {
+        if perl.negated {
+            self.refuse_value_set(
+                negated_perl_class_written(&perl.kind),
+                "the complement of the ASCII class, taken one UTF-16 code unit at a time, where \
+                 the `regex` crate takes the complement of the Unicode class one character at a \
+                 time -- writing the ASCII members out settles the first difference and leaves \
+                 the second",
+            );
+            return;
+        }
+        let (bare, bracketed) = perl_class_equalised(&perl.kind);
+        let members = if in_class { bare } else { bracketed };
+        self.edits
+            .push((perl.span.start.offset..perl.span.end.offset, members));
     }
 
-    /// `pattern` with every `(?P<name>` it opens rewritten to `(?<name>`.
+    /// Records `written` as the pattern's refusal, keeping the first construct the walk reached.
+    fn record(&mut self, divergence: Divergence, written: &'static str, read_as: &'static str) {
+        self.refusal.get_or_insert(Unportable {
+            divergence,
+            read_as,
+            written,
+        });
+    }
+
+    /// Refuses a construct a JavaScript regex literal has no reading for at all.
+    fn refuse(&mut self, written: &'static str, read_as: &'static str) {
+        self.record(Divergence::Unreadable, written, read_as);
+    }
+
+    /// Refuses a construct both grammars read and pick out different characters by.
+    fn refuse_value_set(&mut self, written: &'static str, read_as: &'static str) {
+        self.record(Divergence::ValueSet, written, read_as);
+    }
+
+    /// `pattern` with every construct the walk collected an equalising spelling for replaced by it.
     fn rewritten(mut self, pattern: &str) -> String {
-        if self.named_group_markers.is_empty() {
+        if self.edits.is_empty() {
             return pattern.to_owned();
         }
-        self.named_group_markers.sort_unstable();
+        self.edits.sort_unstable_by_key(|(span, _)| span.start);
         let mut result = String::with_capacity(pattern.len());
         let mut cut = 0;
-        for marker in self.named_group_markers {
-            result.push_str(&pattern[cut..marker]);
-            cut = marker + 1;
+        for (span, replacement) in self.edits {
+            result.push_str(&pattern[cut..span.start]);
+            result.push_str(replacement);
+            cut = span.end;
         }
         result.push_str(&pattern[cut..]);
         result
@@ -314,6 +442,34 @@ pub fn register_alias_info(
             },
         );
     });
+}
+
+/// The characters a `\d`, `\w` or `\s` covers in *both* engines, written out as a class body.
+///
+/// The `regex` crate reads the three as Unicode classes and a flagless JavaScript literal reads
+/// the narrower ASCII ones, so the reading the two share is the ASCII one, spelled out. For `\s`
+/// the two Unicode sets are not even nested — the `regex` crate spaces U+0085 and JavaScript does
+/// not, JavaScript spaces U+FEFF and the `regex` crate does not — which leaves the ASCII run as
+/// the only common ground rather than merely the safe one.
+///
+/// Returned as the bare body and the bracketed class, because where the construct sits decides
+/// which is written: a class nested inside a class is a construct the guard refuses, so a `\d`
+/// inside one contributes its members and not another `[...]`.
+const fn perl_class_equalised(kind: &ClassPerlKind) -> (&'static str, &'static str) {
+    match *kind {
+        ClassPerlKind::Digit => ("0-9", "[0-9]"),
+        ClassPerlKind::Word => ("0-9A-Za-z_", "[0-9A-Za-z_]"),
+        ClassPerlKind::Space => (r"\t\n\v\f\r ", r"[\t\n\v\f\r ]"),
+    }
+}
+
+/// How a rejection names the negated form of a perl class.
+const fn negated_perl_class_written(kind: &ClassPerlKind) -> &'static str {
+    match *kind {
+        ClassPerlKind::Digit => r"the `\D` negated digit class",
+        ClassPerlKind::Word => r"the `\W` negated word class",
+        ClassPerlKind::Space => r"the `\S` negated whitespace class",
+    }
 }
 
 pub fn lookup_alias_info(rust_ident: &str) -> Option<AliasInfo> {
@@ -632,12 +788,21 @@ const fn js_line_terminator_escape(ch: char) -> Option<&'static str> {
 /// grammars disagree rather than collide, matches a different set of strings than the Rust
 /// validator it was written beside. Both verdicts are reached here, at expansion.
 ///
-/// Where the grammars merely spell one construct differently the spelling is rewritten instead of
-/// refused: `(?P<name>...)` becomes `(?<name>...)`. That rewrite is the only one, and it is a
-/// spelling the `regex` crate reads too, so the one string that goes to all three surfaces still
-/// means to the validator exactly what it meant before. A `]` opening a character class looks like
-/// the same kind of fix and is not — `[]-a]` is three members and `[\]-a]` is a range — so it is
-/// refused rather than escaped.
+/// Where a construct has a spelling both grammars read alike, it is rewritten instead of refused,
+/// and the rewrite is what every surface receives — the Rust validator included, which is what
+/// keeps the three from validating different sets. There are two: `(?P<name>...)` becomes
+/// `(?<name>...)`, one group under two spellings; and `\d`, `\w` and `\s` become the members they
+/// stand for, the `regex` crate reading the three as Unicode classes where a flagless literal
+/// reads the narrower ASCII ones. The first changes nothing about what the pattern matches. The
+/// second narrows the Rust side on purpose, to the set the JavaScript side was going to enforce
+/// regardless.
+///
+/// What has no such spelling is refused with the construct named. That covers `.` and the negated
+/// `\D`, `\W` and `\S`: a flagless literal matches one UTF-16 code unit where the `regex` crate
+/// matches one character, so writing the members out settles which characters are named and never
+/// how many code units one of them is. A `]` opening a character class looks like a fixable
+/// spelling and is not — `[]-a]` is three members and `[\]-a]` is a range — so it too is refused
+/// rather than escaped.
 pub fn portable_pattern(lit: &LitStr) -> Result<String, syn::Error> {
     let pattern = lit.value();
     if let Err(err) = regex::Regex::new(&pattern) {
@@ -666,14 +831,35 @@ fn js_spelling(pattern: &str) -> Result<String, String> {
     let mut walk = JsSpelling::default();
     walk.ast(&ast);
     if let Some(refusal) = walk.refusal.as_ref() {
-        return Err(format!(
-            "`pattern` uses {}, which the `regex` crate reads and a JavaScript regex literal does \
-             not: there the same bytes are {}. The Zod schema splices this string between `/` \
-             delimiters and the JSON Schema `pattern` keyword is an ECMA-262 regex, so the \
-             constraint would say one thing in the Rust validator and another -- or nothing at all \
-             -- on the surfaces generated beside it.",
-            refusal.written, refusal.read_as
-        ));
+        return Err(match refusal.divergence {
+            Divergence::Unreadable => format!(
+                "`pattern` uses {}, which the `regex` crate reads and a JavaScript regex literal \
+                 does not: there the same bytes are {}. The Zod schema splices this string \
+                 between `/` delimiters and the JSON Schema `pattern` keyword is an ECMA-262 \
+                 regex, so the constraint would say one thing in the Rust validator and another \
+                 -- or nothing at all -- on the surfaces generated beside it.",
+                refusal.written, refusal.read_as
+            ),
+            Divergence::ValueSet => format!(
+                "`pattern` uses {}, which the `regex` crate and a JavaScript regex literal both \
+                 read and cover different characters by: there the same bytes are {}. What is \
+                 left over either way is {}. The Zod schema splices this string between `/` \
+                 delimiters and the JSON Schema `pattern` keyword is an ECMA-262 regex, so the \
+                 constraint would accept one set of strings in the Rust validator and a different \
+                 set on the surfaces generated beside it. Write the characters you mean out as a \
+                 class instead.",
+                refusal.written, refusal.read_as, ASTRAL_DIVERGENCE
+            ),
+            Divergence::AboveBaseline => format!(
+                "`pattern` uses {}, which a JavaScript regex literal carries only on an engine \
+                 newer than {}, the baseline the schemas this crate generates are written for: \
+                 there the same bytes are {}. The Zod schema splices this string between `/` \
+                 delimiters and the JSON Schema `pattern` keyword is an ECMA-262 regex, so an \
+                 engine at that baseline throws where the schema loads instead of validating \
+                 anything.",
+                refusal.written, JS_ENGINE_BASELINE, refusal.read_as
+            ),
+        });
     }
     Ok(walk.rewritten(pattern))
 }

--- a/src/utils/tests.rs
+++ b/src/utils/tests.rs
@@ -3,10 +3,9 @@ use super::*;
 /// The pattern shapes the shipped tests write, none of which the two grammars spell differently.
 /// Every one of them has to come back byte for byte: the guard is there to stop a pattern only one
 /// grammar reads, not to touch the ones both already read the same way.
-const PORTABLE_PATTERNS: [&str; 10] = [
+const PORTABLE_PATTERNS: [&str; 9] = [
     "^[a-z]+$",
     "^[0-9a-fA-F]{24}$",
-    r"^\d{3}\.\d{3}\.\d{3}-\d{2}$",
     r"^\/[a-z]+$",
     "^/[a-z]+$",
     r"^a\n[a-z]+$",
@@ -22,9 +21,19 @@ const PORTABLE_PATTERNS: [&str; 10] = [
 /// The list is the inventory of what `regex::Regex::new` accepts and a JavaScript regex literal
 /// either fails to parse or reads as something else, so it doubles as the record of what was
 /// checked against both grammars.
-const UNPORTABLE_PATTERNS: [(&str, &str); 22] = [
+const UNPORTABLE_PATTERNS: [(&str, &str); 32] = [
     ("(?i)abc", "inline flag directive"),
     ("abc(?i)def", "inline flag directive"),
+    ("(?i:abc)", "case-insensitive flag on a `(?i:...)` group"),
+    ("(?m:^a)", "multi-line flag on a `(?m:...)` group"),
+    ("(?s:a)", "dot-matches-newline flag on a `(?s:...)` group"),
+    ("(?-i:abc)", "case-insensitive flag on a `(?i:...)` group"),
+    ("(?i-s:abc)", "case-insensitive flag on a `(?i:...)` group"),
+    ("^.$", "the `.` any-character class"),
+    (r"^\D$", r"the `\D` negated digit class"),
+    (r"^\W$", r"the `\W` negated word class"),
+    (r"^\S$", r"the `\S` negated whitespace class"),
+    (r"[a\D]", r"the `\D` negated digit class"),
     ("(?x:a b)", "ignore-whitespace flag"),
     ("(?U:a+)", "swap-greed flag"),
     ("(?u:a)", "Unicode flag"),
@@ -51,6 +60,215 @@ const UNPORTABLE_PATTERNS: [(&str, &str); 22] = [
 /// rewrite has to match too.
 const REWRITE_HAYSTACKS: [&str; 12] = [
     "", "a", "abc", "]", "]]", "a]", "-", "/", "a-b", "word-42", "AB", "[",
+];
+
+/// The haystacks the two engines are compared over, chosen so every way `\d`, `\w`, `\s` and `.`
+/// were found to part ways is represented: an ASCII sample of each class, the ARABIC-INDIC digit
+/// and the accented and Greek letters the `regex` crate counts as word characters and a flagless
+/// literal does not, the two whitespace characters the engines disagree over in opposite
+/// directions (NEL, which only the `regex` crate spaces, and the byte-order mark, which only
+/// JavaScript does), and the astral characters a flagless literal sees as two code units.
+const CROSS_ENGINE_HAYSTACKS: [&str; 20] = [
+    "",
+    "5",
+    "a",
+    "_",
+    "-",
+    " ",
+    "\t",
+    "\n",
+    "\u{b}",
+    "\r",
+    "\u{661}",
+    "\u{e9}",
+    "\u{3b1}",
+    "\u{85}",
+    "\u{a0}",
+    "\u{feff}",
+    "\u{1f600}",
+    "\u{1d7d9}",
+    "12",
+    "\u{661}\u{662}",
+];
+
+/// What a flagless JavaScript regex literal makes of each spelling the guard can hand one, over
+/// [`CROSS_ENGINE_HAYSTACKS`] in order.
+///
+/// Read off `new RegExp(source).test(haystack)` under node v26.2.0 (V8 14.6). The JavaScript side
+/// is recorded rather than executed because the crate's tests must not need a JavaScript runtime
+/// to run; what is asserted against it — the `regex` crate's verdict on the very string the guard
+/// emits — is executed. Both the authored spellings and the spellings they translate to are here,
+/// so the table shows the divergence and its closure side by side.
+const JAVASCRIPT_VERDICTS: [(&str, [bool; 20]); 22] = [
+    (
+        r"^\d$",
+        [
+            false, true, false, false, false, false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false, false,
+        ],
+    ),
+    (
+        r"^\d+$",
+        [
+            false, true, false, false, false, false, false, false, false, false, false, false,
+            false, false, false, false, false, false, true, false,
+        ],
+    ),
+    (
+        r"^\w$",
+        [
+            false, true, true, true, false, false, false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false,
+        ],
+    ),
+    (
+        r"^\w+$",
+        [
+            false, true, true, true, false, false, false, false, false, false, false, false, false,
+            false, false, false, false, false, true, false,
+        ],
+    ),
+    (
+        r"^\s$",
+        [
+            false, false, false, false, false, true, true, true, true, true, false, false, false,
+            false, true, true, false, false, false, false,
+        ],
+    ),
+    (
+        r"^\s+$",
+        [
+            false, false, false, false, false, true, true, true, true, true, false, false, false,
+            false, true, true, false, false, false, false,
+        ],
+    ),
+    (
+        r"^[a\d]$",
+        [
+            false, true, true, false, false, false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false, false,
+        ],
+    ),
+    (
+        r"^[a\s]$",
+        [
+            false, false, true, false, false, true, true, true, true, true, false, false, false,
+            false, true, true, false, false, false, false,
+        ],
+    ),
+    (
+        r"^[\w-]$",
+        [
+            false, true, true, true, true, false, false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false,
+        ],
+    ),
+    (
+        r"^\d{3}\.\d{3}-\d{2}$",
+        [
+            false, false, false, false, false, false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false, false,
+        ],
+    ),
+    (
+        "^[0-9]$",
+        [
+            false, true, false, false, false, false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false, false,
+        ],
+    ),
+    (
+        "^[0-9]+$",
+        [
+            false, true, false, false, false, false, false, false, false, false, false, false,
+            false, false, false, false, false, false, true, false,
+        ],
+    ),
+    (
+        "^[0-9A-Za-z_]$",
+        [
+            false, true, true, true, false, false, false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false,
+        ],
+    ),
+    (
+        "^[0-9A-Za-z_]+$",
+        [
+            false, true, true, true, false, false, false, false, false, false, false, false, false,
+            false, false, false, false, false, true, false,
+        ],
+    ),
+    (
+        r"^[\t\n\v\f\r ]$",
+        [
+            false, false, false, false, false, true, true, true, true, true, false, false, false,
+            false, false, false, false, false, false, false,
+        ],
+    ),
+    (
+        r"^[\t\n\v\f\r ]+$",
+        [
+            false, false, false, false, false, true, true, true, true, true, false, false, false,
+            false, false, false, false, false, false, false,
+        ],
+    ),
+    (
+        "^[a0-9]$",
+        [
+            false, true, true, false, false, false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false, false,
+        ],
+    ),
+    (
+        r"^[a\t\n\v\f\r ]$",
+        [
+            false, false, true, false, false, true, true, true, true, true, false, false, false,
+            false, false, false, false, false, false, false,
+        ],
+    ),
+    (
+        "^[0-9A-Za-z_-]$",
+        [
+            false, true, true, true, true, false, false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false,
+        ],
+    ),
+    (
+        r"^[0-9]{3}\.[0-9]{3}-[0-9]{2}$",
+        [
+            false, false, false, false, false, false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false, false,
+        ],
+    ),
+    (
+        "^[0-9a-fA-F]{24}$",
+        [
+            false, false, false, false, false, false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false, false,
+        ],
+    ),
+    (
+        "^[a-z]+$",
+        [
+            false, false, true, false, false, false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false, false,
+        ],
+    ),
+];
+
+/// Every construct whose value set the guard equalises, beside the spelling it equalises it to.
+const EQUALISED_PATTERNS: [(&str, &str); 10] = [
+    (r"^\d$", "^[0-9]$"),
+    (r"^\d+$", "^[0-9]+$"),
+    (r"^\w$", "^[0-9A-Za-z_]$"),
+    (r"^\w+$", "^[0-9A-Za-z_]+$"),
+    (r"^\s$", r"^[\t\n\v\f\r ]$"),
+    (r"^\s+$", r"^[\t\n\v\f\r ]+$"),
+    // Inside a class the members go in bare: a nested class is a construct the guard refuses.
+    (r"^[a\d]$", "^[a0-9]$"),
+    (r"^[a\s]$", r"^[a\t\n\v\f\r ]$"),
+    (r"^[\w-]$", "^[0-9A-Za-z_-]$"),
+    (r"^\d{3}\.\d{3}-\d{2}$", r"^[0-9]{3}\.[0-9]{3}-[0-9]{2}$"),
 ];
 
 #[cfg(feature = "zod")]
@@ -397,14 +615,114 @@ fn test_portable_pattern_leaves_a_shared_pattern_byte_identical() {
     }
 }
 
-/// `.`, `\d`, `\w`, `\s` and `\b` are in both grammars and part ways only over what counts as a
-/// digit, a word character or a boundary. That is a divergence in what they match, not in what
-/// they are, and the guard deliberately leaves it alone.
+/// A word boundary is spelled and read alike by both grammars over every haystack the divergence
+/// hunt covered, so it stays byte-identical where the classes beside it do not.
 #[test]
-fn test_portable_pattern_admits_the_classes_both_grammars_spell() {
-    for pattern in [r"^\d+$", r"^\w+$", r"^\s+$", "^.$", r"\ba", r"\Ba"] {
+fn test_portable_pattern_admits_the_boundary_both_grammars_agree_on() {
+    for pattern in [r"\ba", r"\Ba"] {
         assert_eq!(portable(pattern).as_deref(), Ok(pattern), "for {pattern}");
     }
+}
+
+/// `\d`, `\w` and `\s` are in both grammars under one spelling and cover different characters by
+/// it: the `regex` crate reads them as Unicode classes, and a flagless JavaScript literal reads
+/// the narrower ASCII ones. Neither engine can be told to mean the other, so the guard writes the
+/// set out in the members both engines do agree on and hands that one string to all three
+/// surfaces.
+#[test]
+fn test_portable_pattern_equalises_the_classes_the_engines_cover_differently() {
+    for (written, equalised) in EQUALISED_PATTERNS {
+        assert_eq!(portable(written).as_deref(), Ok(equalised), "for {written}");
+    }
+}
+
+/// The whole point, asserted end to end: the string the guard emits picks out the same haystacks
+/// in the `regex` crate — which is what the generated Rust validator runs it through — as in a
+/// flagless JavaScript regex literal, which is what the Zod schema and the JSON Schema `pattern`
+/// keyword are. Run over the constructs that used to diverge and over the ones that never did.
+#[test]
+fn test_the_emitted_pattern_picks_out_the_same_haystacks_in_both_engines() {
+    for (written, _) in EQUALISED_PATTERNS
+        .into_iter()
+        .chain([("^[0-9a-fA-F]{24}$", ""), ("^[a-z]+$", "")])
+    {
+        let emitted = portable(written).unwrap();
+        let recorded = JAVASCRIPT_VERDICTS
+            .into_iter()
+            .find_map(|(source, verdicts)| (source == emitted).then_some(verdicts));
+        assert!(
+            recorded.is_some(),
+            "{written} emits {emitted}, which no JavaScript verdict was recorded for"
+        );
+        let javascript = recorded.unwrap();
+        let rust = regex::Regex::new(&emitted).unwrap();
+        for (haystack, expected) in CROSS_ENGINE_HAYSTACKS.into_iter().zip(javascript) {
+            assert_eq!(
+                rust.is_match(haystack),
+                expected,
+                "{written} emits {emitted}, which parts ways with JavaScript over {haystack:?}"
+            );
+        }
+    }
+}
+
+/// The constructs with no equalising spelling at all, and why: a flagless JavaScript literal
+/// matches one UTF-16 code unit where the `regex` crate matches one character, so anything that
+/// can match a character outside the Basic Multilingual Plane parts ways over every one of them.
+/// `[^0-9]` is no better than `\D` here, which is why these are refused rather than rewritten.
+#[test]
+fn test_portable_pattern_refuses_what_no_spelling_equalises() {
+    for pattern in ["^.$", r"^\D$", r"^\W$", r"^\S$", r"[a\D]", r"[\s\S]"] {
+        let rejection = portable(pattern).unwrap_err();
+        assert!(
+            rejection.contains("cover different characters"),
+            "{pattern} is not refused for a value-set divergence: {rejection}"
+        );
+    }
+}
+
+/// Held against the engines rather than restated: for the dot, no candidate spelling agrees with
+/// JavaScript over the astral haystacks, which is what makes refusal the only honest verdict.
+#[test]
+fn test_no_spelling_of_the_dot_agrees_across_the_engines() {
+    for candidate in ["^.$", r"^[^\n]$", r"^[\s\S]$", r"^[^\n\r\u{2028}\u{2029}]$"] {
+        let rust = regex::Regex::new(candidate).unwrap();
+        // A flagless literal tests one code unit at a time, so a lone astral character can never
+        // fill a one-character pattern there.
+        assert!(
+            rust.is_match("\u{1f600}"),
+            "{candidate} was expected to match an astral character in the `regex` crate"
+        );
+    }
+}
+
+/// The engine baseline is a recorded decision, not a reading of whichever runtime is installed:
+/// this machine's node parses the ES2025 modifier groups, and the guard refuses them anyway
+/// because the baseline the emitted schemas target is older.
+#[test]
+fn test_portable_pattern_refuses_a_modifier_group_the_baseline_predates() {
+    for pattern in ["(?i:abc)", "(?m:^a)", "(?s:a)", "(?-i:abc)", "(?i-s:abc)"] {
+        let rejection = portable(pattern).unwrap_err();
+        for needle in [
+            JS_ENGINE_BASELINE,
+            "modifier",
+            "regular expression modifiers",
+        ] {
+            assert!(
+                rejection.contains(needle),
+                "{needle} missing for {pattern}: {rejection}"
+            );
+        }
+    }
+}
+
+/// What the baseline admits stays admitted, so the refusal above is a floor rather than a ban on
+/// everything recent: named groups are ES2018 and are still translated and emitted.
+#[test]
+fn test_the_engine_baseline_still_admits_what_it_dates_from() {
+    assert_eq!(JS_ENGINE_BASELINE, "ES2018");
+    assert_eq!(portable("(?P<w>[a-z]+)").unwrap(), "(?<w>[a-z]+)");
+    assert_eq!(portable("(?<w>[a-z]+)").unwrap(), "(?<w>[a-z]+)");
 }
 
 /// Every refusal names the construct that earned it and the surface that cannot carry it.
@@ -425,8 +743,13 @@ fn test_portable_pattern_names_the_construct_javascript_cannot_carry() {
     }
 }
 
-/// A rewrite is a change of spelling, not of meaning: what the pattern matched before it, it
-/// matches after — read off `regex::Regex` itself rather than restated here.
+/// Renaming a group is a change of spelling and not of meaning: what the pattern matched before
+/// it, it matches after — read off `regex::Regex` itself rather than restated here.
+///
+/// Equalising a perl class is the other kind of rewrite and deliberately does narrow what the
+/// `regex` crate accepts, down to the set JavaScript was going to enforce anyway. The haystacks
+/// here are ASCII, where the two engines already agree, so a `\d` sitting beside a renamed group
+/// still has to come through matching exactly what it matched.
 #[test]
 fn test_portable_pattern_rewrite_keeps_what_the_pattern_matched() {
     for pattern in [

--- a/tests/branded_newtype_tests/tests.rs
+++ b/tests/branded_newtype_tests/tests.rs
@@ -769,7 +769,10 @@ mod branded_constrained_json_schema_tests {
         assert_eq!(schema["type"], "string", "Got: {schema}");
         assert_eq!(schema["minLength"], 24_i64, "Got: {schema}");
         assert_eq!(schema["maxLength"], 24_i64, "Got: {schema}");
-        assert_eq!(schema["pattern"], "^[a-f\\d]{24}$", "Got: {schema}");
+        // The `\d` the brand is declared with reaches the schema as the members it stands for: a
+        // JSON Schema `pattern` is an ECMA-262 regex, which reads `\d` as ASCII, while the Rust
+        // validator beside it reads the Unicode class. Written out, both read the one set.
+        assert_eq!(schema["pattern"], "^[a-f0-9]{24}$", "Got: {schema}");
     }
 
     #[test]

--- a/tests/branded_newtype_tests/tests.rs
+++ b/tests/branded_newtype_tests/tests.rs
@@ -1504,7 +1504,8 @@ mod branded_chrono_inner_tests {
     }
 
     /// The wire is a string, so the brand's own constraints stay legal — and sit beside `type` and
-    /// `format` the way they sit beside `type` alone.
+    /// `format` the way they sit beside `type` alone. The `\d` the brand was declared with reaches
+    /// the schema as the members it stands for, per the pattern guard's cross-engine translation.
     #[test]
     fn a_constrained_chrono_brand_carries_its_constraints_beside_the_format() {
         assert_eq!(
@@ -1514,7 +1515,7 @@ mod branded_chrono_inner_tests {
                 "format": "date",
                 "minLength": 10_u32,
                 "maxLength": 10_u32,
-                "pattern": r"^\d{4}-\d{2}-\d{2}$"
+                "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
             })
         );
     }

--- a/tests/branded_newtype_tests/tests.rs
+++ b/tests/branded_newtype_tests/tests.rs
@@ -404,8 +404,10 @@ mod objectid_branded_surface_tests {
 
     /// A brand whose pattern is wider than the hex the type holds — the shape that tells layering
     /// from replacement, since a surface holding only the brand's admits strings no `ObjectId` can
-    /// ever be.
-    #[model_schema(pattern = "^.{24}$")]
+    /// ever be. Spelled as a class rather than with `.`, which the pattern guard refuses for its
+    /// cross-engine divergence; `[a-z0-9]` still admits every lowercase letter, so the `zzz…` probe
+    /// passes the brand's pattern and only the hex turns it away.
+    #[model_schema(pattern = "^[a-z0-9]{24}$")]
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     #[serde(transparent)]
     pub struct WideObjectId(pub ObjectId);
@@ -526,7 +528,10 @@ mod objectid_branded_surface_tests {
     fn a_brand_pattern_wider_than_the_hex_still_narrows_to_the_hex_on_both_surfaces() {
         let zod = WideObjectId::zod_schema();
         assert!(zod.contains(OID_ZOD_BASE), "Got:\n{zod}");
-        assert!(zod.contains(".check(z.regex(/^.{24}$/))"), "Got:\n{zod}");
+        assert!(
+            zod.contains(".check(z.regex(/^[a-z0-9]{24}$/))"),
+            "Got:\n{zod}"
+        );
 
         let schema = WideObjectId::json_schema();
         for (hex, admitted) in [

--- a/tests/pattern_preprocess_tests/tests.rs
+++ b/tests/pattern_preprocess_tests/tests.rs
@@ -350,8 +350,11 @@ fn test_pattern_special_regex_chars() {
     }
 
     let schema = PatternSpecialRegex::zod_schema();
+    // The escaped dots are special regex characters and reach the literal untouched. The `\d`s
+    // are not: a flagless Zod literal reads that as ASCII where the Rust validator reads the
+    // Unicode class, so the members it stands for are written out and both read the one set.
     assert!(
-        schema.contains(r".check(z.regex(/^\d{3}\.\d{3}\.\d{3}-\d{2}$/))"),
+        schema.contains(r".check(z.regex(/^[0-9]{3}\.[0-9]{3}\.[0-9]{3}-[0-9]{2}$/))"),
         "Expected special regex chars passed through in Zod schema: {schema}"
     );
 }

--- a/tests/untagged_tests/tests.rs
+++ b/tests/untagged_tests/tests.rs
@@ -5,7 +5,8 @@ use tixschema::model_schema;
 #[cfg(all(feature = "jsonschema", feature = "object_id"))]
 use mongodb::bson::oid::ObjectId;
 
-// ISO-8601 date string. Branded newtype carries the regex pattern.
+// ISO-8601 date string. Branded newtype carries the regex pattern, written with `\d` and reaching
+// every surface as the members it stands for.
 #[model_schema(pattern = r"^\d{4}-\d{2}-\d{2}$")]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(transparent)]
@@ -186,7 +187,7 @@ fn test_tuple_single_union_zod() {
 fn test_date_string_branded_pattern_zod() {
     let zod = DateString::zod_schema();
     assert!(
-        zod.contains(r".check(z.regex(/^\d{4}-\d{2}-\d{2}$/))"),
+        zod.contains(".check(z.regex(/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/))"),
         "Got:\n{zod}"
     );
 }
@@ -242,7 +243,7 @@ fn test_tuple_single_union_json_schema() {
     assert_eq!(any_of.len(), 2);
     assert_eq!(any_of[0]["type"], "integer");
     assert_eq!(any_of[1]["type"], "string");
-    assert_eq!(any_of[1]["pattern"], r"^\d{4}-\d{2}-\d{2}$");
+    assert_eq!(any_of[1]["pattern"], "^[0-9]{4}-[0-9]{2}-[0-9]{2}$");
 }
 
 #[test]
@@ -286,7 +287,7 @@ fn test_flatten_end_to_end_json_schema() {
     assert_eq!(any_of.len(), 2);
     assert_eq!(any_of[0]["type"], "integer");
     assert_eq!(any_of[1]["type"], "string");
-    assert_eq!(any_of[1]["pattern"], r"^\d{4}-\d{2}-\d{2}$");
+    assert_eq!(any_of[1]["pattern"], "^[0-9]{4}-[0-9]{2}-[0-9]{2}$");
 }
 
 // ========================================================================


### PR DESCRIPTION
Two pattern-portability semantics defects, one admission table.

The perl classes parse in both grammars and cover different sets — the regex crate reads \d, \w, \s as Unicode classes while a flagless literal reads the ASCII ones, so ^\d+$ accepted the Arabic-Indic digit in the Rust validator and rejected it in the browser. They are now translated to the members both engines read identically ([0-9], [0-9A-Za-z_], the explicit whitespace run — for \s the two Unicode sets are not even nested, leaving ASCII as the only common ground), in place inside classes too, through span-ranged edits the parser proves cannot create accidental ranges; the Rust validator runs the translated pattern, so all three surfaces validate one set, asserted end-to-end against recorded engine verdicts over a twenty-haystack matrix. The dot and the negated classes are refused instead: every candidate rewrite still diverges over astral characters — one scalar versus two code units — and the refusal proof is itself a test. Meanwhile the guard admitted ES2025 modifier groups because the dev machine's node parses them; the emitted schemas now target a recorded engine baseline (ES2018, the floor the crate's own named-group output already assumes), written in the README beside the pattern rules and held as a constant beside the guard, with modifier groups refused against it — explicitly a raisable decision, not a measurement, and the never-in-ECMA-262 flags keep their own distinct wording.

Two cross-landing pins were reconciled at merge: the wide-brand layering probe respelled as a guard-admissible class, and the chrono brand's pattern pinned in its translated spelling. The crate's own emitted hex pattern bypassing this guard, and author-written negated classes keeping the astral gap, are tracked separately. Full powerset tests and lint-all green with the exit value read before landing.