### PR TITLE
render an untagged member's map or tuple through the dispatch its field position uses

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,6 +555,8 @@ Untagged enums compose with `#[serde(flatten)]`: a flattened variant carrying `V
 
 A member of an untagged variant carries `#[model_schema_prop(...)]` exactly as the same field written in a tagged variant does: the constraint reaches the Zod schema and the JSON Schema, and every guard the attribute earns is reported at the member. The one difference is the Rust side -- an untagged enum generates no per-field validators, so a constrained member has no `validate()` contribution and no deserialization check.
 
+A member holding a map or a tuple describes as the struct field written from the same type does, on every surface. A map is dispatched on the classification its key earns -- enumerated properties for a key whose members the expansion knows, `additionalProperties` for an open one -- and a key no surface can write is refused at the member, at whatever depth the map sits at. A tuple is the fixed-arity array Serde writes, `prefixItems` and the arity bounds included. A member the parser could not classify at all is the one shape that stays permissive: it carries no type name to narrow with, so it admits any value, exactly as the same field does.
+
 **Unsupported variants:** unit variants and multi-field tuple variants in an untagged enum produce a compile-time error.
 
 ### Nested Types

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -4692,6 +4692,12 @@ fn string_field_json_schema_value(fld: &FieldDef) -> proc_macro2::TokenStream {
 /// Builds a standalone `serde_json::Value` token expression for a single field, with `Vec<T>`
 /// array wrapping. Sibling type of [`flatten_field_json_schema_ref`]; used by untagged enum
 /// members where the JSON value is consumed directly (not inserted under a property name).
+///
+/// Every composite is dispatched through the renderer its own field position uses — the map
+/// machinery reading the key's classification, the tuple machinery writing the arity bounds — so a
+/// member describes as the struct field written from the same type does. An opaque value is the one
+/// shape that stays permissive: it carries no type name to narrow with, which is the reason field
+/// position leaves it open too.
 #[cfg(all(feature = "serde", feature = "jsonschema"))]
 fn field_json_schema_value(fld: &FieldDef) -> proc_macro2::TokenStream {
     let inner = match &fld.field_type {
@@ -4725,14 +4731,36 @@ fn field_json_schema_value(fld: &FieldDef) -> proc_macro2::TokenStream {
             let item = chrono_json_schema_item(&fld.field_type).unwrap();
             quote! { serde_json::json!(#item) }
         }
-        // Map / Tuple / Unknown inner shapes are out of scope for v1 untagged members;
-        // emit a permissive empty schema rather than silently mis-typing.
-        FieldDefType::Map(_, _) | FieldDefType::Tuple(_) | FieldDefType::Unknown => {
-            quote! { serde_json::json!({}) }
-        }
+        FieldDefType::Map(key, value) => match map_json_schema_value(key, value) {
+            Ok(map_schema) => map_schema,
+            Err(rejection) => return member_rejection_value(&fld.name, &rejection),
+        },
+        FieldDefType::Tuple(elements) => match tuple_json_schema_value(elements) {
+            Ok(tuple_schema) => tuple_schema,
+            Err(rejection) => return member_rejection_value(&fld.name, &rejection),
+        },
+        // An opaque value carries no type name to narrow with, so the member admits any value: the
+        // permissive empty schema, as in field position.
+        FieldDefType::Unknown => quote! { serde_json::json!({}) },
     };
 
     arrayed_json_schema_value(fld, inner)
+}
+
+/// [`map_member_rejection_error`] for a position that holds a value rather than writing a
+/// statement — an untagged variant's member, whose value is consumed straight into the union's
+/// `anyOf`.
+///
+/// It replaces the member's whole rendering, for the reason field position replaces the insertion:
+/// a schema the expansion has already rejected is not one to hand the author. The subject is the
+/// member as it was written, named the way the guards on this same walk name it.
+#[cfg(all(feature = "serde", feature = "jsonschema"))]
+fn member_rejection_value(
+    field_name: &str,
+    rejection: &MapMemberRejection,
+) -> proc_macro2::TokenStream {
+    let message = map_member_rejection_message(&field_label(field_name), rejection);
+    quote! { compile_error!(#message) }
 }
 
 /// Collects each untagged variant's union-member parts: the TypeScript member type, the Zod member
@@ -6185,6 +6213,28 @@ fn enum_key_map_json_schema_value(
     })
 }
 
+/// The object a map describes as, as a standalone `serde_json::Value` expression, dispatched on the
+/// classification its key earns — or the rejection when the key has no rendering here, or the value
+/// none the member dispatch can write.
+///
+/// Written once so every position holding a map reads the same key classification: a field, an
+/// untagged variant's member, whatever comes next. A key that enumerates its members enumerates
+/// them wherever the map is written, and one that opens the object opens it there too.
+#[cfg(feature = "jsonschema")]
+fn map_json_schema_value(
+    key: &FieldDef,
+    value: &FieldDef,
+) -> Result<proc_macro2::TokenStream, MapMemberRejection> {
+    match map_key_path(key) {
+        MapKeyPath::Enumerated(key_type_name) => {
+            enum_key_map_json_schema_value(key_type_name, key.type_span, value)
+        }
+        MapKeyPath::Open => string_key_map_json_schema_value(value),
+        MapKeyPath::Unnarrowed => Ok(unnarrowed_key_map_json_schema_value(key)),
+        MapKeyPath::Refused(rejection) => Err(MapMemberRejection::Key(rejection)),
+    }
+}
+
 /// The `properties` insertion a map-typed field produces.
 ///
 /// Every key path builds the map as a standalone value, which is then wrapped for the slot the
@@ -6202,15 +6252,7 @@ fn build_map_field_schema(
 ) -> proc_macro2::TokenStream {
     log::trace!("Map => field_name: {field_name_str}, key: {key:?}, value: {value:?}");
 
-    let rendered = match map_key_path(key) {
-        MapKeyPath::Enumerated(key_type_name) => {
-            enum_key_map_json_schema_value(key_type_name, key.type_span, value)
-        }
-        MapKeyPath::Open => string_key_map_json_schema_value(value),
-        MapKeyPath::Unnarrowed => Ok(unnarrowed_key_map_json_schema_value(key)),
-        MapKeyPath::Refused(rejection) => Err(MapMemberRejection::Key(rejection)),
-    };
-    match rendered {
+    match map_json_schema_value(key, value) {
         Ok(map_schema) => {
             let field_schema = arrayed_json_schema_value(fld, map_schema);
             quote! {

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -496,6 +496,164 @@ fn untagged_member_with_an_enumerable_map_key_is_left_alone() {
     }
 }
 
+/// The refusal every map-key spelling no surface can write earns, read off the untagged walk.
+/// Field position refuses each of these; a member is the same map, so it is refused here too — and
+/// the walk is the only thing that has to say so, the guard failure dropping the schema surface
+/// before any member rendering reaches the author.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn untagged_member_reaching_an_unwritable_map_key_is_refused() {
+    for (member_type, needle) in [
+        (quote::quote! { HashMap<Vec<String>, u32> }, "String"),
+        (quote::quote! { HashMap<[String; 2], u32> }, "String"),
+        (quote::quote! { HashMap<Option<String>, u32> }, "String"),
+        (
+            quote::quote! { HashMap<(String, u32), u32> },
+            "`(_, _)` as a JSON array",
+        ),
+        (
+            quote::quote! { HashMap<HashMap<String, u32>, u32> },
+            "`HashMap<_, _>` as a JSON object",
+        ),
+        (
+            quote::quote! { Vec<HashMap<Option<String>, u32>> },
+            "String",
+        ),
+    ] {
+        let errors = untagged_guard_errors(syn::parse_quote! {
+            enum Untagged {
+                Counts { counts: #member_type },
+            }
+        });
+        assert_eq!(errors.len(), 1, "for {member_type}, got: {errors:?}");
+        assert!(
+            errors[0].contains("compile_error"),
+            "for {member_type}: {}",
+            errors[0]
+        );
+        assert!(
+            errors[0].contains("field `counts`"),
+            "for {member_type}: {}",
+            errors[0]
+        );
+        assert!(
+            errors[0].contains(needle),
+            "for {member_type}: {}",
+            errors[0]
+        );
+    }
+}
+
+/// The JSON-schema values the untagged walk renders its members as.
+#[cfg(all(feature = "serde", feature = "jsonschema"))]
+fn untagged_member_values(mut item: syn::ItemEnum) -> Vec<String> {
+    collect_untagged_members(&mut item)
+        .2
+        .iter()
+        .map(ToString::to_string)
+        .collect()
+}
+
+/// A member holding a map is the map its key classification earns, at the depth it is written —
+/// the renderings field position produces from the same types, reached through the same dispatch.
+#[cfg(all(feature = "serde", feature = "jsonschema"))]
+#[test]
+fn untagged_member_holding_a_map_renders_the_field_position_map() {
+    register_alias_info("Bucket", "Bucket", "bucket_schema", AliasKind::EnumMembers);
+    for map_type in [
+        "HashMap<Bucket, u32>",
+        "HashMap<String, u32>",
+        "Vec<HashMap<String, u32>>",
+        "HashMap<String, HashMap<Bucket, u32>>",
+    ] {
+        let member_type: syn::Type = syn::parse_str(map_type).unwrap();
+        let values = untagged_member_values(syn::parse_quote! {
+            enum Untagged {
+                Counts { m: #member_type },
+            }
+        });
+        assert!(
+            values[0].contains(&inserted_field_value(map_type)),
+            "for {map_type}, got: {}",
+            values[0]
+        );
+    }
+}
+
+/// A tuple member is the fixed-arity array its own field position writes, arity bounds included:
+/// without them a shorter array serde can neither write nor read back still validates.
+#[cfg(all(feature = "serde", feature = "jsonschema"))]
+#[test]
+fn untagged_member_holding_a_tuple_renders_the_arity_bounds() {
+    let values = untagged_member_values(syn::parse_quote! {
+        enum Untagged {
+            Pair { pair: (i64, String) },
+        }
+    });
+    assert!(
+        values[0].contains(r#""minItems" : 2usize , "maxItems" : 2usize"#),
+        "got: {}",
+        values[0]
+    );
+    assert!(
+        values[0].contains(r#""items" : false"#),
+        "got: {}",
+        values[0]
+    );
+}
+
+/// An opaque member keeps the permissive empty schema: no type name reaches it to narrow with,
+/// which is the reason field position leaves it open too.
+#[cfg(all(feature = "serde", feature = "jsonschema"))]
+#[test]
+fn untagged_member_holding_an_opaque_value_stays_permissive() {
+    let values = untagged_member_values(syn::parse_quote! {
+        enum Untagged {
+            Raw { raw: serde_json::Value },
+        }
+    });
+    assert!(
+        values[0].contains("serde_json :: json ! ({ })"),
+        "got: {}",
+        values[0]
+    );
+}
+
+/// A map value the member dispatch cannot render replaces the member's whole rendering with the
+/// diagnostic, as it replaces the insertion in field position: a schema the expansion has already
+/// rejected is not one to hand the author. No guard answers for this shape, so the rendering is
+/// where it has to be said — once, naming the field and the reason, with no rendered map left
+/// beside it.
+#[cfg(all(feature = "serde", feature = "jsonschema"))]
+#[test]
+fn untagged_member_holding_an_unsupported_map_value_emits_only_the_compile_error() {
+    let values = untagged_member_values(syn::parse_quote! {
+        enum Untagged {
+            Rows { rows: HashMap<String, (String, u32)> },
+        }
+    });
+    assert_eq!(
+        values[0].matches("compile_error !").count(),
+        1,
+        "got: {}",
+        values[0]
+    );
+    assert!(values[0].contains("field `rows`"), "got: {}", values[0]);
+    assert!(
+        values[0].contains("a tuple is not supported as a map value"),
+        "got: {}",
+        values[0]
+    );
+    assert!(
+        !values[0].contains("additionalProperties\" :"),
+        "got: {}",
+        values[0]
+    );
+}
+
 /// Collects the internally tagged path's guard failures as rendered `compile_error!` token strings.
 #[cfg(feature = "serde")]
 fn internal_guard_errors(item: &syn::ItemEnum) -> Vec<String> {

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -697,7 +697,7 @@ fn untagged_member_reaching_an_unwritable_map_key_is_refused() {
 /// The JSON-schema values the untagged walk renders its members as.
 #[cfg(all(feature = "serde", feature = "jsonschema"))]
 fn untagged_member_values(mut item: syn::ItemEnum) -> Vec<String> {
-    collect_untagged_members(&mut item)
+    collect_untagged_members(&mut item, UNTAGGED_MODULE)
         .2
         .iter()
         .map(ToString::to_string)

--- a/tests/untagged_tests/tests.rs
+++ b/tests/untagged_tests/tests.rs
@@ -84,11 +84,37 @@ enum Bucket {
 
 // The map keys a variant's member may carry: one the registry enumerates, one open by nature.
 #[model_schema()]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 enum KeyedUnion {
     Counts { counts: HashMap<Bucket, u32> },
     Labels { labels: HashMap<String, String> },
+}
+
+// A tuple written in an untagged member. Serde writes it as the fixed-arity array a tuple field
+// writes, so the member has to describe as that field does.
+#[model_schema()]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+enum ShapedUnion {
+    Pair { pair: (i64, String) },
+}
+
+// The field-position twins: the same members written as struct fields. Field position is the
+// rendering an untagged member is held against, so it is written out rather than restated.
+#[cfg(feature = "jsonschema")]
+#[model_schema()]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct KeyedFields {
+    counts: HashMap<Bucket, u32>,
+    labels: HashMap<String, String>,
+}
+
+#[cfg(feature = "jsonschema")]
+#[model_schema()]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ShapedFields {
+    pair: (i64, String),
 }
 
 // An untagged struct variant carrying a constrained member, beside the same member written in a
@@ -443,18 +469,177 @@ fn test_untagged_map_member_keys_zod() {
     );
 }
 
-/// A map is one of the inner shapes an untagged member leaves open for v1, so each branch keeps
-/// the member as a required key carrying the permissive empty schema.
+/// What serde writes for an untagged member holding a map — the capture the three surfaces are
+/// held against. The enumerated key reaches the wire as the member name it spells; the open key
+/// reaches it as itself.
+#[test]
+fn test_untagged_map_member_wire() {
+    let counts = KeyedUnion::Counts {
+        counts: HashMap::from([(Bucket::Large, 3_u32)]),
+    };
+    let labels = KeyedUnion::Labels {
+        labels: HashMap::from([("a".to_owned(), "b".to_owned())]),
+    };
+
+    let counts_wire = serde_json::to_value(&counts).unwrap();
+    let labels_wire = serde_json::to_value(&labels).unwrap();
+    assert_eq!(
+        counts_wire,
+        serde_json::json!({ "counts": { "Large": 3_i32 } })
+    );
+    assert_eq!(labels_wire, serde_json::json!({ "labels": { "a": "b" } }));
+
+    assert_eq!(
+        serde_json::from_value::<KeyedUnion>(counts_wire).unwrap(),
+        counts
+    );
+    assert_eq!(
+        serde_json::from_value::<KeyedUnion>(labels_wire).unwrap(),
+        labels
+    );
+}
+
+/// The same capture for a tuple member: serde writes the fixed-arity array, in declaration order.
+#[test]
+fn test_untagged_tuple_member_wire() {
+    let pair = ShapedUnion::Pair {
+        pair: (7_i64, "seven".to_owned()),
+    };
+
+    let wire = serde_json::to_value(&pair).unwrap();
+    assert_eq!(wire, serde_json::json!({ "pair": [7_i64, "seven"] }));
+    assert_eq!(serde_json::from_value::<ShapedUnion>(wire).unwrap(), pair);
+}
+
+/// A member holding a map describes as the wire it was captured from: the enumerated key spells its
+/// properties, the open key its `additionalProperties`. Held against the struct field written from
+/// the same type, which is the rendering a member must not diverge from.
 #[test]
 #[cfg(feature = "jsonschema")]
 fn test_untagged_map_member_keys_json_schema() {
     let schema = KeyedUnion::json_schema();
+    let fields = KeyedFields::json_schema();
     let any_of = schema["anyOf"].as_array().unwrap();
     assert_eq!(any_of.len(), 2, "Got:\n{schema}");
+
+    assert_eq!(
+        any_of[0]["properties"]["counts"],
+        serde_json::json!({
+            "type": "object",
+            "properties": { "Large": { "type": "integer" }, "Small": { "type": "integer" } },
+            "additionalProperties": false
+        }),
+        "Got:\n{schema}"
+    );
+    assert_eq!(
+        any_of[1]["properties"]["labels"],
+        serde_json::json!({
+            "type": "object",
+            "additionalProperties": { "type": "string" }
+        }),
+        "Got:\n{schema}"
+    );
+
     for (branch, member) in any_of.iter().zip(["counts", "labels"]) {
-        assert_eq!(branch["properties"][member], serde_json::json!({}));
+        assert_eq!(
+            branch["properties"][member], fields["properties"][member],
+            "the field-position twin must render the same member"
+        );
         assert_eq!(branch["required"], serde_json::json!([member]));
     }
+}
+
+/// The schema admits the wire the capture recorded: every key serde writes for the enumerated map
+/// is one the branch names, and the branch names no key serde cannot write. The object is closed,
+/// so a property set that drifted either way would reject the payload the type produces.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_untagged_map_member_schema_admits_the_captured_wire() {
+    let counts = KeyedUnion::Counts {
+        counts: HashMap::from([(Bucket::Large, 1_u32), (Bucket::Small, 2_u32)]),
+    };
+    let wire = serde_json::to_value(&counts).unwrap();
+    let schema = KeyedUnion::json_schema();
+    let member = &schema["anyOf"][0]["properties"]["counts"];
+
+    let mut written: Vec<&String> = wire["counts"].as_object().unwrap().keys().collect();
+    let mut named: Vec<&String> = member["properties"].as_object().unwrap().keys().collect();
+    written.sort_unstable();
+    named.sort_unstable();
+    assert_eq!(written, named, "Got:\n{schema}");
+    assert_eq!(member["additionalProperties"], serde_json::json!(false));
+}
+
+/// The same for the tuple member: the array serde writes has the arity the bounds pin and the
+/// element types `prefixItems` names, in order.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_untagged_tuple_member_schema_admits_the_captured_wire() {
+    let pair = ShapedUnion::Pair {
+        pair: (7_i64, "seven".to_owned()),
+    };
+    let wire = serde_json::to_value(&pair).unwrap();
+    let schema = ShapedUnion::json_schema();
+    let member = &schema["anyOf"][0]["properties"]["pair"];
+    let written = wire["pair"].as_array().unwrap();
+
+    assert_eq!(member["minItems"], serde_json::json!(written.len()));
+    assert_eq!(member["maxItems"], serde_json::json!(written.len()));
+
+    let named: Vec<&str> = member["prefixItems"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|item| item["type"].as_str().unwrap())
+        .collect();
+    assert_eq!(named, ["integer", "string"], "Got:\n{schema}");
+    assert!(written[0].is_i64(), "Got:\n{wire}");
+    assert!(written[1].is_string(), "Got:\n{wire}");
+}
+
+/// A member holding a tuple describes as the array serde writes, arity bounds and all — the same
+/// rendering the struct field written from the same type carries.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_untagged_tuple_member_json_schema() {
+    let schema = ShapedUnion::json_schema();
+    let member = &schema["anyOf"][0]["properties"]["pair"];
+    assert_eq!(
+        *member,
+        serde_json::json!({
+            "type": "array",
+            "prefixItems": [{ "type": "integer" }, { "type": "string" }],
+            "items": false,
+            "minItems": 2_i32,
+            "maxItems": 2_i32
+        }),
+        "Got:\n{schema}"
+    );
+    assert_eq!(
+        *member,
+        ShapedFields::json_schema()["properties"]["pair"],
+        "the field-position twin must render the same member"
+    );
+}
+
+#[test]
+#[cfg(feature = "typescript")]
+fn test_untagged_tuple_member_typescript() {
+    let ts = ShapedUnion::ts_definition();
+    assert!(
+        ts.contains("export type ShapedUnion = { pair: [number, string] };"),
+        "Got:\n{ts}"
+    );
+}
+
+#[test]
+#[cfg(feature = "zod")]
+fn test_untagged_tuple_member_zod() {
+    let zod = ShapedUnion::zod_schema();
+    assert!(
+        zod.contains("z.strictObject({ pair: z.tuple([z.number().int(), z.string()]), })"),
+        "Got:\n{zod}"
+    );
 }
 
 /// The member's constraint reaches Zod in the spelling the tagged twin's does. Before this, the


### PR DESCRIPTION
An untagged member holding a map or a tuple rendered `serde_json::json!({})` on the JSON surface — an unconstrained anything — while TypeScript and Zod rendered the full shape. The v1 catch-all arm now splits three ways:

- A map goes through a new `map_json_schema_value(key, value)`, the key-classification dispatch lifted out of `build_map_field_schema` so both positions read one code path: enumerated properties for a key whose members the registry knows, `additionalProperties` for an open one, the unnarrowed object for the rest.
- A tuple renders `prefixItems`, `items: false`, and its arity bounds — the fixed-arity array serde writes.
- An opaque value keeps the permissive empty schema, exactly as field position leaves it, for the same reason (no type name to narrow with).

A map value the member dispatch cannot render replaces the member's whole rendering with the spanned diagnostic (`member_rejection_value`), matching field position's insertion replacement. Refused key spellings were already covered by the shared guard walk — pinned across six spellings anyway. Twin structs (`KeyedFields`/`ShapedFields`) hold member and field position to the same output, and wire↔schema agreement is asserted against serde's captured payloads.