### PR TITLE
publish the enum-level validate() the members' own checks already earn, and pin the untagged error sentence

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,7 +580,26 @@ z.union([z.strictObject({ x: z.string(), }), z.strictObject({ y: z.number().int(
 
 Untagged enums compose with `#[serde(flatten)]`: a flattened variant carrying `Vec<DateValue>` renders `sampleValues: z.array(DateValue$Schema)` (TypeScript `Array<DateValue>`), and the JSON-schema `items` for that field is the `DateValue` `anyOf`.
 
-A member of an untagged variant carries `#[model_schema_prop(...)]` exactly as the same field written in a tagged variant does: the constraint reaches the Zod schema and the JSON Schema, and every guard the attribute earns is reported at the member. The one difference is the Rust side -- an untagged enum generates no per-field validators, so a constrained member has no `validate()` contribution and no deserialization check.
+A member of an untagged variant carries `#[model_schema_prop(...)]` exactly as the same field written in a tagged variant does: the constraint reaches the Zod schema, the JSON Schema and the Rust side alike -- the same per-member validator, the same `deserialize_with` hook, and the same [`validate()` accessor](#the-validate-method) -- and every guard the attribute earns is reported at the member.
+
+What differs is the position, and it costs the read its diagnosis. Serde tries an untagged enum's variants in declaration order, and a member whose bound fails takes its variant out of the candidate set rather than ending the read -- which is exactly what the same declaration means under `anyOf` and under `z.union`. So a value the bound rejects lands on the next variant that accepts it, and when none does, serde's derived `Deserialize` has already discarded each candidate's own error and answers with one sentence of its own:
+
+```rust
+#[model_schema()]
+#[derive(Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum SoleConstrained {
+    Slug {
+        #[model_schema_prop(minLength = 2)]
+        slug: String,
+    },
+}
+
+let refused = serde_json::from_str::<SoleConstrained>(r#"{"slug":"A"}"#).unwrap_err();
+assert_eq!(refused.to_string(), "data did not match any variant of untagged enum SoleConstrained");
+```
+
+The tagged twin of that declaration reads back `'slug' is too short: minimum length is 2, got 1`, because its tag names the variant before its members are read. To learn which bound refused an untagged value, ask a surface that answers per member rather than per variant: validate the payload against the generated Zod schema or JSON Schema for a diagnosable verdict, or -- once the value is in hand -- call the enum's `validate()`, or the schema module's `validate_{variant}_{member}_value` directly.
 
 **Unsupported variants:** unit variants and multi-field tuple variants in an untagged enum produce a compile-time error.
 
@@ -1085,6 +1104,34 @@ The macro also generates into the type's schema module:
 - `deserialize_{field}(D) -> Result<FieldType, E>` -- serde hook that calls the static validator
 
 A constrained field of an enum variant is named for its variant too -- `validate_{variant}_{field}_value` and `deserialize_{variant}_{field}`, with `{variant}` in `snake_case`. One schema module holds every variant's helpers, and a field name is unique only within the variant that declares it, so two variants naming one field carry their own constraints.
+
+An enum whose members carry constraints publishes the same `validate(&self) -> Result<(), Vec<String>>`, under every tagging serde offers (externally, internally and adjacently tagged, and `#[serde(untagged)]`). A value holds one variant at a time, so the check runs that variant's members and no other's, collecting every violation in the words a struct's field is answered in:
+
+```rust
+#[model_schema()]
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "kind")]
+pub enum Action {
+    Delete {
+        #[model_schema_prop(minLength = 5)]
+        note: String,
+    },
+    Upload {
+        #[model_schema_prop(minLength = 3)]
+        note: String,
+    },
+}
+
+let deleting = Action::Delete { note: "abc".to_string() };
+assert_eq!(
+    deleting.validate().unwrap_err(),
+    vec!["'note' is too short: minimum length is 5, got 3".to_string()],
+);
+// The same value read as an `Upload` is held to that variant's own minimum, and passes.
+assert!(Action::Upload { note: "abc".to_string() }.validate().is_ok());
+```
+
+Parity with structs runs both ways: an enum no member of which carries a constraint publishes no `validate()`, exactly as a constraint-free struct publishes none.
 
 #### Constraints under `Option`, wrappers, and sequences
 

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -131,8 +131,9 @@ struct DiscriminatedVariant {
     kind: VariantKind,
 }
 
-/// Per-variant data collected from a discriminated enum, plus the collected serde validators and
-/// the `compile_error!` tokens for any field-level guard violations.
+/// Per-variant data collected from a discriminated enum, plus the collected serde validators, the
+/// `compile_error!` tokens for any field-level guard violations, and the `validate()` match arms,
+/// empty where no variant carries a constrained member and there is nothing to aggregate.
 ///
 /// The variants are a sequence, not a map: their order is the enum's declaration order and it
 /// reaches the emitted output verbatim (JSON-schema `oneOf`, the TypeScript union, the Zod
@@ -140,6 +141,7 @@ struct DiscriminatedVariant {
 /// build.
 type DiscriminatedVariantData = (
     Vec<DiscriminatedVariant>,
+    Vec<proc_macro2::TokenStream>,
     Vec<proc_macro2::TokenStream>,
     Vec<proc_macro2::TokenStream>,
 );
@@ -154,11 +156,13 @@ type RenderedVariants = (
 
 /// Per-member data collected from an untagged enum: the TypeScript member types, the Zod member
 /// schemas, the JSON-schema value tokens, the `compile_error!` tokens for any field-level guard
-/// violations, and the per-member serde validation functions.
+/// violations, the per-member serde validation functions, and the `validate()` match arms those
+/// functions are run from.
 #[cfg(feature = "serde")]
 type UntaggedMemberData = (
     Vec<String>,
     Vec<String>,
+    Vec<proc_macro2::TokenStream>,
     Vec<proc_macro2::TokenStream>,
     Vec<proc_macro2::TokenStream>,
     Vec<proc_macro2::TokenStream>,
@@ -295,6 +299,18 @@ enum ConstraintLeaf {
 enum CheckSink {
     Collect,
     Fail,
+}
+
+/// How the body that checks a constrained member reaches the value.
+///
+/// A struct's field is read off `self`, which is what `validate()` is called on. A variant's member
+/// is not reachable that way — the value only names it once the arm that matched the variant has
+/// bound it — so the check reads the binding the arm introduced.
+#[cfg(feature = "serde")]
+#[derive(Clone, Copy)]
+enum MemberAccess {
+    SelfField,
+    VariantBinding,
 }
 
 /// A wrapper a constrained field can be written under, outermost first.
@@ -1006,6 +1022,96 @@ fn build_struct_validate_method(
                 use #module_ident::*;
                 let mut errors: Vec<String> = Vec::new();
                 #(#validate_bodies)*
+                if errors.is_empty() { Ok(()) } else { Err(errors) }
+            }
+        }
+    })
+}
+
+/// The pattern one variant is matched by in the enum-level `validate()`.
+///
+/// Only the constrained members are bound, each under the name its check reads; everything else the
+/// variant holds is left unread, and a variant that binds every member it has needs no rest pattern
+/// to say so.
+fn variant_check_pattern(
+    variant_ident: &proc_macro2::Ident,
+    kind: &VariantKind,
+    total_fields: usize,
+    bound: &[(proc_macro2::Ident, proc_macro2::Ident)],
+) -> proc_macro2::TokenStream {
+    if bound.is_empty() {
+        return match *kind {
+            VariantKind::Unit => quote! { Self::#variant_ident },
+            VariantKind::TupleSingle | VariantKind::TupleMultiple => {
+                quote! { Self::#variant_ident(..) }
+            }
+            VariantKind::Named if total_fields == 0 => quote! { Self::#variant_ident {} },
+            VariantKind::Named => quote! { Self::#variant_ident { .. } },
+        };
+    }
+    let fields = bound.iter().map(|(field, _)| field);
+    let bindings = bound.iter().map(|(_, binding)| binding);
+    if bound.len() == total_fields {
+        quote! { Self::#variant_ident { #(#fields: #bindings),* } }
+    } else {
+        quote! { Self::#variant_ident { #(#fields: #bindings,)* .. } }
+    }
+}
+
+/// The match arms the enum-level `validate()` runs — empty when no variant carries a constrained
+/// member, which is the parity a constraint-free struct has: it publishes no `validate()` either.
+///
+/// Every variant is named, so the match stays exhaustive without a wildcard standing in for shapes
+/// the declaration already lists. The ones with nothing to check share a single arm: their bodies
+/// would be the same empty body written once per variant, which is the arm an or-pattern says in
+/// one place.
+fn build_member_check_arms(
+    per_variant: Vec<(proc_macro2::TokenStream, Vec<proc_macro2::TokenStream>)>,
+) -> Vec<proc_macro2::TokenStream> {
+    let mut arms: Vec<proc_macro2::TokenStream> = Vec::new();
+    let mut unchecked: Vec<proc_macro2::TokenStream> = Vec::new();
+    for (pattern, checks) in per_variant {
+        if checks.is_empty() {
+            unchecked.push(pattern);
+        } else {
+            arms.push(quote! { #pattern => { #(#checks)* } });
+        }
+    }
+    if arms.is_empty() {
+        return Vec::new();
+    }
+    if !unchecked.is_empty() {
+        arms.push(quote! { #(#unchecked)|* => {} });
+    }
+    arms
+}
+
+/// Builds the type-level `validate()` method for an enum, aggregating the checks of whichever
+/// variant the value holds, or `None` when no variant carries a constrained member.
+///
+/// The per-member validators are the ones a struct's fields already generate, so the enum's
+/// accessor answers in the same words for the same violation: what differs is only that a value
+/// carries one variant's members at a time, so the walk is a match rather than a straight run
+/// through every field.
+///
+/// The arms are built from what `serde`'s own attributes name, so without that feature there are
+/// none to aggregate and the gate here is the one every emitted `impl` item already sits under.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn build_enum_validate_method(
+    arms: &[proc_macro2::TokenStream],
+    module_ident: &Ident,
+) -> Option<proc_macro2::TokenStream> {
+    (!arms.is_empty()).then(|| {
+        quote! {
+            /// Validates all constrained fields and returns all validation errors.
+            ///
+            /// Returns `Ok(())` if all constraints pass, or `Err(Vec<String>)` with all errors.
+            pub fn validate(&self) -> Result<(), Vec<String>> {
+                use #module_ident::*;
+                let mut errors: Vec<String> = Vec::new();
+                match self {
+                    #(#arms),*
+                }
                 if errors.is_empty() { Ok(()) } else { Err(errors) }
             }
         }
@@ -3643,7 +3749,12 @@ fn process_plain_enum(
 }
 
 /// Processes each variant of a discriminated enum, returning per-variant field defs, doc strings,
-/// and variant kinds in declaration order, plus the collected serde validation functions.
+/// and variant kinds in declaration order, plus the collected serde validation functions and the
+/// `validate()` arms those functions are run from.
+///
+/// A member's check is generated here whatever the enum's tagging, so the accessor built from these
+/// arms exists on all three tagged flavors alike — the tag decides how the value is written, not
+/// which of its members carry a bound.
 fn collect_discriminated_variants(
     item_enum: &mut syn::ItemEnum,
     rename_all: Option<&str>,
@@ -3652,6 +3763,8 @@ fn collect_discriminated_variants(
     let mut variants: Vec<DiscriminatedVariant> = Vec::new();
     let mut enum_validation_fns: Vec<proc_macro2::TokenStream> = Vec::new();
     let mut guard_errors: Vec<proc_macro2::TokenStream> = Vec::new();
+    let mut per_variant_checks: Vec<(proc_macro2::TokenStream, Vec<proc_macro2::TokenStream>)> =
+        Vec::new();
     let enum_type_name = item_enum.ident.to_string();
 
     for item in &mut item_enum.variants {
@@ -3666,8 +3779,11 @@ fn collect_discriminated_variants(
         let variant_kind = classify_variant(item);
 
         let mut field_defs: Vec<FieldDef> = Vec::new();
+        let mut bound: Vec<(proc_macro2::Ident, proc_macro2::Ident)> = Vec::new();
+        let mut checks: Vec<proc_macro2::TokenStream> = Vec::new();
+        let total_fields = item.fields.len();
         for field in &mut item.fields {
-            let (f_def, validation_fn, _validate_body, field_guard_errors) = process_field(
+            let (f_def, validation_fn, validate_body, field_guard_errors) = process_field(
                 rename_all,
                 field,
                 enum_module_name_opt,
@@ -3677,9 +3793,20 @@ fn collect_discriminated_variants(
             if let Some(vfn) = validation_fn {
                 enum_validation_fns.push(vfn);
             }
+            // A constrained positional slot is refused by its own guard, so a member with a body to
+            // run is always one the arm can name.
+            if let (Some(body), Some(ident)) = (validate_body, field.ident.as_ref()) {
+                let binding = member_binding(ident);
+                bound.push((ident.clone(), binding));
+                checks.push(body);
+            }
             guard_errors.extend(field_guard_errors);
             field_defs.push(f_def);
         }
+        per_variant_checks.push((
+            variant_check_pattern(&item.ident, &variant_kind, total_fields, &bound),
+            checks,
+        ));
 
         let discriminator_docs = build_jsdoc_body(get_variant_docs(item).as_deref(), &final_name);
         variants.push(DiscriminatedVariant {
@@ -3690,7 +3817,12 @@ fn collect_discriminated_variants(
         });
     }
 
-    (variants, enum_validation_fns, guard_errors)
+    (
+        variants,
+        enum_validation_fns,
+        guard_errors,
+        build_member_check_arms(per_variant_checks),
+    )
 }
 
 /// Renders the TypeScript type fragments, Zod schema fragments (with optional-field lists), and
@@ -3849,14 +3981,14 @@ fn process_discriminated_enum(
     ];
 
     // Build delegating impl items; the discriminated-enum delegates match the struct ones (the
-    // `zod_schema` example injection uses the same `.meta()`-before-`;` form), with no `validate()`.
+    // `zod_schema` example injection uses the same `.meta()`-before-`;` form).
     #[cfg(any(feature = "zod", feature = "typescript", feature = "jsonschema"))]
     let delegate_impl_items = build_struct_delegate_items(
         &module_ident,
         item_name,
         &name.to_string(),
         schema_example_method.as_ref(),
-        None,
+        build_enum_validate_method(&variants.3, &module_ident),
     );
 
     #[cfg(any(feature = "zod", feature = "typescript", feature = "jsonschema"))]
@@ -4256,7 +4388,7 @@ fn process_externally_tagged_enum(
         item_name,
         &name.to_string(),
         schema_example_method.as_ref(),
-        None,
+        build_enum_validate_method(&variants.3, &module_ident),
     );
 
     #[cfg(any(feature = "zod", feature = "typescript", feature = "jsonschema"))]
@@ -4273,7 +4405,7 @@ fn process_externally_tagged_enum(
 
     #[cfg(not(any(feature = "zod", feature = "typescript", feature = "jsonschema")))]
     {
-        let _: &_ = &variants.1;
+        let _: &_ = &(&variants.1, &variants.3);
         let output = quote! {
             #item_enum
         };
@@ -4662,7 +4794,7 @@ fn process_internally_tagged_enum(
         item_name,
         &name.to_string(),
         schema_example_method.as_ref(),
-        None,
+        build_enum_validate_method(&variants.3, &module_ident),
     );
 
     #[cfg(any(feature = "zod", feature = "typescript", feature = "jsonschema"))]
@@ -4679,7 +4811,7 @@ fn process_internally_tagged_enum(
 
     #[cfg(not(any(feature = "zod", feature = "typescript", feature = "jsonschema")))]
     {
-        let _: &_ = &variants.1;
+        let _: &_ = &(&variants.1, &variants.3);
         let output = quote! {
             #item_enum
         };
@@ -4996,12 +5128,17 @@ fn collect_untagged_members(
     let mut json_parts: Vec<proc_macro2::TokenStream> = Vec::new();
     let mut guard_errors: Vec<proc_macro2::TokenStream> = Vec::new();
     let mut validation_fns: Vec<proc_macro2::TokenStream> = Vec::new();
+    let mut per_variant_checks: Vec<(proc_macro2::TokenStream, Vec<proc_macro2::TokenStream>)> =
+        Vec::new();
 
     for variant in &mut item_enum.variants {
         let kind = classify_variant(variant);
         let variant_name = variant.ident.to_string();
 
         let mut field_defs: Vec<FieldDef> = Vec::new();
+        let mut bound: Vec<(proc_macro2::Ident, proc_macro2::Ident)> = Vec::new();
+        let mut checks: Vec<proc_macro2::TokenStream> = Vec::new();
+        let total_fields = variant.fields.len();
         for field in &mut variant.fields {
             let field_name = field
                 .ident
@@ -5017,16 +5154,21 @@ fn collect_untagged_members(
                 .filter(|attr| !attr.path().is_ident("model_schema_prop"))
                 .cloned()
                 .collect();
-            let (validation_fn, _, positional_constraint_error) = generate_field_validation(
-                field,
-                schema_module_name,
-                &field_name,
-                Some(&variant_name),
-                &prop_meta,
-                &mut new_attrs,
-            );
+            let (validation_fn, validate_body, positional_constraint_error) =
+                generate_field_validation(
+                    field,
+                    schema_module_name,
+                    &field_name,
+                    Some(&variant_name),
+                    &prop_meta,
+                    &mut new_attrs,
+                );
             field.attrs = new_attrs;
             validation_fns.extend(validation_fn);
+            if let (Some(body), Some(ident)) = (validate_body, field.ident.as_ref()) {
+                bound.push((ident.clone(), member_binding(ident)));
+                checks.push(body);
+            }
 
             let mut field_def = get_field_def(&field_name, &field.ty, "");
             let serde_guard_errors = field_guard_errors(
@@ -5049,6 +5191,11 @@ fn collect_untagged_members(
             field_defs.push(field_def);
         }
 
+        per_variant_checks.push((
+            variant_check_pattern(&variant.ident, &kind, total_fields, &bound),
+            checks,
+        ));
+
         match render_untagged_variant(&kind, variant, &field_defs, &enum_type_name) {
             Ok((ts, zod, json_val)) => {
                 ts_parts.push(ts);
@@ -5065,6 +5212,7 @@ fn collect_untagged_members(
         json_parts,
         guard_errors,
         validation_fns,
+        build_member_check_arms(per_variant_checks),
     )
 }
 
@@ -5183,7 +5331,7 @@ fn process_untagged_enum(
     let enum_module_name_opt = None;
 
     // Render each variant into its union member (TS / Zod / JSON parts).
-    let (ts_parts, zod_parts, json_parts, guard_errors, enum_validation_fns) =
+    let (ts_parts, zod_parts, json_parts, guard_errors, enum_validation_fns, validate_arms) =
         collect_untagged_members(&mut item_enum, enum_module_name_opt);
 
     // A violated field guard makes the whole contract unsound, so the schema surface is dropped
@@ -5214,13 +5362,17 @@ fn process_untagged_enum(
         &json_parts,
     );
 
+    // The union's own accessor is where a violated member bound is named in Rust at all: the read
+    // path hands the bound to serde, which drops the sentence with the candidate it removes (see
+    // `collect_untagged_members`), so this is the one surface that answers with the constraint
+    // rather than with `data did not match any variant`.
     #[cfg(any(feature = "zod", feature = "typescript", feature = "jsonschema"))]
     let delegate_impl_items = build_struct_delegate_items(
         &module_ident,
         item_name,
         &name.to_string(),
         schema_example_method.as_ref(),
-        None,
+        build_enum_validate_method(&validate_arms, &module_ident),
     );
 
     #[cfg(any(feature = "zod", feature = "typescript", feature = "jsonschema"))]
@@ -5237,7 +5389,7 @@ fn process_untagged_enum(
 
     #[cfg(not(any(feature = "zod", feature = "typescript", feature = "jsonschema")))]
     {
-        let _: &_ = &enum_validation_fns;
+        let _: &_ = &(&enum_validation_fns, &validate_arms);
         let output = quote! {
             #item_enum
         };
@@ -6888,6 +7040,35 @@ fn wrap_binding(depth: usize) -> proc_macro2::Ident {
     proc_macro2::Ident::new(&format!("value_{depth}"), proc_macro2::Span::call_site())
 }
 
+/// The name a variant's constrained member is bound under in the arm that matched it.
+///
+/// The member cannot keep its own name there: the body it is bound for reads `errors`, and a member
+/// spelled that way would take the accumulator's name out from under the very pushes it is being
+/// checked to feed. The prefix is what keeps the arm's bindings clear of every name the body
+/// already spells — the accumulator and the walk's own `value_{depth}` steps — and clear of each
+/// other, two members differing wherever their idents do.
+fn member_binding(field_ident: &proc_macro2::Ident) -> proc_macro2::Ident {
+    proc_macro2::Ident::new(
+        &format!("member_{field_ident}"),
+        proc_macro2::Span::call_site(),
+    )
+}
+
+/// The expression a check reads its value from, in whichever position the member was written.
+#[cfg(feature = "serde")]
+fn member_access_expr(
+    access: MemberAccess,
+    field_ident_tok: &proc_macro2::Ident,
+) -> proc_macro2::TokenStream {
+    match access {
+        MemberAccess::SelfField => quote! { &self.#field_ident_tok },
+        MemberAccess::VariantBinding => {
+            let binding = member_binding(field_ident_tok);
+            quote! { #binding }
+        }
+    }
+}
+
 /// Builds the `validate()` contribution for a field, reaching through its wrappers to run the
 /// check on the value the constraint actually describes.
 ///
@@ -6895,15 +7076,21 @@ fn wrap_binding(depth: usize) -> proc_macro2::Ident {
 /// through. Otherwise the chain is bound once and walked: the head binding keeps every later step
 /// dereferencing a binding rather than a fresh borrow, and the block keeps its names off the
 /// enclosing body, where the next field's chain reuses them.
+///
+/// Only where the value is reached differs between a struct's field and a variant's member; the
+/// walk and the check are the same, so both positions run the identical rule and report it in the
+/// identical words.
 #[cfg(feature = "serde")]
 fn build_field_validation(
     wraps: &[ConstraintWrap],
+    access: MemberAccess,
     field_ident_tok: &proc_macro2::Ident,
     validate_value_fn_ident: &proc_macro2::Ident,
 ) -> proc_macro2::TokenStream {
+    let checked = member_access_expr(access, field_ident_tok);
     if wraps.is_empty() {
         return quote! {
-            if let Err(e) = #validate_value_fn_ident(&self.#field_ident_tok) {
+            if let Err(e) = #validate_value_fn_ident(#checked) {
                 errors.push(e);
             }
         };
@@ -6912,7 +7099,7 @@ fn build_field_validation(
     let walk = walk_wraps(wraps, &head, 1, validate_value_fn_ident, CheckSink::Collect);
     quote! {
         {
-            let #head = &self.#field_ident_tok;
+            let #head = #checked;
             #walk
         }
     }
@@ -7064,6 +7251,7 @@ fn generate_string_validation_code(
     meta: &ModelSchemaPropMeta,
     shape: &ConstrainedShape,
     field_ty: &syn::Type,
+    access: MemberAccess,
 ) -> FieldValidationCode {
     let wraps: &[ConstraintWrap] = &shape.wraps;
     let validate_value_fn_name = format!("validate_{helper_stem}_value");
@@ -7162,7 +7350,8 @@ fn generate_string_validation_code(
 
     let field_ident_tok = proc_macro2::Ident::new(field_ident, proc_macro2::Span::call_site());
 
-    let validate_body = build_field_validation(wraps, &field_ident_tok, &validate_value_fn_ident);
+    let validate_body =
+        build_field_validation(wraps, access, &field_ident_tok, &validate_value_fn_ident);
 
     FieldValidationCode {
         module_items,
@@ -7180,6 +7369,7 @@ fn generate_numeric_validation_code(
     meta: &ModelSchemaPropMeta,
     shape: &ConstrainedShape,
     field_ty: &syn::Type,
+    access: MemberAccess,
 ) -> FieldValidationCode {
     let wraps: &[ConstraintWrap] = &shape.wraps;
     let validate_value_fn_name = format!("validate_{helper_stem}_value");
@@ -7254,7 +7444,8 @@ fn generate_numeric_validation_code(
 
     let field_ident_tok = proc_macro2::Ident::new(field_ident, proc_macro2::Span::call_site());
 
-    let validate_body = build_field_validation(wraps, &field_ident_tok, &validate_value_fn_ident);
+    let validate_body =
+        build_field_validation(wraps, access, &field_ident_tok, &validate_value_fn_ident);
 
     FieldValidationCode {
         module_items,
@@ -7886,6 +8077,14 @@ fn generate_field_validation(
     };
 
     let helper_stem = helper_name_stem(raw_field_ident, variant_ident);
+    // The variant that scopes the helper names is the same thing that says where the value is
+    // reached from: a member of one is bound by the arm that matched it, and a struct's field is
+    // read off `self`.
+    let access = if variant_ident.is_some() {
+        MemberAccess::VariantBinding
+    } else {
+        MemberAccess::SelfField
+    };
     let generated = match shape.leaf {
         ConstraintLeaf::Path | ConstraintLeaf::Str => has_string_constraints.then(|| {
             generate_string_validation_code(
@@ -7894,6 +8093,7 @@ fn generate_field_validation(
                 model_schema_prop_meta,
                 &shape,
                 &field.ty,
+                access,
             )
         }),
         ConstraintLeaf::Number(rust_type) => has_numeric_constraints.then(|| {
@@ -7904,6 +8104,7 @@ fn generate_field_validation(
                 model_schema_prop_meta,
                 &shape,
                 &field.ty,
+                access,
             )
         }),
     };

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -6,11 +6,12 @@ use super::{
 
 #[cfg(feature = "serde")]
 use super::{
-    ConstraintLeaf, ModelSchemaPropMeta, build_field_validation, cfg_attr_guard_error,
-    check_optional_field_serialization, collect_untagged_members, constrained_shape,
-    enum_cfg_attr_guard_errors, generate_field_validation, generate_numeric_validation_code,
-    generate_string_validation_code, helper_name_stem, internally_tagged_guard_errors,
-    needs_injected_default, parse_serde_field_attributes, parse_serde_type_attributes,
+    ConstraintLeaf, MemberAccess, ModelSchemaPropMeta, build_field_validation,
+    cfg_attr_guard_error, check_optional_field_serialization, collect_untagged_members,
+    constrained_shape, enum_cfg_attr_guard_errors, generate_field_validation,
+    generate_numeric_validation_code, generate_string_validation_code, helper_name_stem,
+    internally_tagged_guard_errors, needs_injected_default, parse_serde_field_attributes,
+    parse_serde_type_attributes,
 };
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
@@ -475,7 +476,7 @@ fn untagged_member_carries_its_constraint_to_the_surfaces() {
             },
         }
     };
-    let (_, zod_parts, _, errors, _) = collect_untagged_members(&mut item, UNTAGGED_MODULE);
+    let (_, zod_parts, _, errors, _, _) = collect_untagged_members(&mut item, UNTAGGED_MODULE);
     assert!(errors.is_empty(), "got: {errors:?}");
     assert!(
         zod_parts[0].contains("z.string().min(2).check(z.regex(/^[a-z]+$/))"),
@@ -497,7 +498,7 @@ fn untagged_member_constraint_generates_the_validator_and_hangs_it_on_the_member
             },
         }
     };
-    let (_, _, _, errors, validation_fns) = collect_untagged_members(&mut item, UNTAGGED_MODULE);
+    let (_, _, _, errors, validation_fns, _) = collect_untagged_members(&mut item, UNTAGGED_MODULE);
     assert!(errors.is_empty(), "got: {errors:?}");
     assert_eq!(validation_fns.len(), 1, "got: {validation_fns:?}");
     let rendered = validation_fns[0].to_string();
@@ -531,7 +532,7 @@ fn untagged_member_constraint_generates_nothing_without_a_schema_module() {
             },
         }
     };
-    let (_, _, _, errors, validation_fns) = collect_untagged_members(&mut item, None);
+    let (_, _, _, errors, validation_fns, _) = collect_untagged_members(&mut item, None);
     assert!(errors.is_empty(), "got: {errors:?}");
     assert!(validation_fns.is_empty(), "got: {validation_fns:?}");
     let attrs = &item.variants[0].fields.iter().next().unwrap().attrs;
@@ -4498,14 +4499,41 @@ fn discriminated_union_rendering_is_stable_across_runs() {
     }
 }
 
-/// The `validate()` contribution for a field spelled `spelling`, as tokens.
+/// The `validate()` contribution for a field spelled `spelling`, reached from `access`, as tokens.
 #[cfg(feature = "serde")]
-fn emitted_validation(spelling: &str) -> String {
+fn emitted_validation_from(spelling: &str, access: MemberAccess) -> String {
     let ty: syn::Type = syn::parse_str(spelling).unwrap();
     let shape = constrained_shape(&ty).unwrap();
     let field = proc_macro2::Ident::new("field", proc_macro2::Span::call_site());
     let checker = proc_macro2::Ident::new("check", proc_macro2::Span::call_site());
-    build_field_validation(&shape.wraps, &field, &checker).to_string()
+    build_field_validation(&shape.wraps, access, &field, &checker).to_string()
+}
+
+/// The `validate()` contribution for a struct's field spelled `spelling`, as tokens.
+#[cfg(feature = "serde")]
+fn emitted_validation(spelling: &str) -> String {
+    emitted_validation_from(spelling, MemberAccess::SelfField)
+}
+
+/// The two positions differ in one place and nowhere else: where the checked value is reached.
+/// Everything downstream of that — the walk through the wrappers, the check, the push — is the
+/// same body, which is what makes a variant's member answer for its bound in a struct's words.
+#[cfg(feature = "serde")]
+#[test]
+fn a_variant_member_is_reached_through_the_binding_its_arm_made() {
+    for spelling in [
+        "String",
+        "u32",
+        "Option<String>",
+        "Vec<String>",
+        "Option<Arc<[String]>>",
+    ] {
+        assert_eq!(
+            emitted_validation_from(spelling, MemberAccess::VariantBinding),
+            emitted_validation(spelling).replace("& self . field", "member_field"),
+            "spelling {spelling}"
+        );
+    }
 }
 
 /// The one spelling whose emitted body predates the reach-through and must not move: anything else
@@ -4591,6 +4619,7 @@ fn emitted_string_module(spelling: &str) -> String {
         &meta,
         &shape,
         &ty,
+        MemberAccess::SelfField,
     )
     .module_items
     .to_string()
@@ -4632,6 +4661,7 @@ fn a_bare_field_deserializes_the_constrained_value_itself() {
         &numeric_meta,
         &constrained_shape(&numeric_ty).unwrap(),
         &numeric_ty,
+        MemberAccess::SelfField,
     )
     .module_items
     .to_string();
@@ -4786,7 +4816,7 @@ fn wire_walk_of(spelling: &str) -> String {
     let shape = constrained_shape(&ty).unwrap();
     let field = proc_macro2::Ident::new("field", proc_macro2::Span::call_site());
     let checker = proc_macro2::Ident::new("validate_field_value", proc_macro2::Span::call_site());
-    build_field_validation(&shape.wraps, &field, &checker)
+    build_field_validation(&shape.wraps, MemberAccess::SelfField, &field, &checker)
         .to_string()
         .replace(
             "if let Err (e) = validate_field_value (",

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -4975,6 +4975,7 @@ fn emitted_pattern_validator(pattern: &str) -> String {
         &meta,
         &constrained_shape(&ty).unwrap(),
         &ty,
+        MemberAccess::SelfField,
     )
     .module_items
     .to_string();

--- a/tests/untagged_tests/tests.rs
+++ b/tests/untagged_tests/tests.rs
@@ -127,6 +127,18 @@ enum SoleConstrainedUnion {
     },
 }
 
+// A tagged twin of `SoleConstrainedUnion`: the same member under the same bound, written where the
+// tag keeps a failing read on the variant it names.
+#[model_schema()]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind")]
+enum SoleConstrainedTagged {
+    Slug {
+        #[model_schema_prop(minLength = 2, pattern = "^[a-z]+$")]
+        slug: String,
+    },
+}
+
 // The same member written twice, bound first and bare second: what a failing bound costs is the
 // branch, not the read.
 #[model_schema()]
@@ -579,5 +591,77 @@ fn test_untagged_objectid_member_spells_the_one_oid_object() {
             "additionalProperties": false
         }),
         "Got:\n{schema}"
+    );
+}
+
+/// What the read costs the author, pinned. serde's derived `Deserialize` for an untagged enum drops
+/// each candidate's own error as it moves to the next, so when no variant accepts, the bound that
+/// refused the value is gone and one generic sentence stands in its place. The tagged twin, whose
+/// tag names the variant before its members are read, keeps the bound's own words. A serde upgrade
+/// that rewords the sentence lands here.
+#[test]
+fn test_untagged_member_bound_failure_reports_serdes_generic_sentence() {
+    assert_eq!(
+        serde_json::from_str::<SoleConstrainedUnion>(r#"{"slug":"A"}"#)
+            .unwrap_err()
+            .to_string(),
+        "data did not match any variant of untagged enum SoleConstrainedUnion"
+    );
+    assert_eq!(
+        serde_json::from_str::<SoleConstrainedTagged>(r#"{"kind":"Slug","slug":"A"}"#)
+            .unwrap_err()
+            .to_string(),
+        "'slug' is too short: minimum length is 2, got 1"
+    );
+}
+
+/// The accessor is the one Rust surface that names the bound a union's value violates: the read
+/// path hands the bound to serde, which discards the sentence with the candidate it removes, so a
+/// value built or read back in Rust has nothing else to ask. It answers in the tagged twin's words.
+#[test]
+fn test_untagged_union_publishes_validate_for_its_constrained_members() {
+    let expected = vec!["'slug' is too short: minimum length is 2, got 1".to_owned()];
+    assert_eq!(
+        SoleConstrainedUnion::Slug {
+            slug: "A".to_owned()
+        }
+        .validate()
+        .unwrap_err(),
+        expected
+    );
+    assert_eq!(
+        SoleConstrainedTagged::Slug {
+            slug: "A".to_owned()
+        }
+        .validate()
+        .unwrap_err(),
+        expected
+    );
+    SoleConstrainedUnion::Slug {
+        slug: "ab".to_owned(),
+    }
+    .validate()
+    .unwrap();
+}
+
+/// A union whose variants differ in what they bind: the value's own variant decides which checks
+/// run, and a variant carrying no bound has nothing to answer for.
+#[test]
+fn test_untagged_validate_runs_only_the_held_variants_checks() {
+    assert_eq!(
+        CheckedThenLooseUnion::Checked {
+            name: "A".to_owned()
+        }
+        .validate()
+        .unwrap_err(),
+        vec!["'name' is too short: minimum length is 2, got 1".to_owned()]
+    );
+    assert!(
+        CheckedThenLooseUnion::Loose {
+            name: "A".to_owned()
+        }
+        .validate()
+        .is_ok(),
+        "the bare member is held to no bound"
     );
 }

--- a/tests/validation_tests/tests.rs
+++ b/tests/validation_tests/tests.rs
@@ -19,6 +19,19 @@ use serde::{Deserialize, Serialize};
 ))]
 use tixschema::model_schema;
 
+/// What a type answers when it publishes no inherent `validate()` of its own. An inherent method
+/// takes precedence over a trait's, so reaching this one is what says none was published — the same
+/// question asked of a constraint-free struct, which has never published one either.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+trait UnpublishedValidate {
+    fn validate(&self) -> &'static str {
+        "no inherent validate()"
+    }
+}
+
 // ==================== String constraint: maxLength ====================
 
 #[cfg(all(feature = "serde", feature = "zod"))]
@@ -1758,4 +1771,390 @@ fn test_two_variants_naming_one_field_keep_their_own_constraints() {
         serde_json::from_str::<Action>(r#"{"kind":"Upload","note":"abc"}"#).is_ok(),
         "A value Upload admits is not held to Delete's minimum"
     );
+}
+
+// ==================== validate() method — enum members ====================
+
+/// The struct and its single-variant tagged twin carry the same constraint on the same member, so
+/// an author who changes the one declaration into the other reads the identical sentence back.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn test_tagged_enum_validate_answers_in_the_struct_twins_words() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug)]
+    pub struct SlugStruct {
+        #[model_schema_prop(minLength = 2)]
+        pub slug: String,
+    }
+
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug)]
+    #[serde(tag = "kind")]
+    pub enum SlugTagged {
+        One {
+            #[model_schema_prop(minLength = 2)]
+            slug: String,
+        },
+    }
+
+    let from_struct = SlugStruct {
+        slug: "A".to_owned(),
+    }
+    .validate()
+    .unwrap_err();
+    let from_enum = SlugTagged::One {
+        slug: "A".to_owned(),
+    }
+    .validate()
+    .unwrap_err();
+
+    assert_eq!(
+        from_struct,
+        vec!["'slug' is too short: minimum length is 2, got 1".to_owned()]
+    );
+    assert_eq!(from_enum, from_struct);
+
+    SlugTagged::One {
+        slug: "ab".to_owned(),
+    }
+    .validate()
+    .unwrap();
+}
+
+/// The tag decides how a value is written, not which of its members carry a bound — so every
+/// tagging serde offers publishes the accessor, and all three answer the same violation alike.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn test_every_tagged_flavor_publishes_validate_for_its_constrained_members() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug)]
+    pub enum External {
+        One {
+            #[model_schema_prop(minLength = 2)]
+            slug: String,
+        },
+    }
+
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug)]
+    #[serde(tag = "kind")]
+    pub enum Internal {
+        One {
+            #[model_schema_prop(minLength = 2)]
+            slug: String,
+        },
+    }
+
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug)]
+    #[serde(tag = "kind", content = "data")]
+    pub enum Adjacent {
+        One {
+            #[model_schema_prop(minLength = 2)]
+            slug: String,
+        },
+    }
+
+    let expected = vec!["'slug' is too short: minimum length is 2, got 1".to_owned()];
+    assert_eq!(
+        External::One {
+            slug: "A".to_owned()
+        }
+        .validate()
+        .unwrap_err(),
+        expected
+    );
+    assert_eq!(
+        Internal::One {
+            slug: "A".to_owned()
+        }
+        .validate()
+        .unwrap_err(),
+        expected
+    );
+    assert_eq!(
+        Adjacent::One {
+            slug: "A".to_owned()
+        }
+        .validate()
+        .unwrap_err(),
+        expected
+    );
+}
+
+/// A value holds one variant at a time, so the walk runs that variant's checks and no other's —
+/// two variants naming one member are two constraints, and only the held one answers.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn test_enum_validate_runs_only_the_held_variants_checks() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug)]
+    #[serde(tag = "kind")]
+    pub enum Action {
+        Delete {
+            #[model_schema_prop(minLength = 5)]
+            note: String,
+        },
+        Upload {
+            #[model_schema_prop(minLength = 3)]
+            note: String,
+        },
+    }
+
+    assert_eq!(
+        Action::Delete {
+            note: "abc".to_owned()
+        }
+        .validate()
+        .unwrap_err(),
+        vec!["'note' is too short: minimum length is 5, got 3".to_owned()]
+    );
+    assert!(
+        Action::Upload {
+            note: "abc".to_owned()
+        }
+        .validate()
+        .is_ok(),
+        "a value Upload admits is not held to Delete's minimum"
+    );
+}
+
+/// A variant that carries no bound contributes no check, and one that carries several answers with
+/// every violation at once — the struct accessor's own collecting shape, per arm.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn test_enum_validate_collects_every_violation_of_the_held_variant() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug)]
+    #[serde(tag = "kind")]
+    pub enum Mixed {
+        Bounded {
+            #[model_schema_prop(maxLength = 3)]
+            code: String,
+            #[model_schema_prop(minimum = 10)]
+            size: u32,
+        },
+        Free {
+            note: String,
+        },
+        Nothing,
+    }
+
+    assert_eq!(
+        Mixed::Bounded {
+            code: "toolong".to_owned(),
+            size: 1,
+        }
+        .validate()
+        .unwrap_err(),
+        vec![
+            "'code' is too long: maximum length is 3, got 7".to_owned(),
+            "'size' is too small: minimum is 10, got 1".to_owned(),
+        ]
+    );
+    Mixed::Free {
+        note: "anything".to_owned(),
+    }
+    .validate()
+    .unwrap();
+    Mixed::Nothing.validate().unwrap();
+}
+
+/// A member written under wrappers is checked where the constraint lands, exactly as the same field
+/// written in a struct is: a `None` writes nothing to check, and a sequence answers per element.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn test_enum_validate_reaches_through_a_members_wrappers() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug)]
+    #[serde(tag = "kind")]
+    pub enum Wrapped {
+        One {
+            #[model_schema_prop(minLength = 2)]
+            tags: Vec<String>,
+            #[model_schema_prop(minLength = 2)]
+            #[serde(skip_serializing_if = "Option::is_none")]
+            note: Option<String>,
+        },
+    }
+
+    assert!(
+        Wrapped::One {
+            tags: vec!["ab".to_owned()],
+            note: None,
+        }
+        .validate()
+        .is_ok(),
+        "a None writes nothing for the bound to describe"
+    );
+    assert_eq!(
+        Wrapped::One {
+            tags: vec!["ab".to_owned(), "c".to_owned()],
+            note: Some("d".to_owned()),
+        }
+        .validate()
+        .unwrap_err(),
+        vec![
+            "'tags' is too short: minimum length is 2, got 1".to_owned(),
+            "'note' is too short: minimum length is 2, got 1".to_owned(),
+        ]
+    );
+}
+
+/// Parity with the struct convention: an enum whose members carry no bound publishes no accessor,
+/// which is what a constraint-free struct has always published. The trait's method is reached only
+/// because no inherent one shadows it.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn test_a_constraint_free_enum_publishes_no_validate_just_as_a_struct_does() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug)]
+    pub struct FreeStruct {
+        pub name: String,
+    }
+
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug)]
+    #[serde(tag = "kind")]
+    pub enum FreeTagged {
+        One { name: String },
+        Two,
+    }
+
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug)]
+    #[serde(tag = "kind")]
+    pub enum BoundTagged {
+        One {
+            #[model_schema_prop(minLength = 2)]
+            name: String,
+        },
+    }
+
+    impl UnpublishedValidate for FreeStruct {}
+    impl UnpublishedValidate for FreeTagged {}
+
+    assert_eq!(
+        FreeStruct {
+            name: String::new()
+        }
+        .validate(),
+        "no inherent validate()"
+    );
+    assert_eq!(
+        FreeTagged::One {
+            name: String::new()
+        }
+        .validate(),
+        "no inherent validate()"
+    );
+    assert_eq!(FreeTagged::Two.validate(), "no inherent validate()");
+    // An enum whose member does carry a bound answers with the accessor's own type, which is what
+    // makes the assertions above a statement about publication rather than about the trait: a
+    // published `validate()` would shadow the trait's and none of them would even compile.
+    assert_eq!(
+        BoundTagged::One {
+            name: "A".to_owned()
+        }
+        .validate()
+        .unwrap_err(),
+        vec!["'name' is too short: minimum length is 2, got 1".to_owned()]
+    );
+}
+
+/// The arm binds each constrained member under a name of its own, so a member spelled like
+/// something the body already reads is still checked rather than taking that name over: `errors` is
+/// the accumulator every check pushes into, and `value_0` is the head of the walk a wrapped member
+/// is reached through.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn test_a_member_named_like_the_walks_own_bindings_is_still_checked() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug)]
+    #[serde(tag = "kind")]
+    pub enum Shadowing {
+        One {
+            #[model_schema_prop(minLength = 2)]
+            errors: String,
+            #[model_schema_prop(minLength = 2)]
+            value_0: Vec<String>,
+        },
+    }
+
+    assert_eq!(
+        Shadowing::One {
+            errors: "A".to_owned(),
+            value_0: vec!["B".to_owned()],
+        }
+        .validate()
+        .unwrap_err(),
+        vec![
+            "'errors' is too short: minimum length is 2, got 1".to_owned(),
+            "'value_0' is too short: minimum length is 2, got 1".to_owned(),
+        ]
+    );
+}
+
+/// The match names every variant the enum declares, whatever shape each one was written in, so a
+/// value of any of them reaches the accessor and only the constrained one answers.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn test_every_variant_shape_reaches_the_accessor() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug)]
+    pub enum EveryShape {
+        Bare {
+            note: String,
+        },
+        Named {
+            #[model_schema_prop(minLength = 2)]
+            slug: String,
+        },
+        Nothing,
+        Pair(String, String),
+        Single(String),
+    }
+
+    assert_eq!(
+        EveryShape::Named {
+            slug: "A".to_owned()
+        }
+        .validate()
+        .unwrap_err(),
+        vec!["'slug' is too short: minimum length is 2, got 1".to_owned()]
+    );
+    EveryShape::Bare {
+        note: "A".to_owned(),
+    }
+    .validate()
+    .unwrap();
+    EveryShape::Single("A".to_owned()).validate().unwrap();
+    EveryShape::Pair("A".to_owned(), "B".to_owned())
+        .validate()
+        .unwrap();
+    EveryShape::Nothing.validate().unwrap();
 }


### PR DESCRIPTION
An enum's constrained members already generate per-member validators; the collectors discarded the validate bodies, so a struct published `validate()` while its enum twin got E0599. The bodies now thread out of both collectors and an enum-level `pub fn validate(&self) -> Result<(), Vec<String>>` matches on self and runs the active variant's checks — the struct aggregation's error strings byte-for-byte, one arm per checked variant, one shared or-pattern arm for the rest (exhaustive, no wildcard). A `MemberAccess` enum is the only seam difference: a struct's field reads off `self`, a variant's member reads the arm's binding. All three tagged flavors, and the untagged path too — serde's untagged read discards each candidate's error, so this accessor is the only Rust surface that names the bound a union value violates. Constraint-free enums publish nothing, the parity a constraint-free struct has.

The README's untagged section now states the fall-through cost honestly — a violated member bound surfaces as serde's generic did-not-match sentence — shows both sentences side by side, names the remedy, and a test pins serde's exact sentence so upgrade drift breaks the build.