### PR TITLE
describe a generic brand by its inner's shape on every surface instead of collapsing to string

### DIFF
--- a/README.md
+++ b/README.md
@@ -757,8 +757,8 @@ Generated TypeScript (with `zod` feature):
 
 ```typescript
 export type UserId<ID_TYPE> = ID_TYPE & z.$brand<"UserId">;
-const UserId$RawSchema = z.string().brand<"UserId">();
-export const UserId$Schema: ZodType<UserId<string>> = UserId$RawSchema;
+const UserId$RawSchema = ID_TYPE$Schema.brand<"UserId">();
+export const UserId$Schema: $ZodBranded<typeof ID_TYPE$Schema, "UserId"> = UserId$RawSchema;
 
 export type CorrelationId = string & z.$brand<"CorrelationId">;
 const CorrelationId$RawSchema = z.string().brand<"CorrelationId">();
@@ -781,6 +781,7 @@ Notes:
 
 - If the Rust type name ends with `Json`, the suffix is stripped in the generated TypeScript (e.g., `UserIdJson` becomes `UserId`). Otherwise, the Rust name is used as-is.
 - Generic parameter names (e.g., `ID_TYPE`) are preserved exactly.
+- A brand describes what its inner writes whether or not the inner names the brand's type parameters, so `TagList<T>(pub Vec<T>)` is an array on every surface — `Array<T>`, `z.array(T$Schema)`, `$ZodBranded<ZodArray, "TagList">`, `{"type": "array", "items": {}}` — and not the bare parameter. The parameter itself carries what an uninstantiated parameter carries anywhere else: its own name in TypeScript, the `$Schema` binding named after it in Zod, and the permissive empty schema in JSON, since one schema is written for every instantiation.
 - Serde transparent serialization works normally -- the wrapper is invisible in JSON.
 - Use branded newtypes for opaque IDs and phantom types to prevent passing the wrong ID type across domain boundaries.
 

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -2429,42 +2429,50 @@ fn branded_generic_params(generics: &syn::Generics) -> Vec<String> {
 }
 
 /// Resolves the TypeScript inner type name and generic parameter list for a branded newtype.
+///
+/// The inner is read the same way whether or not the brand declares parameters: what the brand
+/// publishes is what `#[serde(transparent)]` puts on the wire, and a parameter appearing inside the
+/// inner leaves that wire the inner's own — a `Vec<T>` writes its array however `T` is filled in.
+/// A parameter reached on its own renders as the name it was written with, which is what
+/// `typescript_base` gives every unresolvable name and what a generic alias's target already
+/// publishes for one.
+///
+/// The parameter list is the struct's, because it is the exported type's own list and has to name
+/// every parameter the type carries — not just the ones the inner happens to reach.
 #[cfg(feature = "typescript")]
 fn branded_ts_type_and_generics(
-    is_generic: bool,
     generic_params: &[String],
     inner_ty: &syn::Type,
 ) -> (String, String) {
-    let ts_inner_type = if is_generic {
-        generic_params[0].clone()
-    } else {
-        get_field_def("_inner", inner_ty, "").typescript_typename()
-    };
-    let ts_generics = if is_generic {
-        format!("<{}>", generic_params.join(", "))
-    } else {
+    let ts_inner_type = get_field_def("_inner", inner_ty, "").typescript_typename();
+    let ts_generics = if generic_params.is_empty() {
         String::new()
+    } else {
+        format!("<{}>", generic_params.join(", "))
     };
     (ts_inner_type, ts_generics)
 }
 
 /// Resolves the JSON schema shape for a branded newtype's inner field.
 ///
-/// For generic newtypes this is always `"string"` (mirrors the Zod logic). An `ObjectId`, a
-/// composite and a named type are read off their own `FieldDef`, because none of them writes a
-/// value one `"type"` keyword describes; a chrono type writes a string one keyword names but not
-/// the only one it carries. Every remaining non-generic inner maps from the resolved TypeScript
+/// The brand's own type parameters are replaced by the opaque type before the inner is classified,
+/// exactly as [`alias_json_schema_field_def`] replaces an alias's: a parameter names no type until
+/// the brand is instantiated, and the schema is written once for every instantiation. So the
+/// parameter admits any value while the shape it sits in — an array, a map's keys, a tuple's arity
+/// — is still described, which is what `#[serde(transparent)]` puts on the wire.
+///
+/// An `ObjectId`, a composite and a named type are then read off their own `FieldDef`, because none
+/// of them writes a value one `"type"` keyword describes; a chrono type writes a string one keyword
+/// names but not the only one it carries. Every remaining inner maps from the resolved TypeScript
 /// type name.
 ///
 /// The composite question is asked before the other two, so an inner written under array levels
 /// answers for the array around whatever it holds — which is what `#[serde(transparent)]` puts on
 /// the wire — rather than for the item.
 #[cfg(feature = "jsonschema")]
-fn branded_json_inner(is_generic: bool, inner_ty: &syn::Type) -> BrandedJsonInner {
-    if is_generic {
-        return BrandedJsonInner::Scalar("string".to_owned());
-    }
-    let inner = get_field_def("_inner", inner_ty, "");
+fn branded_json_inner(generic_params: &[String], inner_ty: &syn::Type) -> BrandedJsonInner {
+    let mut inner = get_field_def("_inner", inner_ty, "");
+    inner.erase_type_parameters(generic_params);
     #[cfg(feature = "object_id")]
     if branded_inner_is_object_id(&inner) {
         return BrandedJsonInner::ObjectId;
@@ -2574,12 +2582,13 @@ fn branded_inner_composite(inner: &FieldDef) -> Option<BrandedComposite> {
 /// The constraints measure the inner's `Display` rendering, which for every inner but an
 /// `ObjectId` is the value the schema itself describes. An `ObjectId` writes `{"$oid": hex}`, so
 /// its `Display` is the `$oid` member and the checks land there.
+///
+/// A brand's own type parameters are rendered here as they are anywhere else the value expression
+/// reaches one: through the `Name$Schema` binding `zod_array_base` names every unresolved type
+/// after, which is what a generic alias's value already publishes for a parameter.
 #[cfg(feature = "zod")]
-fn branded_zod_inner(args: &ModelSchemaArgs, is_generic: bool, inner_ty: &syn::Type) -> String {
+fn branded_zod_inner(args: &ModelSchemaArgs, inner_ty: &syn::Type) -> String {
     let checks = branded_zod_string_checks(args);
-    if is_generic {
-        return format!("z.string(){checks}");
-    }
     let inner = get_field_def("_inner", inner_ty, "");
     #[cfg(feature = "object_id")]
     if branded_inner_is_object_id(&inner) {
@@ -2603,11 +2612,12 @@ fn branded_zod_inner(args: &ModelSchemaArgs, is_generic: bool, inner_ty: &syn::T
 /// composed from, read back off that same rendering. A check the brand adds returns the schema it
 /// was called on, so the binding's type is the base schema's type whether or not the brand
 /// constrains it.
+///
+/// A type parameter is a name like any other, so it is annotated through that same named-inner arm
+/// — the type of the binding the value was composed from — and the two surfaces cannot disagree
+/// about what the brand wraps.
 #[cfg(all(feature = "zod", feature = "typescript"))]
-fn branded_zod_type_name(is_generic: bool, inner_ty: &syn::Type) -> String {
-    if is_generic {
-        return "ZodString".to_owned();
-    }
+fn branded_zod_type_name(inner_ty: &syn::Type) -> String {
     let inner = get_field_def("_inner", inner_ty, "");
     #[cfg(feature = "object_id")]
     if branded_inner_is_object_id(&inner) {
@@ -2672,7 +2682,6 @@ fn build_branded_ts_definition_method(
 fn build_branded_zod_schema_method(
     item_name: &str,
     rust_ident: &str,
-    is_generic: bool,
     inner_ty: &syn::Type,
     zod_inner: &str,
     plain_description: &str,
@@ -2680,7 +2689,7 @@ fn build_branded_zod_schema_method(
     let reexport = ident_reexport_zod(rust_ident, item_name);
     #[cfg(feature = "typescript")]
     {
-        let zod_type_name = branded_zod_type_name(is_generic, inner_ty);
+        let zod_type_name = branded_zod_type_name(inner_ty);
         let zod_type_annotation = format!("$ZodBranded<{zod_type_name}, \"{item_name}\">");
         quote! {
             pub fn zod_schema() -> String {
@@ -2693,7 +2702,7 @@ fn build_branded_zod_schema_method(
     }
     #[cfg(not(feature = "typescript"))]
     {
-        let _: &_ = &(is_generic, inner_ty);
+        let _: &_ = &inner_ty;
         quote! {
             pub fn zod_schema() -> String {
                 format!(
@@ -2897,8 +2906,9 @@ fn build_branded_schema_example(
     };
     let code_tokens: proc_macro2::TokenStream = code.parse().unwrap();
     if is_generic {
-        // For generic newtypes, the example constructs a concrete type (e.g., DocumentId<String>).
-        // We use String as the concrete type since the Zod schema always uses z.string().
+        // The example is Rust the expansion has to compile, and a parameter names no type to
+        // compile it at, so it is instantiated at `String` (e.g. `DocumentId<String>`) — the one
+        // concrete type every brand's example can be written against.
         quote! {
             pub fn schema_example() -> serde_json::Value {
                 let value: #name<String> = {
@@ -3092,16 +3102,16 @@ fn process_branded_newtype(item_struct: syn::ItemStruct, args: &ModelSchemaArgs)
 
     // `ts_pair`: (ts_inner_type, ts_generics).
     #[cfg(feature = "typescript")]
-    let ts_pair = branded_ts_type_and_generics(is_generic, &generic_params, inner_ty);
+    let ts_pair = branded_ts_type_and_generics(&generic_params, inner_ty);
 
     #[cfg(not(any(feature = "typescript", feature = "zod")))]
     let _: &_ = &inner_ty;
 
     #[cfg(feature = "jsonschema")]
-    let json_inner = branded_json_inner(is_generic, inner_ty);
+    let json_inner = branded_json_inner(&generic_params, inner_ty);
 
     #[cfg(feature = "zod")]
-    let zod_inner = branded_zod_inner(args, is_generic, inner_ty);
+    let zod_inner = branded_zod_inner(args, inner_ty);
 
     // --- Generate ts_definition method ---
     #[cfg(feature = "typescript")]
@@ -3113,7 +3123,6 @@ fn process_branded_newtype(item_struct: syn::ItemStruct, args: &ModelSchemaArgs)
     let zod_schema_method = build_branded_zod_schema_method(
         &item_name,
         &rust_ident,
-        is_generic,
         inner_ty,
         &zod_inner,
         &plain_description,

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -4478,7 +4478,7 @@ fn a_sibling_slot_carries_the_schema_module_reference() {
 fn brand_json_schema_over(inner_ty: &syn::Type) -> String {
     super::build_branded_json_schema_method(
         &super::ModelSchemaArgs::default(),
-        &super::branded_json_inner(false, inner_ty),
+        &super::branded_json_inner(&[], inner_ty),
         "Wrapped",
     )
     .to_string()

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -2212,8 +2212,9 @@ fn branded_newtype_over_option_is_rejected() {
     assert!(errors[0].contains("null"), "got: {}", errors[0]);
 }
 
-/// The generic arm renders the type parameter and drops the `Option` wrapper outright, so the
-/// shape is no more representable there than in the concrete case.
+/// An inner naming a type parameter is read exactly as a concrete one is, so the `Option`
+/// collapses onto what it holds there too and the shape is no more representable than in the
+/// concrete case.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
 fn generic_branded_newtype_over_option_is_rejected() {

--- a/tests/branded_newtype_tests/tests.rs
+++ b/tests/branded_newtype_tests/tests.rs
@@ -49,12 +49,15 @@ mod zod_ts_tests {
         );
     }
 
+    /// The parameter is what the brand wraps, so the value is composed from the binding named
+    /// after it and the annotation is that binding's own type — the pair a named inner publishes,
+    /// and the same `$Schema` reference a generic alias's value publishes for a parameter.
     #[test]
     fn test_branded_newtype_zod_schema() {
         let zod = RoleId::<String>::zod_schema();
-        assert!(zod.contains("z.string().brand"), "Got: {zod}");
+        assert!(zod.contains("IdType$Schema.brand"), "Got: {zod}");
         assert!(
-            zod.contains("$ZodBranded<ZodString, \"RoleId\">"),
+            zod.contains("$ZodBranded<typeof IdType$Schema, \"RoleId\">"),
             "Got: {zod}"
         );
     }
@@ -659,13 +662,12 @@ mod branded_in_struct_all_features_tests {
         );
     }
 
+    /// A brand whose inner is a bare parameter names no type to describe — one schema is written
+    /// for every instantiation — so it admits any value, as an uninstantiated parameter does
+    /// wherever else it is written.
     #[test]
     fn test_generic_branded_newtype_own_json_schema() {
-        let schema = TaskTypeId::<String>::json_schema();
-        assert_eq!(
-            schema["type"], "string",
-            "Generic branded type should have type 'string'. Got: {schema}"
-        );
+        assert_eq!(TaskTypeId::<String>::json_schema(), serde_json::json!({}));
     }
 }
 
@@ -765,8 +767,7 @@ mod branded_in_struct_jsonschema_only_tests {
 
     #[test]
     fn test_generic_branded_own_json_schema_only() {
-        let schema = TaskTypeIdJO::<String>::json_schema();
-        assert_eq!(schema["type"], "string", "Got: {schema}");
+        assert_eq!(TaskTypeIdJO::<String>::json_schema(), serde_json::json!({}));
     }
 }
 
@@ -826,16 +827,27 @@ mod branded_constrained_json_schema_tests {
     #[serde(transparent)]
     pub struct ShortId(pub String);
 
+    /// A bare parameter names no type to describe, so the brand's own constraints narrow it from
+    /// inside the `allOf` every inner without a `"type"` of its own is layered under, rather than
+    /// asserting a `"string"` the parameter was never held to.
     #[test]
     fn test_constrained_branded_json_schema() {
-        let schema = ConstrainedId::<String>::json_schema();
-        assert_eq!(schema["type"], "string", "Got: {schema}");
-        assert_eq!(schema["minLength"], 24_i64, "Got: {schema}");
-        assert_eq!(schema["maxLength"], 24_i64, "Got: {schema}");
         // The `\d` the brand is declared with reaches the schema as the members it stands for: a
         // JSON Schema `pattern` is an ECMA-262 regex, which reads `\d` as ASCII, while the Rust
         // validator beside it reads the Unicode class. Written out, both read the one set.
-        assert_eq!(schema["pattern"], "^[a-f0-9]{24}$", "Got: {schema}");
+        assert_eq!(
+            ConstrainedId::<String>::json_schema(),
+            serde_json::json!({
+                "allOf": [
+                    {},
+                    {
+                        "minLength": 24_u32,
+                        "maxLength": 24_u32,
+                        "pattern": "^[a-f0-9]{24}$"
+                    }
+                ]
+            })
+        );
     }
 
     #[test]
@@ -1236,6 +1248,204 @@ mod branded_composite_inner_tests {
         assert_eq!(LabelList::json_schema(), holder["properties"]["labels"]);
         assert_eq!(LabelPair::json_schema(), holder["properties"]["pair"]);
         assert_eq!(WeightMap::json_schema(), holder["properties"]["weights"]);
+    }
+}
+
+/// The four surfaces of a brand whose inner is written out of the brand's own type parameters,
+/// pinned against what serde writes for it.
+///
+/// A parameter changes nothing about what `#[serde(transparent)]` puts on the wire: a `Vec` inner
+/// writes its array whether the elements are `String` or a parameter. So the shape around the
+/// parameter is described here exactly as the same shape is described where it is written without
+/// a brand — the generic alias beside each brand is that shape, and every surface is asserted to
+/// carry the same rendering it does.
+///
+/// The parameter itself carries what an uninstantiated parameter carries in every other position:
+/// its own name in TypeScript, the `$Schema` binding named after it in Zod, and the permissive
+/// empty schema in JSON, where a parameter names no type to describe.
+#[cfg(all(
+    feature = "jsonschema",
+    feature = "serde",
+    feature = "typescript",
+    feature = "zod"
+))]
+mod branded_generic_inner_tests {
+    use super::branded_no_display_tests::TagList;
+    use super::*;
+    use std::collections::HashMap;
+
+    #[model_schema()]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct BareTag<T>(pub T);
+
+    #[model_schema(no_display)]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct WeightIndex<T>(pub HashMap<String, T>);
+
+    #[model_schema()]
+    pub type BareSeq<T> = T;
+
+    #[model_schema()]
+    pub type TagSeq<T> = Vec<T>;
+
+    #[model_schema()]
+    pub type WeightSeq<T> = HashMap<String, T>;
+
+    #[test]
+    fn a_generic_container_brand_writes_the_container_its_inner_writes() {
+        let tags = TagList(vec!["a".to_owned()]);
+        assert_eq!(serde_json::to_string(&tags).unwrap(), r#"["a"]"#);
+        assert_eq!(
+            serde_json::from_str::<TagList<String>>(&serde_json::to_string(&tags).unwrap())
+                .unwrap(),
+            tags
+        );
+
+        let weights = WeightIndex(HashMap::from([("a".to_owned(), 1_u32)]));
+        assert_eq!(serde_json::to_string(&weights).unwrap(), r#"{"a":1}"#);
+        assert_eq!(
+            serde_json::from_str::<WeightIndex<u32>>(&serde_json::to_string(&weights).unwrap())
+                .unwrap(),
+            weights
+        );
+
+        let bare = BareTag("a".to_owned());
+        assert_eq!(serde_json::to_string(&bare).unwrap(), r#""a""#);
+        assert_eq!(
+            serde_json::from_str::<BareTag<String>>(&serde_json::to_string(&bare).unwrap())
+                .unwrap(),
+            bare
+        );
+
+        // The alias beside each brand is the same shape with nothing branding it, and the wire is
+        // the same — which is what makes the surfaces asserted equal below comparable at all.
+        let tag_seq: TagSeq<String> = vec!["a".to_owned()];
+        assert_eq!(serde_json::to_string(&tag_seq).unwrap(), r#"["a"]"#);
+        let weight_seq: WeightSeq<u32> = HashMap::from([("a".to_owned(), 1_u32)]);
+        assert_eq!(serde_json::to_string(&weight_seq).unwrap(), r#"{"a":1}"#);
+        let bare_seq: BareSeq<String> = "a".to_owned();
+        assert_eq!(serde_json::to_string(&bare_seq).unwrap(), r#""a""#);
+    }
+
+    #[test]
+    fn an_arrayed_parameter_brand_describes_the_array_on_every_surface() {
+        assert_eq!(
+            TagList::<String>::ts_definition(),
+            r#"export type TagList<T> = Array<T> & $brand<"TagList">;"#
+        );
+        let zod = TagList::<String>::zod_schema();
+        assert!(
+            zod.contains(r#"const TagList$RawSchema = z.array(T$Schema).brand<"TagList">()"#),
+            "Got:\n{zod}"
+        );
+        assert!(
+            zod.contains(r#"TagList$Schema: $ZodBranded<ZodArray, "TagList">"#),
+            "Got:\n{zod}"
+        );
+        assert_eq!(
+            TagList::<String>::json_schema(),
+            serde_json::json!({ "type": "array", "items": {} })
+        );
+    }
+
+    #[test]
+    fn a_mapped_parameter_brand_describes_the_object_on_every_surface() {
+        assert_eq!(
+            WeightIndex::<u32>::ts_definition(),
+            r#"export type WeightIndex<T> = Partial<Record<string, T>> & $brand<"WeightIndex">;"#
+        );
+        let zod = WeightIndex::<u32>::zod_schema();
+        assert!(
+            zod.contains(
+                r#"const WeightIndex$RawSchema = z.record(z.string(), T$Schema).brand<"WeightIndex">()"#
+            ),
+            "Got:\n{zod}"
+        );
+        assert!(
+            zod.contains(r#"WeightIndex$Schema: $ZodBranded<ZodRecord, "WeightIndex">"#),
+            "Got:\n{zod}"
+        );
+        assert_eq!(
+            WeightIndex::<u32>::json_schema(),
+            serde_json::json!({ "type": "object", "additionalProperties": {} })
+        );
+    }
+
+    /// A parameter on its own carries no shape of its own, so each surface writes for it what it
+    /// writes for a bare generic field — which is the alias asserted beside it.
+    #[test]
+    fn a_bare_parameter_brand_matches_the_generic_field_convention() {
+        assert_eq!(
+            BareTag::<String>::ts_definition(),
+            r#"export type BareTag<T> = T & $brand<"BareTag">;"#
+        );
+        let zod = BareTag::<String>::zod_schema();
+        assert!(
+            zod.contains(r#"const BareTag$RawSchema = T$Schema.brand<"BareTag">()"#),
+            "Got:\n{zod}"
+        );
+        assert!(
+            zod.contains(r#"BareTag$Schema: $ZodBranded<typeof T$Schema, "BareTag">"#),
+            "Got:\n{zod}"
+        );
+        assert_eq!(BareTag::<String>::json_schema(), serde_json::json!({}));
+    }
+
+    /// The rendering each surface gives the brand is the one it gives the same shape written
+    /// without a brand: the JSON schemas are equal outright, and the TypeScript type and the Zod
+    /// value each carry the fragment the alias carries, under the brand's own wrapping.
+    #[test]
+    fn a_generic_brand_renders_what_the_same_generic_alias_renders() {
+        assert_eq!(
+            TagList::<String>::json_schema(),
+            tag_seq_schema::Schema::json_schema()
+        );
+        assert_eq!(
+            WeightIndex::<u32>::json_schema(),
+            weight_seq_schema::Schema::json_schema()
+        );
+        assert_eq!(
+            BareTag::<String>::json_schema(),
+            bare_seq_schema::Schema::json_schema()
+        );
+
+        for (brand, alias, shared) in [
+            (
+                TagList::<String>::ts_definition(),
+                tag_seq_schema::Schema::ts_definition(),
+                "Array<T>",
+            ),
+            (
+                TagList::<String>::zod_schema(),
+                tag_seq_schema::Schema::zod_schema(),
+                "z.array(T$Schema)",
+            ),
+            (
+                WeightIndex::<u32>::ts_definition(),
+                weight_seq_schema::Schema::ts_definition(),
+                "Partial<Record<string, T>>",
+            ),
+            (
+                WeightIndex::<u32>::zod_schema(),
+                weight_seq_schema::Schema::zod_schema(),
+                "z.record(z.string(), T$Schema)",
+            ),
+            (
+                BareTag::<String>::ts_definition(),
+                bare_seq_schema::Schema::ts_definition(),
+                "<T> = T",
+            ),
+            (
+                BareTag::<String>::zod_schema(),
+                bare_seq_schema::Schema::zod_schema(),
+                "= T$Schema",
+            ),
+        ] {
+            assert!(brand.contains(shared), "brand got:\n{brand}");
+            assert!(alias.contains(shared), "alias got:\n{alias}");
+        }
     }
 }
 


### PR DESCRIPTION
`process_branded_newtype` short-circuited on whether the STRUCT had type parameters, so `TagList<T>(pub Vec<T>)` published the bare parameter / `z.string()` / `ZodString` / `{"type":"string"}` while serde wrote `["a"]`. The four short-circuits are gone: each renderer reads the INNER through the dispatch the non-generic path already used, with a parameter rendered the way the crate's generic machinery renders it anywhere else — its own name in TypeScript, the `$Schema` binding named after it in Zod, `typeof` that binding in the annotation, the permissive empty schema in JSON (the brand's parameters erased to the opaque type before classification, as the alias path does). The struct's parameter list still supplies the exported `<…>` since it must name every parameter the type carries.

`is_generic` survives only where it answers Rust-codegen questions (serde hooks, Display bounds, example instantiation). Non-generic byte-identity proven by diffing 22-brand probe output against a baseline archive — empty diff.