### PR TITLE
read the oid hex under one case rule on both surfaces

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -647,12 +647,12 @@ export type Document = {
 
 ```typescript
 export const Document$Schema = z.strictObject({
-  id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: "Invalid ObjectId" }) }),
-  author_id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: "Invalid ObjectId" }) }),
-  tags: z.array(z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: "Invalid ObjectId" }) })),
-  metadata: z.record(z.string(), z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: "Invalid ObjectId" }) })),
-  parent_id: z.union([z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: "Invalid ObjectId" }) }), z.undefined()]).prefault(undefined),
-  related: z.record(z.string(), z.array(z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: "Invalid ObjectId" }) }))),
+  id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) }),
+  author_id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) }),
+  tags: z.array(z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) })),
+  metadata: z.record(z.string(), z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) })),
+  parent_id: z.union([z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) }), z.undefined()]).prefault(undefined),
+  related: z.record(z.string(), z.array(z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) }))),
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -1366,13 +1366,13 @@ export type Document = {
 };
 
 export const Document$Schema = z.strictObject({
-  id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: "Invalid ObjectId" }) }),
+  id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) }),
   title: z.string(),
-  author_id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: "Invalid ObjectId" }) }),
-  tags: z.array(z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: "Invalid ObjectId" }) })),
-  metadata: z.record(z.string(), z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: "Invalid ObjectId" }) })),
-  parent_id: z.union([z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: "Invalid ObjectId" }) }), z.undefined()]).prefault(undefined),
-  related_docs: z.record(z.string(), z.array(z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: "Invalid ObjectId" }) }))),
+  author_id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) }),
+  tags: z.array(z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) })),
+  metadata: z.record(z.string(), z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) })),
+  parent_id: z.union([z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) }), z.undefined()]).prefault(undefined),
+  related_docs: z.record(z.string(), z.array(z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) }))),
 });
 ```
 

--- a/src/features/object_id.rs
+++ b/src/features/object_id.rs
@@ -35,10 +35,16 @@ pub fn get_object_id_zod_schema() -> String {
 ///
 /// String checks belong on that member and never on the object around it: `$oid` is the only
 /// string an `ObjectId` writes, and a `z.object` has no string check to take.
+///
+/// The literal carries no flags, so it constrains `$oid` by exactly what the JSON Schema `pattern`
+/// keyword beside it constrains it by. A `pattern` is a flagless ECMA-262 regex with nowhere to
+/// hold an `i`, so a flag here would be case-insensitivity granted on one surface and unobtainable
+/// on the other — from the one constant both splice, and for a member `ObjectId::to_hex()` only
+/// ever writes in lower-case.
 #[cfg(all(feature = "object_id", any(test, feature = "zod")))]
 pub fn get_object_id_zod_schema_with(hex_checks: &str) -> String {
     format!(
-        "z.object({{ $oid: z.string().regex(/{OBJECT_ID_HEX_PATTERN}/i, {{ message: \"Invalid ObjectId\" }}){hex_checks} }})"
+        "z.object({{ $oid: z.string().regex(/{OBJECT_ID_HEX_PATTERN}/, {{ message: \"Invalid ObjectId\" }}){hex_checks} }})"
     )
 }
 

--- a/src/features/object_id/tests.rs
+++ b/src/features/object_id/tests.rs
@@ -1,5 +1,14 @@
 use super::*;
 
+/// The `$oid` strings the two surfaces were told apart by, with the verdict a flagless ECMA-262
+/// regex gives each: `new RegExp(OBJECT_ID_HEX_PATTERN).test(oid)` under node v26.2.0. The upper-
+/// case hex is the one a flag turns, and the lower-case one is what `ObjectId::to_hex()` writes.
+#[cfg(feature = "object_id")]
+const OBJECT_ID_HEX_STRINGS: [(&str, bool); 2] = [
+    ("507f1f77bcf86cd799439011", true),
+    ("507F1F77BCF86CD799439011", false),
+];
+
 #[test]
 fn test_object_id_detection() {
     assert!(is_object_id_type("ObjectId"));
@@ -19,4 +28,61 @@ fn test_object_id_zod_schema() {
     assert!(schema.contains("$oid"));
     assert!(schema.contains("regex"));
     assert!(schema.contains("24"));
+}
+
+/// The regex literal the Zod surface writes, split into its source and the flags it carries.
+#[cfg(feature = "object_id")]
+fn emitted_zod_literal(zod_schema: &str) -> (&str, &str) {
+    let literal = zod_schema.split_once(".regex(/").unwrap().1;
+    let (source, after) = literal.split_once('/').unwrap();
+    let (flags, _) = after.split_once(',').unwrap();
+    (source, flags)
+}
+
+/// A JavaScript regex literal as the `regex` crate reads it, on the same recorded-JavaScript
+/// discipline the emitted-pattern tests use. The flags decide a verdict as much as the source does,
+/// so they are translated rather than dropped; a flag with no reading recorded here stops the test
+/// instead of being silently ignored.
+#[cfg(feature = "object_id")]
+fn javascript_literal(source: &str, flags: &str) -> regex::Regex {
+    assert!(
+        flags.chars().all(|flag| flag == 'i'),
+        "no reading is recorded for the flag set /{flags}"
+    );
+    let case_folding = if flags.contains('i') { "(?i)" } else { "" };
+    regex::Regex::new(&format!("{case_folding}{source}")).unwrap()
+}
+
+/// Both surfaces constrain `$oid` by one hex under one case rule.
+///
+/// A JSON Schema `pattern` is a flagless ECMA-262 regex with nowhere to hold a flag, so agreement
+/// can only come from the source spelling — which leaves the Zod literal's flag set as the one
+/// place the two can part ways, and an empty one as the only way they cannot. The contract both
+/// describe is what serde writes, and `ObjectId::to_hex()` writes lower-case.
+#[cfg(feature = "object_id")]
+#[test]
+fn test_both_object_id_surfaces_read_one_hex_under_one_case_rule() {
+    let zod_schema = get_object_id_zod_schema();
+    let (source, flags) = emitted_zod_literal(&zod_schema);
+    assert_eq!(
+        source, OBJECT_ID_HEX_PATTERN,
+        "the Zod literal spells the `$oid` hex its own way"
+    );
+    let zod = javascript_literal(source, flags);
+    // The `pattern` keyword takes the constant with no flag, because it has nowhere to put one.
+    let json_schema = javascript_literal(OBJECT_ID_HEX_PATTERN, "");
+
+    for (oid, javascript) in OBJECT_ID_HEX_STRINGS {
+        assert_eq!(
+            json_schema.is_match(oid),
+            javascript,
+            "the JSON Schema `pattern` parts ways with JavaScript over {oid:?}"
+        );
+        assert_eq!(
+            zod.is_match(oid),
+            json_schema.is_match(oid),
+            "the two `$oid` surfaces part ways over {oid:?}: Zod reads /{source}/{flags}, \
+             the JSON Schema `pattern` reads {source} with no flag"
+        );
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,12 +157,12 @@ pub struct Document {
 // };
 //
 // export const Document$Schema = z.strictObject({
-//   id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: "Invalid ObjectId" }) }),
+//   id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) }),
 //   title: z.string(),
-//   author_id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: "Invalid ObjectId" }) }),
-//   tags: z.array(z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: "Invalid ObjectId" }) })),
-//   metadata: z.record(z.string(), z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: "Invalid ObjectId" }) })),
-//   parent_id: z.union([z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: "Invalid ObjectId" }) }), z.undefined()]).prefault(undefined),
+//   author_id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) }),
+//   tags: z.array(z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) })),
+//   metadata: z.record(z.string(), z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) })),
+//   parent_id: z.union([z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) }), z.undefined()]).prefault(undefined),
 // });
 ```
 "#

--- a/tests/branded_newtype_tests/tests.rs
+++ b/tests/branded_newtype_tests/tests.rs
@@ -390,7 +390,7 @@ mod objectid_branded_surface_tests {
     use mongodb::bson::oid::ObjectId;
 
     const OID_ZOD_BASE: &str =
-        r#"z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: "Invalid ObjectId" })"#;
+        r#"z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" })"#;
 
     #[model_schema()]
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/tests/mongodb_real_tests/tests.rs
+++ b/tests/mongodb_real_tests/tests.rs
@@ -89,7 +89,7 @@ fn test_real_objectid_basic_types() {
 
     // Zod schema should use the MongoDB ObjectId structure with regex validation - now in separate method
     let zod_schema = RealUser::zod_schema();
-    assert!(zod_schema.contains("id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: \"Invalid ObjectId\" }) }),"));
+    assert!(zod_schema.contains("id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: \"Invalid ObjectId\" }) }),"));
     assert!(zod_schema.contains("name: z.string(),"));
     assert!(
         zod_schema.contains("email: z.union([z.string(), z.undefined()]).prefault(undefined),")
@@ -182,7 +182,7 @@ fn test_real_objectid_complex_structures() {
 
     // Zod schema should handle all ObjectId variations with regex validation - now in separate method
     let zod_schema = RealDocument::zod_schema();
-    let regex_pattern = "z.string().regex(/^[a-f0-9]{24}$/i, { message: \"Invalid ObjectId\" })";
+    let regex_pattern = "z.string().regex(/^[a-f0-9]{24}$/, { message: \"Invalid ObjectId\" })";
     assert!(zod_schema.contains(&format!("id: z.object({{ $oid: {regex_pattern} }}),")));
     assert!(zod_schema.contains(&format!(
         "author_id: z.object({{ $oid: {regex_pattern} }}),"
@@ -476,6 +476,56 @@ fn test_real_objectid_serialization() {
     assert_eq!(deserialized.email, Some("test@example.com".to_owned()));
 }
 
+/// The hex a real `ObjectId` round-trips through serde, held to both generated surfaces at once.
+///
+/// The `pattern` keyword is a flagless ECMA-262 regex, so the Zod literal's flags are read here
+/// rather than dropped: a flag on one surface and not on the other is two contracts for one member,
+/// whatever the source spelling says. Lower-case is the only case there is to pin, because
+/// `ObjectId::to_hex()` is the only thing that writes this member.
+#[test]
+#[cfg(all(feature = "object_id", feature = "jsonschema", feature = "zod"))]
+fn a_real_object_id_hex_satisfies_the_zod_literal_and_the_json_schema_pattern_alike() {
+    let real_oid = ObjectId::new();
+    let user = RealUser {
+        id: real_oid,
+        name: "Test User".to_owned(),
+        email: Some("test@example.com".to_owned()),
+    };
+
+    let wire = serde_json::to_value(&user).unwrap();
+    let hex = wire["id"]["$oid"].as_str().unwrap().to_owned();
+    assert_eq!(hex, real_oid.to_hex());
+    assert_eq!(
+        serde_json::from_value::<RealUser>(wire).unwrap(),
+        user,
+        "the `$oid` object serde wrote does not read back"
+    );
+
+    let pattern = RealUser::json_schema()["properties"]["id"]["properties"]["$oid"]["pattern"]
+        .as_str()
+        .unwrap()
+        .to_owned();
+
+    let zod_schema = RealUser::zod_schema();
+    let literal = zod_schema.split_once(".regex(/").unwrap().1;
+    let (source, after) = literal.split_once('/').unwrap();
+    let (flags, _) = after.split_once(',').unwrap();
+    assert_eq!(
+        source, pattern,
+        "the two surfaces spell the `$oid` hex differently"
+    );
+    assert_eq!(
+        flags, "",
+        "the Zod literal carries flags the `pattern` keyword has nowhere to hold"
+    );
+
+    let hex_pattern = regex::Regex::new(&pattern).unwrap();
+    assert!(
+        hex_pattern.is_match(&hex),
+        "the one hex both surfaces read rejects what serde wrote: {hex}"
+    );
+}
+
 #[test]
 fn test_real_objectid_validation_compatibility() {
     // Test that real ObjectIds produce valid hex strings that match our regex
@@ -485,7 +535,7 @@ fn test_real_objectid_validation_compatibility() {
     // Should be exactly 24 characters
     assert_eq!(hex_string.len(), 24);
 
-    // Should match our regex pattern: /^[a-f0-9]{24}$/i
+    // Should match our regex pattern: /^[a-f0-9]{24}$/
     let regex = regex::Regex::new("^[a-f0-9]{24}$").unwrap();
     assert!(
         regex.is_match(&hex_string),

--- a/tests/mongodb_tests/tests.rs
+++ b/tests/mongodb_tests/tests.rs
@@ -242,7 +242,7 @@ fn test_basic_object_id_types() {
 
     // Zod schema should use the MongoDB ObjectId structure with regex validation - now in separate method
     let zod_schema = User::zod_schema();
-    assert!(zod_schema.contains("id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: \"Invalid ObjectId\" }) }),"));
+    assert!(zod_schema.contains("id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: \"Invalid ObjectId\" }) }),"));
     assert!(zod_schema.contains("name: z.string(),"));
     assert!(
         zod_schema.contains("email: z.union([z.string(), z.undefined()]).prefault(undefined),")
@@ -264,7 +264,7 @@ fn test_complex_nested_object_id_structures() {
 
     // Zod schema should handle all ObjectId variations with regex validation - now in separate method
     let zod_schema = ComplexDocument::zod_schema();
-    let regex_pattern = "z.string().regex(/^[a-f0-9]{24}$/i, { message: \"Invalid ObjectId\" })";
+    let regex_pattern = "z.string().regex(/^[a-f0-9]{24}$/, { message: \"Invalid ObjectId\" })";
     assert!(zod_schema.contains(&format!("id: z.object({{ $oid: {regex_pattern} }}),")));
     assert!(zod_schema.contains(&format!(
         "author_id: z.object({{ $oid: {regex_pattern} }}),"
@@ -307,7 +307,7 @@ fn test_complex_object_id_zod_schema() {
     let zod_schema = ComplexDocument::zod_schema();
 
     // Test that complex nested ObjectId structures work
-    let regex_pattern = "z.string().regex(/^[a-f0-9]{24}$/i, { message: \"Invalid ObjectId\" })";
+    let regex_pattern = "z.string().regex(/^[a-f0-9]{24}$/, { message: \"Invalid ObjectId\" })";
     assert!(zod_schema.contains(&format!(
         "nested_refs: z.record(z.string(), z.array(z.object({{ $oid: {regex_pattern} }}))),"
     )));
@@ -351,7 +351,7 @@ fn test_hashmap_object_id_zod_schema() {
     let zod_schema = UserWithObjectIdMap::zod_schema();
 
     // Should handle HashMap<String, ObjectId> correctly
-    assert!(zod_schema.contains("relationships: z.record(z.string(), z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: \"Invalid ObjectId\" }) })),"));
+    assert!(zod_schema.contains("relationships: z.record(z.string(), z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: \"Invalid ObjectId\" }) })),"));
 }
 
 #[test]
@@ -366,9 +366,9 @@ fn test_hashmap_with_object_id_values() {
 
     // Zod schema should use the MongoDB ObjectId structure with regex validation - now in separate method
     let zod_schema = UserWithObjectIdMap::zod_schema();
-    assert!(zod_schema.contains("id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: \"Invalid ObjectId\" }) }),"));
+    assert!(zod_schema.contains("id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: \"Invalid ObjectId\" }) }),"));
     assert!(zod_schema.contains("name: z.string(),"));
-    assert!(zod_schema.contains("relationships: z.record(z.string(), z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: \"Invalid ObjectId\" }) })),"));
+    assert!(zod_schema.contains("relationships: z.record(z.string(), z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: \"Invalid ObjectId\" }) })),"));
 }
 
 #[test]
@@ -401,9 +401,9 @@ fn test_object_id_arrays() {
 
     // Zod schema should use the MongoDB ObjectId structure with regex validation - now in separate method
     let zod_schema = UserWithObjectIdArray::zod_schema();
-    assert!(zod_schema.contains("id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: \"Invalid ObjectId\" }) }),"));
+    assert!(zod_schema.contains("id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: \"Invalid ObjectId\" }) }),"));
     assert!(zod_schema.contains("name: z.string(),"));
-    assert!(zod_schema.contains("friend_ids: z.array(z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: \"Invalid ObjectId\" }) })),"));
+    assert!(zod_schema.contains("friend_ids: z.array(z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: \"Invalid ObjectId\" }) })),"));
 }
 
 #[test]
@@ -429,7 +429,7 @@ fn test_object_id_arrays_zod_schema() {
     let zod_schema = UserWithObjectIdArray::zod_schema();
 
     // Should handle array of ObjectId correctly
-    assert!(zod_schema.contains("friend_ids: z.array(z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: \"Invalid ObjectId\" }) })),"));
+    assert!(zod_schema.contains("friend_ids: z.array(z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: \"Invalid ObjectId\" }) })),"));
 }
 
 #[test]
@@ -468,7 +468,7 @@ fn test_object_id_zod_schema() {
     let zod_schema = Post::zod_schema();
 
     // Should handle optional ObjectId correctly
-    assert!(zod_schema.contains("parent_id: z.union([z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: \"Invalid ObjectId\" }) }), z.undefined()]).prefault(undefined),"));
+    assert!(zod_schema.contains("parent_id: z.union([z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: \"Invalid ObjectId\" }) }), z.undefined()]).prefault(undefined),"));
 }
 
 #[test]
@@ -483,7 +483,7 @@ fn test_optional_object_id() {
 
     // Zod schema should use the MongoDB ObjectId structure with regex validation - now in separate method
     let zod_schema = UserWithOptionalId::zod_schema();
-    assert!(zod_schema.contains("id: z.union([z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: \"Invalid ObjectId\" }) }), z.undefined()]).prefault(undefined),"));
+    assert!(zod_schema.contains("id: z.union([z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: \"Invalid ObjectId\" }) }), z.undefined()]).prefault(undefined),"));
     assert!(zod_schema.contains("name: z.string(),"));
     assert!(zod_schema.contains("email: z.string(),"));
 }
@@ -494,7 +494,7 @@ fn test_optional_object_id_zod_schema() {
     let zod_schema = UserWithOptionalId::zod_schema();
 
     // Should handle optional ObjectId correctly
-    assert!(zod_schema.contains("id: z.union([z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/i, { message: \"Invalid ObjectId\" }) }), z.undefined()]).prefault(undefined),"));
+    assert!(zod_schema.contains("id: z.union([z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: \"Invalid ObjectId\" }) }), z.undefined()]).prefault(undefined),"));
     assert!(zod_schema.contains("name: z.string(),"));
     assert!(zod_schema.contains("email: z.string(),"));
 }


### PR DESCRIPTION
The `$oid` hex was written once but read under two case rules: the Zod literal spliced the shared constant under `/i` while the JSON Schema `pattern` keyword — a flagless ECMA-262 regex with nowhere to hold a flag — read it case-sensitively, so 24 upper-case hex characters validated on one surface and failed on the other. The `i` is dropped: both surfaces now constrain `$oid` by case-sensitive lower-case hex, the only form `ObjectId::to_hex()` writes, and the one case rule agreement can come from is the source spelling both splice.

A test parses the emitted Zod literal into source and flags, asserts the source is the shared constant with an empty flag set, and holds both surfaces to one verdict over the recorded haystacks (an unrecorded flag stops the test rather than being dropped). A round-trip pins a real ObjectId's written hex against both generated surfaces. This also removes the asymmetry where authors are refused `(?i)` on every surface while the crate granted itself case-insensitivity on exactly one.