### PR TITLE
spell an optional flattened base as the two-branch choice serde writes, on TypeScript and Zod

### DIFF
--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -666,6 +666,19 @@ impl FieldDef {
         })
     }
 
+    /// What this field contributes to an object that writes its members beside its own, on the
+    /// TypeScript surface: the value itself, with no answer for the outermost `Option`.
+    ///
+    /// A merged source has no key of its own, so that `Option` is not the question
+    /// [`Self::typescript_typename`] answers. There, a `None` is a key the object leaves out; here
+    /// it is every one of the source's keys left out at once — the object writes its own members
+    /// merged with the source's or writes its own alone, and a choice between two key sets belongs
+    /// where the merge is assembled rather than on the operand it is assembled from.
+    #[cfg(feature = "typescript")]
+    pub fn typescript_merged_typename(&self) -> String {
+        self.typescript_base()
+    }
+
     /// The TypeScript type for a value in a slot that cannot be dropped — a tuple element, a map
     /// entry, or the content key of a single-element tuple variant, which serde always writes. An
     /// `Option` there is null-flavored (`{base} | null`) rather than undefined-flavored: none of
@@ -841,6 +854,14 @@ impl FieldDef {
         } else {
             array_result
         }
+    }
+
+    /// The same value on the Zod surface, for the same reason: what a merged source validates, with
+    /// the outermost `Option` left to whatever assembles the merge. See
+    /// [`Self::typescript_merged_typename`].
+    #[cfg(feature = "zod")]
+    pub fn zod_merged_schema(&self) -> String {
+        self.zod_base()
     }
 
     /// Builds the Zod schema string for a numeric field, applying any min/max constraints.

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -426,6 +426,20 @@ struct ModelSchemaArgs {
     pattern_rejection: Option<syn::Error>,
 }
 
+/// One `#[serde(flatten)]` source as a surface writes it: the spelling of what its members are, and
+/// whether the object writes them at all.
+///
+/// The two travel together for the reason the JSON-schema surface keeps them together in
+/// `MergedSource`. What the `Option` around a source says is not what an `Option` on any other
+/// field says — a merged source has no key to leave out, so the absence is every one of its keys at
+/// once, and the payloads the object writes are its own keys merged with the source's or its own
+/// keys alone. Where that choice is spelled is each surface's to answer.
+#[cfg(any(feature = "typescript", feature = "zod"))]
+struct MergedOperand {
+    optional: bool,
+    spelling: String,
+}
+
 /// Mutable output buffers shared by the discriminated-enum variant writers. Bundled so each writer
 /// takes a single always-mutated `&mut`, keeping its conditionally-written fields (Zod schema, JSON
 /// fields) from tripping `needless_pass_by_ref_mut` under feature subsets.
@@ -1012,19 +1026,36 @@ fn build_struct_validate_method(
 }
 
 /// Computes the TypeScript types and Zod schemas contributed by a struct's `#[serde(flatten)]`
-/// fields (an empty vector for either disabled output feature).
+/// fields, each beside the answer for whether the object writes those members at all (an empty
+/// vector for either disabled output feature).
+///
+/// The `Option` around a source is read here and spent by the surfaces rather than folded into the
+/// spelling: `typescript_typename` and `zod_type` answer the question a field with a key of its own
+/// asks, and a merged source has no key to leave out. It is the same `Option` the JSON-schema
+/// surface reads in `flatten_merged_source`.
 #[cfg(any(feature = "typescript", feature = "zod"))]
-fn compute_flatten_outputs(flattened_fields: &[FieldDef]) -> (Vec<String>, Vec<String>) {
+fn compute_flatten_outputs(
+    flattened_fields: &[FieldDef],
+) -> (Vec<MergedOperand>, Vec<MergedOperand>) {
     #[cfg(feature = "typescript")]
     let ts_types = flattened_fields
         .iter()
-        .map(FieldDef::typescript_typename)
+        .map(|fld| MergedOperand {
+            optional: fld.is_optional(),
+            spelling: fld.typescript_merged_typename(),
+        })
         .collect();
     #[cfg(not(feature = "typescript"))]
     let ts_types = Vec::new();
 
     #[cfg(feature = "zod")]
-    let zod_schemas = flattened_fields.iter().map(FieldDef::zod_type).collect();
+    let zod_schemas = flattened_fields
+        .iter()
+        .map(|fld| MergedOperand {
+            optional: fld.is_optional(),
+            spelling: fld.zod_merged_schema(),
+        })
+        .collect();
     #[cfg(not(feature = "zod"))]
     let zod_schemas = Vec::new();
 
@@ -7953,6 +7984,23 @@ fn flatten_merged_source(fld: &FieldDef) -> MergedSource {
     }
 }
 
+/// What one merged source is written as inside the intersection.
+///
+/// A source reached through an `Option` writes all of its members or none of them, so what it
+/// contributes is a choice: the source itself, or an object carrying no member of it. The second
+/// branch is the source's own keys mapped to `never`, which is the spelling that excludes a source
+/// written in part — `{}` is every object, so a payload carrying some of the source's members
+/// passes through it, and that payload is one the object never writes.
+#[cfg(feature = "typescript")]
+fn ts_merged_operand(operand: &MergedOperand) -> String {
+    let MergedOperand { optional, spelling } = operand;
+    if *optional {
+        format!("({spelling} | {{ [K in keyof {spelling}]?: never }})")
+    } else {
+        spelling.clone()
+    }
+}
+
 #[cfg(feature = "typescript")]
 /// Generates the TypeScript definition method (TypeScript types only, no Zod schema).
 fn generate_ts_definition_method(
@@ -7961,12 +8009,13 @@ fn generate_ts_definition_method(
     rust_ident: &str,
     type_code: &str,
     fields_empty: bool,
-    flatten_types: &[String],
+    flatten_types: &[MergedOperand],
 ) -> proc_macro2::TokenStream {
     let reexport = ident_reexport_ts(rust_ident, item_name, "");
     let has_flatten = !flatten_types.is_empty();
-    let intersection_only = flatten_types.join(" & ");
-    let intersection_suffix: String = flatten_types.iter().fold(String::new(), |mut acc, t| {
+    let operands: Vec<String> = flatten_types.iter().map(ts_merged_operand).collect();
+    let intersection_only = operands.join(" & ");
+    let intersection_suffix: String = operands.iter().fold(String::new(), |mut acc, t| {
         let _ = write!(acc, " & {t}");
         acc
     });
@@ -8023,52 +8072,97 @@ fn deferred_zod_operand(schema: &str) -> String {
     format!("z.lazy(() => {schema})")
 }
 
+/// What the object's schema is written as: the statements bound ahead of it, and the expression
+/// itself.
+///
+/// A source reached through an `Option` contributes its members or contributes nothing, and every
+/// other source contributes always, so what the object writes is one intersection per combination
+/// of the sources it merges — the multiplication the JSON-schema document is written from, in the
+/// order that document writes it. Zod can only say that as a union around the intersections: an
+/// intersection recognizes exactly the keys its operands name, and an operand that is itself a
+/// choice leaves each of its branches answering for the keys the other branch carries — which
+/// rejects every payload the object writes rather than admitting two of them.
+///
+/// With no absence to offer there is one intersection and no choice to write, so the object's own
+/// keys stay where they were. With one, they are bound to a name the branches read: they are the
+/// same keys in every branch, and a branch says what it adds to them rather than repeating them.
+#[cfg(feature = "zod")]
+fn zod_merged_statements(
+    item_name: &str,
+    own: &str,
+    operands: &[MergedOperand],
+) -> (String, String) {
+    let joined = |acc: &mut String, operand: &MergedOperand| {
+        let _ = write!(acc, ".and({})", deferred_zod_operand(&operand.spelling));
+    };
+    if !operands.iter().any(|operand| operand.optional) {
+        let mut expression = own.to_owned();
+        for operand in operands {
+            joined(&mut expression, operand);
+        }
+        return (String::new(), expression);
+    }
+
+    let own_name = format!("{item_name}$OwnSchema");
+    let mut branches = vec![own_name.clone()];
+    for operand in operands {
+        branches = branches
+            .into_iter()
+            .flat_map(|branch| {
+                let mut present = branch.clone();
+                joined(&mut present, operand);
+                if operand.optional {
+                    vec![present, branch]
+                } else {
+                    vec![present]
+                }
+            })
+            .collect();
+    }
+    let written = branches.iter().fold(String::new(), |mut acc, branch| {
+        let _ = writeln!(acc, "  {branch},");
+        acc
+    });
+    (
+        format!("const {own_name} = {own};\n\n"),
+        format!("z.union([\n{written}])"),
+    )
+}
+
 #[cfg(feature = "zod")]
 /// Generates the Zod schema method (Zod schemas only, no TypeScript types).
 ///
-/// Each flattened base joins the intersection through [`deferred_zod_operand`]: a base names a
+/// Each flattened base joins an intersection through [`deferred_zod_operand`]: a base names a
 /// `const` of its own, and one macro invocation sees one type, so nothing here can know whether
-/// that `const` is declared above the module this writes or below it.
+/// that `const` is declared above the module this writes or below it. How many intersections there
+/// are, and what is bound ahead of them, is [`zod_merged_statements`]'.
 fn generate_zod_schema_method(
     item_name: &str,
     rust_ident: &str,
     schema_code: &str,
     show_opts: &str,
-    flatten_schemas: &[String],
+    flatten_schemas: &[MergedOperand],
 ) -> proc_macro2::TokenStream {
-    #[cfg_attr(not(feature = "zod"), allow(unused_variables))]
-    let and_suffix: String = flatten_schemas.iter().fold(String::new(), |mut acc, s| {
-        let _ = write!(acc, ".and({})", deferred_zod_operand(s));
-        acc
-    });
-
     #[cfg(feature = "zod")]
     {
         let reexport = ident_reexport_zod(rust_ident, item_name);
+        let own = format!("z.strictObject({{\n{schema_code}\n}}){show_opts}");
+        let (preamble, expression) = zod_merged_statements(item_name, &own, flatten_schemas);
         // When typescript feature is enabled, generate TypeScript-style Zod schema
         // Note: Example injection is handled by the delegating method on the type itself
         #[cfg(feature = "typescript")]
-        {
-            quote::quote! {
-                pub fn zod_schema() -> String {
-                    format!(r#"const {}$RawSchema = z.strictObject({{
-{}
-}}){}{};
-
-export const {}$Schema: ZodType<{}> = {}$RawSchema;{}"#, #item_name, #schema_code, #show_opts, #and_suffix, #item_name, #item_name, #item_name, #reexport)
-                }
-            }
-        }
+        let body = format!(
+            "{preamble}const {item_name}$RawSchema = {expression};\n\nexport const \
+             {item_name}$Schema: ZodType<{item_name}> = {item_name}$RawSchema;{reexport}"
+        );
 
         // When typescript feature is disabled, generate JavaScript-style Zod schema
         #[cfg(not(feature = "typescript"))]
-        {
-            quote::quote! {
-                pub fn zod_schema() -> String {
-                    format!(r#"export const {}$Schema = z.strictObject({{
-{}
-}}){}{};{}"#, #item_name, #schema_code, #show_opts, #and_suffix, #reexport)
-                }
+        let body = format!("{preamble}export const {item_name}$Schema = {expression};{reexport}");
+
+        quote::quote! {
+            pub fn zod_schema() -> String {
+                #body.to_owned()
             }
         }
     }

--- a/tests/flatten_tests/tests.rs
+++ b/tests/flatten_tests/tests.rs
@@ -1437,3 +1437,131 @@ fn test_an_optional_flattened_union_offers_every_member_and_their_absence() {
         r#"{"type":"object","anyOf":[{"type":"object","oneOf":[{"type":"object","properties":{"own":{"type":"string"},"kind":{"type":"string","const":"Left"},"left":{"type":"string"}},"required":["own","kind","left"],"additionalProperties":false},{"type":"object","properties":{"own":{"type":"string"},"kind":{"type":"string","const":"Right"},"right":{"type":"boolean"}},"required":["own","kind","right"],"additionalProperties":false}]},{"type":"object","properties":{"own":{"type":"string"}},"required":["own"],"additionalProperties":false}]}"#
     );
 }
+
+/// The same two key sets on the TypeScript surface: the object's own members beside the base's, or
+/// the object's own beside none of them. `| undefined` said something else — that the whole value
+/// may be missing — and `&` binds tighter than `|`, so it admitted neither payload the object
+/// writes for an absent base.
+///
+/// The absent branch is the base's own keys mapped to `never` rather than `{}`. Both spell the same
+/// two payloads for a base written whole, and only the mapped one keeps a base written in part out:
+/// `{}` is every object, so a payload carrying one of the base's members passes through it.
+#[test]
+#[cfg(feature = "typescript")]
+fn test_the_optional_flatten_type_offers_the_base_and_its_absence() {
+    let ts = OptHolder::ts_definition();
+    assert!(
+        ts.contains("} & (OptBase | { [K in keyof OptBase]?: never });"),
+        "expected the base beside its absence, got: {ts}"
+    );
+    assert!(
+        !ts.contains("| undefined"),
+        "the whole value is offered as absent in: {ts}"
+    );
+}
+
+/// And when the optional source is a union, the absence joins it from outside: the members keep the
+/// spelling their own enum was written under, and the branch that carries none of them is written
+/// over the keys every member shares.
+#[test]
+#[cfg(feature = "typescript")]
+fn test_an_optional_flattened_union_type_offers_its_members_and_their_absence() {
+    let ts = OptUnionHolder::ts_definition();
+    assert!(
+        ts.contains("} & (NestTagged | { [K in keyof NestTagged]?: never });"),
+        "expected the union beside its absence, got: {ts}"
+    );
+    assert!(
+        !ts.contains("| undefined"),
+        "the whole value is offered as absent in: {ts}"
+    );
+}
+
+/// What Zod says about the same base: a choice between the object's own keys merged with the base
+/// and the object's own keys alone. The choice is written outside the intersection because that is
+/// the only place Zod can read it — an intersection recognizes the keys its operands name, and an
+/// operand that is itself a choice leaves each branch answering for the keys the other one carries,
+/// which rejects every payload the object writes.
+#[test]
+#[cfg(feature = "zod")]
+fn test_the_optional_flatten_schema_offers_the_base_and_its_absence() {
+    let zod = OptHolder::zod_schema();
+    assert!(
+        zod.contains(
+            "z.union([\n  OptHolder$OwnSchema.and(z.lazy(() => OptBase$Schema)),\n  OptHolder$OwnSchema,\n])"
+        ),
+        "expected the base beside its absence, got: {zod}"
+    );
+    assert!(
+        !zod.contains(".and(z.lazy(() => z.union("),
+        "the choice is written inside the intersection in: {zod}"
+    );
+}
+
+/// And no branch of it admits a base written in part. The base joins a branch whole, under the name
+/// its own schema is bound to, or the branch is the object's own keys alone — so a payload carrying
+/// some of the base's members belongs to neither, and neither does a bare `undefined`.
+///
+/// Read off zod 4.4.3: this union accepts `{"left":"l","right":true,"own":"o"}` and `{"own":"o"}`,
+/// and rejects `{"left":"l","own":"o"}`, `{"right":true,"own":"o"}`, `undefined`, and any payload
+/// carrying a key neither the object nor the base names.
+#[test]
+#[cfg(feature = "zod")]
+fn test_the_optional_flatten_schema_admits_no_partial_base() {
+    let zod = OptHolder::zod_schema();
+    assert!(
+        !zod.contains("z.undefined()") && !zod.contains(".prefault("),
+        "the whole value is offered as absent in: {zod}"
+    );
+    assert!(
+        !zod.contains(".optional()"),
+        "the base's members are offered one at a time in: {zod}"
+    );
+    assert_eq!(
+        zod.matches("OptBase$Schema").count(),
+        1,
+        "the base is named more than once in: {zod}"
+    );
+}
+
+/// What the object's own keys are bound to, so each branch names them rather than repeating them:
+/// one strict object, read by both branches of the choice.
+#[test]
+#[cfg(feature = "zod")]
+fn test_the_optional_flatten_schema_binds_the_objects_own_keys_once() {
+    let zod = OptHolder::zod_schema();
+    assert!(
+        zod.contains("const OptHolder$OwnSchema = z.strictObject({\n  own: z.string(),\n\n});"),
+        "expected the object's own keys bound once, got: {zod}"
+    );
+    assert_eq!(
+        zod.matches("z.strictObject(").count(),
+        1,
+        "the object's own keys are written more than once in: {zod}"
+    );
+}
+
+/// The absence is a question about the `Option` and nothing else, so a base written without one is
+/// spelled exactly as it was before there was a second branch to spell — byte for byte, on both
+/// surfaces.
+#[test]
+#[cfg(feature = "typescript")]
+fn test_a_non_optional_flatten_type_is_byte_identical() {
+    let ts = MultiFlatten::ts_definition();
+    let declared = &ts[ts.find("export type").unwrap()..];
+    assert_eq!(
+        declared,
+        "export type MultiFlatten = {\n  /**\n * id\n * \n**/\n  id: string;\n\n} & BasePart & ExtraPart;"
+    );
+}
+
+#[test]
+#[cfg(feature = "zod")]
+fn test_a_non_optional_flatten_schema_is_byte_identical() {
+    #[cfg(feature = "typescript")]
+    const EXPECTED: &str = "const MultiFlatten$RawSchema = z.strictObject({\n  id: z.string(),\n\n}).and(z.lazy(() => BasePart$Schema)).and(z.lazy(() => ExtraPart$Schema));\n\nexport const MultiFlatten$Schema: ZodType<MultiFlatten> = MultiFlatten$RawSchema;";
+    #[cfg(not(feature = "typescript"))]
+    const EXPECTED: &str = "export const MultiFlatten$Schema = z.strictObject({\n  id: z.string(),\n\n}).and(z.lazy(() => BasePart$Schema)).and(z.lazy(() => ExtraPart$Schema));";
+
+    assert_eq!(MultiFlatten::zod_schema(), EXPECTED);
+}


### PR DESCRIPTION
An `Option` around a `#[serde(flatten)]` source was answered by the code that answers an `Option` on a keyed field, so TypeScript wrote `} & Base | undefined` and Zod wrote `.and(z.union([Base, z.undefined()]))` — whole-object optionality, which admits neither payload serde writes. Both surfaces now express the payload set the JSON-schema surface already landed: {own keys merged with base} ∪ {own keys alone}.

- `compute_flatten_outputs` produces a `MergedOperand { optional, spelling }` per source, reading the base below the outermost `Option` — the same split `MergedSource` carries on the JSON side.
- TypeScript writes the absent branch as the source's own keys mapped to `never` — `(Base | { [K in keyof Base]?: never })` inside the intersection. Chosen against `| {}` on evidence: run through tsc --strict, `{}` admits a partial base, the `never` map rejects it.
- Zod hoists the choice outside the intersection — the object's own keys bound once to a `$OwnSchema` const, then `z.union` over the 2^k present/absent combinations in the order the JSON-schema merge multiplies them. An intersection over a union operand rejects every payload (Zod v4 reads key sets off operands), so the union must be outermost; verified verbatim against zod 4.4.3.
- Non-optional flatten byte-identical, pinned by byte-exact goldens.