### PR TITLE
instantiate every declared brand parameter in the doc example, and make the brand docs and coverage helper tell the truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -758,13 +758,19 @@ pub struct CorrelationId(pub String);
 Generated TypeScript (with `zod` feature):
 
 ```typescript
-export type UserId<ID_TYPE> = ID_TYPE & z.$brand<"UserId">;
-const UserId$RawSchema = ID_TYPE$Schema.brand<"UserId">();
+export type UserId<ID_TYPE> = ID_TYPE & $brand<"UserId">;
+const UserId$RawSchema = ID_TYPE$Schema.brand<"UserId">().meta({
+  description: "UserId",
+});
+
 export const UserId$Schema: $ZodBranded<typeof ID_TYPE$Schema, "UserId"> = UserId$RawSchema;
 
-export type CorrelationId = string & z.$brand<"CorrelationId">;
-const CorrelationId$RawSchema = z.string().brand<"CorrelationId">();
-export const CorrelationId$Schema: ZodType<CorrelationId> = CorrelationId$RawSchema;
+export type CorrelationId = string & $brand<"CorrelationId">;
+const CorrelationId$RawSchema = z.string().brand<"CorrelationId">().meta({
+  description: "CorrelationId",
+});
+
+export const CorrelationId$Schema: $ZodBranded<ZodString, "CorrelationId"> = CorrelationId$RawSchema;
 ```
 
 Generated TypeScript (without `zod` feature):
@@ -772,11 +778,9 @@ Generated TypeScript (without `zod` feature):
 ```typescript
 declare const __brand_UserId: unique symbol;
 export type UserId<ID_TYPE> = ID_TYPE & { readonly [__brand_UserId]: true };
-export function assertUserId<ID_TYPE>(value: ID_TYPE): asserts value is UserId<ID_TYPE> {}
 
 declare const __brand_CorrelationId: unique symbol;
 export type CorrelationId = string & { readonly [__brand_CorrelationId]: true };
-export function assertCorrelationId(value: string): asserts value is CorrelationId {}
 ```
 
 Notes:
@@ -872,14 +876,9 @@ pub struct SlugId(pub String);
 Generated Zod:
 
 ```typescript
-const SlugId$RawSchema = z.string()
-  .min(3)
-  .max(50)
-  .check(z.regex(/^[a-z0-9_]+$/))
-  .brand<"SlugId">()
-  .meta({
-    description: "SlugId",
-  });
+const SlugId$RawSchema = z.string().min(3).max(50).check(z.regex(/^[a-z0-9_]+$/)).brand<"SlugId">().meta({
+  description: "SlugId",
+});
 
 export const SlugId$Schema: $ZodBranded<ZodString, "SlugId"> = SlugId$RawSchema;
 ```
@@ -994,12 +993,12 @@ pub struct DocumentId<ID_TYPE>(pub ID_TYPE);
 Generated Zod:
 
 ```typescript
-const DocumentId$RawSchema = z.string().brand<"DocumentId">().meta({
-  description: "Generic document identifier.\n...",
+const DocumentId$RawSchema = ID_TYPE$Schema.brand<"DocumentId">().meta({
+  description: "Generic document identifier.\n- `DocumentId<String>` for API/HTTP layer\n- `DocumentId<ObjectId>` for MongoDB layer",
   example: "64de3d95ff45b119e5b53a7e",
 });
 
-export const DocumentId$Schema: $ZodBranded<ZodString, "DocumentId"> = DocumentId$RawSchema;
+export const DocumentId$Schema: $ZodBranded<typeof ID_TYPE$Schema, "DocumentId"> = DocumentId$RawSchema;
 ```
 
 ## Field Validation (`model_schema_prop`)

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -2944,32 +2944,29 @@ fn tokens_name_any(tokens: &proc_macro2::TokenStream, names: &[String]) -> bool 
 fn build_branded_schema_example(
     example_code: Option<&String>,
     name: &Ident,
-    is_generic: bool,
+    generic_params: &[String],
 ) -> proc_macro2::TokenStream {
     let Some(code) = example_code else {
         return quote! {};
     };
     let code_tokens: proc_macro2::TokenStream = code.parse().unwrap();
-    if is_generic {
-        // The example is Rust the expansion has to compile, and a parameter names no type to
-        // compile it at, so it is instantiated at `String` (e.g. `DocumentId<String>`) — the one
-        // concrete type every brand's example can be written against.
-        quote! {
-            pub fn schema_example() -> serde_json::Value {
-                let value: #name<String> = {
-                    #code_tokens
-                };
-                serde_json::to_value(&value).unwrap()
-            }
-        }
+    // The example is Rust the expansion has to compile, and a parameter names no type to compile
+    // it at, so every parameter the brand declares is instantiated at `String` (e.g.
+    // `DocumentId<String>`, `PairId<String, String>`) — the one concrete type every brand's
+    // example can be written against. A brand's arity is whatever it declares, so the argument
+    // list is as long as the parameter list rather than one long.
+    let value_ty = if generic_params.is_empty() {
+        quote! { #name }
     } else {
-        quote! {
-            pub fn schema_example() -> serde_json::Value {
-                let value: #name = {
-                    #code_tokens
-                };
-                serde_json::to_value(&value).unwrap()
-            }
+        let args = generic_params.iter().map(|_| quote! { String });
+        quote! { #name<#(#args),*> }
+    };
+    quote! {
+        pub fn schema_example() -> serde_json::Value {
+            let value: #value_ty = {
+                #code_tokens
+            };
+            serde_json::to_value(&value).unwrap()
         }
     }
 }
@@ -3198,7 +3195,7 @@ fn process_branded_newtype(item_struct: syn::ItemStruct, args: &ModelSchemaArgs)
 
     #[cfg(feature = "zod")]
     let schema_example_tokens =
-        build_branded_schema_example(example_code.as_ref(), &name, is_generic);
+        build_branded_schema_example(example_code.as_ref(), &name, &generic_params);
     #[cfg(not(feature = "zod"))]
     let schema_example_tokens = quote! {};
 

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -2124,12 +2124,20 @@ fn branded_json_schema_method_carries_no_cfg_attribute() {
 }
 
 /// Every shape [`super::branded_json_inner`] resolves to, so the dispatch is covered whole.
+///
+/// The `Slot` and `Chrono` shapes build their bodies through [`super::branded_slot_json_schema`]
+/// and [`super::branded_chrono_schema`], which is where a stray `cfg` attribute would land unseen,
+/// so they are walked here beside the two that render inline.
 #[cfg(feature = "jsonschema")]
 fn branded_json_inners() -> Vec<super::BrandedJsonInner> {
+    let composite: syn::Type = syn::parse_quote!(Vec<String>);
     vec![
-        super::BrandedJsonInner::Scalar("string".to_owned()),
+        #[cfg(feature = "chrono")]
+        super::BrandedJsonInner::Chrono("date-time"),
         #[cfg(feature = "object_id")]
         super::BrandedJsonInner::ObjectId,
+        super::BrandedJsonInner::Scalar("string".to_owned()),
+        super::BrandedJsonInner::Slot(Box::new(super::get_field_def("_inner", &composite, ""))),
     ]
 }
 
@@ -2138,9 +2146,34 @@ fn branded_json_inners() -> Vec<super::BrandedJsonInner> {
 fn branded_schema_example_carries_no_cfg_attribute() {
     let name: syn::Ident = syn::parse_quote!(DocumentId);
     let example = "DocumentId(\"abc\".to_string())".to_owned();
-    for is_generic in [false, true] {
-        let tokens = super::build_branded_schema_example(Some(&example), &name, is_generic);
+    for generic_params in [
+        Vec::new(),
+        vec!["A".to_owned()],
+        vec!["A".to_owned(), "B".to_owned()],
+    ] {
+        let tokens = super::build_branded_schema_example(Some(&example), &name, &generic_params);
         assert_no_cfg_attribute(&tokens, "build_branded_schema_example");
+    }
+}
+
+/// The type the example is bound at carries one argument per declared parameter, and none at all
+/// where the brand declares none — so a brand of any arity annotates a type it can be built as.
+#[cfg(feature = "zod")]
+#[test]
+fn branded_schema_example_instantiates_every_parameter() {
+    let name: syn::Ident = syn::parse_quote!(DocumentId);
+    let example = "DocumentId(\"abc\".to_string())".to_owned();
+    for (generic_params, expected) in [
+        (Vec::new(), "let value : DocumentId ="),
+        (vec!["A".to_owned()], "let value : DocumentId < String > ="),
+        (
+            vec!["A".to_owned(), "B".to_owned()],
+            "let value : DocumentId < String , String > =",
+        ),
+    ] {
+        let rendered =
+            super::build_branded_schema_example(Some(&example), &name, &generic_params).to_string();
+        assert!(rendered.contains(expected), "Got: {rendered}");
     }
 }
 

--- a/tests/branded_newtype_tests/tests.rs
+++ b/tests/branded_newtype_tests/tests.rs
@@ -1449,6 +1449,47 @@ mod branded_generic_inner_tests {
     }
 }
 
+/// A brand's doc example is Rust the expansion has to compile, so it is instantiated at as many
+/// concrete types as the brand declares parameters — one per parameter, not one overall.
+#[cfg(feature = "zod")]
+mod branded_example_arity_tests {
+    use super::*;
+
+    /// One parameter per side of the pair.
+    ///
+    /// ```rust example
+    /// PairId(("a".to_string(), "b".to_string()))
+    /// ```
+    #[model_schema(no_display)]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct PairId<A, B>(pub (A, B));
+
+    /// The one parameter the example is written against.
+    ///
+    /// ```rust example
+    /// SoloId("a".to_string())
+    /// ```
+    #[model_schema()]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct SoloId<T>(pub T);
+
+    #[test]
+    fn a_two_parameter_brand_renders_the_example_its_inner_writes() {
+        assert_eq!(
+            PairId::<String, String>::schema_example(),
+            serde_json::json!(["a", "b"])
+        );
+    }
+
+    /// A single parameter is instantiated exactly as it was before arity was counted.
+    #[test]
+    fn a_one_parameter_brand_renders_the_example_it_always_did() {
+        assert_eq!(SoloId::<String>::schema_example(), serde_json::json!("a"));
+    }
+}
+
 /// The four surfaces of a brand whose inner names another type, pinned against what serde writes
 /// for it.
 ///


### PR DESCRIPTION
Three small brand-area corrections:

- `build_branded_schema_example` wrote `#name<String>` with exactly one argument whatever the brand declared, so a two-parameter brand with a doc example failed E0107. The argument list is now as long as the parameter list (each parameter instantiated at String, the existing convention extended to arity). Single-parameter emission pinned byte-identical.
- The README's Branded Newtypes generated-output blocks are swept to byte-equality with captured emissions: the marker is `$brand` (not `z.$brand`), the export annotation is `$ZodBranded<Class, "Name">` (not `ZodType`), the raw schemas carry `.meta({ description })`, the no-zod block emits no assert helper (none exists in the crate), and the generic example defers to the parameter's own `$Schema` binding per the generic-inner landing.
- The json-inner coverage helper now holds every variant its doc line claims (Slot, and Chrono under its feature), so the no-cfg-attribute test demonstrably walks the two arms where a stray cfg would land — verified by temporary local mutations, both reverted.