### PR TITLE
emit the str call a trivial pattern says the same thing as, instead of a regex the consumer's clippy refuses

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -44,6 +44,9 @@ use crate::features::object_id::get_object_id_zod_schema_with;
 use crate::utils::{AliasKind, lookup_alias_info, portable_pattern};
 
 #[cfg(feature = "serde")]
+use crate::utils::{TrivialPattern, trivial_pattern};
+
+#[cfg(feature = "serde")]
 use crate::features::serde::{SerdeFieldMeta, SerdeTypeMeta, has_serde_default};
 
 #[cfg(feature = "serde")]
@@ -2138,21 +2141,15 @@ fn build_branded_validation(
             });
         }
         if let Some(pattern) = &args.pattern {
-            let pattern_lit = pattern.clone();
-            checks.push(quote! {
-                {
-                    use std::sync::LazyLock;
-                    static RE: LazyLock<regex::Regex> = LazyLock::new(|| {
-                        regex::Regex::new(#pattern_lit).unwrap()
-                    });
-                    if !RE.is_match(value) {
-                        return Err(format!(
-                            "value does not match pattern '{}'",
-                            #pattern_lit
-                        ));
-                    }
-                }
-            });
+            checks.push(pattern_check(
+                pattern,
+                &quote! {
+                    return Err(format!(
+                        "value does not match pattern '{}'",
+                        #pattern
+                    ));
+                },
+            ));
         }
 
         let validate_fn = quote! {
@@ -7026,6 +7023,78 @@ fn helper_name_stem(field_ident: &str, variant_ident: Option<&str>) -> String {
     )
 }
 
+/// The check a `pattern` constraint holds `value` to, taking `failure` where the value is turned
+/// away.
+///
+/// A pattern that a regex engine is avoidable work for — see [`crate::utils::trivial_pattern`] for
+/// which those are — is emitted as the `str` call it says the same thing as, because the
+/// `regex::Regex::new` otherwise emitted here lands in the consumer's crate, where
+/// `clippy::trivial_regex` reports it against a `#[model_schema]` attribute that has no edit
+/// available to answer it. Everything else keeps the regex, built once per process.
+///
+/// `failure` is spliced in unchanged either way: the two paths turn away the same values, and say
+/// the same words about the pattern as written when they do.
+#[cfg(feature = "serde")]
+fn pattern_check(pattern: &str, failure: &proc_macro2::TokenStream) -> proc_macro2::TokenStream {
+    trivial_pattern(pattern).map_or_else(
+        || {
+            quote! {
+                {
+                    use std::sync::LazyLock;
+                    static RE: LazyLock<regex::Regex> = LazyLock::new(|| {
+                        regex::Regex::new(#pattern).unwrap()
+                    });
+                    if !RE.is_match(value) {
+                        #failure
+                    }
+                }
+            }
+        },
+        |trivial| {
+            let turned_away = pattern_rejects(&trivial);
+            quote! {
+                if #turned_away {
+                    #failure
+                }
+            }
+        },
+    )
+}
+
+/// The condition under which a trivial pattern turns `value` away — the negation of what it
+/// accepts, which is the form the emitted check reads it in.
+#[cfg(feature = "serde")]
+fn pattern_rejects(trivial: &TrivialPattern) -> proc_macro2::TokenStream {
+    match trivial {
+        TrivialPattern::IsEmpty => quote! { !value.is_empty() },
+        TrivialPattern::Equals(needle) => quote! { value != #needle },
+        TrivialPattern::StartsWith(needle) => {
+            let sought = needle_pattern(needle);
+            quote! { !value.starts_with(#sought) }
+        }
+        TrivialPattern::EndsWith(needle) => {
+            let sought = needle_pattern(needle);
+            quote! { !value.ends_with(#sought) }
+        }
+        TrivialPattern::Contains(needle) => {
+            let sought = needle_pattern(needle);
+            quote! { !value.contains(#sought) }
+        }
+    }
+}
+
+/// A needle in the spelling the `str` pattern methods want it where the call is written into a
+/// crate that denies `clippy::single_char_pattern`: one character as a `char`, anything else as
+/// the string it is. Both name the same pattern to the same method.
+#[cfg(feature = "serde")]
+fn needle_pattern(needle: &str) -> proc_macro2::TokenStream {
+    let mut chars = needle.chars();
+    if let (Some(only), None) = (chars.next(), chars.next()) {
+        return quote! { #only };
+    }
+    quote! { #needle }
+}
+
 /// The parameter a string validator takes and the rendering its checks read `value` from.
 ///
 /// A path is the one leaf the checks cannot be handed as-is: it arrives borrowed — the form every
@@ -7104,21 +7173,15 @@ fn generate_string_validation_code(
     }
 
     if let Some(pattern) = &meta.pattern {
-        let pattern_lit = pattern.clone();
-        checks.push(quote! {
-            {
-                use std::sync::LazyLock;
-                static RE: LazyLock<regex::Regex> = LazyLock::new(|| {
-                    regex::Regex::new(#pattern_lit).unwrap()
-                });
-                if !RE.is_match(value) {
-                    return Err(format!(
-                        "'{}' does not match pattern '{}'",
-                        #field_name_lit, #pattern_lit
-                    ));
-                }
-            }
-        });
+        checks.push(pattern_check(
+            pattern,
+            &quote! {
+                return Err(format!(
+                    "'{}' does not match pattern '{}'",
+                    #field_name_lit, #pattern
+                ));
+            },
+        ));
     }
 
     let deserializer = if wraps.is_empty() {

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -4596,6 +4596,27 @@ fn emitted_string_module(spelling: &str) -> String {
     .to_string()
 }
 
+/// The validator emitted for a `String` field constrained by `pattern`, as tokens — everything the
+/// schema module holds ahead of the deserializer.
+#[cfg(feature = "serde")]
+fn emitted_pattern_validator(pattern: &str) -> String {
+    let ty: syn::Type = syn::parse_str("String").unwrap();
+    let meta = ModelSchemaPropMeta {
+        pattern: Some(pattern.to_owned()),
+        ..ModelSchemaPropMeta::default()
+    };
+    let module = generate_string_validation_code(
+        "field",
+        &helper_name_stem("field", None),
+        &meta,
+        &constrained_shape(&ty).unwrap(),
+        &ty,
+    )
+    .module_items
+    .to_string();
+    module[..module.find("pub fn deserialize_field").unwrap()].to_owned()
+}
+
 /// Just the deserializer of [`emitted_string_module`], which is everything after the validator.
 #[cfg(feature = "serde")]
 fn emitted_string_deserializer(spelling: &str) -> String {
@@ -5030,5 +5051,42 @@ fn a_wrapped_path_field_deserializes_its_declared_type() {
     assert_eq!(
         emitted_string_deserializer("Box<Path>"),
         emitted_string_deserializer("Box<str>").replace("Box < str >", "Box < Path >")
+    );
+}
+
+/// A `pattern` a regex engine is avoidable work for is emitted as the `str` call
+/// `clippy::trivial_regex` names for it, with a one-character needle as a `char` so the emitted
+/// call also answers `clippy::single_char_pattern`. Both lints are denied by the crates this code
+/// is written into, and neither has an edit available at the `#[model_schema]` attribute the
+/// diagnostic lands on.
+#[cfg(feature = "serde")]
+#[test]
+fn a_trivial_pattern_is_emitted_as_the_call_it_says_the_same_thing_as() {
+    assert_eq!(
+        emitted_pattern_validator("^/"),
+        "pub fn validate_field_value (value : & str) -> Result < () , String > \
+         { if ! value . starts_with ('/') { \
+         return Err (format ! (\"'{}' does not match pattern '{}'\" , \"field\" , \"^/\")) ; } Ok (()) } "
+    );
+    assert_eq!(
+        emitted_pattern_validator("^abc$"),
+        "pub fn validate_field_value (value : & str) -> Result < () , String > \
+         { if value != \"abc\" { \
+         return Err (format ! (\"'{}' does not match pattern '{}'\" , \"field\" , \"^abc$\")) ; } Ok (()) } "
+    );
+}
+
+/// A `pattern` of any real shape keeps the regex it has always been checked by, built once per
+/// process, and the words it is turned away with do not move either way.
+#[cfg(feature = "serde")]
+#[test]
+fn a_pattern_of_any_real_shape_keeps_its_regex() {
+    assert_eq!(
+        emitted_pattern_validator("^[a-z]+$"),
+        "pub fn validate_field_value (value : & str) -> Result < () , String > \
+         { { use std :: sync :: LazyLock ; \
+         static RE : LazyLock < regex :: Regex > = LazyLock :: new (|| { regex :: Regex :: new (\"^[a-z]+$\") . unwrap () }) ; \
+         if ! RE . is_match (value) { \
+         return Err (format ! (\"'{}' does not match pattern '{}'\" , \"field\" , \"^[a-z]+$\")) ; } } Ok (()) } "
     );
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,11 +1,15 @@
 use core::cell::RefCell;
 use core::ops::Range;
+#[cfg(feature = "serde")]
+use core::slice::from_ref;
 use regex_syntax::ast::parse::Parser as PatternParser;
 use regex_syntax::ast::{
     Assertion, AssertionKind, Ast, ClassPerl, ClassPerlKind, ClassSet, ClassSetBinaryOpKind,
     ClassSetItem, Flag, FlagsItemKind, Group, GroupKind, HexLiteralKind, Literal, LiteralKind,
     SpecialLiteralKind,
 };
+#[cfg(feature = "serde")]
+use regex_syntax::hir;
 use std::collections::HashMap;
 use syn::{Attribute, Expr, Field, Lit, LitStr, Meta, Variant};
 
@@ -101,6 +105,27 @@ pub enum AliasKind {
     Stringified,
     /// Undecidable at this expansion — an alias naming a type that was not registered before it.
     Unknown,
+}
+
+/// The `str` method call a `pattern` says the same thing as, for the patterns a regex engine is
+/// avoidable work for.
+///
+/// Each variant carries the needle in the spelling the check takes it, which is the literal the
+/// pattern's own escapes already resolved to and not the pattern text: `^foo\.bar` starts with
+/// `foo.bar`, five bytes shorter than what was written.
+#[cfg(feature = "serde")]
+#[derive(Debug, PartialEq, Eq)]
+pub enum TrivialPattern {
+    /// `abc` -- the value has this string somewhere in it.
+    Contains(String),
+    /// `abc$` -- the value ends with this string.
+    EndsWith(String),
+    /// `^abc$` -- the value is this string.
+    Equals(String),
+    /// `^$` -- the value is the empty string.
+    IsEmpty,
+    /// `^abc` -- the value begins with this string.
+    StartsWith(String),
 }
 
 #[derive(Clone)]
@@ -883,6 +908,104 @@ fn js_spelling(pattern: &str) -> Result<String, String> {
         });
     }
     Ok(walk.rewritten(pattern))
+}
+
+/// What a `pattern` accepts stated without a regex, for exactly the patterns
+/// `clippy::trivial_regex` proves one is unnecessary for -- and `None` for every other pattern,
+/// which keeps its `regex::Regex` and is the only thing that reads a pattern of any real shape.
+///
+/// The lint is right, and it is the consumer who pays for being wrong: the `Regex::new` it fires
+/// on is written by this crate into the consumer's crate, so the diagnostic lands on their
+/// `#[model_schema]` attribute with no edit available at that site. Answering it means emitting
+/// the call it asks for, and the emitted call has to accept and reject the same values the regex
+/// did, byte for byte, or a pattern would mean one thing in a consumer denying the lint and
+/// another in one that does not.
+///
+/// So the classification is clippy's own, read off `clippy_lints/src/regex.rs::is_trivial_regex`
+/// (rust-lang/rust-clippy) and mirrored arm for arm: a bare literal, and a concatenation whose
+/// only non-literal parts are a leading `^`, a trailing `$`, or both. It is deliberately no wider
+/// than that. A shape the lint does not name is left on the regex path, where it costs nothing;
+/// a shape misread as trivial would silently change which values a constraint admits.
+///
+/// The two shapes the lint calls trivial and offers no replacement for -- a pattern that matches
+/// everything (`""`, `^`, `$`), and one whose alternatives are all empty (`|`) -- are not
+/// classified here: there is no call to emit for them, only the absence of a check.
+///
+/// The HIR walked is the one the lint reads, parsed with the options it parses with, so what is
+/// classified here is what it classifies. Anchors are the whole-haystack `Look::Start` and
+/// `Look::End` alone -- the line anchors `(?m)` turns those into never reach this crate, since
+/// [`portable_pattern`] refuses an inline flag before a pattern is ever emitted.
+#[cfg(feature = "serde")]
+pub fn trivial_pattern(pattern: &str) -> Option<TrivialPattern> {
+    let parsed = regex_syntax::ParserBuilder::new()
+        .unicode(true)
+        .utf8(true)
+        .build()
+        .parse(pattern)
+        .ok()?;
+    match parsed.kind() {
+        hir::HirKind::Literal(_) => literal_needle(from_ref(&parsed)).map(TrivialPattern::Contains),
+        hir::HirKind::Concat(parts) => trivial_concat(parts),
+        hir::HirKind::Empty
+        | hir::HirKind::Class(_)
+        | hir::HirKind::Look(_)
+        | hir::HirKind::Repetition(_)
+        | hir::HirKind::Capture(_)
+        | hir::HirKind::Alternation(_) => None,
+    }
+}
+
+/// A concatenation's equivalent check, decided by what sits at its two ends.
+///
+/// The arms are in the lint's order, and the fall-through it relies on is not reachable from any
+/// of them: a concatenation that starts or ends with an anchor holds something that is not a
+/// literal, so the all-literals reading is already ruled out by the time an anchored arm's needle
+/// comes back missing.
+#[cfg(feature = "serde")]
+fn trivial_concat(parts: &[hir::Hir]) -> Option<TrivialPattern> {
+    let opens_at_text_start = is_anchor(parts.first()?, hir::Look::Start);
+    let closes_at_text_end = is_anchor(parts.last()?, hir::Look::End);
+    let inner = parts.get(1..parts.len() - 1).unwrap_or_default();
+
+    if opens_at_text_start && closes_at_text_end {
+        if inner.is_empty() {
+            return Some(TrivialPattern::IsEmpty);
+        }
+        return literal_needle(inner).map(TrivialPattern::Equals);
+    }
+    if opens_at_text_start && matches!(*parts.last()?.kind(), hir::HirKind::Literal(_)) {
+        return literal_needle(&parts[1..]).map(TrivialPattern::StartsWith);
+    }
+    if closes_at_text_end && matches!(*parts.first()?.kind(), hir::HirKind::Literal(_)) {
+        return literal_needle(&parts[..parts.len() - 1]).map(TrivialPattern::EndsWith);
+    }
+    literal_needle(parts).map(TrivialPattern::Contains)
+}
+
+/// Whether one part of a concatenation is the given whole-haystack anchor.
+#[cfg(feature = "serde")]
+fn is_anchor(part: &hir::Hir, anchor: hir::Look) -> bool {
+    matches!(*part.kind(), hir::HirKind::Look(look) if look == anchor)
+}
+
+/// The non-empty `str` a run of parts spells, or `None` where any of them is not a literal.
+///
+/// An empty needle would name a check that always passes, which is a different statement than any
+/// of these variants makes; bytes that are not UTF-8 name no `str` at all. Neither is reachable
+/// through a `pattern` parsed in UTF-8 mode, and both keep the regex rather than guess.
+#[cfg(feature = "serde")]
+fn literal_needle(parts: &[hir::Hir]) -> Option<String> {
+    let mut bytes: Vec<u8> = Vec::new();
+    for part in parts {
+        let hir::HirKind::Literal(hir::Literal(run)) = part.kind() else {
+            return None;
+        };
+        bytes.extend_from_slice(run);
+    }
+    if bytes.is_empty() {
+        return None;
+    }
+    String::from_utf8(bytes).ok()
 }
 
 /// Escapes a regex pattern for splicing between the `/` delimiters of a JavaScript regex literal.

--- a/src/utils/tests.rs
+++ b/src/utils/tests.rs
@@ -271,6 +271,89 @@ const EQUALISED_PATTERNS: [(&str, &str); 10] = [
     (r"^\d{3}\.\d{3}-\d{2}$", r"^[0-9]{3}\.[0-9]{3}-[0-9]{2}$"),
 ];
 
+#[cfg(feature = "serde")]
+/// Patterns a regex engine is avoidable work for, in every shape `clippy::trivial_regex` proves
+/// one is — a bare literal, and a literal run under a leading `^`, a trailing `$`, or both.
+const TRIVIAL_PATTERNS: [&str; 10] = [
+    "^/",
+    "^abc",
+    r"^foo\.bar",
+    "^\u{e9}",
+    "abc$",
+    "/$",
+    "^abc$",
+    "^/$",
+    "^$",
+    "abc",
+];
+
+#[cfg(feature = "serde")]
+/// Patterns that keep their regex. The first eight are the shapes the shipped tests and the
+/// reports write; the rest are the near misses — a literal with one non-literal part in it, and
+/// the constructs whose trivial reading the lint offers no call for and this crate therefore
+/// declines to make one up for.
+const NON_TRIVIAL_PATTERNS: [&str; 16] = [
+    "^[a-z]+$",
+    "^/[a-z]+$",
+    "^[0-9a-fA-F]{24}$",
+    "^[a-z0-9_]+$",
+    r"^\s*$",
+    "(?<word>[a-z]+)",
+    r"^[0-9]{3}\.[0-9]{3}-[0-9]{2}$",
+    "^[a-z]+",
+    "^a[0-9]",
+    "[0-9]a$",
+    "^a[0-9]b$",
+    "",
+    "^",
+    "$",
+    r"\b",
+    "a|b",
+];
+
+#[cfg(feature = "serde")]
+/// The haystacks a classified pattern is held to, in the two senses that matter: every character
+/// the equalised classes are compared over, and the strings the rewrite tests use, which carry the
+/// delimiters and the near-miss prefixes a `^/` sort of pattern turns on.
+fn trivial_haystacks() -> Vec<String> {
+    CROSS_ENGINE_HAYSTACKS
+        .iter()
+        .chain(REWRITE_HAYSTACKS.iter())
+        .map(|haystack| (*haystack).to_owned())
+        .chain(
+            [
+                "/",
+                "/var",
+                "var/",
+                "/var/log",
+                "abc",
+                "xabc",
+                "abcx",
+                "xabcx",
+                "foo.bar",
+                "fooxbar",
+                "\u{e9}t\u{e9}",
+                "t\u{e9}",
+            ]
+            .into_iter()
+            .map(str::to_owned),
+        )
+        .collect()
+}
+
+#[cfg(feature = "serde")]
+/// What a classified pattern says about one haystack — the verdict the emitted call reaches,
+/// reached here instead so it can be held against the regex the call replaced.
+fn accepts(trivial: &TrivialPattern, haystack: &str) -> bool {
+    match trivial {
+        TrivialPattern::Contains(needle) => haystack.contains(needle),
+        TrivialPattern::EndsWith(needle) => haystack.ends_with(needle),
+        TrivialPattern::Equals(needle) => haystack == needle,
+        TrivialPattern::IsEmpty => haystack.is_empty(),
+        TrivialPattern::StartsWith(needle) => haystack.starts_with(needle),
+    }
+}
+
 #[cfg(feature = "zod")]
 #[test]
 fn test_extract_example_simple() {
@@ -819,5 +902,72 @@ fn test_portable_pattern_quotes_the_regex_crate_on_a_pattern_it_refuses() {
         "panic",
     ] {
         assert!(rejection.contains(needle), "{needle} missing: {rejection}");
+    }
+}
+
+#[cfg(feature = "serde")]
+/// Every shape the lint proves a regex is avoidable work for is classified as the call the lint
+/// names for it, with the needle the pattern's own escapes resolve to.
+#[test]
+fn test_trivial_pattern_names_the_call_the_lint_names() {
+    let expected = [
+        ("^/", TrivialPattern::StartsWith("/".to_owned())),
+        ("^abc", TrivialPattern::StartsWith("abc".to_owned())),
+        (
+            r"^foo\.bar",
+            TrivialPattern::StartsWith("foo.bar".to_owned()),
+        ),
+        ("^\u{e9}", TrivialPattern::StartsWith("\u{e9}".to_owned())),
+        ("abc$", TrivialPattern::EndsWith("abc".to_owned())),
+        ("/$", TrivialPattern::EndsWith("/".to_owned())),
+        ("^abc$", TrivialPattern::Equals("abc".to_owned())),
+        ("^/$", TrivialPattern::Equals("/".to_owned())),
+        ("^$", TrivialPattern::IsEmpty),
+        ("abc", TrivialPattern::Contains("abc".to_owned())),
+    ];
+    assert_eq!(
+        expected.len(),
+        TRIVIAL_PATTERNS.len(),
+        "every classified pattern needs the call it is classified as written down"
+    );
+    for (pattern, call) in expected {
+        assert_eq!(
+            trivial_pattern(pattern),
+            Some(call),
+            "{pattern} was not classified as the call the lint names for it"
+        );
+    }
+}
+
+#[cfg(feature = "serde")]
+/// A pattern of any real shape keeps its regex, and so do the two the lint calls trivial without
+/// naming a call: what a wrong reading would cost is a constraint that admits a different set of
+/// values than it was written to, and there is nothing to gain by guessing at one.
+#[test]
+fn test_trivial_pattern_leaves_every_other_pattern_its_regex() {
+    for pattern in NON_TRIVIAL_PATTERNS {
+        assert!(
+            trivial_pattern(pattern).is_none(),
+            "{pattern} was classified as trivial and is not"
+        );
+    }
+}
+
+#[cfg(feature = "serde")]
+/// The classified call and the regex it replaces accept the same haystacks and reject the same
+/// haystacks — which is the whole of what a `pattern` constraint says.
+#[test]
+fn test_trivial_pattern_accepts_exactly_what_its_regex_accepts() {
+    let haystacks = trivial_haystacks();
+    for pattern in TRIVIAL_PATTERNS {
+        let trivial = trivial_pattern(pattern).unwrap();
+        let regex = regex::Regex::new(pattern).unwrap();
+        for haystack in &haystacks {
+            assert_eq!(
+                accepts(&trivial, haystack),
+                regex.is_match(haystack),
+                "{pattern} and the call it was classified as part ways over {haystack:?}"
+            );
+        }
     }
 }

--- a/src/utils/tests.rs
+++ b/src/utils/tests.rs
@@ -318,6 +318,28 @@ const NON_TRIVIAL_PATTERNS: [&str; 16] = [
     "a|b",
 ];
 
+/// The negated classes the verdict was decided over: a single member, the ranges an author reaches
+/// for to bound one to ASCII, an escape, and the `\d` the guard writes out to `0-9` on its way in.
+/// The last is the one that shows rewriting cannot help — its members come out ASCII and the
+/// complement is still taken two different ways.
+const NEGATED_CLASS_PATTERNS: [&str; 6] = [
+    "^[^a]$",
+    "^[^0-9]$",
+    r"^[^\n]$",
+    "^[^a-z]$",
+    r"^[^\x00-\x7F]$",
+    r"^[^\d]$",
+];
+
+/// Every regex this crate writes into a generated schema itself, rather than carrying over from an
+/// author's `pattern`.
+///
+/// An author's pattern reaches the three surfaces through the guard, which equalises what it can
+/// and refuses the rest. One the crate writes reaches them directly, so without this list there
+/// are two contracts and only one of them is enforced.
+#[cfg(feature = "object_id")]
+const CRATE_EMITTED_PATTERNS: [&str; 1] = [OBJECT_ID_HEX_PATTERN];
+
 #[cfg(feature = "serde")]
 /// The haystacks a classified pattern is held to, in the two senses that matter: every character
 /// the equalised classes are compared over, and the strings the rewrite tests use, which carry the
@@ -360,28 +382,6 @@ fn accepts(trivial: &TrivialPattern, haystack: &str) -> bool {
         TrivialPattern::StartsWith(needle) => haystack.starts_with(needle),
     }
 }
-
-/// The negated classes the verdict was decided over: a single member, the ranges an author reaches
-/// for to bound one to ASCII, an escape, and the `\d` the guard writes out to `0-9` on its way in.
-/// The last is the one that shows rewriting cannot help — its members come out ASCII and the
-/// complement is still taken two different ways.
-const NEGATED_CLASS_PATTERNS: [&str; 6] = [
-    "^[^a]$",
-    "^[^0-9]$",
-    r"^[^\n]$",
-    "^[^a-z]$",
-    r"^[^\x00-\x7F]$",
-    r"^[^\d]$",
-];
-
-/// Every regex this crate writes into a generated schema itself, rather than carrying over from an
-/// author's `pattern`.
-///
-/// An author's pattern reaches the three surfaces through the guard, which equalises what it can
-/// and refuses the rest. One the crate writes reaches them directly, so without this list there
-/// are two contracts and only one of them is enforced.
-#[cfg(feature = "object_id")]
-const CRATE_EMITTED_PATTERNS: [&str; 1] = [OBJECT_ID_HEX_PATTERN];
 
 #[cfg(feature = "zod")]
 #[test]

--- a/tests/branded_newtype_tests/tests.rs
+++ b/tests/branded_newtype_tests/tests.rs
@@ -197,6 +197,14 @@ mod constrained_branded_tests {
     #[serde(transparent)]
     pub struct SlugId(pub String);
 
+    /// A pattern simple enough that a regex engine is avoidable work — the brand-side spelling of
+    /// what a consumer denying `clippy::nursery` cannot compile if the validator builds a regex
+    /// for it anyway.
+    #[model_schema(pattern = "^/")]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct MountPath(pub String);
+
     #[test]
     fn test_constrained_branded_zod_has_constraints() {
         let zod = SlugId::zod_schema();
@@ -270,6 +278,35 @@ mod constrained_branded_tests {
         let result: Result<SlugId, _> = serde_json::from_str("\"hello_world\"");
         assert!(result.is_ok(), "Should accept valid value via serde");
         assert_eq!(result.unwrap(), SlugId("hello_world".to_owned()));
+    }
+
+    /// The brand's simple pattern turns away the same values the regex would have, with the same
+    /// words, and still reaches every surface as written.
+    #[test]
+    fn test_anchored_single_character_prefix_branded() {
+        let zod = MountPath::zod_schema();
+        assert!(
+            zod.contains(".check(z.regex(/^\\//))"),
+            "Should contain pattern. Got:\n{zod}"
+        );
+
+        MountPath("/var/log".to_owned()).validate().unwrap();
+
+        let result = MountPath("var/log".to_owned()).validate();
+        assert_eq!(
+            result.unwrap_err()[0],
+            "value does not match pattern '^/'",
+            "Rejection should read exactly as the regex path words it"
+        );
+
+        assert!(
+            serde_json::from_str::<MountPath>("\"/etc\"").is_ok(),
+            "Should accept a rooted path via serde"
+        );
+        assert!(
+            serde_json::from_str::<MountPath>("\"etc\"").is_err(),
+            "Should reject an unrooted path via serde"
+        );
     }
 
     #[test]

--- a/tests/validation_tests/tests.rs
+++ b/tests/validation_tests/tests.rs
@@ -1146,6 +1146,45 @@ fn test_pattern_empty_string_match() {
     );
 }
 
+/// A pattern simple enough that a regex engine is avoidable work — the shape a consumer denying
+/// `clippy::nursery` cannot compile if the validator reaches for `Regex::new` anyway, since the
+/// diagnostic lands on the attribute and there is no edit at that site to silence it.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn test_pattern_anchored_single_character_prefix() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug)]
+    pub struct PatternRootedPath {
+        #[model_schema_prop(pattern = "^/")]
+        pub mount: String,
+    }
+
+    let accepted = PatternRootedPath {
+        mount: "/var/log".to_owned(),
+    };
+    assert!(
+        accepted.validate().is_ok(),
+        "A value starting with '/' should match pattern '^/'"
+    );
+
+    let rejected = PatternRootedPath {
+        mount: "var/log".to_owned(),
+    };
+    let result = rejected.validate();
+    assert!(
+        result.is_err(),
+        "A value not starting with '/' should not match pattern '^/'"
+    );
+    let errors = result.unwrap_err();
+    assert_eq!(
+        errors[0], "'mount' does not match pattern '^/'",
+        "Rejection should read exactly as the regex path words it: {errors:?}"
+    );
+}
+
 // ==================== Constraints under Option / wrappers / sequences ====================
 
 #[cfg(all(


### PR DESCRIPTION
A `pattern` constraint always emitted `regex::Regex::new` into the consumer's crate, where `clippy::trivial_regex` fires on simple patterns and blames a `#[model_schema]` attribute the consumer cannot edit. A classifier mirroring clippy's own `is_trivial_regex` (same regex-syntax parse, HIR matched arm for arm) now routes the shapes clippy proves trivial to the `str` call it names — `contains`, `starts_with`, `ends_with`, equality, `is_empty` — with a one-character needle emitted as a `char` so `clippy::single_char_pattern` is satisfied too.

One shared `pattern_check` serves both call sites (field validators and branded validation), replacing two copies of the `LazyLock<regex::Regex>` block; the rejection arm is spliced unchanged so both paths turn away the same values in the same words, pinned at token level and by a 44-haystack verdict-agreement sweep. Shapes clippy calls trivial while naming no replacement (``, `^`, `$`, `|`, `\b`) deliberately keep the regex; their emission decision is a separate question. Everything non-trivial keeps the regex byte-identically.