### PR TITLE
read sequence wrappers through one seam in every position that renders them

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -4938,6 +4938,14 @@ fn string_field_json_schema_value(fld: &FieldDef) -> proc_macro2::TokenStream {
 /// position leaves it open too.
 #[cfg(all(feature = "serde", feature = "jsonschema"))]
 fn field_json_schema_value(fld: &FieldDef) -> proc_macro2::TokenStream {
+    // A covered sequence wrapper writes the JSON array of its element, so the member is dispatched
+    // as the arrayed element it stands for — through the seam field position reads it through, and
+    // the array levels it carries are the whole field's, which is why it replaces this call rather
+    // than being wrapped again.
+    if let Some(element_field) = sequence_wrapper_field(fld) {
+        return field_json_schema_value(&element_field);
+    }
+
     let inner = match &fld.field_type {
         FieldDefType::SiblingType(name, _) => sibling_json_schema_value(name, fld.type_span),
         FieldDefType::String => string_field_json_schema_value(fld),
@@ -5977,6 +5985,19 @@ fn sequence_wrapper_element(fld: &FieldDef) -> Option<&FieldDef> {
     is_sequence_wrapper(wrapper_name).then_some(element)
 }
 
+/// The field a sequence-spelled type stands for: its element, carrying the array level the wrapper
+/// writes — and `None` for everything else.
+///
+/// Every position that renders a wrapper renders it through here, so the detection and the unwrap
+/// live in one place: a field, a slot, and an untagged variant's member cannot answer differently
+/// for the same name, and none of them can name a schema module after a wrapper the expansion never
+/// declares. The result stands for the whole field, so a caller re-dispatches it in place of the
+/// field rather than wrapping it again.
+#[cfg(feature = "jsonschema")]
+fn sequence_wrapper_field(fld: &FieldDef) -> Option<FieldDef> {
+    sequence_wrapper_element(fld).map(|element| fld.collection_element_field(element))
+}
+
 /// The classification every position reads a map key through.
 ///
 /// The rule it applies is serde's own: a JSON object key is a string, so a key serde writes as a
@@ -6349,11 +6370,8 @@ fn map_member_slot_value(
 #[cfg(feature = "jsonschema")]
 fn normalized_slot_value(value: &FieldDef) -> FieldDef {
     let mut normalized = value.clone();
-    while let FieldDefType::SiblingType(wrapper_name, wrapper_args) = &normalized.field_type
-        && is_sequence_wrapper(wrapper_name)
-        && let [element] = wrapper_args.as_slice()
-    {
-        normalized = normalized.collection_element_field(element);
+    while let Some(element_field) = sequence_wrapper_field(&normalized) {
+        normalized = element_field;
     }
     normalized
 }
@@ -6696,25 +6714,22 @@ fn build_sibling_type_field_schema(
     // exactly as the `Vec` of the same element does — element by element, at every type. Which
     // wrappers those are is the surfaces' one shared answer, so no name reaches one surface as an
     // array and another as a schema module of its own.
-    if let [element] = lst
-        && is_sequence_wrapper(name)
-    {
-        build_field_type_schema(&fld.collection_element_field(element), field_name_str)
-    } else {
-        // Every remaining shape is carried by the named type's own schema module: the non-generic
-        // sibling (lst.is_empty()), and the generic branded wrapper like DocumentTypeId<String>,
-        // whose schema is defined on the wrapper and whose type params do not affect it. A map is
-        // not among them — the parser claims both 2-argument map idents before the sibling fallback
-        // is reached, so a map arrives as a `Map` and is rendered once, there. A name this arm
-        // cannot resolve is the compile error the reference raises at the type, which is what keeps
-        // a second rendering — free to widen or to drop the array the one rendering carries — from
-        // growing back here.
-        generate_type_schema(
-            fld,
-            field_name_str,
-            &sibling_json_schema_value(name, fld.type_span),
-        )
+    if let Some(element_field) = sequence_wrapper_field(fld) {
+        return build_field_type_schema(&element_field, field_name_str);
     }
+
+    // Every remaining shape is carried by the named type's own schema module: the non-generic
+    // sibling (lst.is_empty()), and the generic branded wrapper like DocumentTypeId<String>, whose
+    // schema is defined on the wrapper and whose type params do not affect it. A map is not among
+    // them — the parser claims both 2-argument map idents before the sibling fallback is reached,
+    // so a map arrives as a `Map` and is rendered once, there. A name this arm cannot resolve is
+    // the compile error the reference raises at the type, which is what keeps a second rendering —
+    // free to widen or to drop the array the one rendering carries — from growing back here.
+    generate_type_schema(
+        fld,
+        field_name_str,
+        &sibling_json_schema_value(name, fld.type_span),
+    )
 }
 
 /// The `json!` literal an `ObjectId` describes as — the closed `$oid` object serde writes — with

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -4446,6 +4446,23 @@ fn every_sequence_wrapper_describes_as_the_vec_of_its_element_in_a_slot() {
     }
 }
 
+/// And in an untagged variant's member, the third position that dispatches a value. It reads the
+/// wrappers through the seam the other positions read them through, so a member describes a covered
+/// wrapper as the `Vec` of its element too — and none of them can name a schema module after a
+/// wrapper, which is a module the expansion never declares and rustc reports at the member's type.
+#[cfg(all(feature = "jsonschema", feature = "serde"))]
+#[test]
+fn every_sequence_wrapper_describes_as_the_vec_of_its_element_in_an_untagged_member() {
+    let expected = super::field_json_schema_value(&parsed_u32_vec_value()).to_string();
+    for wrapper in SEQUENCE_WRAPPERS {
+        assert_eq!(
+            super::field_json_schema_value(&wrapped_u32_value(wrapper)).to_string(),
+            expected,
+            "for: {wrapper}"
+        );
+    }
+}
+
 /// A sibling is carried by reference in every position that holds one, so the two slot positions
 /// name one schema module and wrap it the same way — a tuple element that fell back to the open
 /// object would admit values the same type in a map member rejects.

--- a/tests/untagged_tests.rs
+++ b/tests/untagged_tests.rs
@@ -1,5 +1,7 @@
 //! Tests for `#[serde(untagged)]` enum support (TypeScript union / Zod `z.union` / JSON `anyOf`).
 
+extern crate alloc;
+
 // `#[serde(untagged)]` parsing requires the `serde` feature, and the branded `DateString`
 // newtype is only emitted when a generation feature (typescript/zod/jsonschema) is enabled.
 #[cfg(test)]

--- a/tests/untagged_tests/tests.rs
+++ b/tests/untagged_tests/tests.rs
@@ -1,9 +1,14 @@
+use alloc::collections::{BTreeSet, VecDeque};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use tixschema::model_schema;
 
 #[cfg(all(feature = "jsonschema", feature = "object_id"))]
 use mongodb::bson::oid::ObjectId;
+
+/// The members of `WrappedUnion`, in the order the union declares them.
+#[cfg(any(feature = "jsonschema", feature = "typescript", feature = "zod"))]
+const WRAPPED_MEMBERS: [&str; 3] = ["ids", "ordered", "queued"];
 
 // ISO-8601 date string. Branded newtype carries the regex pattern, written with `\d` and reaching
 // every surface as the members it stands for.
@@ -100,6 +105,20 @@ enum ShapedUnion {
     Pair { pair: (i64, String) },
 }
 
+// The std wrappers serde writes as a JSON array of their element, written in untagged members. Each
+// writes what a `Vec` of the same element writes, so each member has to describe as that field does
+// rather than as a schema module named after the wrapper. `LinkedList` is covered too and has no
+// member here, the crate's own lints forbidding it a value of one; it is covered by name at the
+// dispatch's own unit tests instead.
+#[model_schema()]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+enum WrappedUnion {
+    Ids { ids: HashSet<u32> },
+    Ordered { ordered: BTreeSet<u32> },
+    Queued { queued: VecDeque<u32> },
+}
+
 // The field-position twins: the same members written as struct fields. Field position is the
 // rendering an untagged member is held against, so it is written out rather than restated.
 #[cfg(feature = "jsonschema")]
@@ -115,6 +134,15 @@ struct KeyedFields {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct ShapedFields {
     pair: (i64, String),
+}
+
+#[cfg(feature = "jsonschema")]
+#[model_schema()]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct WrappedFields {
+    ids: HashSet<u32>,
+    ordered: BTreeSet<u32>,
+    queued: VecDeque<u32>,
 }
 
 // An untagged struct variant carrying a constrained member, beside the same member written in a
@@ -667,6 +695,107 @@ fn test_untagged_tuple_member_zod() {
         zod.contains("z.strictObject({ pair: z.tuple([z.number().int(), z.string()]), })"),
         "Got:\n{zod}"
     );
+}
+
+/// What serde writes for an untagged member holding a covered sequence wrapper — the capture the
+/// three surfaces are held against. Every one of them writes the JSON array a `Vec` of the same
+/// element writes, which is the whole reason the wrapper is covered.
+#[test]
+fn test_untagged_wrapper_member_wire() {
+    for value in [
+        WrappedUnion::Ids {
+            ids: HashSet::from([7_u32]),
+        },
+        WrappedUnion::Ordered {
+            ordered: BTreeSet::from([7_u32]),
+        },
+        WrappedUnion::Queued {
+            queued: VecDeque::from([7_u32]),
+        },
+    ] {
+        let wire = serde_json::to_value(&value).unwrap();
+        let (member, written) = wire.as_object().unwrap().iter().next().unwrap();
+        assert_eq!(*written, serde_json::json!([7_u32]), "for: {member}");
+        assert_eq!(
+            serde_json::from_value::<WrappedUnion>(wire.clone()).unwrap(),
+            value,
+            "for: {member}"
+        );
+    }
+}
+
+/// A member holding a covered sequence wrapper describes as the array serde writes: the element's
+/// own schema under array wrapping. Held against the struct field written from the same type, which
+/// is the rendering a member must not diverge from — and which is where the wrapper name stopped
+/// standing for a schema module of its own.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_untagged_wrapper_member_json_schema() {
+    let schema = WrappedUnion::json_schema();
+    let fields = WrappedFields::json_schema();
+    let any_of = schema["anyOf"].as_array().unwrap();
+    assert_eq!(any_of.len(), WRAPPED_MEMBERS.len(), "Got:\n{schema}");
+
+    for (branch, member) in any_of.iter().zip(WRAPPED_MEMBERS) {
+        assert_eq!(
+            branch["properties"][member],
+            serde_json::json!({ "type": "array", "items": { "type": "integer" } }),
+            "Got:\n{schema}"
+        );
+        assert_eq!(
+            branch["properties"][member], fields["properties"][member],
+            "the field-position twin must render the same member"
+        );
+        assert_eq!(branch["required"], serde_json::json!([member]));
+    }
+}
+
+/// The schema admits the wire the capture recorded: serde writes an array, and each item is what
+/// the member's `items` schema names. A member still carrying the wrapper's own name could not have
+/// described this payload at all — it named a schema module no expansion declares.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_untagged_wrapper_member_schema_admits_the_captured_wire() {
+    let queued = WrappedUnion::Queued {
+        queued: VecDeque::from([7_u32, 8_u32]),
+    };
+    let wire = serde_json::to_value(&queued).unwrap();
+    let schema = WrappedUnion::json_schema();
+    let member = &schema["anyOf"][2]["properties"]["queued"];
+    let written = wire["queued"].as_array().unwrap();
+
+    assert_eq!(member["type"], serde_json::json!("array"), "Got:\n{schema}");
+    assert_eq!(member["items"]["type"], serde_json::json!("integer"));
+    assert!(
+        written.iter().all(serde_json::Value::is_u64),
+        "Got:\n{wire}"
+    );
+}
+
+#[test]
+#[cfg(feature = "typescript")]
+fn test_untagged_wrapper_member_typescript() {
+    let ts = WrappedUnion::ts_definition();
+    for member in WRAPPED_MEMBERS {
+        assert!(
+            ts.contains(&format!("{{ {member}: Array<number> }}")),
+            "Got:\n{ts}"
+        );
+    }
+}
+
+#[test]
+#[cfg(feature = "zod")]
+fn test_untagged_wrapper_member_zod() {
+    let zod = WrappedUnion::zod_schema();
+    for member in WRAPPED_MEMBERS {
+        assert!(
+            zod.contains(&format!(
+                "z.strictObject({{ {member}: z.array(z.number().int()), }})"
+            )),
+            "Got:\n{zod}"
+        );
+    }
 }
 
 /// The member's constraint reaches Zod in the spelling the tagged twin's does. Before this, the


### PR DESCRIPTION
An untagged member holding `HashSet<T>`, `BTreeSet<T>`, or `VecDeque<T>` failed under jsonschema with E0433 naming `hash_set_schema` — the member dispatch built a module reference from the raw wrapper name while field position normalized the covered wrappers to array-wrapped element schemas. A single `sequence_wrapper_field` helper now answers all three positions (field, map/tuple slot, untagged member): detection and unwrap live once, so the positions cannot drift, and no name reaches one surface as an array and another as a module of its own. The member arm re-dispatches the element field in place of the member — the element stands for the whole field, so the outer array wrap is not applied twice, and optionality survives the normalization.

Red-first per wrapper against the field-position twin; field and slot positions pinned byte-identical across all six covered spellings. Fixtures use integer elements: the arrayed-String member has a separate, pre-existing compile defect in the String arm's block-vs-expression emission, tracked and specced on its own.