### PR TITLE
answer every registered key by what serde writes for it

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ pub struct Schedule {
 }
 ```
 
-A `#[serde(transparent)]` branded newtype over a string — a brand over `String` or `PathBuf`, or over another such brand — is the open case wearing a name. serde writes the brand as the bare string its inner is, which is exactly what a JSON object key is, so the map is an object keyed by arbitrary strings. TypeScript and Zod keep the brand's own spelling as the key type the way they keep an enum's — `Partial<Record<CorrelationId, V>>` and `z.record(CorrelationId$Schema, V)` — while the JSON schema is the open object, having no brand to say. A brand over anything else is refused as a key.
+A `#[serde(transparent)]` branded newtype over a string — a brand over `String` or `PathBuf`, or over another such brand — is the open case wearing a name. serde writes the brand as the bare string its inner is, which is exactly what a JSON object key is, so the map is an object keyed by arbitrary strings. TypeScript and Zod keep the brand's own spelling as the key type the way they keep an enum's — `Partial<Record<CorrelationId, V>>` and `z.record(CorrelationId$Schema, V)` — while the JSON schema is the open object, having no brand to say.
 
 ```rust
 use std::collections::HashMap;
@@ -162,7 +162,34 @@ pub struct Traces {
 }
 ```
 
-A key path is the one spelling that can name an enum or a brand, so a key path the expansion can prove is *neither* a plain enum nor a string-shaped brand — a struct, a brand over a non-string inner, a tagged or untagged enum, or a `#[model_schema()]` alias of any of them — is refused where it is written, at whatever depth the map sits at, naming the type as the author spelled it. A key path the expansion has not seen yet, one declared after the type that writes the map or one from another crate, cannot be ruled out and is emitted as an enumerating key; a key that turns out to have no members surfaces as an `E0599` at the key type instead.
+A brand adds a name to its inner's wire and nothing else, so it keys a map however its inner keys one — at every link of a chain of brands. A brand over a **plain enum** is the open case too: serde writes the variant name, which is a bare string, and the brand publishes no `enum_members()` of its own for a schema to close the object over, so it opens the object under its own name rather than closing it over members nothing can supply. A brand over a value serde **stringifies** — a number, a `bool`, a chrono type — describes exactly as that bare inner describes, the open object with nothing said about its members, while TypeScript and Zod keep the brand's name as the key type. Only a brand over something serde writes as no key at all — a struct, a container, a tuple, a nested map, an `ObjectId` — is refused, and so is a brand over an inner this expansion has not classified yet: what serde writes for such an inner is exactly what cannot be told.
+
+A `#[model_schema()]` **alias** answers the same way, its target standing in for it because a type path resolves straight through an alias. An alias of `String` or `PathBuf`, of a string-shaped brand, or of another such alias is written as that bare string, so it keys a map exactly as a `String` does — under the alias's own exported name on the nominal surfaces and as the open object on the structural one. An alias of a plain enum enumerates its members, as it always has.
+
+```rust
+use std::collections::HashMap;
+
+#[model_schema()]
+type SlotKey = String;
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(transparent)]
+pub struct Tick(u32);
+
+#[model_schema()]
+#[derive(Serialize, Deserialize)]
+pub struct Samples {
+    // {"type": "object", "additionalProperties": {"type": "number"}}, serialized {"abc": 1.0}
+    // TypeScript `Partial<Record<SlotKeyType, number>>`, Zod `z.record(SlotKeyType$Schema, ...)`
+    pub by_slot: HashMap<SlotKey, f64>,
+    // {"type": "object", "additionalProperties": true}, serialized {"7": 1.0}
+    // TypeScript `Partial<Record<Tick, number>>`, Zod `z.record(Tick$Schema, ...)`
+    pub by_tick: HashMap<Tick, f64>,
+}
+```
+
+A key path is the one spelling that can name an enum, an alias or a brand, so a key path the expansion can prove serde writes as no key at all — a struct, a brand over one or over a container, a tagged or untagged enum, or a `#[model_schema()]` alias of any of them — is refused where it is written, at whatever depth the map sits at, naming the type as the author spelled it. A key path the expansion has not seen yet, one declared after the type that writes the map or one from another crate, cannot be ruled out and is emitted as an enumerating key; a key that turns out to have no members surfaces as an `E0599` at the key type instead.
 
 The remaining refusals are all one rule: a JSON object key is a string, and `serde_json` raises `key must be a string` — refusing the whole map at serialization, with no fallback form — for every key whose own wire form is not one. Each of these is therefore refused rather than described, there being no object to describe:
 
@@ -173,7 +200,7 @@ The remaining refusals are all one rule: a JSON object key is a string, and `ser
 
 All of them are covered under [Compilation Errors](#compilation-errors), with the exact diagnostic each produces.
 
-Every other key is neither open nor enumerable, and none of them is refused: serde stringifies each one into a key for you. The JSON schema describes such a map as an object and says nothing about its members — `{"type": "object", "additionalProperties": true}` — while TypeScript and Zod keep the key's own type, so a `HashMap<u32, String>` is `Partial<Record<number, string>>` and `z.record(z.number().int(), z.string())`. serde writes the object with the key's string form for its keys: `7` becomes `"7"`, `true` becomes `"true"`, a chrono `NaiveDate` its ISO rendering. Only the narrowing is missing, not the object. The rule the refusals apply is refuse-what-serde-refuses, never refuse-what-is-not-a-`String`.
+Every other key is neither open nor enumerable, and none of them is refused: serde stringifies each one into a key for you. The JSON schema describes such a map as an object and says nothing about its members — `{"type": "object", "additionalProperties": true}` — while TypeScript and Zod keep the key's own type, so a `HashMap<u32, String>` is `Partial<Record<number, string>>` and `z.record(z.number().int(), z.string())`. serde writes the object with the key's string form for its keys: `7` becomes `"7"`, `true` becomes `"true"`, a chrono `NaiveDate` its ISO rendering. A brand over one of those writes the same object and describes as the same one, under the brand's name. Only the narrowing is missing, not the object. The rule the refusals apply is refuse-what-serde-refuses, never refuse-what-is-not-a-`String`.
 
 ### Pointers and Borrowed Values
 
@@ -1563,7 +1590,7 @@ If the `serde` feature is disabled but serde attributes are present, you will se
 
 2. **Type References**: Nested types reference each other by their TypeScript name (with the `Json` suffix stripped if present).
 
-3. **Map Keys**: `HashMap` and `BTreeMap` are both supported, and the key decides what the map describes as: a `String` key gives an object open to any string key, and a plain `#[model_schema()]` enum key gives one closed to the enum's members. A key path proved to be neither, and any sequence-wrapped key, is refused at expansion; every other key describes as an open object. See [Collections and Maps](#collections-and-maps).
+3. **Map Keys**: `HashMap` and `BTreeMap` are both supported, and the key decides what the map describes as: a `String` key gives an object open to any string key, and a plain `#[model_schema()]` enum key gives one closed to the enum's members. A brand and a `#[model_schema()]` alias answer by their inner and their target, keeping their own name on the TypeScript and Zod surfaces. A key path proved to be one serde writes as no key at all, and any sequence-wrapped key, is refused at expansion; every other key describes as an open object. See [Collections and Maps](#collections-and-maps).
 
 4. **Array Types**: `Vec<T>` becomes `Array<T>` in TypeScript, one `Array<...>` per level written — `Vec<Vec<T>>` is `Array<Array<T>>`.
 
@@ -1633,9 +1660,9 @@ tixschema = { features = ["serde"] }
 
 **Error:** *a map key must be a plain `#[model_schema()]` enum, whose members become the object's keys — `<type>` resolves to a type with no `enum_members()`*, reported at the field; or `no associated function or constant named enum_members found for <type>` (`E0599`), reported at the map's key type.
 
-A map key written as a type path must be a plain `#[model_schema()]` enum, whose members become the object's keys, or a `#[serde(transparent)]` brand over a string, which keys the map the way a `String` does. A `String` key is the third supported spelling, and every key that is none of them is covered under [Collections and Maps](#collections-and-maps) — this entry is about the two diagnostics a type path earns.
+A map key written as a type path must be something serde writes into a key: a plain `#[model_schema()]` enum, whose members become the object's keys; a `#[serde(transparent)]` brand or a `#[model_schema()]` alias whose wire form is one serde writes into a key; or a `String`. [Collections and Maps](#collections-and-maps) sets out what each of those describes as, and every key that is none of them is covered there too — this entry is about the two diagnostics a type path earns.
 
-A key the expansion has already seen and knows is neither — a struct, a brand over a non-string inner, a tagged or untagged enum, or a `#[model_schema()]` alias of one of those — is named directly, at the field that writes the map:
+A key the expansion has already seen and knows serde writes as no key at all — a struct, a brand over one or over a container, a tagged or untagged enum, or a `#[model_schema()]` alias of one of those — is named directly, at the field that writes the map:
 
 ```rust
 #[model_schema()]
@@ -1655,7 +1682,8 @@ An alias resolves through to what it names, so an alias of a struct is refused u
 Items expand in the order they are written, though, so a key declared after the type that writes the map, like one from another crate, has not been seen yet and is emitted as an enumerating key. When such a key carries no `enum_members()`, the same requirement surfaces as an `E0599` at the key type:
 
 ```rust
-// Wrong: `LateKey` resolves to `String`, which has no members to enumerate
+// Wrong: `LateKey` has not expanded yet, so it is emitted as an enumerating key — and it
+// resolves to `String`, which has no members to enumerate
 #[model_schema()]
 pub struct BadConfig {
     pub slots: HashMap<LateKey, String>, // E0599, reported at `LateKey`
@@ -1671,13 +1699,18 @@ pub enum Slot {
     Secondary,
 }
 
+// Correct: the alias expands first, so the registry knows serde writes it as a bare string
+#[model_schema()]
+pub type EarlyKey = String;
+
 #[model_schema()]
 pub struct Config {
     pub slots: HashMap<Slot, String>,
+    pub names: HashMap<EarlyKey, String>,
 }
 ```
 
-Declaration order decides only which of the two diagnostics is reported. A plain enum key works wherever it is declared.
+A plain enum key works wherever it is declared: it carries `enum_members()`, so the emitted call resolves whichever order the two items expand in, and declaration order decides only which of the two diagnostics a key *without* members earns. Every other supported spelling — an alias of a string, a brand — is known only through the registry, so it has to expand before the type that keys a map by it; until then the expansion cannot tell it from a plain enum declared later, and emits the enumerating key it would need to be.
 
 #### Sequence-Wrapped Map Keys
 

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -646,13 +646,22 @@ pub fn exec_model_schema(args: TokenStream, input: TokenStream) -> TokenStream {
 
 /// Classifies what an alias resolves to, for the registry.
 ///
-/// A `SiblingType` is the only shape that can reach a plain enum, and it answers with whatever the
-/// named type registered: an alias of an alias of an enum inherits `EnumMembers` down the chain.
-/// A target registered after its alias reads as `Unknown`, which callers must treat as "cannot
-/// rule it out" rather than as a negative. An array (`Vec<Slot>`, `[Slot; 4]`) is a collection, not
-/// the enum it holds.
+/// A target serde writes as a bare string answers first, and it answers for the alias too: an alias
+/// is the type it names, so `type LateKey = String` is written as that bare string and keys a map
+/// exactly as a `String` does, under the alias's own exported name. `PathBuf`, a string-wire brand,
+/// and an alias chain ending in either are the same target wearing another spelling, which is why
+/// the question is asked of the key dispatch rather than of the target's syntax.
+///
+/// Below that, a `SiblingType` is the only shape that can reach a plain enum, and it answers with
+/// whatever the named type registered: an alias of an alias of an enum inherits `EnumMembers` down
+/// the chain. A target registered after its alias reads as `Unknown`, which callers must treat as
+/// "cannot rule it out" rather than as a negative. An array (`Vec<Slot>`, `[Slot; 4]`) is a
+/// collection, not the enum it holds.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn alias_target_kind(alias_field_def: &FieldDef) -> AliasKind {
+    if matches!(map_key_path(alias_field_def), MapKeyPath::Open) {
+        return AliasKind::StringWire;
+    }
     let FieldDefType::SiblingType(target_name, generic_args) = &alias_field_def.field_type else {
         return AliasKind::NoEnumMembers;
     };
@@ -1331,22 +1340,33 @@ fn branded_pattern_error(name: &Ident, args: &ModelSchemaArgs) -> Option<proc_ma
 
 /// What the registry records for a brand.
 ///
-/// A brand is `#[serde(transparent)]`, so its wire form is its inner's: a brand over a string is
-/// written as that bare string, which is exactly what a JSON object key is, and so it keys a map the
-/// way `String` does — under its own name on the nominal surfaces, and as the open object on the
-/// structural one, which has no brand to say. The inner is asked through the very dispatch a map key
-/// is read by, so only an inner that opens a map opens the brand: a brand over a number, a chrono
-/// value, an `ObjectId`, or a container answers `NoEnumMembers` and stays refused as a key, which is
-/// what it was before this question was asked at all.
+/// A brand is `#[serde(transparent)]`, so its wire form is its inner's, and the registry's question
+/// is what serde writes: the brand's answer is the inner's answer, read through the very dispatch a
+/// map key is read by. A brand over a string is written as that bare string, which is exactly what a
+/// JSON object key is, so it keys a map the way `String` does; a brand over a value serde
+/// stringifies — a number, a `bool`, a chrono rendering — writes the object its bare inner writes,
+/// so it describes as that inner does, with nothing said about the members; a brand over a struct, a
+/// container, an `ObjectId` or a tuple writes no key at all, and stays refused. Either way the
+/// nominal surfaces keep the brand's own name, which is all the brand adds to its inner's wire.
 ///
 /// It is never `EnumMembers`: the brand publishes no `enum_members()` of its own, whatever it wraps.
+/// A brand over a plain enum is `StringWire` instead — serde writes the variant name, which is a
+/// bare string — so the object is open under the brand's name rather than closed to members the
+/// brand has no method to supply. An inner this expansion has not classified keeps the refusal it
+/// had: what serde writes for it is exactly what cannot be told yet, and the brand has no members of
+/// its own to fall back on.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn branded_alias_kind(inner_field: &Field) -> AliasKind {
     let inner = get_field_def("", &inner_field.ty, "");
-    if matches!(map_key_path(&inner), MapKeyPath::Open) {
-        AliasKind::StringWire
-    } else {
-        AliasKind::NoEnumMembers
+    match map_key_path(&inner) {
+        MapKeyPath::Open => AliasKind::StringWire,
+        MapKeyPath::Unnarrowed => AliasKind::Stringified,
+        MapKeyPath::Refused(_) => AliasKind::NoEnumMembers,
+        MapKeyPath::Enumerated(inner_name) => match registered_key_kind(inner_name) {
+            Some(AliasKind::EnumMembers) => AliasKind::StringWire,
+            Some(AliasKind::Stringified) => AliasKind::Stringified,
+            _ => AliasKind::NoEnumMembers,
+        },
     }
 }
 
@@ -5449,9 +5469,11 @@ fn sequence_wrapper_element(fld: &FieldDef) -> Option<&FieldDef> {
 /// and reading past one would answer for the inner instead — enumerating an enum's members as keys
 /// the map cannot hold. A sequence writes an array; an `Option` writes its inner or nothing at all.
 ///
-/// Below them, only a bare type path can name an enum or a brand, and the registry says which: a
-/// generic spelling is a type this expansion has no `enum_members()` for, and every other type
-/// names keys the schema cannot enumerate.
+/// Below them, only a bare type path can name an enum, an alias or a brand, and the registry says
+/// which by saying what serde writes for it: a bare string opens the object, a value serde
+/// stringifies leaves its members unnarrowed, and anything else stays on the enumerating path,
+/// where a name the registry positively rules out earns the refusal. A generic spelling is a type
+/// this expansion has no `enum_members()` for, and every other type names keys it cannot enumerate.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn map_key_path(key: &FieldDef) -> MapKeyPath<'_> {
     if key.array_depth > 0 || sequence_wrapper_element(key).is_some() {
@@ -5463,10 +5485,10 @@ fn map_key_path(key: &FieldDef) -> MapKeyPath<'_> {
     match &key.field_type {
         FieldDefType::String => MapKeyPath::Open,
         FieldDefType::SiblingType(key_type_name, args) if args.is_empty() => {
-            if writes_string_wire(key_type_name) {
-                MapKeyPath::Open
-            } else {
-                MapKeyPath::Enumerated(key_type_name.as_str())
+            match registered_key_kind(key_type_name) {
+                Some(AliasKind::StringWire) => MapKeyPath::Open,
+                Some(AliasKind::Stringified) => MapKeyPath::Unnarrowed,
+                _ => MapKeyPath::Enumerated(key_type_name.as_str()),
             }
         }
         FieldDefType::Tuple(..) => MapKeyPath::Refused(unwritable_key(key, WRITTEN_AS_ARRAY)),
@@ -5574,21 +5596,19 @@ fn proves_no_enum_members(key_type_name: &str) -> bool {
     lookup_alias_info(key_type_name).is_some_and(|key_alias| {
         matches!(
             key_alias.kind,
-            AliasKind::NoEnumMembers | AliasKind::StringWire
+            AliasKind::NoEnumMembers | AliasKind::StringWire | AliasKind::Stringified
         )
     })
 }
 
-/// Whether the registry proves serde writes the named type as a bare string — the wire form a JSON
-/// object key has, so such a key opens the map the way a `String` key does, under its own name.
+/// What the registry says serde writes for a key spelled by this name, and `None` for a name it
+/// never saw registered.
 ///
-/// Only a `#[serde(transparent)]` brand over a string-shaped inner earns this, and an alias chain
-/// ending in one inherits it. An unregistered name earns nothing: the expansion cannot tell it from
-/// a plain enum declared later.
+/// An unregistered name earns nothing: the expansion cannot tell it from a plain enum declared
+/// later, which is why the dispatch above leaves such a key on the enumerating path.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-fn writes_string_wire(key_type_name: &str) -> bool {
-    lookup_alias_info(key_type_name)
-        .is_some_and(|key_alias| key_alias.kind == AliasKind::StringWire)
+fn registered_key_kind(key_type_name: &str) -> Option<AliasKind> {
+    lookup_alias_info(key_type_name).map(|key_alias| key_alias.kind)
 }
 
 /// Why the first map key this field reaches, at any depth, has no rendering.

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -2893,18 +2893,29 @@ fn a_required_map_value_carries_no_nullable_wrap() {
 }
 
 /// The kind an alias registers is its *target's* answer, because a type path resolves through the
-/// alias. `Vec<Slot>` is the collection, not the enum it holds; a target this expansion has not
-/// seen registered is `Unknown`, which is not a negative.
+/// alias. A target serde writes as a bare string makes the alias one too, whatever spelling that
+/// target wears. `Vec<Slot>` is the collection, not the enum it holds; a target this expansion has
+/// not seen registered is `Unknown`, which is not a negative.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
 fn an_alias_registers_the_kind_of_what_it_targets() {
     register_alias_info("Slot", "Slot", "slot_schema", AliasKind::EnumMembers);
     register_alias_info("Doc", "Doc", "doc_schema", AliasKind::NoEnumMembers);
+    register_alias_info(
+        "CorrelationId",
+        "CorrelationId",
+        "correlation_id_schema",
+        AliasKind::StringWire,
+    );
     for (target, expected) in [
         ("Slot", AliasKind::EnumMembers),
         ("Doc", AliasKind::NoEnumMembers),
-        ("String", AliasKind::NoEnumMembers),
+        ("String", AliasKind::StringWire),
+        ("PathBuf", AliasKind::StringWire),
+        ("CorrelationId", AliasKind::StringWire),
         ("u32", AliasKind::NoEnumMembers),
+        ("Vec<String>", AliasKind::NoEnumMembers),
+        ("Option<String>", AliasKind::NoEnumMembers),
         ("Vec<Slot>", AliasKind::NoEnumMembers),
         ("HashMap<Slot, String>", AliasKind::NoEnumMembers),
         ("Wrapper<Slot>", AliasKind::NoEnumMembers),
@@ -2914,6 +2925,133 @@ fn an_alias_registers_the_kind_of_what_it_targets() {
         let kind = super::alias_target_kind(&super::get_field_def("AliasType", &ty, ""));
         assert_eq!(kind, expected, "for alias target {target}");
     }
+}
+
+/// An alias of an alias of a string is still that bare string at the type path, so the chain carries
+/// `StringWire` through every link — and so does a chain ending at a string-wire brand.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn an_alias_chain_carries_the_string_wire_kind_to_its_end() {
+    register_alias_info(
+        "CorrelationId",
+        "CorrelationId",
+        "correlation_id_schema",
+        AliasKind::StringWire,
+    );
+    for end in ["String", "CorrelationId"] {
+        let first_target: syn::Type = syn::parse_str(end).unwrap();
+        let first = super::alias_target_kind(&super::get_field_def("FirstType", &first_target, ""));
+        assert_eq!(first, AliasKind::StringWire, "for a chain ending at {end}");
+        register_alias_info("First", "FirstType", "first_type_schema", first);
+
+        let second_target: syn::Type = syn::parse_str("First").unwrap();
+        let second =
+            super::alias_target_kind(&super::get_field_def("SecondType", &second_target, ""));
+        assert_eq!(second, AliasKind::StringWire, "for a chain ending at {end}");
+    }
+}
+
+/// [`super::branded_alias_kind`] read off the one field a brand is written with.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn brand_kind(inner: &str) -> AliasKind {
+    let inner_ty: syn::Type = syn::parse_str(inner).unwrap();
+    let item: syn::ItemStruct = syn::parse_quote! { struct Brand(#inner_ty); };
+    super::branded_alias_kind(item.fields.iter().next().unwrap())
+}
+
+/// The kind a brand registers is what serde writes for its inner, the brand being
+/// `#[serde(transparent)]` over it. A string-shaped inner is written as the bare string a JSON
+/// object key is; a plain enum's variant name is that bare string too, and the brand carries no
+/// `enum_members()` of its own to close an object over; a value serde stringifies is written as the
+/// object its bare inner writes; and an inner serde refuses as a key, or one this expansion has not
+/// classified, leaves the brand refused.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn a_brand_registers_what_serde_writes_for_its_inner() {
+    register_alias_info("Slot", "Slot", "slot_schema", AliasKind::EnumMembers);
+    register_alias_info("Doc", "Doc", "doc_schema", AliasKind::NoEnumMembers);
+    register_alias_info(
+        "CorrelationId",
+        "CorrelationId",
+        "correlation_id_schema",
+        AliasKind::StringWire,
+    );
+    register_alias_info("Tick", "Tick", "tick_schema", AliasKind::Stringified);
+    for (inner, expected) in [
+        ("String", AliasKind::StringWire),
+        ("PathBuf", AliasKind::StringWire),
+        ("CorrelationId", AliasKind::StringWire),
+        ("Slot", AliasKind::StringWire),
+        ("u32", AliasKind::Stringified),
+        ("bool", AliasKind::Stringified),
+        ("f64", AliasKind::Stringified),
+        ("Tick", AliasKind::Stringified),
+        ("Doc", AliasKind::NoEnumMembers),
+        ("Vec<String>", AliasKind::NoEnumMembers),
+        ("(String, String)", AliasKind::NoEnumMembers),
+        ("HashMap<String, u32>", AliasKind::NoEnumMembers),
+        ("Ghost", AliasKind::NoEnumMembers),
+    ] {
+        assert_eq!(brand_kind(inner), expected, "for brand inner {inner}");
+    }
+}
+
+/// The chrono renderings are keys serde stringifies, so a brand over one is written as the object
+/// its bare inner is written as.
+#[cfg(all(
+    feature = "chrono",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn a_brand_over_a_chrono_inner_is_stringified() {
+    for inner in ["NaiveDate", "NaiveTime", "NaiveDateTime", "DateTime<Utc>"] {
+        assert_eq!(
+            brand_kind(inner),
+            AliasKind::Stringified,
+            "for brand inner {inner}"
+        );
+    }
+}
+
+/// An `ObjectId` writes a JSON object, which serde uses as no key at all, so a brand over one stays
+/// refused where the stringifying inners are let through.
+#[cfg(all(
+    feature = "object_id",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn a_brand_over_an_object_id_stays_refused() {
+    assert_eq!(brand_kind("ObjectId"), AliasKind::NoEnumMembers);
+}
+
+/// A key the registry proves serde stringifies keeps the open object its bare inner describes as,
+/// at every depth a map is written at — and the refusals around it are untouched, a brand over a
+/// container or a struct still writing no key at all.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn a_stringified_key_is_left_alone_wherever_it_is_written() {
+    register_alias_info("Slot", "Slot", "slot_schema", AliasKind::EnumMembers);
+    register_alias_info("Tick", "Tick", "tick_schema", AliasKind::Stringified);
+    register_alias_info("Tags", "Tags", "tags_schema", AliasKind::NoEnumMembers);
+    for field_type in [
+        quote::quote! { HashMap<Tick, u32> },
+        quote::quote! { HashMap<String, HashMap<Tick, u32>> },
+        quote::quote! { HashMap<Slot, HashMap<Tick, u32>> },
+        quote::quote! { HashMap<Tick, HashMap<Tick, u32>> },
+        quote::quote! { Vec<HashMap<Tick, u32>> },
+        quote::quote! { (String, HashMap<Tick, u32>) },
+        quote::quote! { Wrapper<HashMap<Tick, u32>> },
+    ] {
+        let error = field_map_key_error(&field_type);
+        assert!(error.is_empty(), "for {field_type}, got: {error}");
+    }
+
+    let refused = field_map_key_error(&quote::quote! { HashMap<Tags, u32> });
+    assert!(
+        refused.contains("a map key must be a plain"),
+        "got: {refused}"
+    );
+    assert!(refused.contains("Tags"), "got: {refused}");
 }
 
 /// An alias of an alias of a plain enum is still a plain enum at the type path, so the chain

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -26,23 +26,33 @@ const UNICODE_CLASS_READ_AS: &str = "an escaped `p` or `P` followed by a literal
 /// A Unicode class, in the three spellings the `regex` crate reads one by.
 const UNICODE_CLASS_WRITTEN: &str = "a Unicode class -- `\\p{...}`, `\\pL` or `\\P{...}`";
 
-/// What a registered Rust ident, *written as a type path*, resolves to — the two facts a map key
-/// asks of it: whether it carries an inherent `enum_members()`, the enumeration the JSON-schema
-/// map-key expansion calls, and whether serde writes it as a bare string, which is what a JSON
-/// object key is. Only a plain unit enum gets that method, and a type path sees straight through an
-/// alias, so an alias answers for whatever it targets rather than for itself.
+/// What a registered Rust ident, *written as a type path*, resolves to — the one question a map key
+/// asks of a name: what does serde write for a key spelled this way. A plain unit enum answers with
+/// its members, the enumeration the JSON-schema map-key expansion calls `enum_members()` for; every
+/// other answer is about the key's own wire form, a JSON object key being a string.
+///
+/// A type path sees straight through an alias and a `#[serde(transparent)]` brand writes what its
+/// inner writes, so both answer for their target and their inner rather than for themselves — and
+/// through the registry, so a chain of either carries its end's answer to every link.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum AliasKind {
     /// A plain unit enum, or an alias chain ending in one.
     EnumMembers,
-    /// Provably has neither: a struct, a brand over a non-string inner, a non-plain enum, or an
-    /// alias whose target is a primitive, a collection, or one of those.
+    /// serde writes it as neither a string nor anything it will stringify, so it keys no map at
+    /// all: a struct, a brand over one or over a container, a non-plain enum, or an alias whose
+    /// target is any of those.
     NoEnumMembers,
-    /// No `enum_members()`, but serde writes it as a bare string: a `#[serde(transparent)]` brand
-    /// whose inner is itself string-shaped, or an alias chain ending in one. Such a type keys a map
+    /// No `enum_members()`, but serde writes it as a bare string: `String` and `PathBuf`, a
+    /// `#[serde(transparent)]` brand over one of those or over a plain enum, whose variant name is
+    /// itself a bare string, and an alias chain ending in any of them. Such a type keys a map
     /// exactly as `String` does, under its own name.
     StringWire,
+    /// No `enum_members()` and no bare string either, but serde stringifies it into a key all the
+    /// same — a number, a `bool`, a chrono rendering, or a brand over one of those. The map is an
+    /// object with nothing said about its members, which is what the bare inner already describes
+    /// as; the brand's own name still stands on the nominal surfaces.
+    Stringified,
     /// Undecidable at this expansion — an alias naming a type that was not registered before it.
     Unknown,
 }

--- a/tests/collection_tests/tests.rs
+++ b/tests/collection_tests/tests.rs
@@ -1,7 +1,10 @@
 use alloc::collections::{BTreeSet, BinaryHeap, VecDeque};
+#[cfg(feature = "chrono")]
+use chrono::NaiveDate;
 use core::iter::once;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
 use tixschema::model_schema;
 
 /// The covered wrappers by the name a generated surface could leak. `Vec` is covered too but
@@ -158,6 +161,131 @@ struct StringKeyedBrandTwin {
     counts: HashMap<String, u64>,
     nested: HashMap<String, HashMap<String, u64>>,
     samples: HashMap<String, MetricSample>,
+}
+
+/// An alias of `String`. A type path resolves straight through it, so serde writes a key spelled
+/// this way as the bare string its target is — `{"abc": 1}`, the `String`-keyed map's own wire.
+#[model_schema()]
+type SlotKey = String;
+
+/// An alias of that alias, and an alias of a string-wire brand: every link of either chain ends at
+/// the same bare string.
+#[model_schema()]
+type SlotKeyRef = SlotKey;
+
+#[model_schema()]
+type CorrelationRef = CorrelationId;
+
+/// `PathBuf` writes the bare string a `String` writes, so an alias of one keys a map the same way.
+#[model_schema()]
+type PathKey = PathBuf;
+
+// An alias key is the open case under the alias's own exported name: the alias resolves to a
+// string, so the object is keyed by arbitrary strings — held below against the `String`-keyed twin.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct AliasKeyedMaps {
+    branded: HashMap<CorrelationRef, u64>,
+    chained: HashMap<SlotKeyRef, u64>,
+    counts: HashMap<SlotKey, u64>,
+    nested: HashMap<SlotKey, HashMap<SlotKey, u64>>,
+    paths: HashMap<PathKey, u64>,
+    samples: HashMap<SlotKey, MetricSample>,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct StringKeyedAliasKeyTwin {
+    branded: HashMap<String, u64>,
+    chained: HashMap<String, u64>,
+    counts: HashMap<String, u64>,
+    nested: HashMap<String, HashMap<String, u64>>,
+    paths: HashMap<String, u64>,
+    samples: HashMap<String, MetricSample>,
+}
+
+/// A brand over a stringifying scalar. serde writes the key its inner writes — `{"7": …}` — so the
+/// map serializes and reads back exactly as the bare-keyed one does, and describes as it does too.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[serde(transparent)]
+struct Tick(u32);
+
+/// A brand over that brand: the wire is the same stringified number at every link of the chain.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[serde(transparent)]
+struct TickRef(Tick);
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[serde(transparent)]
+struct Enabled(bool);
+
+/// A brand over a plain enum. serde writes the variant name, which is a bare string, so the brand
+/// keys a map the way a string does — under its own name, and open, the brand publishing no
+/// `enum_members()` of its own for a schema to close the object with. `no_display` is the inner's
+/// business, not the key's: a plain enum carries no `Display`, and the brand's key path never
+/// consults one.
+#[model_schema(no_display)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[serde(transparent)]
+struct SlotBrand(MetricSlot);
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct ScalarBrandKeyedMaps {
+    by_enabled: HashMap<Enabled, u64>,
+    by_tick: HashMap<Tick, u64>,
+    chained: HashMap<TickRef, u64>,
+    nested: HashMap<Tick, HashMap<Enabled, u64>>,
+    samples: HashMap<Tick, MetricSample>,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct ScalarKeyedBrandTwin {
+    by_enabled: HashMap<bool, u64>,
+    by_tick: HashMap<u32, u64>,
+    chained: HashMap<u32, u64>,
+    nested: HashMap<u32, HashMap<bool, u64>>,
+    samples: HashMap<u32, MetricSample>,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct EnumBrandKeyedMaps {
+    counts: HashMap<SlotBrand, u64>,
+    samples: HashMap<SlotBrand, MetricSample>,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct StringKeyedEnumBrandTwin {
+    counts: HashMap<String, u64>,
+    samples: HashMap<String, MetricSample>,
+}
+
+/// A brand over a chrono value: serde renders the inner into the key — `{"2020-01-02": …}` — the
+/// way it does for the bare chrono key.
+#[cfg(feature = "chrono")]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[serde(transparent)]
+struct Day(NaiveDate);
+
+#[cfg(feature = "chrono")]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct ChronoBrandKeyedMaps {
+    by_day: HashMap<Day, u64>,
+}
+
+#[cfg(feature = "chrono")]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct ChronoKeyedBrandTwin {
+    by_day: HashMap<NaiveDate, u64>,
 }
 
 // A String key enumerates nothing, so one `additionalProperties` schema stands for every member —
@@ -1522,6 +1650,363 @@ fn test_brand_keyed_maps_match_the_serialized_form() {
 
     let read_back: BrandKeyedMaps = serde_json::from_value(payload).unwrap();
     assert_eq!(read_back, maps);
+}
+
+/// An alias key clears the derive under every feature set that reads one: the key is read off the
+/// field all three surfaces render from, so the same source cannot be a schema under one toggle and
+/// a refusal under another.
+#[test]
+fn test_alias_keyed_maps_constructible() {
+    let key: SlotKey = "abc".to_owned();
+    let maps = AliasKeyedMaps {
+        branded: HashMap::from([(CorrelationId(key.clone()), 4)]),
+        chained: HashMap::from([(key.clone(), 2)]),
+        counts: HashMap::from([(key.clone(), 1)]),
+        nested: HashMap::from([(key.clone(), HashMap::from([(key.clone(), 3)]))]),
+        paths: HashMap::from([(PathBuf::from("a/b"), 5)]),
+        samples: HashMap::from([(
+            key.clone(),
+            MetricSample {
+                label: "s".to_owned(),
+            },
+        )]),
+    };
+    assert_eq!(maps.counts[&key], 1);
+    assert_eq!(maps.nested[&key][&key], 3);
+
+    let twin = StringKeyedAliasKeyTwin {
+        branded: HashMap::from([("abc".to_owned(), 4)]),
+        chained: HashMap::from([("abc".to_owned(), 2)]),
+        counts: HashMap::from([("abc".to_owned(), 1)]),
+        nested: HashMap::from([("abc".to_owned(), HashMap::from([("abc".to_owned(), 3)]))]),
+        paths: HashMap::from([("a/b".to_owned(), 5)]),
+        samples: HashMap::new(),
+    };
+    assert_eq!(twin.counts["abc"], maps.counts[&key]);
+}
+
+/// An alias is the type it names, so a map keyed by an alias of a string builds the object a
+/// `String` key builds — field for field the `String`-keyed twin's, the alias's name being spent on
+/// the nominal surfaces and having nothing to say on the structural one.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_alias_keyed_maps_describe_as_their_string_keyed_twin() {
+    assert_eq!(
+        AliasKeyedMaps::json_schema()["properties"],
+        StringKeyedAliasKeyTwin::json_schema()["properties"]
+    );
+}
+
+/// The nominal surfaces keep the alias's own exported name as the key type, the way they keep an
+/// enum's and a brand's — a `Record` and a `z.record` keyed by the alias, not by bare `string`.
+#[test]
+#[cfg(all(feature = "typescript", feature = "zod"))]
+fn test_alias_keyed_maps_name_the_alias_as_the_key_type() {
+    let ts_definition = AliasKeyedMaps::ts_definition();
+    for expected in [
+        "branded: Partial<Record<CorrelationRefType, number>>;",
+        "chained: Partial<Record<SlotKeyRefType, number>>;",
+        "counts: Partial<Record<SlotKeyType, number>>;",
+        "nested: Partial<Record<SlotKeyType, Partial<Record<SlotKeyType, number>>>>;",
+        "paths: Partial<Record<PathKeyType, number>>;",
+        "samples: Partial<Record<SlotKeyType, MetricSample>>;",
+    ] {
+        assert!(
+            ts_definition.contains(expected),
+            "{expected} missing: {ts_definition}"
+        );
+    }
+
+    let zod_schema = AliasKeyedMaps::zod_schema();
+    for expected in [
+        "branded: z.record(CorrelationRefType$Schema, z.number().int())",
+        "chained: z.record(SlotKeyRefType$Schema, z.number().int())",
+        "counts: z.record(SlotKeyType$Schema, z.number().int())",
+        "nested: z.record(SlotKeyType$Schema, z.record(SlotKeyType$Schema, z.number().int()))",
+        "paths: z.record(PathKeyType$Schema, z.number().int())",
+        "samples: z.record(SlotKeyType$Schema, MetricSample$Schema)",
+    ] {
+        assert!(
+            zod_schema.contains(expected),
+            "{expected} missing: {zod_schema}"
+        );
+    }
+}
+
+/// The whole reason an alias of a string keys a map: serde writes the bare string the target is, so
+/// what the schema describes as an open object is the object the value actually writes — and reads
+/// back.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_alias_keyed_maps_match_the_serialized_form() {
+    let key: SlotKey = "abc".to_owned();
+    let maps = AliasKeyedMaps {
+        branded: HashMap::from([(CorrelationId(key.clone()), 4)]),
+        chained: HashMap::from([(key.clone(), 2)]),
+        counts: HashMap::from([(key.clone(), 1)]),
+        nested: HashMap::from([(key.clone(), HashMap::from([(key.clone(), 3)]))]),
+        paths: HashMap::from([(PathBuf::from("a/b"), 5)]),
+        samples: HashMap::from([(
+            key,
+            MetricSample {
+                label: "s".to_owned(),
+            },
+        )]),
+    };
+    let payload = serde_json::to_value(&maps).unwrap();
+    assert_eq!(payload["counts"], serde_json::json!({ "abc": 1_u64 }));
+    assert_eq!(payload["chained"], serde_json::json!({ "abc": 2_u64 }));
+    assert_eq!(payload["branded"], serde_json::json!({ "abc": 4_u64 }));
+    assert_eq!(payload["paths"], serde_json::json!({ "a/b": 5_u64 }));
+    assert_eq!(
+        payload["nested"],
+        serde_json::json!({ "abc": { "abc": 3_u64 } })
+    );
+
+    let schema = AliasKeyedMaps::json_schema();
+    for field_name in ["branded", "chained", "counts", "nested", "paths", "samples"] {
+        let field = &schema["properties"][field_name];
+        assert_eq!(field["type"], json_type_name(&payload[field_name]));
+        assert!(field["additionalProperties"].is_object(), "in: {field}");
+    }
+    assert_eq!(
+        schema["properties"]["samples"]["additionalProperties"],
+        MetricSample::json_schema()
+    );
+
+    let read_back: AliasKeyedMaps = serde_json::from_value(payload).unwrap();
+    assert_eq!(read_back, maps);
+}
+
+#[test]
+fn test_scalar_brand_keyed_maps_constructible() {
+    let maps = ScalarBrandKeyedMaps {
+        by_enabled: HashMap::from([(Enabled(true), 4)]),
+        by_tick: HashMap::from([(Tick(7), 1)]),
+        chained: HashMap::from([(TickRef(Tick(7)), 2)]),
+        nested: HashMap::from([(Tick(7), HashMap::from([(Enabled(true), 3)]))]),
+        samples: HashMap::from([(
+            Tick(7),
+            MetricSample {
+                label: "s".to_owned(),
+            },
+        )]),
+    };
+    assert_eq!(maps.by_tick[&Tick(7)], 1);
+    assert_eq!(maps.nested[&Tick(7)][&Enabled(true)], 3);
+
+    let twin = ScalarKeyedBrandTwin {
+        by_enabled: HashMap::from([(true, 4)]),
+        by_tick: HashMap::from([(7, 1)]),
+        chained: HashMap::from([(7, 2)]),
+        nested: HashMap::from([(7, HashMap::from([(true, 3)]))]),
+        samples: HashMap::new(),
+    };
+    assert_eq!(twin.by_tick[&7], maps.by_tick[&Tick(7)]);
+
+    let enum_branded = EnumBrandKeyedMaps {
+        counts: HashMap::from([(SlotBrand(MetricSlot::Daily), 1)]),
+        samples: HashMap::new(),
+    };
+    let enum_twin = StringKeyedEnumBrandTwin {
+        counts: HashMap::from([("Daily".to_owned(), 1)]),
+        samples: HashMap::new(),
+    };
+    assert_eq!(
+        enum_twin.counts["Daily"],
+        enum_branded.counts[&SlotBrand(MetricSlot::Daily)]
+    );
+}
+
+#[cfg(feature = "chrono")]
+#[test]
+fn test_chrono_brand_keyed_maps_constructible() {
+    let day = NaiveDate::from_ymd_opt(2020, 1, 2).unwrap();
+    let maps = ChronoBrandKeyedMaps {
+        by_day: HashMap::from([(Day(day), 1)]),
+    };
+    let twin = ChronoKeyedBrandTwin {
+        by_day: HashMap::from([(day, 1)]),
+    };
+    assert_eq!(twin.by_day[&day], maps.by_day[&Day(day)]);
+}
+
+/// A brand adds a name to its inner's wire and nothing else, so a brand over a value serde
+/// stringifies describes exactly as that bare inner describes — the open object with nothing said
+/// about its members, which is what the bare-keyed twin has always produced.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_scalar_brand_keyed_maps_describe_as_their_bare_inner_twin() {
+    assert_eq!(
+        ScalarBrandKeyedMaps::json_schema()["properties"],
+        ScalarKeyedBrandTwin::json_schema()["properties"]
+    );
+    assert_eq!(
+        ScalarBrandKeyedMaps::json_schema()["properties"]["by_tick"],
+        serde_json::json!({ "type": "object", "additionalProperties": true })
+    );
+}
+
+/// The name is the one thing the brand adds, and the nominal surfaces are where it lands: a
+/// `Record` and a `z.record` keyed by the brand, where the bare-inner twin writes `number` and
+/// `boolean`.
+#[test]
+#[cfg(all(feature = "typescript", feature = "zod"))]
+fn test_scalar_brand_keyed_maps_name_the_brand_as_the_key_type() {
+    let ts_definition = ScalarBrandKeyedMaps::ts_definition();
+    for expected in [
+        "by_enabled: Partial<Record<Enabled, number>>;",
+        "by_tick: Partial<Record<Tick, number>>;",
+        "chained: Partial<Record<TickRef, number>>;",
+        "nested: Partial<Record<Tick, Partial<Record<Enabled, number>>>>;",
+        "samples: Partial<Record<Tick, MetricSample>>;",
+    ] {
+        assert!(
+            ts_definition.contains(expected),
+            "{expected} missing: {ts_definition}"
+        );
+    }
+
+    let zod_schema = ScalarBrandKeyedMaps::zod_schema();
+    for expected in [
+        "by_enabled: z.record(Enabled$Schema, z.number().int())",
+        "by_tick: z.record(Tick$Schema, z.number().int())",
+        "chained: z.record(TickRef$Schema, z.number().int())",
+        "nested: z.record(Tick$Schema, z.record(Enabled$Schema, z.number().int()))",
+        "samples: z.record(Tick$Schema, MetricSample$Schema)",
+    ] {
+        assert!(
+            zod_schema.contains(expected),
+            "{expected} missing: {zod_schema}"
+        );
+    }
+}
+
+/// The premise the whole classification rests on: serde stringifies these keys, so the map it
+/// writes is a real object, and it reads back.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_scalar_brand_keyed_maps_match_the_serialized_form() {
+    let maps = ScalarBrandKeyedMaps {
+        by_enabled: HashMap::from([(Enabled(true), 4)]),
+        by_tick: HashMap::from([(Tick(7), 1)]),
+        chained: HashMap::from([(TickRef(Tick(7)), 2)]),
+        nested: HashMap::from([(Tick(7), HashMap::from([(Enabled(true), 3)]))]),
+        samples: HashMap::from([(
+            Tick(7),
+            MetricSample {
+                label: "s".to_owned(),
+            },
+        )]),
+    };
+    let payload = serde_json::to_value(&maps).unwrap();
+    assert_eq!(payload["by_tick"], serde_json::json!({ "7": 1_u64 }));
+    assert_eq!(payload["chained"], serde_json::json!({ "7": 2_u64 }));
+    assert_eq!(payload["by_enabled"], serde_json::json!({ "true": 4_u64 }));
+    assert_eq!(
+        payload["nested"],
+        serde_json::json!({ "7": { "true": 3_u64 } })
+    );
+
+    let schema = ScalarBrandKeyedMaps::json_schema();
+    for field_name in ["by_enabled", "by_tick", "chained", "nested", "samples"] {
+        let field = &schema["properties"][field_name];
+        assert_eq!(field["type"], json_type_name(&payload[field_name]));
+    }
+
+    let read_back: ScalarBrandKeyedMaps = serde_json::from_value(payload).unwrap();
+    assert_eq!(read_back, maps);
+}
+
+/// A brand over a plain enum writes the variant name, which is a bare string — so it describes as
+/// the `String`-keyed twin does, keeping the value's own schema under `additionalProperties`. The
+/// enum-keyed spelling closes the object over `enum_members()`; the brand has no such method, and
+/// the object it describes is open rather than closed over members nothing can supply.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_enum_brand_keyed_maps_describe_as_their_string_keyed_twin() {
+    assert_eq!(
+        EnumBrandKeyedMaps::json_schema()["properties"],
+        StringKeyedEnumBrandTwin::json_schema()["properties"]
+    );
+    assert_eq!(
+        EnumBrandKeyedMaps::json_schema()["properties"]["samples"]["additionalProperties"],
+        MetricSample::json_schema()
+    );
+}
+
+#[test]
+#[cfg(all(feature = "typescript", feature = "zod"))]
+fn test_enum_brand_keyed_maps_name_the_brand_as_the_key_type() {
+    let ts_definition = EnumBrandKeyedMaps::ts_definition();
+    assert!(
+        ts_definition.contains("counts: Partial<Record<SlotBrand, number>>;"),
+        "got: {ts_definition}"
+    );
+    let zod_schema = EnumBrandKeyedMaps::zod_schema();
+    assert!(
+        zod_schema.contains("samples: z.record(SlotBrand$Schema, MetricSample$Schema)"),
+        "got: {zod_schema}"
+    );
+}
+
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_enum_brand_keyed_maps_match_the_serialized_form() {
+    let maps = EnumBrandKeyedMaps {
+        counts: HashMap::from([(SlotBrand(MetricSlot::Daily), 1)]),
+        samples: HashMap::from([(
+            SlotBrand(MetricSlot::Weekly),
+            MetricSample {
+                label: "s".to_owned(),
+            },
+        )]),
+    };
+    let payload = serde_json::to_value(&maps).unwrap();
+    assert_eq!(payload["counts"], serde_json::json!({ "Daily": 1_u64 }));
+    assert!(payload["samples"]["Weekly"].is_object(), "got: {payload}");
+
+    let read_back: EnumBrandKeyedMaps = serde_json::from_value(payload).unwrap();
+    assert_eq!(read_back, maps);
+}
+
+/// A chrono value is stringified into a key by its own rendering, and a brand over one carries that
+/// rendering unchanged — the same twin equality the numeric brands keep.
+#[test]
+#[cfg(all(feature = "chrono", feature = "jsonschema"))]
+fn test_chrono_brand_keyed_maps_describe_as_their_bare_inner_twin() {
+    assert_eq!(
+        ChronoBrandKeyedMaps::json_schema()["properties"],
+        ChronoKeyedBrandTwin::json_schema()["properties"]
+    );
+
+    let day = NaiveDate::from_ymd_opt(2020, 1, 2).unwrap();
+    let maps = ChronoBrandKeyedMaps {
+        by_day: HashMap::from([(Day(day), 1)]),
+    };
+    let payload = serde_json::to_value(&maps).unwrap();
+    assert_eq!(
+        payload["by_day"],
+        serde_json::json!({ "2020-01-02": 1_u64 })
+    );
+
+    let read_back: ChronoBrandKeyedMaps = serde_json::from_value(payload).unwrap();
+    assert_eq!(read_back, maps);
+}
+
+#[test]
+#[cfg(all(feature = "chrono", feature = "typescript", feature = "zod"))]
+fn test_chrono_brand_keyed_maps_name_the_brand_as_the_key_type() {
+    let ts_definition = ChronoBrandKeyedMaps::ts_definition();
+    assert!(
+        ts_definition.contains("by_day: Partial<Record<Day, number>>;"),
+        "got: {ts_definition}"
+    );
+    let zod_schema = ChronoBrandKeyedMaps::zod_schema();
+    assert!(
+        zod_schema.contains("by_day: z.record(Day$Schema, z.number().int())"),
+        "got: {zod_schema}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
A registered ident used as a map key now answers one question — what does serde write for a key spelled this way — instead of the two-fact enum-members/string-wire split.

- `alias_target_kind` short-circuits an open map-key path to `StringWire` before consulting the registry.
- `branded_alias_kind` becomes a four-arm mirror of the key classification: string wires stay open, stringified scalars stay unnarrowed, enum brands enumerate, everything else keys no map.
- `registered_key_kind` replaces `writes_string_wire` as the registry's single lookup, so a chain of aliases or transparent brands carries its end's answer to every link.
- Twin tests pin each arm: alias-keyed and scalar-brand-keyed maps against their inline twins, plus enum-brand and chrono-brand keyed maps.