### PR TITLE
carry an untagged member's bound to the Rust side and refuse unspellable variant shapes as spanned errors

### DIFF
--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -239,6 +239,52 @@ impl FieldDef {
         arrayed
     }
 
+    /// The shape this field renders when the values a bound could be spelled against are its
+    /// members rather than the field itself.
+    ///
+    /// A map writes its keys and its values, a tuple writes each of its elements, and every surface
+    /// builds those from the inner field defs — which carry no meta, the field's own sitting on the
+    /// outer def none of them reads. A length, a pattern or a range names one value, and
+    /// `model_schema_prop` has no way to say which member it meant, so a bound written here reaches
+    /// nothing on any surface; the caller turns that into a guard error naming the field.
+    pub const fn composite_shape_name(&self) -> Option<&'static str> {
+        match &self.field_type {
+            FieldDefType::Map(_, _) => Some("a map"),
+            FieldDefType::Tuple(_) => Some("a tuple"),
+            #[cfg(feature = "object_id")]
+            FieldDefType::ObjectId => None,
+            #[cfg(feature = "chrono")]
+            FieldDefType::NaiveDate
+            | FieldDefType::NaiveTime
+            | FieldDefType::NaiveDateTime
+            | FieldDefType::DateTime => None,
+            FieldDefType::SiblingType(_, _)
+            | FieldDefType::Unknown
+            | FieldDefType::StringLiteral(_)
+            | FieldDefType::Boolean
+            | FieldDefType::String
+            | FieldDefType::U8
+            | FieldDefType::U16
+            | FieldDefType::U32
+            | FieldDefType::U64
+            | FieldDefType::I8
+            | FieldDefType::I16
+            | FieldDefType::I32
+            | FieldDefType::I64
+            | FieldDefType::Usize
+            | FieldDefType::Isize
+            | FieldDefType::F32
+            | FieldDefType::F64 => None,
+        }
+    }
+
+    /// Whether a length, a pattern or a range written on this field reaches no surface at all —
+    /// the one question both the refusal and the docs are written from, so neither can come to
+    /// answer it differently from the other.
+    pub const fn constraints_reach_nothing(&self) -> bool {
+        self.fixed_shape_name().is_some() || self.composite_shape_name().is_some()
+    }
+
     #[cfg(feature = "zod")]
     /// Checks if this field contains a reference to the given type name.
     ///
@@ -376,7 +422,8 @@ impl FieldDef {
     /// caller turns that into a guard error naming the field instead of dropping it.
     ///
     /// Only the field's own rendering is asked about. A map or a tuple holding one of these
-    /// describes its members separately, and a bound on the field around them was never theirs.
+    /// describes its members separately, and a bound on the field around them is
+    /// [`Self::composite_shape_name`]'s to answer for.
     pub const fn fixed_shape_name(&self) -> Option<&'static str> {
         match &self.field_type {
             #[cfg(feature = "object_id")]

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -150,12 +150,13 @@ type RenderedVariants = (
 );
 
 /// Per-member data collected from an untagged enum: the TypeScript member types, the Zod member
-/// schemas, the JSON-schema value tokens, and the `compile_error!` tokens for any field-level
-/// guard violations.
+/// schemas, the JSON-schema value tokens, the `compile_error!` tokens for any field-level guard
+/// violations, and the per-member serde validation functions.
 #[cfg(feature = "serde")]
 type UntaggedMemberData = (
     Vec<String>,
     Vec<String>,
+    Vec<proc_macro2::TokenStream>,
     Vec<proc_macro2::TokenStream>,
     Vec<proc_macro2::TokenStream>,
 );
@@ -4481,32 +4482,50 @@ fn process_internally_tagged_enum(
 /// - `zod` is the member schema (e.g. `DateString$Schema`, `z.number().int()`)
 /// - `json_value` is a standalone `serde_json::Value` token expression (cfg jsonschema)
 ///
-/// Only `TupleSingle` (`S(T)`) and `Named` (`{ a: A }`) variant kinds are supported; `Unit` and
-/// `TupleMultiple` produce a clear compile-time `panic!` because an untagged choice has no
-/// discriminator to carry them.
+/// Only `TupleSingle` (`S(T)`) and `Named` (`{ a: A }`) variant kinds have a member spelling here;
+/// every other shape is refused as an error spanned on the variant, which the caller collects so
+/// one expansion reports every offender rather than stopping at the first.
+///
+/// The single-member pattern is what rules out a `TupleSingle` carrying no field. That shape is
+/// unreachable — [`classify_variant`] sends an empty `Foo()` to `Unit` — and a slice pattern says
+/// so structurally, where a length assertion would have to be written and then never fire.
 #[cfg(feature = "serde")]
 fn render_untagged_variant(
     kind: &VariantKind,
-    variant_name: &str,
+    variant: &syn::Variant,
     field_defs: &[FieldDef],
     self_type_name: &str,
-) -> (String, String, proc_macro2::TokenStream) {
-    match kind {
-        VariantKind::TupleSingle => {
-            render_untagged_tuple_single(variant_name, field_defs, self_type_name)
-        }
-        VariantKind::Named => render_untagged_named(field_defs, self_type_name),
-        VariantKind::Unit | VariantKind::TupleMultiple => {
-            // An untagged choice has no discriminator to carry these shapes. The assert fails
-            // unconditionally here (the match already proved `kind` is Unit/TupleMultiple),
-            // surfacing a clear compile-time error during macro expansion.
-            assert!(
-                matches!(kind, VariantKind::TupleSingle | VariantKind::Named),
-                "#[serde(untagged)] supports newtype and struct variants only; `{variant_name}` is unsupported"
-            );
-            (String::new(), String::new(), quote! {})
+) -> Result<(String, String, proc_macro2::TokenStream), syn::Error> {
+    match (kind, field_defs) {
+        (VariantKind::TupleSingle, [fld]) => Ok(render_untagged_tuple_single(fld, self_type_name)),
+        (VariantKind::Named, _) => Ok(render_untagged_named(field_defs, self_type_name)),
+        (VariantKind::Unit, _) => Err(unsupported_untagged_variant_error(
+            variant,
+            "a unit variant",
+        )),
+        (VariantKind::TupleSingle | VariantKind::TupleMultiple, fields) => {
+            Err(unsupported_untagged_variant_error(
+                variant,
+                &format!("a tuple variant with {} fields", fields.len()),
+            ))
         }
     }
+}
+
+/// Refuses a variant shape the untagged union has no member spelling for, spanned on the variant.
+#[cfg(feature = "serde")]
+fn unsupported_untagged_variant_error(variant: &syn::Variant, shape: &str) -> syn::Error {
+    let variant_name = &variant.ident;
+    syn::Error::new_spanned(
+        variant,
+        format!(
+            "model_schema: variant `{variant_name}`: `#[serde(untagged)]` supports newtype \
+             (`V(T)`) and struct (`V {{ … }}`) variants only — `{variant_name}` is {shape}, which \
+             the union has no member spelling for: a member is written as the inner type or as an \
+             object of named fields, and a variant that is neither has nothing to be written as. \
+             Give it a single inner type or named fields, or drop `#[serde(untagged)]`."
+        ),
+    )
 }
 
 /// Renders a `TupleSingle` (`S(T)`) untagged variant as a union member (`T` / `T$Schema` / value).
@@ -4516,16 +4535,9 @@ fn render_untagged_variant(
 /// going absent. All three surfaces read it through the slot spellings for that reason.
 #[cfg(feature = "serde")]
 fn render_untagged_tuple_single(
-    variant_name: &str,
-    field_defs: &[FieldDef],
+    fld: &FieldDef,
     self_type_name: &str,
 ) -> (String, String, proc_macro2::TokenStream) {
-    assert!(
-        !field_defs.is_empty(),
-        "#[serde(untagged)] newtype variant `{variant_name}` has no inner field"
-    );
-    let fld = &field_defs[0];
-
     let ts = fld.typescript_slot_typename();
 
     #[cfg(feature = "zod")]
@@ -4750,13 +4762,27 @@ fn field_json_schema_value(fld: &FieldDef) -> proc_macro2::TokenStream {
 /// [`process_field`] strips it: it is this crate's own and inert to every derive, so a copy left on
 /// the emitted item is one rustc reports as an attribute that does not exist, pointing at the
 /// user's line with a diagnostic naming the wrong macro.
+///
+/// A member's bound reaches the Rust side through the very generation the tagged twin uses — the
+/// validator, the deserializer, and the `deserialize_with` that hangs the one on the other — under
+/// the variant-scoped helper naming. What the hook costs in this position is the variant, not the
+/// read: serde tries the variants in order, and a member whose bound fails takes its variant out of
+/// the candidate set, so a violating value lands on the next branch that accepts it and errors only
+/// when none does — under serde's own `data did not match any variant` rather than the bound's
+/// sentence. That is what the member's schema already means on the other two surfaces, where the
+/// same declaration is one branch of an `anyOf` and one member of a `z.union`; leaving the hook out
+/// is what would have made the Rust side the odd one, reading back values both schemas reject.
 #[cfg(feature = "serde")]
-fn collect_untagged_members(item_enum: &mut syn::ItemEnum) -> UntaggedMemberData {
+fn collect_untagged_members(
+    item_enum: &mut syn::ItemEnum,
+    schema_module_name: Option<&str>,
+) -> UntaggedMemberData {
     let enum_type_name = item_enum.ident.to_string();
     let mut ts_parts: Vec<String> = Vec::new();
     let mut zod_parts: Vec<String> = Vec::new();
     let mut json_parts: Vec<proc_macro2::TokenStream> = Vec::new();
     let mut guard_errors: Vec<proc_macro2::TokenStream> = Vec::new();
+    let mut validation_fns: Vec<proc_macro2::TokenStream> = Vec::new();
 
     for variant in &mut item_enum.variants {
         let kind = classify_variant(variant);
@@ -4770,18 +4796,32 @@ fn collect_untagged_members(item_enum: &mut syn::ItemEnum) -> UntaggedMemberData
                 .map(ToString::to_string)
                 .unwrap_or_default();
             let prop_meta = parse_model_schema_prop_attributes(&field.attrs);
-            field
+            let serde_field_meta = parse_serde_field_attributes(&field.attrs);
+
+            let mut new_attrs: Vec<syn::Attribute> = field
                 .attrs
-                .retain(|attr| !attr.path().is_ident("model_schema_prop"));
+                .iter()
+                .filter(|attr| !attr.path().is_ident("model_schema_prop"))
+                .cloned()
+                .collect();
+            let (validation_fn, _, positional_constraint_error) = generate_field_validation(
+                field,
+                schema_module_name,
+                &field_name,
+                Some(&variant_name),
+                &prop_meta,
+                &mut new_attrs,
+            );
+            field.attrs = new_attrs;
+            validation_fns.extend(validation_fn);
 
             let mut field_def = get_field_def(&field_name, &field.ty, "");
-            let serde_field_meta = parse_serde_field_attributes(&field.attrs);
             let serde_guard_errors = field_guard_errors(
                 field,
                 &field_name,
                 field_def.is_optional(),
                 &serde_field_meta,
-                None,
+                positional_constraint_error,
             );
             guard_errors.extend(collect_field_guard_errors(
                 field,
@@ -4796,14 +4836,23 @@ fn collect_untagged_members(item_enum: &mut syn::ItemEnum) -> UntaggedMemberData
             field_defs.push(field_def);
         }
 
-        let (ts, zod, json_val) =
-            render_untagged_variant(&kind, &variant_name, &field_defs, &enum_type_name);
-        ts_parts.push(ts);
-        zod_parts.push(zod);
-        json_parts.push(json_val);
+        match render_untagged_variant(&kind, variant, &field_defs, &enum_type_name) {
+            Ok((ts, zod, json_val)) => {
+                ts_parts.push(ts);
+                zod_parts.push(zod);
+                json_parts.push(json_val);
+            }
+            Err(err) => guard_errors.push(err.to_compile_error()),
+        }
     }
 
-    (ts_parts, zod_parts, json_parts, guard_errors)
+    (
+        ts_parts,
+        zod_parts,
+        json_parts,
+        guard_errors,
+        validation_fns,
+    )
 }
 
 /// Processes an untagged enum (`#[serde(untagged)]`) and generates its definitions.
@@ -4818,7 +4867,7 @@ fn process_untagged_enum(
 ) -> TokenStream {
     // Compute the schema module name and register the enum so other types can find it.
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-    let (_, module_ident) = enum_module_idents(name, item_name, AliasKind::NoEnumMembers);
+    let (module_name, module_ident) = enum_module_idents(name, item_name, AliasKind::NoEnumMembers);
 
     // Extract docs early for example extraction
     #[cfg(any(feature = "typescript", feature = "zod"))]
@@ -4829,8 +4878,14 @@ fn process_untagged_enum(
         .as_ref()
         .and_then(|docs| extract_example_from_docs(docs));
 
+    #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+    let enum_module_name_opt = Some(module_name.as_str());
+    #[cfg(not(any(feature = "typescript", feature = "zod", feature = "jsonschema")))]
+    let enum_module_name_opt = None;
+
     // Render each variant into its union member (TS / Zod / JSON parts).
-    let (ts_parts, zod_parts, json_parts, guard_errors) = collect_untagged_members(&mut item_enum);
+    let (ts_parts, zod_parts, json_parts, guard_errors, enum_validation_fns) =
+        collect_untagged_members(&mut item_enum, enum_module_name_opt);
 
     // A violated field guard makes the whole contract unsound, so the schema surface is dropped
     // and only the original item plus the errors are emitted.
@@ -4907,9 +4962,6 @@ fn process_untagged_enum(
     #[cfg(any(feature = "zod", feature = "typescript", feature = "jsonschema"))]
     let delegate_impl_items =
         build_struct_delegate_items(&module_ident, schema_example_method.as_ref(), None);
-
-    // Untagged enums have no per-field serde validation functions.
-    let enum_validation_fns: Vec<proc_macro2::TokenStream> = Vec::new();
 
     #[cfg(any(feature = "zod", feature = "typescript", feature = "jsonschema"))]
     {
@@ -7260,34 +7312,49 @@ fn written_constraint_keys(prop_meta: &ModelSchemaPropMeta) -> Vec<&'static str>
     .collect()
 }
 
-/// Rejects a length, pattern or range written on a field whose schema this crate writes whole.
+/// Rejects a length, pattern or range written on a field no surface reads one beside.
 ///
-/// The types [`FieldDef::fixed_shape_name`] answers for render a shape fixed in this crate rather
-/// than the plain string or number a bound is spelled against, and every surface writes that shape
-/// without ever reading the meta — so the bound is accepted at expansion and reaches nothing, which
-/// leaves the author holding a contract that says the value is checked when nothing checks it.
+/// Two shapes earn it. The types [`FieldDef::fixed_shape_name`] answers for render a shape fixed in
+/// this crate rather than the plain string or number a bound is spelled against; the ones
+/// [`FieldDef::composite_shape_name`] answers for render their members, which are built from inner
+/// field defs that carry no meta. Either way every surface writes the field without ever reading the
+/// bound — so it is accepted at expansion and reaches nothing, which leaves the author holding a
+/// contract that says the value is checked when nothing checks it.
 fn check_fixed_shape_constraints(
     field: &Field,
     field_def: &FieldDef,
     prop_meta: &ModelSchemaPropMeta,
     label: &str,
 ) -> Result<(), syn::Error> {
-    let Some(name) = field_def.fixed_shape_name() else {
-        return Ok(());
-    };
-    let keys = written_constraint_keys(prop_meta);
-    if keys.is_empty() {
+    let written = written_constraint_keys(prop_meta);
+    if written.is_empty() {
         return Ok(());
     }
+    let keys = written.join("`, `");
+    if let Some(name) = field_def.fixed_shape_name() {
+        return Err(syn::Error::new_spanned(
+            field,
+            format!(
+                "model_schema: {label}: `{keys}` cannot apply to `{name}` — this crate writes that \
+                 type's schema whole, not as the plain string or number a bound is spelled \
+                 against, and no surface reads a bound beside it: the constraint would reach \
+                 neither Zod, nor the JSON schema, nor the generated validator. Drop it, or carry \
+                 the value in a `String` field the bound can measure."
+            ),
+        ));
+    }
+    let Some(shape) = field_def.composite_shape_name() else {
+        return Ok(());
+    };
     Err(syn::Error::new_spanned(
         field,
         format!(
-            "model_schema: {label}: `{}` cannot apply to `{name}` — this crate writes that type's \
-             schema whole, not as the plain string or number a bound is spelled against, and no \
-             surface reads a bound beside it: the constraint would reach neither Zod, nor the JSON \
-             schema, nor the generated validator. Drop it, or carry the value in a `String` field \
-             the bound can measure.",
-            keys.join("`, `")
+            "model_schema: {label}: `{keys}` cannot apply to {shape} — a map renders its keys and \
+             its values, a tuple renders each of its elements, and every surface builds those from \
+             the members: the bound names no value here, and `model_schema_prop` has no way to say \
+             which member it meant, so the constraint would reach neither Zod, nor the JSON schema, \
+             nor the generated validator. Constrain the member instead — declare its type as a \
+             branded newtype carrying the bound — or drop it."
         ),
     ))
 }
@@ -7639,7 +7706,15 @@ fn apply_model_schema_prop_meta(
 }
 
 /// Appends length/range constraint information to a field's generated docs.
+///
+/// The sentence states the bound as a rule the value is held to, so it is written only where
+/// something holds the value to it. A placement [`check_fixed_shape_constraints`] refuses gets
+/// none: there the bound reaches no surface, and the doc would be the only place it appeared at all
+/// — the claim standing exactly where nothing backs it.
 fn apply_constraint_docs(field_def: &mut FieldDef, final_name: &str) {
+    if field_def.constraints_reach_nothing() {
+        return;
+    }
     let Some(meta) = &field_def.model_schema_prop_meta else {
         return;
     };

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -5068,6 +5068,81 @@ fn collect_untagged_members(
     )
 }
 
+/// Builds the schema module's impl items for an untagged enum: its JSON schema, its `TypeScript`
+/// definition, and its Zod schema, in the order the module publishes them.
+///
+/// An untagged member is matched on its own shape rather than on a shared tag, so the three
+/// surfaces join the rendered members as plain alternatives — an `anyOf` with no `type` pinned over
+/// it, a `|` union, a `z.union`. The joins live next to the method that reads them because each is
+/// read exactly once and every one is feature-gated; keeping the pair together is what lets a
+/// disabled surface take its join with it.
+#[cfg(any(feature = "zod", feature = "typescript", feature = "jsonschema"))]
+fn build_untagged_schema_impl_items(
+    name: &syn::Ident,
+    item_name: &str,
+    docs_vec: Option<&[String]>,
+    ts_parts: &[String],
+    zod_parts: &[String],
+    json_parts: &[proc_macro2::TokenStream],
+) -> Vec<proc_macro2::TokenStream> {
+    #[cfg(not(any(feature = "typescript", feature = "zod")))]
+    let _: &_ = &name;
+    #[cfg(not(feature = "typescript"))]
+    let _: &_ = &(ts_parts, docs_vec);
+    #[cfg(not(feature = "zod"))]
+    let _: &_ = &zod_parts;
+    #[cfg(not(feature = "jsonschema"))]
+    let _: &_ = &json_parts;
+
+    #[cfg(feature = "jsonschema")]
+    let main_schema_code = quote! {
+        let mut schema_obj = serde_json::Map::new();
+        schema_obj.insert("anyOf".to_string(), {
+            let result: Vec<serde_json::Value> = vec![
+                #(#json_parts), *
+            ];
+
+            serde_json::Value::Array(result)
+        });
+
+        serde_json::Value::Object(schema_obj)
+    };
+
+    #[cfg(feature = "typescript")]
+    let type_code = ts_parts.join(" | ");
+
+    #[cfg(feature = "zod")]
+    let schema_code = format!("z.union([{}])", zod_parts.join(", "));
+
+    #[cfg(feature = "typescript")]
+    let docs = build_jsdoc_body(docs_vec, item_name);
+
+    #[cfg(feature = "jsonschema")]
+    let json_schema_method =
+        generate_discriminated_enum_json_schema_method(&main_schema_code, item_name);
+
+    #[cfg(feature = "typescript")]
+    let ts_definition_method = generate_discriminated_enum_ts_definition_method(
+        &docs,
+        item_name,
+        &name.to_string(),
+        &type_code,
+    );
+
+    #[cfg(feature = "zod")]
+    let zod_schema_method =
+        generate_discriminated_enum_zod_schema_method(item_name, &name.to_string(), &schema_code);
+
+    vec![
+        #[cfg(feature = "jsonschema")]
+        json_schema_method,
+        #[cfg(feature = "typescript")]
+        ts_definition_method,
+        #[cfg(feature = "zod")]
+        zod_schema_method,
+    ]
+}
+
 /// Processes an untagged enum (`#[serde(untagged)]`) and generates its definitions.
 ///
 /// Emits a TypeScript union (`A | B`), a Zod `z.union([...])`, and a JSON-schema `anyOf`.
@@ -5085,6 +5160,14 @@ fn process_untagged_enum(
     // Extract docs early for example extraction
     #[cfg(any(feature = "typescript", feature = "zod"))]
     let docs_vec = get_enum_docs(&item_enum);
+    // The schema module is built under a wider gate than the one that reads docs, so the binding
+    // it takes has to exist on that gate's own terms.
+    #[cfg(all(
+        not(feature = "typescript"),
+        not(feature = "zod"),
+        feature = "jsonschema"
+    ))]
+    let docs_vec: Option<Vec<String>> = None;
 
     #[cfg(feature = "zod")]
     let example_code = docs_vec
@@ -5107,56 +5190,7 @@ fn process_untagged_enum(
     }
 
     #[cfg(not(any(feature = "typescript", feature = "zod", feature = "jsonschema")))]
-    let _: &_ = &name;
-    #[cfg(not(feature = "zod"))]
-    let _: &_ = &&zod_parts;
-    #[cfg(not(feature = "jsonschema"))]
-    let _: &_ = &&json_parts;
-
-    #[cfg(feature = "jsonschema")]
-    let main_schema_code = quote! {
-        let mut schema_obj = serde_json::Map::new();
-        schema_obj.insert("anyOf".to_string(), {
-            let result: Vec<serde_json::Value> = vec![
-                #(#json_parts), *
-            ];
-
-            serde_json::Value::Array(result)
-        });
-
-        serde_json::Value::Object(schema_obj)
-    };
-
-    #[cfg(feature = "typescript")]
-    let type_code = ts_parts.join(" | ");
-    #[cfg(not(feature = "typescript"))]
-    let _: &_ = &&ts_parts;
-
-    #[cfg(feature = "zod")]
-    let schema_code = format!("z.union([{}])", zod_parts.join(", "));
-
-    #[cfg(feature = "typescript")]
-    let docs = build_jsdoc_body(docs_vec.as_deref(), item_name);
-
-    // Generate schema module methods
-    #[cfg(feature = "jsonschema")]
-    let json_schema_method =
-        generate_discriminated_enum_json_schema_method(&main_schema_code, item_name);
-
-    #[cfg(feature = "typescript")]
-    let ts_definition_method = generate_discriminated_enum_ts_definition_method(
-        &docs,
-        item_name,
-        &name.to_string(),
-        &type_code,
-    );
-
-    #[cfg(feature = "zod")]
-    let zod_schema_method =
-        generate_discriminated_enum_zod_schema_method(item_name, &name.to_string(), &schema_code);
-
-    #[cfg(not(any(feature = "typescript", feature = "zod")))]
-    let _: &_ = &item_name;
+    let _: &_ = &(name, item_name, &ts_parts, &zod_parts, &json_parts);
 
     #[cfg(feature = "zod")]
     let schema_example_method = build_struct_schema_example(example_code.as_ref(), name);
@@ -5168,14 +5202,14 @@ fn process_untagged_enum(
 
     // Build schema module impl items (without schema_example)
     #[cfg(any(feature = "zod", feature = "typescript", feature = "jsonschema"))]
-    let schema_impl_items: Vec<proc_macro2::TokenStream> = vec![
-        #[cfg(feature = "jsonschema")]
-        json_schema_method,
-        #[cfg(feature = "typescript")]
-        ts_definition_method,
-        #[cfg(feature = "zod")]
-        zod_schema_method,
-    ];
+    let schema_impl_items = build_untagged_schema_impl_items(
+        name,
+        item_name,
+        docs_vec.as_deref(),
+        &ts_parts,
+        &zod_parts,
+        &json_parts,
+    );
 
     #[cfg(any(feature = "zod", feature = "typescript", feature = "jsonschema"))]
     let delegate_impl_items = build_struct_delegate_items(

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -5076,7 +5076,10 @@ fn collect_untagged_members(
 /// it, a `|` union, a `z.union`. The joins live next to the method that reads them because each is
 /// read exactly once and every one is feature-gated; keeping the pair together is what lets a
 /// disabled surface take its join with it.
-#[cfg(any(feature = "zod", feature = "typescript", feature = "jsonschema"))]
+#[cfg(all(
+    feature = "serde",
+    any(feature = "zod", feature = "typescript", feature = "jsonschema")
+))]
 fn build_untagged_schema_impl_items(
     name: &syn::Ident,
     item_name: &str,

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -74,6 +74,11 @@ const SEQUENCE_WRAPPERS: [&str; 6] = [
     "VecDeque",
 ];
 
+/// The module name a generated hook is written against, standing in for the one the enum's own
+/// expansion registers.
+#[cfg(feature = "serde")]
+const UNTAGGED_MODULE: Option<&str> = Some("choice_schema");
+
 #[test]
 fn ts_optional_ok_on_option_field() {
     validate_ts_optional_flag(true, true).unwrap();
@@ -286,11 +291,16 @@ fn positional_option_field_is_exempt() {
     guard_result(&item).unwrap();
 }
 
+/// Collects the untagged-path guard failures as rendered `compile_error!` token streams.
+#[cfg(feature = "serde")]
+fn untagged_guard_error_tokens(item: &mut syn::ItemEnum) -> Vec<proc_macro2::TokenStream> {
+    collect_untagged_members(item, UNTAGGED_MODULE).3
+}
+
 /// Collects the untagged-path guard failures as rendered `compile_error!` token strings.
 #[cfg(feature = "serde")]
 fn untagged_guard_errors(mut item: syn::ItemEnum) -> Vec<String> {
-    collect_untagged_members(&mut item)
-        .3
+    untagged_guard_error_tokens(&mut item)
         .iter()
         .map(ToString::to_string)
         .collect()
@@ -334,6 +344,68 @@ fn untagged_tuple_variant_option_is_exempt() {
     let errors = untagged_guard_errors(syn::parse_quote! {
         enum Choice {
             Maybe(Option<i64>),
+        }
+    });
+    assert!(errors.is_empty(), "got: {errors:?}");
+}
+
+/// Every shape the untagged rendering has no member spelling for is refused the way every other
+/// misuse is — as an error the enum reports for each offender, rather than a panic that stops the
+/// expansion at the first one and demotes its sentence to a `help:` note.
+#[cfg(feature = "serde")]
+#[test]
+fn untagged_unsupported_variant_shapes_are_all_reported() {
+    let errors = untagged_guard_errors(syn::parse_quote! {
+        enum Choice {
+            Bare,
+            Pair(String, String),
+            Note { id: String },
+            Empty(),
+        }
+    });
+    assert_eq!(errors.len(), 3, "got: {errors:?}");
+    for (error, needles) in errors.iter().zip([
+        ["`Bare`", "a unit variant"],
+        ["`Pair`", "a tuple variant with 2 fields"],
+        ["`Empty`", "a unit variant"],
+    ]) {
+        assert!(error.contains("compile_error"), "got: {error}");
+        for needle in needles {
+            assert!(error.contains(needle), "got: {error}");
+        }
+        assert!(
+            error.contains("supports newtype (`V(T)`) and struct"),
+            "got: {error}"
+        );
+    }
+}
+
+/// The refusal points at the variant it is about, not at the attribute on the enum: an enum with
+/// many variants otherwise sends its author to the wrong line.
+#[cfg(feature = "serde")]
+#[test]
+fn untagged_unsupported_variant_refusal_points_at_the_variant() {
+    use syn::spanned::Spanned as _;
+
+    let mut item: syn::ItemEnum =
+        syn::parse_str("enum Choice { Note { id: String }, Pair(String, String) }").unwrap();
+    let errors = untagged_guard_error_tokens(&mut item);
+    assert_eq!(errors.len(), 1, "got: {errors:?}");
+    assert_eq!(
+        errors[0].span().source_text().as_deref(),
+        Some("Pair(String, String)")
+    );
+}
+
+/// The supported shapes are untouched: a newtype and a struct variant still render, and neither
+/// earns a word from the shape guard.
+#[cfg(feature = "serde")]
+#[test]
+fn untagged_supported_variant_shapes_are_left_alone() {
+    let errors = untagged_guard_errors(syn::parse_quote! {
+        enum Choice {
+            Note { id: String },
+            Plain(i64),
         }
     });
     assert!(errors.is_empty(), "got: {errors:?}");
@@ -402,12 +474,86 @@ fn untagged_member_carries_its_constraint_to_the_surfaces() {
             },
         }
     };
-    let (_, zod_parts, _, errors) = collect_untagged_members(&mut item);
+    let (_, zod_parts, _, errors, _) = collect_untagged_members(&mut item, UNTAGGED_MODULE);
     assert!(errors.is_empty(), "got: {errors:?}");
     assert!(
         zod_parts[0].contains("z.string().min(2).check(z.regex(/^[a-z]+$/))"),
         "got: {}",
         zod_parts[0]
+    );
+}
+
+/// The same member reaches the Rust side through the generation the tagged twin uses: the validator
+/// and its deserializer, named for the variant, hung on the member by the injected attribute.
+#[cfg(feature = "serde")]
+#[test]
+fn untagged_member_constraint_generates_the_validator_and_hangs_it_on_the_member() {
+    let mut item: syn::ItemEnum = syn::parse_quote! {
+        enum Choice {
+            Named {
+                #[model_schema_prop(minLength = 2)]
+                name: String,
+            },
+        }
+    };
+    let (_, _, _, errors, validation_fns) = collect_untagged_members(&mut item, UNTAGGED_MODULE);
+    assert!(errors.is_empty(), "got: {errors:?}");
+    assert_eq!(validation_fns.len(), 1, "got: {validation_fns:?}");
+    let rendered = validation_fns[0].to_string();
+    assert!(
+        rendered.contains("fn validate_named_name_value"),
+        "got: {rendered}"
+    );
+    assert!(
+        rendered.contains("fn deserialize_named_name"),
+        "got: {rendered}"
+    );
+
+    let attrs = &item.variants[0].fields.iter().next().unwrap().attrs;
+    let rendered_attrs = quote::quote!(#(#attrs)*).to_string();
+    assert!(
+        rendered_attrs.contains(r#"deserialize_with = "choice_schema::deserialize_named_name""#),
+        "got: {rendered_attrs}"
+    );
+}
+
+/// Without a schema module there is nothing for a `deserialize_with` to name, so the member is left
+/// exactly as written — the same subset in which a struct field generates no validator either.
+#[cfg(feature = "serde")]
+#[test]
+fn untagged_member_constraint_generates_nothing_without_a_schema_module() {
+    let mut item: syn::ItemEnum = syn::parse_quote! {
+        enum Choice {
+            Named {
+                #[model_schema_prop(minLength = 2)]
+                name: String,
+            },
+        }
+    };
+    let (_, _, _, errors, validation_fns) = collect_untagged_members(&mut item, None);
+    assert!(errors.is_empty(), "got: {errors:?}");
+    assert!(validation_fns.is_empty(), "got: {validation_fns:?}");
+    let attrs = &item.variants[0].fields.iter().next().unwrap().attrs;
+    assert!(attrs.is_empty(), "got: {}", quote::quote!(#(#attrs)*));
+}
+
+/// A newtype member has no ident for the two helpers and the accessor to be named from, so the
+/// bound is refused here for the reason it is refused on a tuple field — the position the generation
+/// this path now shares has always answered for.
+#[cfg(feature = "serde")]
+#[test]
+fn untagged_newtype_member_constraint_is_refused() {
+    let errors = untagged_guard_errors(syn::parse_quote! {
+        enum Choice {
+            Slug(#[model_schema_prop(minLength = 2)] String),
+        }
+    });
+    assert_eq!(errors.len(), 1, "got: {errors:?}");
+    assert!(errors[0].contains("tuple field"), "got: {}", errors[0]);
+    assert!(
+        errors[0].contains("unsupported on a positional field"),
+        "got: {}",
+        errors[0]
     );
 }
 
@@ -426,7 +572,7 @@ fn untagged_member_prop_attribute_is_stripped_from_the_emitted_item() {
             },
         }
     };
-    collect_untagged_members(&mut item);
+    collect_untagged_members(&mut item, UNTAGGED_MODULE);
     let attrs = &item.variants[0].fields.iter().next().unwrap().attrs;
     assert!(
         !attrs
@@ -1496,6 +1642,102 @@ fn a_fixed_shape_field_without_a_bound_is_left_alone() {
             }
         });
         assert!(errors.is_empty(), "for {field}: {errors:?}");
+    }
+}
+
+/// A map and a tuple render their members, never themselves, so a bound written beside one reaches
+/// no surface either — the same loss the whole-schema types answer for, refused where it is written.
+#[test]
+fn a_bound_on_a_map_or_tuple_field_is_refused() {
+    for (constraint, key) in [
+        (quote::quote! { minLength = 30 }, "minLength"),
+        (quote::quote! { maxLength = 30 }, "maxLength"),
+        (quote::quote! { pattern = "^[a-z]+$" }, "pattern"),
+        (quote::quote! { minimum = 5 }, "minimum"),
+        (quote::quote! { maximum = 5 }, "maximum"),
+    ] {
+        for (field_type, shape) in [
+            (quote::quote! { HashMap<String, String> }, "a map"),
+            (quote::quote! { Option<HashMap<String, u32>> }, "a map"),
+            (quote::quote! { Vec<HashMap<String, u32>> }, "a map"),
+            (quote::quote! { (String, String) }, "a tuple"),
+            (quote::quote! { Option<(String, u32)> }, "a tuple"),
+        ] {
+            let errors = field_prop_guard_errors(&syn::parse_quote! {
+                struct Report {
+                    #[model_schema_prop(#constraint)]
+                    labels: #field_type,
+                }
+            });
+            assert_eq!(errors.len(), 1, "for {key} on {field_type}: {errors:?}");
+            for needle in ["compile_error", "field `labels`", key, shape, "brand"] {
+                assert!(
+                    errors[0].contains(needle),
+                    "{needle} missing for {key} on {field_type}: {}",
+                    errors[0]
+                );
+            }
+        }
+    }
+}
+
+/// A map or tuple field carrying no bound must not acquire one of these errors, and neither must the
+/// keys that name or wrap the rendering rather than constrain a value.
+#[test]
+fn a_map_or_tuple_field_without_a_bound_is_left_alone() {
+    for field in [
+        quote::quote! { labels: HashMap<String, String> },
+        quote::quote! { pair: (String, u32) },
+        quote::quote! { #[model_schema_prop(preprocess = ["trim"])] pair: (String, u32) },
+    ] {
+        let errors = field_prop_guard_errors(&syn::parse_quote! {
+            struct Report {
+                #field
+            }
+        });
+        assert!(errors.is_empty(), "for {field}: {errors:?}");
+    }
+}
+
+/// The docs a field's meta earns, read off the walk that writes them.
+fn field_docs_after_meta(item: &syn::ItemStruct) -> String {
+    let field = item.fields.iter().next().unwrap();
+    let name = field
+        .ident
+        .as_ref()
+        .map(ToString::to_string)
+        .unwrap_or_default();
+    let mut field_def = get_field_def(&name, &field.ty, "");
+    let meta = super::parse_model_schema_prop_attributes(&field.attrs);
+    super::apply_model_schema_prop_meta(&mut field_def, meta, &name);
+    field_def.docs
+}
+
+/// The `JSDoc` states the bound as a rule the value is held to, so it is written only where
+/// something holds the value to it — never for a placement the guard refuses, which was the one
+/// place the sentence appeared over nothing at all.
+#[test]
+fn the_constraint_docs_are_written_only_where_the_bound_is_kept() {
+    assert!(
+        field_docs_after_meta(&syn::parse_quote! {
+            struct Report {
+                #[model_schema_prop(minLength = 30)]
+                name: String,
+            }
+        })
+        .contains("Minimum length: 30"),
+        "a bound the surfaces render says so in the docs"
+    );
+    for field in [
+        quote::quote! { #[model_schema_prop(minLength = 30)] labels: HashMap<String, String> },
+        quote::quote! { #[model_schema_prop(maximum = 5)] pair: (u32, u32) },
+    ] {
+        let docs = field_docs_after_meta(&syn::parse_quote! {
+            struct Report {
+                #field
+            }
+        });
+        assert!(docs.is_empty(), "for {field}, got: {docs}");
     }
 }
 

--- a/tests/untagged_tests/tests.rs
+++ b/tests/untagged_tests/tests.rs
@@ -114,6 +114,33 @@ enum ConstrainedTagged {
     },
 }
 
+// An untagged union whose only member carries a bound: with no other branch to fall to, a value the
+// bound rejects is a value the whole union rejects.
+#[model_schema()]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+enum SoleConstrainedUnion {
+    Slug {
+        #[model_schema_prop(minLength = 2, pattern = "^[a-z]+$")]
+        slug: String,
+    },
+}
+
+// The same member written twice, bound first and bare second: what a failing bound costs is the
+// branch, not the read.
+#[model_schema()]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+enum CheckedThenLooseUnion {
+    Checked {
+        #[model_schema_prop(minLength = 2)]
+        name: String,
+    },
+    Loose {
+        name: String,
+    },
+}
+
 // An untagged member is written by a dispatch of its own, so it is a position an `ObjectId` can be
 // spelled in.
 #[cfg(all(feature = "jsonschema", feature = "object_id"))]
@@ -486,6 +513,53 @@ fn test_untagged_member_constraint_json_schema() {
     assert_eq!(
         tagged["oneOf"][0]["properties"]["slug"], *member,
         "the tagged twin must render the same member"
+    );
+}
+
+/// The member's bound reaches the Rust side too, so a payload both schema surfaces reject stops
+/// being one serde reads back without a word.
+#[test]
+fn test_untagged_member_constraint_is_enforced_on_deserialize() {
+    serde_json::from_str::<SoleConstrainedUnion>(r#"{"slug":"a"}"#).unwrap_err();
+    serde_json::from_str::<SoleConstrainedUnion>(r#"{"slug":"AB"}"#).unwrap_err();
+    assert_eq!(
+        serde_json::from_str::<SoleConstrainedUnion>(r#"{"slug":"ab"}"#).unwrap(),
+        SoleConstrainedUnion::Slug {
+            slug: "ab".to_owned()
+        }
+    );
+}
+
+/// What a bound means in this position, pinned: serde tries the variants in order and a member the
+/// bound rejects takes its variant out of the running rather than ending the read — the same thing
+/// the union member's own schema does under `anyOf` and under `z.union`. So a violating value lands
+/// on the next branch that accepts it, and errors only when none does.
+#[test]
+fn test_untagged_member_constraint_decides_which_variant_is_read() {
+    assert_eq!(
+        serde_json::from_str::<CheckedThenLooseUnion>(r#"{"name":"ab"}"#).unwrap(),
+        CheckedThenLooseUnion::Checked {
+            name: "ab".to_owned()
+        }
+    );
+    assert_eq!(
+        serde_json::from_str::<CheckedThenLooseUnion>(r#"{"name":"A"}"#).unwrap(),
+        CheckedThenLooseUnion::Loose {
+            name: "A".to_owned()
+        }
+    );
+}
+
+/// Serialization is untouched: the hook is a deserializer, and the value it refuses on the way in
+/// is one the type can still be built with and written out.
+#[test]
+fn test_untagged_member_constraint_leaves_serialization_alone() {
+    let violating = SoleConstrainedUnion::Slug {
+        slug: "A".to_owned(),
+    };
+    assert_eq!(
+        serde_json::to_string(&violating).unwrap(),
+        r#"{"slug":"A"}"#
     );
 }
 


### PR DESCRIPTION
Three related changes to the untagged path and the constraint placement contract:

- An untagged member's `model_schema_prop` bound now reaches the Rust side through the same generation the tagged twin uses — the validator, the deserializer, and the injected `deserialize_with` under variant-scoped naming. What the hook costs in this position is the variant, not the read: serde drops a failing variant from the candidate set, which is exactly what the member's schema already means under `anyOf` and `z.union`. Pinned by twin unions (sole-constrained, checked-then-loose) plus a serialization-untouched test. A newtype member's bound is now refused (positional guard), where it previously rendered on Zod with nothing on the Rust side.
- Unit and multi-field tuple variants are refused as spanned `syn::Error`s collected per offender, replacing the expansion-stopping panic; the empty-newtype assert became structurally unreachable via a slice pattern.
- The constraint placement contract extends to composites: a bound on a map or tuple field reaches no surface (members are built from inner defs that carry no meta), so it is refused where written, and the JSDoc constraint sentence is emitted only where something actually holds the value to it — one shared `constraints_reach_nothing` answers both.

Also lifts the untagged schema-method assembly into its own builder (function-length limit) with the cfg intersection of its caller.