### PR TITLE
show the validate() sentences the generator actually writes, pinned against both drifts

### DIFF
--- a/README.md
+++ b/README.md
@@ -927,9 +927,11 @@ assert!(slug.validate().is_ok());
 let bad = SlugId("ab".to_string());
 match bad.validate() {
     Ok(()) => unreachable!(),
-    Err(errors) => println!("{:?}", errors), // ["'value' is too short: minimum length is 3, got 2"]
+    Err(errors) => println!("{:?}", errors), // ["value is too short: minimum length is 3, got 2"]
 }
 ```
+
+A brand names the rejected value `value`, bare, where a struct field is named and quoted (`'username'`): a newtype has one value and no field name to quote.
 
 You can use any combination of the three constraints:
 
@@ -1126,8 +1128,8 @@ match reg.validate() {
         for e in &errors {
             println!("Error: {e}");
         }
-        // "username: too short (minimum length 3, got 2)"
-        // "age: too large (maximum 120, got 150)"
+        // "'username' is too short: minimum length is 3, got 2"
+        // "'age' is too large: maximum is 120, got 150"
     }
 }
 ```

--- a/tests/validation_tests/tests.rs
+++ b/tests/validation_tests/tests.rs
@@ -2197,3 +2197,82 @@ fn test_every_variant_shape_reaches_the_accessor() {
         .unwrap();
     EveryShape::Nothing.validate().unwrap();
 }
+
+// ==================== The error strings the README prints ====================
+
+/// The README's `validate()` example prints the errors a caller reads back, and a reader who greps
+/// for one of those sentences, or writes an assertion against it, is holding the crate to it. So
+/// the example is expanded here as written and held to the same two things: the generator answers
+/// with those exact sentences, and the README still shows them. Drift on either side fails here
+/// rather than in someone's editor.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn test_readme_struct_validate_example_prints_what_the_generator_writes() {
+    // The README declares `username` first; source here is ordered alphabetically, as this crate's
+    // lints require of Rust source. Only the order the two are collected in differs, and that order
+    // is pinned by `test_enum_validate_collects_every_violation_of_the_held_variant`.
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug)]
+    pub struct Registration {
+        #[model_schema_prop(minimum = 0, maximum = 120)]
+        pub age: u32,
+
+        #[model_schema_prop(minLength = 3, maxLength = 30)]
+        pub username: String,
+    }
+
+    let reg = Registration {
+        age: 150,
+        username: "ab".to_owned(),
+    };
+    let errors = reg.validate().unwrap_err();
+    assert_eq!(
+        errors,
+        vec![
+            "'age' is too large: maximum is 120, got 150".to_owned(),
+            "'username' is too short: minimum length is 3, got 2".to_owned(),
+        ]
+    );
+
+    let readme = include_str!("../../README.md");
+    for error in &errors {
+        assert!(
+            readme.contains(error.as_str()),
+            "the README no longer shows this error verbatim: {error}"
+        );
+    }
+}
+
+/// The same holding for the branded newtype's `validate()` example. A brand names the rejected
+/// value bare where a struct field is named and quoted, which is the difference most easily lost
+/// when the sentence is written from memory.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn test_readme_branded_validate_example_prints_what_the_generator_writes() {
+    #[model_schema(pattern = "^[a-z0-9_]+$", minLength = 3, maxLength = 50)]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct SlugId(pub String);
+
+    SlugId("hello_world".to_owned()).validate().unwrap();
+
+    let errors = SlugId("ab".to_owned()).validate().unwrap_err();
+    assert_eq!(
+        errors,
+        vec!["value is too short: minimum length is 3, got 2".to_owned()]
+    );
+
+    let readme = include_str!("../../README.md");
+    for error in &errors {
+        assert!(
+            readme.contains(error.as_str()),
+            "the README no longer shows this error verbatim: {error}"
+        );
+    }
+}


### PR DESCRIPTION
The README's validate() example printed error strings nothing emits ("username: too short (minimum length 3, got 2)"). All three sites are corrected to captured runs — the struct example's two sentences, and the branded block's bare `value is too short: …` (a newtype has no field name to quote; one sentence added saying so, since bare `value` beside quoted `'username'` otherwise reads as a typo).

Two tests pin each example both ways: they expand the README's own types, assert `validate()` answers with exactly the shown sentences, then `include_str!` the README and assert it still shows each verbatim — generator drift and doc drift both fail the build. The pin was demonstrated to bite by temporarily restoring the old wording.