### PR TITLE
hold the crate's own emitted pattern to the author guard and refuse negated character classes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -647,12 +647,12 @@ export type Document = {
 
 ```typescript
 export const Document$Schema = z.strictObject({
-  id: z.object({ $oid: z.string().regex(/^[a-f\d]{24}$/i, { message: "Invalid ObjectId" }) }),
-  author_id: z.object({ $oid: z.string().regex(/^[a-f\d]{24}$/i, { message: "Invalid ObjectId" }) }),
-  tags: z.array(z.object({ $oid: z.string().regex(/^[a-f\d]{24}$/i, { message: "Invalid ObjectId" }) })),
-  metadata: z.record(z.string(), z.object({ $oid: z.string().regex(/^[a-f\d]{24}$/i, { message: "Invalid ObjectId" }) })),
-  parent_id: z.union([z.object({ $oid: z.string().regex(/^[a-f\d]{24}$/i, { message: "Invalid ObjectId" }) }), z.undefined()]).prefault(undefined),
-  related: z.record(z.string(), z.array(z.object({ $oid: z.string().regex(/^[a-f\d]{24}$/i, { message: "Invalid ObjectId" }) }))),
+  id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: "Invalid ObjectId" }) }),
+  author_id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: "Invalid ObjectId" }) }),
+  tags: z.array(z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: "Invalid ObjectId" }) })),
+  metadata: z.record(z.string(), z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: "Invalid ObjectId" }) })),
+  parent_id: z.union([z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: "Invalid ObjectId" }) }), z.undefined()]).prefault(undefined),
+  related: z.record(z.string(), z.array(z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: "Invalid ObjectId" }) }))),
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -1339,13 +1339,13 @@ export type Document = {
 };
 
 export const Document$Schema = z.strictObject({
-  id: z.object({ $oid: z.string().regex(/^[a-f\d]{24}$/i, { message: "Invalid ObjectId" }) }),
+  id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: "Invalid ObjectId" }) }),
   title: z.string(),
-  author_id: z.object({ $oid: z.string().regex(/^[a-f\d]{24}$/i, { message: "Invalid ObjectId" }) }),
-  tags: z.array(z.object({ $oid: z.string().regex(/^[a-f\d]{24}$/i, { message: "Invalid ObjectId" }) })),
-  metadata: z.record(z.string(), z.object({ $oid: z.string().regex(/^[a-f\d]{24}$/i, { message: "Invalid ObjectId" }) })),
-  parent_id: z.union([z.object({ $oid: z.string().regex(/^[a-f\d]{24}$/i, { message: "Invalid ObjectId" }) }), z.undefined()]).prefault(undefined),
-  related_docs: z.record(z.string(), z.array(z.object({ $oid: z.string().regex(/^[a-f\d]{24}$/i, { message: "Invalid ObjectId" }) }))),
+  author_id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: "Invalid ObjectId" }) }),
+  tags: z.array(z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: "Invalid ObjectId" }) })),
+  metadata: z.record(z.string(), z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: "Invalid ObjectId" }) })),
+  parent_id: z.union([z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: "Invalid ObjectId" }) }), z.undefined()]).prefault(undefined),
+  related_docs: z.record(z.string(), z.array(z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: "Invalid ObjectId" }) }))),
 });
 ```
 

--- a/src/features/object_id.rs
+++ b/src/features/object_id.rs
@@ -3,6 +3,19 @@
 //! This module handles `ObjectId` type detection and generates appropriate
 //! TypeScript and schema code when the "`object_id`" feature is enabled.
 
+/// The 24-character hex an `ObjectId`'s `$oid` member holds, as the regex every surface constrains
+/// it by. Written once so no position can describe the same string a different way: the JSON
+/// Schema `pattern` keyword and the Zod literal both read it from here.
+///
+/// Spelled in the members both engines agree on rather than with a `\d`, for the same reason the
+/// guard refuses an author one. The `regex` crate reads that class as the Unicode digits and a
+/// flagless JavaScript literal reads the ASCII ones, so `[a-f\d]` admits twenty-four ARABIC-INDIC
+/// digits in the generated Rust validator and refuses them wherever the schema is loaded. Hex is
+/// ASCII, so writing `0-9` out leaves the value set this constant is for exactly where it was and
+/// leaves one contract in place of two.
+#[cfg(any(test, feature = "zod", feature = "jsonschema"))]
+pub const OBJECT_ID_HEX_PATTERN: &str = "^[a-f0-9]{24}$";
+
 /// Detects if a type name represents a `MongoDB` `ObjectId`.
 pub fn is_object_id_type(type_name: &str) -> bool {
     type_name == "ObjectId"
@@ -25,7 +38,7 @@ pub fn get_object_id_zod_schema() -> String {
 #[cfg(all(feature = "object_id", any(test, feature = "zod")))]
 pub fn get_object_id_zod_schema_with(hex_checks: &str) -> String {
     format!(
-        "z.object({{ $oid: z.string().regex(/^[a-f\\d]{{24}}$/i, {{ message: \"Invalid ObjectId\" }}){hex_checks} }})"
+        "z.object({{ $oid: z.string().regex(/{OBJECT_ID_HEX_PATTERN}/i, {{ message: \"Invalid ObjectId\" }}){hex_checks} }})"
     )
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,12 +157,12 @@ pub struct Document {
 // };
 //
 // export const Document$Schema = z.strictObject({
-//   id: z.object({ $oid: z.string().regex(/^[a-f\d]{24}$/i, { message: "Invalid ObjectId" }) }),
+//   id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: "Invalid ObjectId" }) }),
 //   title: z.string(),
-//   author_id: z.object({ $oid: z.string().regex(/^[a-f\d]{24}$/i, { message: "Invalid ObjectId" }) }),
-//   tags: z.array(z.object({ $oid: z.string().regex(/^[a-f\d]{24}$/i, { message: "Invalid ObjectId" }) })),
-//   metadata: z.record(z.string(), z.object({ $oid: z.string().regex(/^[a-f\d]{24}$/i, { message: "Invalid ObjectId" }) })),
-//   parent_id: z.union([z.object({ $oid: z.string().regex(/^[a-f\d]{24}$/i, { message: "Invalid ObjectId" }) }), z.undefined()]).prefault(undefined),
+//   author_id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: "Invalid ObjectId" }) }),
+//   tags: z.array(z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: "Invalid ObjectId" }) })),
+//   metadata: z.record(z.string(), z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: "Invalid ObjectId" }) })),
+//   parent_id: z.union([z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: "Invalid ObjectId" }) }), z.undefined()]).prefault(undefined),
 // });
 ```
 "#

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -40,6 +40,12 @@ use crate::utils::{escape_js_regex_literal, extract_example_from_docs};
 #[cfg(all(feature = "zod", feature = "object_id"))]
 use crate::features::object_id::get_object_id_zod_schema_with;
 
+// The 24-character hex an `ObjectId`'s `$oid` member holds, as a JSON-schema `pattern`. Read from
+// the `ObjectId` feature module, which is where the Zod literal reads it from too, so the two
+// surfaces cannot drift into describing the same string different ways.
+#[cfg(all(feature = "jsonschema", feature = "object_id"))]
+use crate::features::object_id::OBJECT_ID_HEX_PATTERN;
+
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 use crate::utils::{AliasKind, lookup_alias_info, portable_pattern};
 
@@ -114,11 +120,6 @@ const FLATTENED_PLAIN_ENUM_SCOPE: &str = "Only a type the registry has already c
 const WRITTEN_AS_ARRAY: &str = "a JSON array";
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 const WRITTEN_AS_OBJECT: &str = "a JSON object";
-
-/// The 24-character hex an `ObjectId`'s `$oid` member holds, as a JSON-schema `pattern`. Written
-/// once so no position can describe the same string a different way.
-#[cfg(all(feature = "jsonschema", feature = "object_id"))]
-const OBJECT_ID_HEX_PATTERN: &str = r"^[a-f\d]{24}$";
 
 /// One variant of a discriminated enum, carrying everything its union member is rendered from.
 struct DiscriminatedVariant {

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -2895,7 +2895,7 @@ fn an_object_id_enum_keyed_map_value_binds_the_one_oid_object() {
     let tokens = enum_key_map_value_binding(FieldDefType::ObjectId);
     assert!(
         tokens.contains(
-            r#"let value_schema = serde_json :: json ! ({ "type" : "object" , "properties" : { "$oid" : (serde_json :: json ! ({ "type" : "string" , "pattern" : "^[a-f\\d]{24}$" })) } , "required" : ["$oid"] , "additionalProperties" : false }) ;"#
+            r#"let value_schema = serde_json :: json ! ({ "type" : "object" , "properties" : { "$oid" : (serde_json :: json ! ({ "type" : "string" , "pattern" : "^[a-f0-9]{24}$" })) } , "required" : ["$oid"] , "additionalProperties" : false }) ;"#
         ),
         "got: {tokens}"
     );
@@ -3299,7 +3299,7 @@ fn a_nested_string_literal_map_value_keeps_its_const() {
 #[cfg(all(feature = "object_id", feature = "jsonschema"))]
 #[test]
 fn a_nested_object_id_map_value_keeps_its_oid_object() {
-    let inner_member = r#"{ "type" : "object" , "additionalProperties" : { "type" : "object" , "properties" : { "$oid" : (serde_json :: json ! ({ "type" : "string" , "pattern" : "^[a-f\\d]{24}$" })) } , "required" : ["$oid"] , "additionalProperties" : false } }"#;
+    let inner_member = r#"{ "type" : "object" , "additionalProperties" : { "type" : "object" , "properties" : { "$oid" : (serde_json :: json ! ({ "type" : "string" , "pattern" : "^[a-f0-9]{24}$" })) } , "required" : ["$oid"] , "additionalProperties" : false } }"#;
     let bare = nested_string_key_map_value_schema(FieldDefType::ObjectId, 0);
     assert!(
         bare.contains(&format!(r#""additionalProperties" : {inner_member}"#)),
@@ -3977,7 +3977,7 @@ fn an_object_id_tuple_element_spells_the_one_oid_object() {
         super::build_tuple_element_json_schema(&parsed)
             .unwrap()
             .to_string(),
-        r#"serde_json :: json ! ({ "type" : "object" , "properties" : { "$oid" : (serde_json :: json ! ({ "type" : "string" , "pattern" : "^[a-f\\d]{24}$" })) } , "required" : ["$oid"] , "additionalProperties" : false })"#
+        r#"serde_json :: json ! ({ "type" : "object" , "properties" : { "$oid" : (serde_json :: json ! ({ "type" : "string" , "pattern" : "^[a-f0-9]{24}$" })) } , "required" : ["$oid"] , "additionalProperties" : false })"#
     );
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,9 +2,9 @@ use core::cell::RefCell;
 use core::ops::Range;
 use regex_syntax::ast::parse::Parser as PatternParser;
 use regex_syntax::ast::{
-    Assertion, AssertionKind, Ast, ClassPerl, ClassPerlKind, ClassSet, ClassSetBinaryOpKind,
-    ClassSetItem, Flag, FlagsItemKind, Group, GroupKind, HexLiteralKind, Literal, LiteralKind,
-    SpecialLiteralKind,
+    Assertion, AssertionKind, Ast, ClassBracketed, ClassPerl, ClassPerlKind, ClassSet,
+    ClassSetBinaryOpKind, ClassSetItem, Flag, FlagsItemKind, Group, GroupKind, HexLiteralKind,
+    Literal, LiteralKind, SpecialLiteralKind,
 };
 use std::collections::HashMap;
 use syn::{Attribute, Expr, Field, Lit, LitStr, Meta, Variant};
@@ -185,7 +185,7 @@ impl JsSpelling {
             Ast::Literal(literal) => self.literal(literal, false),
             Ast::Assertion(assertion) => self.assertion(assertion),
             Ast::ClassUnicode(_) => self.refuse(UNICODE_CLASS_WRITTEN, UNICODE_CLASS_READ_AS),
-            Ast::ClassBracketed(class) => self.class_set(&class.kind),
+            Ast::ClassBracketed(class) => self.bracketed_class(class),
             Ast::Repetition(repetition) => self.ast(&repetition.ast),
             Ast::Group(group) => self.group(group),
             Ast::Alternation(alternation) => self.asts(&alternation.asts),
@@ -197,6 +197,31 @@ impl JsSpelling {
         for ast in asts {
             self.ast(ast);
         }
+    }
+
+    /// Walks a `[...]` class, refusing it first if it is negated.
+    ///
+    /// A negated class is the last construct both grammars read and fill differently, and the
+    /// members cannot settle it: the complement is taken one code unit at a time there and one
+    /// character at a time here, so `[^0-9]` parts ways over an astral character exactly as the
+    /// `\D` above it does. Nothing is bought by admitting the bracketed spelling of a construct
+    /// already refused under its perl one.
+    ///
+    /// The one class whose `regex` reading does leave every astral character out has to name them
+    /// by astral bounds, and a flagless literal reads those as surrogate halves in descending
+    /// order and will not parse the class at all — so there is no admissible spelling to fall back
+    /// to, which is what makes refusal the whole verdict rather than a table of survivors.
+    fn bracketed_class(&mut self, class: &ClassBracketed) {
+        if class.negated {
+            self.refuse_value_set(
+                "a negated character class `[^...]`",
+                "the complement of the same members taken one UTF-16 code unit at a time, where \
+                 the `regex` crate takes it one character at a time -- so a lone character outside \
+                 the Basic Multilingual Plane fills the class here and reaches that literal as the \
+                 two code units no one-character class holds",
+            );
+        }
+        self.class_set(&class.kind);
     }
 
     fn class_item(&mut self, item: &ClassSetItem) {

--- a/src/utils/tests.rs
+++ b/src/utils/tests.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+#[cfg(feature = "object_id")]
+use crate::features::object_id::OBJECT_ID_HEX_PATTERN;
+
 /// The pattern shapes the shipped tests write, none of which the two grammars spell differently.
 /// Every one of them has to come back byte for byte: the guard is there to stop a pattern only one
 /// grammar reads, not to touch the ones both already read the same way.
@@ -21,7 +24,7 @@ const PORTABLE_PATTERNS: [&str; 9] = [
 /// The list is the inventory of what `regex::Regex::new` accepts and a JavaScript regex literal
 /// either fails to parse or reads as something else, so it doubles as the record of what was
 /// checked against both grammars.
-const UNPORTABLE_PATTERNS: [(&str, &str); 32] = [
+const UNPORTABLE_PATTERNS: [(&str, &str); 34] = [
     ("(?i)abc", "inline flag directive"),
     ("abc(?i)def", "inline flag directive"),
     ("(?i:abc)", "case-insensitive flag on a `(?i:...)` group"),
@@ -52,8 +55,12 @@ const UNPORTABLE_PATTERNS: [(&str, &str); 32] = [
     ("[a[b]]", "class nested inside another class"),
     (r"\x{41}", "braced code point escape"),
     ("[]]", "unescaped `]` opening a character class"),
-    ("[^]]", "unescaped `]` opening a character class"),
+    // Negated, so the class is refused for being negated before its members are read at all — the
+    // `]` rule still answers for the two spellings above it.
+    ("[^]]", "negated character class"),
     ("[]-a]", "unescaped `]` opening a character class"),
+    ("[^a]", "negated character class"),
+    (r"[^\w]", "negated character class"),
 ];
 
 /// The haystacks a rewritten pattern is held to: whatever the original matched among them, the
@@ -270,6 +277,28 @@ const EQUALISED_PATTERNS: [(&str, &str); 10] = [
     (r"^[\w-]$", "^[0-9A-Za-z_-]$"),
     (r"^\d{3}\.\d{3}-\d{2}$", r"^[0-9]{3}\.[0-9]{3}-[0-9]{2}$"),
 ];
+
+/// The negated classes the verdict was decided over: a single member, the ranges an author reaches
+/// for to bound one to ASCII, an escape, and the `\d` the guard writes out to `0-9` on its way in.
+/// The last is the one that shows rewriting cannot help — its members come out ASCII and the
+/// complement is still taken two different ways.
+const NEGATED_CLASS_PATTERNS: [&str; 6] = [
+    "^[^a]$",
+    "^[^0-9]$",
+    r"^[^\n]$",
+    "^[^a-z]$",
+    r"^[^\x00-\x7F]$",
+    r"^[^\d]$",
+];
+
+/// Every regex this crate writes into a generated schema itself, rather than carrying over from an
+/// author's `pattern`.
+///
+/// An author's pattern reaches the three surfaces through the guard, which equalises what it can
+/// and refuses the rest. One the crate writes reaches them directly, so without this list there
+/// are two contracts and only one of them is enforced.
+#[cfg(feature = "object_id")]
+const CRATE_EMITTED_PATTERNS: [&str; 1] = [OBJECT_ID_HEX_PATTERN];
 
 #[cfg(feature = "zod")]
 #[test]
@@ -666,6 +695,48 @@ fn test_the_emitted_pattern_picks_out_the_same_haystacks_in_both_engines() {
     }
 }
 
+/// Every regex this crate writes into a generated schema itself, rather than carrying over from an
+/// author's `pattern`.
+///
+/// Held to the guard the crate holds authors to, and held to it the strict way: admitted *and*
+/// handed back unchanged. A pattern the guard rewrites is one that was not written in the spelling
+/// both engines read the same way, and the crate is in a position to write it that way to begin
+/// with — so for these the rewrite is not a fix, it is the failure. That makes this the check a
+/// future emitted pattern has to pass before it can ship.
+#[test]
+#[cfg(feature = "object_id")]
+fn test_every_pattern_the_crate_emits_is_a_fixed_point_of_the_guard() {
+    for pattern in CRATE_EMITTED_PATTERNS {
+        assert_eq!(
+            portable(pattern).as_deref(),
+            Ok(pattern),
+            "the crate emits {pattern}, which the guard does not admit unchanged"
+        );
+    }
+}
+
+/// The `$oid` hex, run over the haystacks that tell the engines apart, on the same recorded-
+/// JavaScript discipline as the table above: twenty-four ARABIC-INDIC digits are what a `\d` in
+/// that class admits in the `regex` crate and a flagless literal refuses, so they are the case the
+/// spelling turns on. The real `ObjectId` and the uppercase hex are there to say the value set the
+/// constant is *for* did not move.
+#[test]
+#[cfg(feature = "object_id")]
+fn test_the_emitted_object_id_hex_agrees_with_javascript_over_every_hex_shaped_haystack() {
+    let emitted = regex::Regex::new(OBJECT_ID_HEX_PATTERN).unwrap();
+    for (haystack, javascript) in [
+        ("507f1f77bcf86cd799439011".to_owned(), true),
+        ("\u{661}".repeat(24), false),
+        ("507F1F77BCF86CD799439011".to_owned(), false),
+    ] {
+        assert_eq!(
+            emitted.is_match(&haystack),
+            javascript,
+            "the emitted `$oid` pattern parts ways with JavaScript over {haystack:?}"
+        );
+    }
+}
+
 /// The constructs with no equalising spelling at all, and why: a flagless JavaScript literal
 /// matches one UTF-16 code unit where the `regex` crate matches one character, so anything that
 /// can match a character outside the Basic Multilingual Plane parts ways over every one of them.
@@ -679,6 +750,54 @@ fn test_portable_pattern_refuses_what_no_spelling_equalises() {
             "{pattern} is not refused for a value-set divergence: {rejection}"
         );
     }
+}
+
+/// A negated class is the last construct that was admitted while covering different characters in
+/// the two engines, and it is refused the same way `\D`, `\W` and `\S` already are — which are the
+/// same class negated, so admitting the bracketed spelling was refusing a construct under one name
+/// and taking it under another.
+#[test]
+fn test_portable_pattern_refuses_a_negated_class_whatever_its_members() {
+    for pattern in NEGATED_CLASS_PATTERNS {
+        let rejection = portable(pattern).unwrap_err();
+        for needle in ["negated character class", "cover different characters"] {
+            assert!(
+                rejection.contains(needle),
+                "{needle} missing for {pattern}: {rejection}"
+            );
+        }
+    }
+}
+
+/// Held against the engines rather than restated, as the dot's verdict was: no spelling of a
+/// negated class agrees with JavaScript, so refusing every one of them is the verdict rather than
+/// an admission table of the ones that survive.
+///
+/// Each candidate below fills in the `regex` crate where a flagless literal cannot fill at all — a
+/// lone astral character is one character here and the two code units it is written from there, so
+/// no one-character class holds it. The one spelling whose `regex` reading does leave every astral
+/// character out has to name them by astral bounds, and that literal reads those bounds as
+/// surrogate halves in descending order: `new RegExp("^[^\u{10000}-\u{10FFFF}]$")` throws `Range
+/// out of order in character class` under node v26.2.0, so it is not a spelling that can be
+/// admitted either.
+#[test]
+fn test_no_spelling_of_a_negated_class_agrees_across_the_engines() {
+    for candidate in NEGATED_CLASS_PATTERNS.into_iter().chain(["^[^\u{1f601}]$"]) {
+        let rust = regex::Regex::new(candidate).unwrap();
+        assert!(
+            rust.is_match("\u{1f600}"),
+            "{candidate} was expected to match an astral character in the `regex` crate"
+        );
+    }
+    let astral_bounded = regex::Regex::new("^[^\u{10000}-\u{10ffff}]$").unwrap();
+    assert!(
+        !astral_bounded.is_match("\u{1f600}"),
+        "the astral-bounded class was expected to be the one whose `regex` reading excludes them"
+    );
+    assert!(
+        astral_bounded.is_match("\u{661}"),
+        "the astral-bounded class was expected to keep every character below the astral range"
+    );
 }
 
 /// Held against the engines rather than restated: for the dot, no candidate spelling agrees with

--- a/tests/branded_newtype_tests/tests.rs
+++ b/tests/branded_newtype_tests/tests.rs
@@ -390,7 +390,7 @@ mod objectid_branded_surface_tests {
     use mongodb::bson::oid::ObjectId;
 
     const OID_ZOD_BASE: &str =
-        r#"z.object({ $oid: z.string().regex(/^[a-f\d]{24}$/i, { message: "Invalid ObjectId" })"#;
+        r#"z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: "Invalid ObjectId" })"#;
 
     #[model_schema()]
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -444,7 +444,7 @@ mod objectid_branded_surface_tests {
             PlainObjectId::json_schema(),
             serde_json::json!({
                 "type": "object",
-                "properties": { "$oid": { "type": "string", "pattern": r"^[a-f\d]{24}$" } },
+                "properties": { "$oid": { "type": "string", "pattern": "^[a-f0-9]{24}$" } },
                 "required": ["$oid"],
                 "additionalProperties": false
             })
@@ -483,7 +483,7 @@ mod objectid_branded_surface_tests {
                 "properties": {
                     "$oid": {
                         "type": "string",
-                        "pattern": r"^[a-f\d]{24}$",
+                        "pattern": "^[a-f0-9]{24}$",
                         "allOf": [{ "pattern": "^[0-9a-fA-F]{24}$" }]
                     }
                 },
@@ -570,7 +570,7 @@ mod objectid_branded_surface_tests {
                 "type": "array",
                 "items": {
                     "type": "object",
-                    "properties": { "$oid": { "type": "string", "pattern": r"^[a-f\d]{24}$" } },
+                    "properties": { "$oid": { "type": "string", "pattern": "^[a-f0-9]{24}$" } },
                     "required": ["$oid"],
                     "additionalProperties": false
                 }

--- a/tests/mongodb_real_tests/tests.rs
+++ b/tests/mongodb_real_tests/tests.rs
@@ -89,7 +89,7 @@ fn test_real_objectid_basic_types() {
 
     // Zod schema should use the MongoDB ObjectId structure with regex validation - now in separate method
     let zod_schema = RealUser::zod_schema();
-    assert!(zod_schema.contains("id: z.object({ $oid: z.string().regex(/^[a-f\\d]{24}$/i, { message: \"Invalid ObjectId\" }) }),"));
+    assert!(zod_schema.contains("id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: \"Invalid ObjectId\" }) }),"));
     assert!(zod_schema.contains("name: z.string(),"));
     assert!(
         zod_schema.contains("email: z.union([z.string(), z.undefined()]).prefault(undefined),")
@@ -182,7 +182,7 @@ fn test_real_objectid_complex_structures() {
 
     // Zod schema should handle all ObjectId variations with regex validation - now in separate method
     let zod_schema = RealDocument::zod_schema();
-    let regex_pattern = "z.string().regex(/^[a-f\\d]{24}$/i, { message: \"Invalid ObjectId\" })";
+    let regex_pattern = "z.string().regex(/^[a-f0-9]{24}$/i, { message: \"Invalid ObjectId\" })";
     assert!(zod_schema.contains(&format!("id: z.object({{ $oid: {regex_pattern} }}),")));
     assert!(zod_schema.contains(&format!(
         "author_id: z.object({{ $oid: {regex_pattern} }}),"
@@ -340,7 +340,7 @@ fn test_nested_objectid_map_json_schema() {
 fn unified_oid_object() -> serde_json::Value {
     serde_json::json!({
         "type": "object",
-        "properties": { "$oid": { "type": "string", "pattern": r"^[a-f\d]{24}$" } },
+        "properties": { "$oid": { "type": "string", "pattern": "^[a-f0-9]{24}$" } },
         "required": ["$oid"],
         "additionalProperties": false
     })
@@ -485,8 +485,8 @@ fn test_real_objectid_validation_compatibility() {
     // Should be exactly 24 characters
     assert_eq!(hex_string.len(), 24);
 
-    // Should match our regex pattern: /^[a-f\d]{24}$/i
-    let regex = regex::Regex::new(r"^[a-f\d]{24}$").unwrap();
+    // Should match our regex pattern: /^[a-f0-9]{24}$/i
+    let regex = regex::Regex::new("^[a-f0-9]{24}$").unwrap();
     assert!(
         regex.is_match(&hex_string),
         "Real ObjectId hex '{hex_string}' should match our validation regex"

--- a/tests/mongodb_tests/tests.rs
+++ b/tests/mongodb_tests/tests.rs
@@ -242,7 +242,7 @@ fn test_basic_object_id_types() {
 
     // Zod schema should use the MongoDB ObjectId structure with regex validation - now in separate method
     let zod_schema = User::zod_schema();
-    assert!(zod_schema.contains("id: z.object({ $oid: z.string().regex(/^[a-f\\d]{24}$/i, { message: \"Invalid ObjectId\" }) }),"));
+    assert!(zod_schema.contains("id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: \"Invalid ObjectId\" }) }),"));
     assert!(zod_schema.contains("name: z.string(),"));
     assert!(
         zod_schema.contains("email: z.union([z.string(), z.undefined()]).prefault(undefined),")
@@ -264,7 +264,7 @@ fn test_complex_nested_object_id_structures() {
 
     // Zod schema should handle all ObjectId variations with regex validation - now in separate method
     let zod_schema = ComplexDocument::zod_schema();
-    let regex_pattern = "z.string().regex(/^[a-f\\d]{24}$/i, { message: \"Invalid ObjectId\" })";
+    let regex_pattern = "z.string().regex(/^[a-f0-9]{24}$/i, { message: \"Invalid ObjectId\" })";
     assert!(zod_schema.contains(&format!("id: z.object({{ $oid: {regex_pattern} }}),")));
     assert!(zod_schema.contains(&format!(
         "author_id: z.object({{ $oid: {regex_pattern} }}),"
@@ -307,7 +307,7 @@ fn test_complex_object_id_zod_schema() {
     let zod_schema = ComplexDocument::zod_schema();
 
     // Test that complex nested ObjectId structures work
-    let regex_pattern = "z.string().regex(/^[a-f\\d]{24}$/i, { message: \"Invalid ObjectId\" })";
+    let regex_pattern = "z.string().regex(/^[a-f0-9]{24}$/i, { message: \"Invalid ObjectId\" })";
     assert!(zod_schema.contains(&format!(
         "nested_refs: z.record(z.string(), z.array(z.object({{ $oid: {regex_pattern} }}))),"
     )));
@@ -351,7 +351,7 @@ fn test_hashmap_object_id_zod_schema() {
     let zod_schema = UserWithObjectIdMap::zod_schema();
 
     // Should handle HashMap<String, ObjectId> correctly
-    assert!(zod_schema.contains("relationships: z.record(z.string(), z.object({ $oid: z.string().regex(/^[a-f\\d]{24}$/i, { message: \"Invalid ObjectId\" }) })),"));
+    assert!(zod_schema.contains("relationships: z.record(z.string(), z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: \"Invalid ObjectId\" }) })),"));
 }
 
 #[test]
@@ -366,9 +366,9 @@ fn test_hashmap_with_object_id_values() {
 
     // Zod schema should use the MongoDB ObjectId structure with regex validation - now in separate method
     let zod_schema = UserWithObjectIdMap::zod_schema();
-    assert!(zod_schema.contains("id: z.object({ $oid: z.string().regex(/^[a-f\\d]{24}$/i, { message: \"Invalid ObjectId\" }) }),"));
+    assert!(zod_schema.contains("id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: \"Invalid ObjectId\" }) }),"));
     assert!(zod_schema.contains("name: z.string(),"));
-    assert!(zod_schema.contains("relationships: z.record(z.string(), z.object({ $oid: z.string().regex(/^[a-f\\d]{24}$/i, { message: \"Invalid ObjectId\" }) })),"));
+    assert!(zod_schema.contains("relationships: z.record(z.string(), z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: \"Invalid ObjectId\" }) })),"));
 }
 
 #[test]
@@ -401,9 +401,9 @@ fn test_object_id_arrays() {
 
     // Zod schema should use the MongoDB ObjectId structure with regex validation - now in separate method
     let zod_schema = UserWithObjectIdArray::zod_schema();
-    assert!(zod_schema.contains("id: z.object({ $oid: z.string().regex(/^[a-f\\d]{24}$/i, { message: \"Invalid ObjectId\" }) }),"));
+    assert!(zod_schema.contains("id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: \"Invalid ObjectId\" }) }),"));
     assert!(zod_schema.contains("name: z.string(),"));
-    assert!(zod_schema.contains("friend_ids: z.array(z.object({ $oid: z.string().regex(/^[a-f\\d]{24}$/i, { message: \"Invalid ObjectId\" }) })),"));
+    assert!(zod_schema.contains("friend_ids: z.array(z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: \"Invalid ObjectId\" }) })),"));
 }
 
 #[test]
@@ -429,7 +429,7 @@ fn test_object_id_arrays_zod_schema() {
     let zod_schema = UserWithObjectIdArray::zod_schema();
 
     // Should handle array of ObjectId correctly
-    assert!(zod_schema.contains("friend_ids: z.array(z.object({ $oid: z.string().regex(/^[a-f\\d]{24}$/i, { message: \"Invalid ObjectId\" }) })),"));
+    assert!(zod_schema.contains("friend_ids: z.array(z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: \"Invalid ObjectId\" }) })),"));
 }
 
 #[test]
@@ -468,7 +468,7 @@ fn test_object_id_zod_schema() {
     let zod_schema = Post::zod_schema();
 
     // Should handle optional ObjectId correctly
-    assert!(zod_schema.contains("parent_id: z.union([z.object({ $oid: z.string().regex(/^[a-f\\d]{24}$/i, { message: \"Invalid ObjectId\" }) }), z.undefined()]).prefault(undefined),"));
+    assert!(zod_schema.contains("parent_id: z.union([z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: \"Invalid ObjectId\" }) }), z.undefined()]).prefault(undefined),"));
 }
 
 #[test]
@@ -483,7 +483,7 @@ fn test_optional_object_id() {
 
     // Zod schema should use the MongoDB ObjectId structure with regex validation - now in separate method
     let zod_schema = UserWithOptionalId::zod_schema();
-    assert!(zod_schema.contains("id: z.union([z.object({ $oid: z.string().regex(/^[a-f\\d]{24}$/i, { message: \"Invalid ObjectId\" }) }), z.undefined()]).prefault(undefined),"));
+    assert!(zod_schema.contains("id: z.union([z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: \"Invalid ObjectId\" }) }), z.undefined()]).prefault(undefined),"));
     assert!(zod_schema.contains("name: z.string(),"));
     assert!(zod_schema.contains("email: z.string(),"));
 }
@@ -494,7 +494,7 @@ fn test_optional_object_id_zod_schema() {
     let zod_schema = UserWithOptionalId::zod_schema();
 
     // Should handle optional ObjectId correctly
-    assert!(zod_schema.contains("id: z.union([z.object({ $oid: z.string().regex(/^[a-f\\d]{24}$/i, { message: \"Invalid ObjectId\" }) }), z.undefined()]).prefault(undefined),"));
+    assert!(zod_schema.contains("id: z.union([z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: \"Invalid ObjectId\" }) }), z.undefined()]).prefault(undefined),"));
     assert!(zod_schema.contains("name: z.string(),"));
     assert!(zod_schema.contains("email: z.string(),"));
 }

--- a/tests/untagged_tests/tests.rs
+++ b/tests/untagged_tests/tests.rs
@@ -500,7 +500,7 @@ fn test_untagged_objectid_member_spells_the_one_oid_object() {
         schema["anyOf"][0]["properties"]["one"],
         serde_json::json!({
             "type": "object",
-            "properties": { "$oid": { "type": "string", "pattern": r"^[a-f\d]{24}$" } },
+            "properties": { "$oid": { "type": "string", "pattern": "^[a-f0-9]{24}$" } },
             "required": ["$oid"],
             "additionalProperties": false
         }),


### PR DESCRIPTION
Two halves of one contract — every regex reaching a generated schema is one both engines read the same way, whether an author wrote it or the crate did:

- The `$oid` hex constant moves to the ObjectId feature module, respelled `^[a-f0-9]{24}$` (writing `0-9` out — hex is ASCII, so the value set does not move), and the Zod literal now interpolates the same constant the JSON Schema `pattern` reads. A strict fixed-point test holds every crate-emitted pattern to the author guard — admitted *and* returned unchanged — plus a recorded-JavaScript agreement test over the haystacks that tell the engines apart (24 ARABIC-INDIC digits filled `[a-f\d]` in the `regex` crate and never in a flagless literal).
- Negated character classes are refused with the value-set divergence: the complement is taken one UTF-16 code unit at a time in a flagless literal and one character at a time in the `regex` crate, so a lone astral character fills `[^...]` here and never there; the one spelling whose Rust reading excludes astral characters needs astral bounds, which that literal will not parse (`Range out of order`). No admissible fallback exists, so refusal is the verdict — the bracketed spelling of the `\D`/`\W`/`\S` rule already landed. Existing shipping patterns containing `[^...]` now fail the derive by design.