### PR TITLE
let an alias key a map exactly as its target does, and document the named-inner contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -784,6 +784,36 @@ Notes:
 - Serde transparent serialization works normally -- the wrapper is invisible in JSON.
 - Use branded newtypes for opaque IDs and phantom types to prevent passing the wrong ID type across domain boundaries.
 
+#### A Named Inner Must Carry `#[model_schema()]`
+
+**Error:** `cannot find module or crate <type>_schema in this scope` (`E0433`), reported at the inner type.
+
+A brand carries its inner's wire form and adds a name to it, so it describes as that inner describes — by reference, through the schema module the inner's own `#[model_schema()]` publishes. A named inner declared without the attribute publishes no such module, and the reference names one that was never emitted. This is the same requirement a field naming that type lives under, reported the same way and at the same place:
+
+```rust
+// Wrong: `Foreign` carries no `#[model_schema()]`, so no `foreign_schema` module exists
+#[derive(Serialize, Deserialize)]
+pub struct Foreign(pub String);
+
+#[model_schema()]
+#[derive(Serialize, Deserialize)]
+pub struct HoldsForeign {
+    pub id: Foreign, // E0433: cannot find module or crate `foreign_schema` in this scope
+}
+
+#[model_schema(no_display)]
+#[derive(Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Wrapped(pub Foreign); // E0433: the same module, named in brand position
+```
+
+The remedy is either of two:
+
+- **Annotate the inner.** Put `#[model_schema()]` on `Foreign`, and both spellings resolve — the brand describing as whatever `Foreign` describes as.
+- **Brand the wire form instead.** Where the inner is a foreign scalar this crate cannot annotate -- `uuid::Uuid`, `rust_decimal::Decimal` -- brand the type it is written as: `pub struct Wrapped(pub String)`, with `pattern` on the brand where the format is worth pinning.
+
+A type this crate describes must be one it can read. The alternative -- letting a name it cannot resolve fall back to `{"type": "string"}` -- describes a struct as a string whenever the inner turns out to be one, which is the failure the brand's schema path exists to rule out.
+
 #### The `Display` Requirement and `no_display`
 
 Every branded newtype gets a `Display` impl that delegates to its inner value, so **the inner type must implement `Display`**. An inner type that does not is reported at the inner field, naming the trait:

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -675,29 +675,31 @@ pub fn exec_model_schema(args: TokenStream, input: TokenStream) -> TokenStream {
 
 /// Classifies what an alias resolves to, for the registry.
 ///
-/// A target serde writes as a bare string answers first, and it answers for the alias too: an alias
-/// is the type it names, so `type LateKey = String` is written as that bare string and keys a map
-/// exactly as a `String` does, under the alias's own exported name. `PathBuf`, a string-wire brand,
-/// and an alias chain ending in either are the same target wearing another spelling, which is why
-/// the question is asked of the key dispatch rather than of the target's syntax.
+/// An alias *is* the type it names — a type path resolves straight through it — so the registry's
+/// question, what serde writes for a value spelled this way, is asked of the target and the answer
+/// stands under the alias's own exported name. That is the same question a brand answers for its
+/// inner, so it is read through the same dispatch, and the four verdicts carry across whole: a
+/// target serde writes as a bare string keys a map the way `String` does; a target serde stringifies
+/// for the author — a number, a `bool`, a chrono rendering, a generic spelling this expansion has no
+/// members for — keys the open object its bare spelling already describes as; a target serde writes
+/// as no key at all leaves the alias refused, under its own name rather than under the target's, so
+/// the diagnostic still points at what the author wrote; and a target that can still reach a plain
+/// enum stays on the enumerating path.
 ///
-/// Below that, a `SiblingType` is the only shape that can reach a plain enum, and it answers with
-/// whatever the named type registered: an alias of an alias of an enum inherits `EnumMembers` down
-/// the chain. A target registered after its alias reads as `Unknown`, which callers must treat as
-/// "cannot rule it out" rather than as a negative. An array (`Vec<Slot>`, `[Slot; 4]`) is a
-/// collection, not the enum it holds.
+/// Only that last verdict consults the registry, and it answers with whatever the named type
+/// registered: an alias of an alias of an enum inherits `EnumMembers` down the chain. A target
+/// registered after its alias reads as `Unknown`, which callers must treat as "cannot rule it out"
+/// rather than as a negative.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn alias_target_kind(alias_field_def: &FieldDef) -> AliasKind {
-    if matches!(map_key_path(alias_field_def), MapKeyPath::Open) {
-        return AliasKind::StringWire;
+    match map_key_path(alias_field_def) {
+        MapKeyPath::Open => AliasKind::StringWire,
+        MapKeyPath::Unnarrowed => AliasKind::Stringified,
+        MapKeyPath::Refused(_) => AliasKind::NoEnumMembers,
+        MapKeyPath::Enumerated(target_name) => {
+            registered_key_kind(target_name).unwrap_or(AliasKind::Unknown)
+        }
     }
-    let FieldDefType::SiblingType(target_name, generic_args) = &alias_field_def.field_type else {
-        return AliasKind::NoEnumMembers;
-    };
-    if !generic_args.is_empty() || alias_field_def.is_array() {
-        return AliasKind::NoEnumMembers;
-    }
-    lookup_alias_info(target_name).map_or(AliasKind::Unknown, |target| target.kind)
 }
 
 /// The `compile_error!` tokens an alias whose target reaches a map key with no `enum_members()`
@@ -725,15 +727,25 @@ fn alias_map_key_guard_error(
 /// name it has already seen: `Unknown` is not a negative, and a struct and a branded newtype
 /// register alike. So this is a partial answer by construction, and the merge is where the rest is
 /// caught.
+///
+/// The name is looked up directly rather than through the map-key dispatch: what is asked here is
+/// whether the named type publishes `enum_members()`, and that stays true of an `Option<Slot>`
+/// whose `Some` writes the variant name straight into the object — where the key dispatch, asking
+/// what serde writes for a *key*, refuses the `Option` for its `None`. A generic spelling and an
+/// array are excluded because neither is the enum: they are a type this expansion has no members
+/// for, and the collection holding it.
 #[cfg(all(
     feature = "serde",
     any(feature = "typescript", feature = "zod", feature = "jsonschema")
 ))]
 fn flattened_plain_enum(inner: &FieldDef) -> Option<&str> {
-    let FieldDefType::SiblingType(name, _) = &inner.field_type else {
+    let FieldDefType::SiblingType(name, generic_args) = &inner.field_type else {
         return None;
     };
-    (alias_target_kind(inner) == AliasKind::EnumMembers).then_some(name.as_str())
+    if !generic_args.is_empty() || inner.is_array() {
+        return None;
+    }
+    (registered_key_kind(name) == Some(AliasKind::EnumMembers)).then_some(name.as_str())
 }
 
 /// The alias schema module is referenced by all three schema features — `typescript` and `zod`

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -3017,9 +3017,12 @@ fn a_required_map_value_carries_no_nullable_wrap() {
 }
 
 /// The kind an alias registers is its *target's* answer, because a type path resolves through the
-/// alias. A target serde writes as a bare string makes the alias one too, whatever spelling that
-/// target wears. `Vec<Slot>` is the collection, not the enum it holds; a target this expansion has
-/// not seen registered is `Unknown`, which is not a negative.
+/// alias — the same four verdicts a brand carries up from its inner, and for the same reason. A
+/// target serde writes as a bare string makes the alias one too, whatever spelling that target
+/// wears; a target serde stringifies for the author makes the alias key the open object that bare
+/// target keys; a target serde writes as no key at all leaves the alias refused, under its own name.
+/// `Vec<Slot>` is the collection, not the enum it holds; a target this expansion has not seen
+/// registered is `Unknown`, which is not a negative.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
 fn an_alias_registers_the_kind_of_what_it_targets() {
@@ -3031,23 +3034,150 @@ fn an_alias_registers_the_kind_of_what_it_targets() {
         "correlation_id_schema",
         AliasKind::StringWire,
     );
+    register_alias_info("Tick", "Tick", "tick_schema", AliasKind::Stringified);
     for (target, expected) in [
         ("Slot", AliasKind::EnumMembers),
         ("Doc", AliasKind::NoEnumMembers),
         ("String", AliasKind::StringWire),
         ("PathBuf", AliasKind::StringWire),
         ("CorrelationId", AliasKind::StringWire),
-        ("u32", AliasKind::NoEnumMembers),
+        ("u32", AliasKind::Stringified),
+        ("bool", AliasKind::Stringified),
+        ("f64", AliasKind::Stringified),
+        ("Tick", AliasKind::Stringified),
+        ("Wrapper<Slot>", AliasKind::Stringified),
         ("Vec<String>", AliasKind::NoEnumMembers),
         ("Option<String>", AliasKind::NoEnumMembers),
         ("Vec<Slot>", AliasKind::NoEnumMembers),
         ("HashMap<Slot, String>", AliasKind::NoEnumMembers),
-        ("Wrapper<Slot>", AliasKind::NoEnumMembers),
+        ("(String, String)", AliasKind::NoEnumMembers),
         ("Ghost", AliasKind::Unknown),
     ] {
         let ty: syn::Type = syn::parse_str(target).unwrap();
         let kind = super::alias_target_kind(&super::get_field_def("AliasType", &ty, ""));
         assert_eq!(kind, expected, "for alias target {target}");
+    }
+}
+
+/// The alias path and the brand path answer the one map-key question the same way, target for
+/// inner: both spellings wrap a value whose wire form is the whole of what they carry, so a
+/// disagreement between them would be a key that opens an object under one spelling and is refused
+/// under the other. `EnumMembers` is the one verdict only the alias can reach — a type path resolves
+/// to the enum, where a brand publishes no `enum_members()` of its own — so the enum spellings are
+/// held apart rather than in this list.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn an_alias_and_a_brand_answer_alike_for_the_same_target() {
+    register_alias_info("Doc", "Doc", "doc_schema", AliasKind::NoEnumMembers);
+    register_alias_info(
+        "CorrelationId",
+        "CorrelationId",
+        "correlation_id_schema",
+        AliasKind::StringWire,
+    );
+    register_alias_info("Tick", "Tick", "tick_schema", AliasKind::Stringified);
+    for target in [
+        "String",
+        "PathBuf",
+        "CorrelationId",
+        "u32",
+        "bool",
+        "f64",
+        "Tick",
+        "Doc",
+        "Vec<String>",
+        "(String, String)",
+        "HashMap<String, u32>",
+    ] {
+        let ty: syn::Type = syn::parse_str(target).unwrap();
+        let alias = super::alias_target_kind(&super::get_field_def("AliasType", &ty, ""));
+        assert_eq!(alias, brand_kind(target), "for target {target}");
+    }
+}
+
+/// A chrono value is one serde stringifies into a key, so an alias of one keys the open object its
+/// bare target keys — the verdict the brand over the same target already carries.
+#[cfg(all(
+    feature = "chrono",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn an_alias_of_a_chrono_target_is_stringified() {
+    for target in ["NaiveDate", "NaiveTime", "NaiveDateTime", "DateTime<Utc>"] {
+        let ty: syn::Type = syn::parse_str(target).unwrap();
+        let kind = super::alias_target_kind(&super::get_field_def("AliasType", &ty, ""));
+        assert_eq!(kind, AliasKind::Stringified, "for alias target {target}");
+    }
+}
+
+/// An `ObjectId` writes a JSON object, which serde uses as no key at all, so an alias of one stays
+/// refused where the stringifying targets are let through.
+#[cfg(all(
+    feature = "object_id",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn an_alias_of_an_object_id_stays_refused() {
+    let ty: syn::Type = syn::parse_str("ObjectId").unwrap();
+    let kind = super::alias_target_kind(&super::get_field_def("AliasType", &ty, ""));
+    assert_eq!(kind, AliasKind::NoEnumMembers);
+}
+
+/// An alias of an alias of a value serde stringifies is still that value at the type path, so the
+/// chain carries `Stringified` through every link — and so does a chain ending at a stringified
+/// brand.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn an_alias_chain_carries_the_stringified_kind_to_its_end() {
+    register_alias_info("Tick", "Tick", "tick_schema", AliasKind::Stringified);
+    for end in ["u32", "Tick"] {
+        let first_target: syn::Type = syn::parse_str(end).unwrap();
+        let first = super::alias_target_kind(&super::get_field_def("FirstType", &first_target, ""));
+        assert_eq!(first, AliasKind::Stringified, "for a chain ending at {end}");
+        register_alias_info("First", "FirstType", "first_type_schema", first);
+
+        let second_target: syn::Type = syn::parse_str("First").unwrap();
+        let second =
+            super::alias_target_kind(&super::get_field_def("SecondType", &second_target, ""));
+        assert_eq!(
+            second,
+            AliasKind::Stringified,
+            "for a chain ending at {end}"
+        );
+    }
+}
+
+/// A refused target keeps the diagnostic naming the *alias*, not the target's own rejection reason:
+/// the alias is what the author wrote at the key, and it is what they can act on. So a field keyed
+/// by an alias of a tuple reads as a name with no `enum_members()` rather than as an array wire, and
+/// so does one keyed by an alias of the wrapper spellings — a target the key dispatch refuses is
+/// refused however it was spelled, including the `Option` and the sequence around a plain enum,
+/// neither of which the alias can supply members for.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn an_alias_of_a_refused_target_is_refused_under_its_own_name() {
+    register_alias_info("Slot", "Slot", "slot_schema", AliasKind::EnumMembers);
+    for target in ["(String, String)", "Option<Slot>", "Vec<Slot>"] {
+        register_alias_info(
+            "RefusedKey",
+            "RefusedKeyType",
+            "refused_key_type_schema",
+            super::alias_target_kind(&super::get_field_def(
+                "RefusedKeyType",
+                &syn::parse_str(target).unwrap(),
+                "",
+            )),
+        );
+        let error = field_map_key_error(&quote::quote! { HashMap<RefusedKey, u32> });
+        assert!(
+            error.contains("a map key must be a plain"),
+            "for {target}, got: {error}"
+        );
+        assert!(error.contains("RefusedKey"), "for {target}, got: {error}");
+        assert!(
+            !error.contains("serde writes"),
+            "for {target}, got: {error}"
+        );
     }
 }
 
@@ -3938,6 +4068,52 @@ fn a_sibling_slot_carries_the_schema_module_reference() {
             element,
             super::build_map_member_schema(&parsed).unwrap().to_string()
         );
+    }
+}
+
+/// The `json_schema()` body a brand over `inner_ty` carries, read off the same dispatch the
+/// branded expansion runs.
+#[cfg(feature = "jsonschema")]
+fn brand_json_schema_over(inner_ty: &syn::Type) -> String {
+    super::build_branded_json_schema_method(
+        &super::ModelSchemaArgs::default(),
+        &super::branded_json_inner(false, inner_ty),
+        "Wrapped",
+    )
+    .to_string()
+}
+
+/// A named type resolves to one schema module wherever it is written, and a brand is one of those
+/// places: it carries its inner by the same reference a field carries it by, so what the module
+/// name is derived from cannot differ between the two. A name the registry knows resolves through
+/// the registry in both, and a name it does not know assumes the module that name's own
+/// `#[model_schema()]` would publish — which for a type declared without the attribute is a module
+/// nothing emits, and rustc reports the `E0433` in either position. Nothing the expansion holds can
+/// tell those two apart, so that report is the whole contract, and it has to be one contract.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_named_type_resolves_to_the_same_module_in_field_and_brand_position() {
+    register_alias_info(
+        "Renamed",
+        "RenamedType",
+        "renamed_type_schema",
+        AliasKind::NoEnumMembers,
+    );
+    for (name, module) in [
+        ("Foreign", "foreign_schema"),
+        ("Renamed", "renamed_type_schema"),
+    ] {
+        let inner_ty: syn::Type = syn::parse_str(name).unwrap();
+        let reference =
+            format!("{module} :: Schema :: json_schema_within (in_flight , hoisted_defs)");
+
+        let field =
+            super::build_field_type_schema(&super::get_field_def("id", &inner_ty, ""), "id")
+                .to_string();
+        assert!(field.contains(&reference), "for {name}, got: {field}");
+
+        let brand = brand_json_schema_over(&inner_ty);
+        assert!(brand.contains(&reference), "for {name}, got: {brand}");
     }
 }
 

--- a/tests/collection_tests/tests.rs
+++ b/tests/collection_tests/tests.rs
@@ -290,6 +290,67 @@ struct ChronoKeyedBrandTwin {
     by_day: HashMap<NaiveDate, u64>,
 }
 
+/// An alias of a stringifying scalar. A type path resolves straight through it, so serde writes a
+/// key spelled this way as the number its target is — `{"7": …}`, the bare-keyed map's own wire.
+#[model_schema()]
+type TickKey = u32;
+
+/// An alias of that alias, and an alias of a stringifying brand: every link of either chain carries
+/// the same stringified number.
+#[model_schema()]
+type TickKeyRef = TickKey;
+
+#[model_schema()]
+type TickBrandKey = Tick;
+
+#[model_schema()]
+type EnabledKey = bool;
+
+// An alias of a stringifying scalar keys the open object its bare target keys, under the alias's own
+// exported name — held below against the bare-keyed twin, which is what the map describes as once
+// the alias's name is spent.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct ScalarAliasKeyedMaps {
+    branded: HashMap<TickBrandKey, u64>,
+    by_enabled: HashMap<EnabledKey, u64>,
+    by_tick: HashMap<TickKey, u64>,
+    chained: HashMap<TickKeyRef, u64>,
+    nested: HashMap<TickKey, HashMap<EnabledKey, u64>>,
+    samples: HashMap<TickKey, MetricSample>,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct ScalarKeyedAliasTwin {
+    branded: HashMap<Tick, u64>,
+    by_enabled: HashMap<bool, u64>,
+    by_tick: HashMap<u32, u64>,
+    chained: HashMap<u32, u64>,
+    nested: HashMap<u32, HashMap<bool, u64>>,
+    samples: HashMap<u32, MetricSample>,
+}
+
+/// An alias of a chrono value: serde renders the target into the key exactly as the bare chrono key
+/// renders, so the alias keys the same open object.
+#[cfg(feature = "chrono")]
+#[model_schema()]
+type DayKey = NaiveDate;
+
+#[cfg(feature = "chrono")]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct ChronoAliasKeyedMaps {
+    by_day: HashMap<DayKey, u64>,
+}
+
+#[cfg(feature = "chrono")]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct ChronoKeyedAliasTwin {
+    by_day: HashMap<NaiveDate, u64>,
+}
+
 // A String key enumerates nothing, so one `additionalProperties` schema stands for every member —
 // and it is the value type's own, which is what the enum-keyed twin above spells out per key.
 #[model_schema()]
@@ -2045,6 +2106,191 @@ fn test_chrono_brand_keyed_maps_name_the_brand_as_the_key_type() {
     let zod_schema = ChronoBrandKeyedMaps::zod_schema();
     assert!(
         zod_schema.contains("by_day: z.record(Day$Schema, z.number().int())"),
+        "got: {zod_schema}"
+    );
+}
+
+/// An alias key clears the derive under every feature set that reads one, as the brand key does:
+/// the key is read off the field all three surfaces render from, so the same source cannot be a
+/// schema under one toggle and a refusal under another.
+#[test]
+fn test_scalar_alias_keyed_maps_constructible() {
+    let tick: TickKey = 7;
+    let maps = ScalarAliasKeyedMaps {
+        branded: HashMap::from([(Tick(tick), 4)]),
+        by_enabled: HashMap::from([(true, 5)]),
+        by_tick: HashMap::from([(tick, 1)]),
+        chained: HashMap::from([(tick, 2)]),
+        nested: HashMap::from([(tick, HashMap::from([(true, 3)]))]),
+        samples: HashMap::from([(
+            tick,
+            MetricSample {
+                label: "s".to_owned(),
+            },
+        )]),
+    };
+    assert_eq!(maps.by_tick[&tick], 1);
+    assert_eq!(maps.nested[&tick][&true], 3);
+
+    let twin = ScalarKeyedAliasTwin {
+        branded: HashMap::from([(Tick(7), 4)]),
+        by_enabled: HashMap::from([(true, 5)]),
+        by_tick: HashMap::from([(7, 1)]),
+        chained: HashMap::from([(7, 2)]),
+        nested: HashMap::from([(7, HashMap::from([(true, 3)]))]),
+        samples: HashMap::new(),
+    };
+    assert_eq!(twin.by_tick[&7], maps.by_tick[&tick]);
+}
+
+/// An alias is the type it names, so a map keyed by an alias of a value serde stringifies builds the
+/// object the bare target builds — field for field the bare-keyed twin's, at every depth and through
+/// either chain, the alias's name being spent on the nominal surfaces and having nothing to say on
+/// the structural one.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_scalar_alias_keyed_maps_describe_as_their_bare_target_twin() {
+    assert_eq!(
+        ScalarAliasKeyedMaps::json_schema()["properties"],
+        ScalarKeyedAliasTwin::json_schema()["properties"]
+    );
+    assert_eq!(
+        ScalarAliasKeyedMaps::json_schema()["properties"]["by_tick"],
+        serde_json::json!({ "type": "object", "additionalProperties": true })
+    );
+}
+
+/// The nominal surfaces keep the alias's own exported name as the key type, the way they keep a
+/// brand's — a `Record` and a `z.record` keyed by the alias, not by bare `number`.
+#[test]
+#[cfg(all(feature = "typescript", feature = "zod"))]
+fn test_scalar_alias_keyed_maps_name_the_alias_as_the_key_type() {
+    let ts_definition = ScalarAliasKeyedMaps::ts_definition();
+    for expected in [
+        "branded: Partial<Record<TickBrandKeyType, number>>;",
+        "by_enabled: Partial<Record<EnabledKeyType, number>>;",
+        "by_tick: Partial<Record<TickKeyType, number>>;",
+        "chained: Partial<Record<TickKeyRefType, number>>;",
+        "nested: Partial<Record<TickKeyType, Partial<Record<EnabledKeyType, number>>>>;",
+        "samples: Partial<Record<TickKeyType, MetricSample>>;",
+    ] {
+        assert!(
+            ts_definition.contains(expected),
+            "{expected} missing: {ts_definition}"
+        );
+    }
+
+    let zod_schema = ScalarAliasKeyedMaps::zod_schema();
+    for expected in [
+        "branded: z.record(TickBrandKeyType$Schema, z.number().int())",
+        "by_enabled: z.record(EnabledKeyType$Schema, z.number().int())",
+        "by_tick: z.record(TickKeyType$Schema, z.number().int())",
+        "chained: z.record(TickKeyRefType$Schema, z.number().int())",
+        "nested: z.record(TickKeyType$Schema, z.record(EnabledKeyType$Schema, z.number().int()))",
+        "samples: z.record(TickKeyType$Schema, MetricSample$Schema)",
+    ] {
+        assert!(
+            zod_schema.contains(expected),
+            "{expected} missing: {zod_schema}"
+        );
+    }
+}
+
+/// The premise the classification rests on, read off the alias spelling: serde stringifies the
+/// target into the key, so the object the schema describes is the object the value writes, and it
+/// reads back.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_scalar_alias_keyed_maps_match_the_serialized_form() {
+    let tick: TickKey = 7;
+    let maps = ScalarAliasKeyedMaps {
+        branded: HashMap::from([(Tick(tick), 4)]),
+        by_enabled: HashMap::from([(true, 5)]),
+        by_tick: HashMap::from([(tick, 1)]),
+        chained: HashMap::from([(tick, 2)]),
+        nested: HashMap::from([(tick, HashMap::from([(true, 3)]))]),
+        samples: HashMap::from([(
+            tick,
+            MetricSample {
+                label: "s".to_owned(),
+            },
+        )]),
+    };
+    let payload = serde_json::to_value(&maps).unwrap();
+    assert_eq!(payload["by_tick"], serde_json::json!({ "7": 1_u64 }));
+    assert_eq!(payload["chained"], serde_json::json!({ "7": 2_u64 }));
+    assert_eq!(payload["branded"], serde_json::json!({ "7": 4_u64 }));
+    assert_eq!(payload["by_enabled"], serde_json::json!({ "true": 5_u64 }));
+    assert_eq!(
+        payload["nested"],
+        serde_json::json!({ "7": { "true": 3_u64 } })
+    );
+
+    let schema = ScalarAliasKeyedMaps::json_schema();
+    for field_name in [
+        "branded",
+        "by_enabled",
+        "by_tick",
+        "chained",
+        "nested",
+        "samples",
+    ] {
+        let field = &schema["properties"][field_name];
+        assert_eq!(field["type"], json_type_name(&payload[field_name]));
+    }
+
+    let read_back: ScalarAliasKeyedMaps = serde_json::from_value(payload).unwrap();
+    assert_eq!(read_back, maps);
+}
+
+/// A chrono value is stringified into a key by its own rendering, and an alias of one carries that
+/// rendering unchanged — the same twin equality the numeric aliases keep.
+#[test]
+#[cfg(all(feature = "chrono", feature = "jsonschema"))]
+fn test_chrono_alias_keyed_maps_describe_as_their_bare_target_twin() {
+    assert_eq!(
+        ChronoAliasKeyedMaps::json_schema()["properties"],
+        ChronoKeyedAliasTwin::json_schema()["properties"]
+    );
+
+    let day = NaiveDate::from_ymd_opt(2020, 1, 2).unwrap();
+    let maps = ChronoAliasKeyedMaps {
+        by_day: HashMap::from([(day, 1)]),
+    };
+    let payload = serde_json::to_value(&maps).unwrap();
+    assert_eq!(
+        payload["by_day"],
+        serde_json::json!({ "2020-01-02": 1_u64 })
+    );
+
+    let read_back: ChronoAliasKeyedMaps = serde_json::from_value(payload).unwrap();
+    assert_eq!(read_back, maps);
+}
+
+#[cfg(feature = "chrono")]
+#[test]
+fn test_chrono_alias_keyed_maps_constructible() {
+    let day: DayKey = NaiveDate::from_ymd_opt(2020, 1, 2).unwrap();
+    let maps = ChronoAliasKeyedMaps {
+        by_day: HashMap::from([(day, 1)]),
+    };
+    let twin = ChronoKeyedAliasTwin {
+        by_day: HashMap::from([(day, 1)]),
+    };
+    assert_eq!(twin.by_day[&day], maps.by_day[&day]);
+}
+
+#[test]
+#[cfg(all(feature = "chrono", feature = "typescript", feature = "zod"))]
+fn test_chrono_alias_keyed_maps_name_the_alias_as_the_key_type() {
+    let ts_definition = ChronoAliasKeyedMaps::ts_definition();
+    assert!(
+        ts_definition.contains("by_day: Partial<Record<DayKeyType, number>>;"),
+        "got: {ts_definition}"
+    );
+    let zod_schema = ChronoAliasKeyedMaps::zod_schema();
+    assert!(
+        zod_schema.contains("by_day: z.record(DayKeyType$Schema, z.number().int())"),
         "got: {zod_schema}"
     );
 }


### PR DESCRIPTION
Two related closures of the name-resolution story:

- `alias_target_kind` becomes the same four-verdict mirror the brand path carries: the map-key dispatch answers Open→StringWire, Unnarrowed→Stringified, Refused→NoEnumMembers, and only the Enumerated arm consults the registry. An alias of u32/bool/f64/chrono/generic-sibling now keys the open-object map its bare target keys, chains included, twin-pinned against the bare spellings at depth. A refused target's alias keeps the diagnostic naming the alias — what the author wrote and can act on. One deliberate improvement beyond byte-identity: an alias of `Option<PlainEnum>` used to register EnumMembers and emit a call to a method a type alias does not have (E0599 blaming the attribute); the mirror refuses it cleanly. The flatten guard now reads the registry directly with its own exclusions, byte-identical, so folding the Option into refusals could not silently narrow it.
- The README's brand section documents the named-inner contract: a type this crate describes must carry `#[model_schema()]`, the E0433 naming the module is the instruction in field and brand position alike, with the two remedies (annotate the inner, or brand the wire form). A test pins that both positions derive the module reference identically — through the registry for a known name, from the ident for an unknown one.