### PR TITLE
erase an item's own type parameters to the opaque value on the validating surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -734,6 +734,35 @@ export type DocumentRecord = {
 };
 ```
 
+### Type Parameters
+
+A generic alias and a generic branded newtype are the two items that can name their own type parameters, and every surface reads such a name under one rule.
+
+**TypeScript binds the parameter for real.** It is a type surface, and the declaration it emits carries the parameter list: `export type WrapperType<T> = Array<T>` is a generic type, and a use site fills `T` in.
+
+**Zod and JSON Schema erase it to the opaque value** -- `z.unknown()` and `{}`. A parameter names no type until the item is instantiated, and one schema is written for every instantiation, so the parameter admits any value while the shape around it -- an array, a map's keys, a tuple's arity -- stays described. Zod could not do otherwise even in principle: it publishes *values*, and a `const` takes no type parameters, so a parameter left to render would name a `$Schema` binding no emitted module declares, and the pasted output would throw a `ReferenceError` before reading a payload. The exported binding's annotation follows its value, taking the same opaque argument the value was composed with.
+
+```rust
+#[model_schema()]
+pub type Wrapper<T> = Vec<T>;
+```
+
+```typescript
+export type WrapperType<T> = Array<T>;
+
+const WrapperType$RawSchema = z.array(z.unknown());
+
+export const WrapperType$Schema: ZodType<WrapperType<unknown>> = WrapperType$RawSchema;
+```
+
+```json
+{ "type": "array", "items": {} }
+```
+
+Only the item's *own* parameters erase. A name the expansion cannot resolve because the type lives elsewhere keeps its `Name$Schema` reference, since that type publishes the binding.
+
+One consequence is worth stating outright: an opaque value carries no string checks, so a branded newtype cannot apply `pattern`, `minLength`, or `maxLength` to one of its own type parameters. See [Branded Newtype Validation Constraints](#branded-newtype-validation-constraints).
+
 ### Branded Newtypes
 
 `#[serde(transparent)]` tuple structs with a single public field generate branded TypeScript types. The newtype is invisible in JSON serialization but carries a distinct type identity in TypeScript, preventing accidental mixing of different ID types.
@@ -782,8 +811,8 @@ export function assertCorrelationId(value: string): asserts value is Correlation
 Notes:
 
 - If the Rust type name ends with `Json`, the suffix is stripped in the generated TypeScript (e.g., `UserIdJson` becomes `UserId`). Otherwise, the Rust name is used as-is.
-- Generic parameter names (e.g., `ID_TYPE`) are preserved exactly.
-- A brand describes what its inner writes whether or not the inner names the brand's type parameters, so `TagList<T>(pub Vec<T>)` is an array on every surface — `Array<T>`, `z.array(T$Schema)`, `$ZodBranded<ZodArray, "TagList">`, `{"type": "array", "items": {}}` — and not the bare parameter. The parameter itself carries what an uninstantiated parameter carries anywhere else: its own name in TypeScript, the `$Schema` binding named after it in Zod, and the permissive empty schema in JSON, since one schema is written for every instantiation.
+- Generic parameter names (e.g., `ID_TYPE`) are preserved exactly in the TypeScript type.
+- A brand describes what its inner writes whether or not the inner names the brand's type parameters, so `TagList<T>(pub Vec<T>)` is an array on every surface — `Array<T>`, `z.array(z.unknown())`, `$ZodBranded<ZodArray, "TagList">`, `{"type": "array", "items": {}}` — and not the bare parameter. The parameter itself carries what an uninstantiated parameter carries anywhere else, under the rule in [Type Parameters](#type-parameters).
 - Serde transparent serialization works normally -- the wrapper is invisible in JSON.
 - Use branded newtypes for opaque IDs and phantom types to prevent passing the wrong ID type across domain boundaries.
 
@@ -847,7 +876,23 @@ A generic brand carries the requirement as a `Display` bound on each type parame
 
 You can add `pattern`, `minLength`, and `maxLength` constraints directly on the `#[model_schema()]` attribute for branded newtypes. Constraints are enforced in three places: the generated Zod schema, serde deserialization, and a `validate()` method on the type.
 
-**The inner type has to be one whose schema is a string** — `String`, `PathBuf`, `ObjectId`, a chrono date/time type, another brand, or a generic parameter. A numeric, boolean, container (`Vec`, array, `HashMap`, tuple), or opaque (`serde_json::Value`) inner is rejected at expansion time, because the three constraints are string checks and each surface would read them differently: Zod's `.min`/`.max` become bounds on the value itself, JSON Schema ignores `minLength`/`maxLength`/`pattern` outside `"type": "string"`, and `validate()` measures the inner's `Display` rendering.
+**The inner type has to be one whose schema is a string** — `String`, `PathBuf`, `ObjectId`, a chrono date/time type, or another brand. A numeric, boolean, container (`Vec`, array, `HashMap`, tuple), or opaque inner is rejected at expansion time, because the three constraints are string checks and each surface would read them differently: Zod's `.min`/`.max` become bounds on the value itself, JSON Schema ignores `minLength`/`maxLength`/`pattern` outside `"type": "string"`, and `validate()` measures the inner's `Display` rendering.
+
+An opaque inner is `serde_json::Value` **or one of the brand's own type parameters**, which both validating surfaces read as the opaque value (see [Type Parameters](#type-parameters)). There is nothing there for the checks to attach to: Zod 4's `z.unknown()` carries no `.min`/`.max` at all, and `.brand()` hands back that same schema rather than a wrapper that could. Constrain a string-typed inner instead, or brand at the instantiation:
+
+```rust
+// Rejected: the checks would have to measure a value no surface has a shape for.
+#[model_schema(minLength = 3)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct GenericSlug<T>(pub T);
+
+// Accepted: the inner is a string, and the brand says so.
+#[model_schema(minLength = 3)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Slug(pub String);
+```
 
 **The inner type also has to implement `Display`,** since validation runs against `to_string()`. That holds whether or not the brand passes `no_display`: the flag drops the `Display` impl, not the requirement.
 
@@ -947,7 +992,7 @@ error: model_schema: branded newtype `BadNum` applies string constraints (patter
   |                   ^^^
 ```
 
-An inner type the macro cannot resolve — another brand, a user type, a generic parameter — is
+An inner type the macro cannot resolve because it lives elsewhere — another brand, a user type — is
 admitted here and checked for `Display` instead, so a non-`Display` one is still reported at the
 field:
 

--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -346,12 +346,29 @@ impl FieldDef {
     /// Replaces every reference to one of the enclosing item's type parameters with the opaque
     /// type.
     ///
-    /// A parameter names no type at expansion — the instantiation names one, and the schema is
-    /// written once for every instantiation. So a parameter describes as an opaque value does,
+    /// This is the one rule the two validating surfaces read a type parameter under, and the one
+    /// place they part company with TypeScript over it. A parameter names no type at expansion —
+    /// the instantiation names one, and one schema is written for every instantiation. So a
+    /// parameter describes as an opaque value does (`{}` in JSON Schema, `z.unknown()` in Zod),
     /// which leaves the shape it sits in — a tuple's arity, an array, a map's keys — described.
+    /// TypeScript needs no such rule: it is a type surface, and `export type Wrapper<T> =
+    /// Array<T>` binds `T` for real.
+    ///
+    /// Zod is why the rule cannot stop at JSON. Zod publishes *values*, and a `const` cannot be
+    /// parameterised, so a parameter left to render as the `Name$Schema` binding every unresolved
+    /// type is named after would reference a binding no emitted module declares — the consumer
+    /// pasting the output gets a `ReferenceError` before a payload is read. That is why only the
+    /// enclosing item's *own* parameters erase: a genuinely unresolved sibling type keeps its
+    /// `$Schema` reference, because the type it names does publish that binding.
+    ///
+    /// The erasure carries into what a schema surface may then claim about the value. An opaque
+    /// value takes no string checks — Zod 4's `z.unknown()` carries no `.min`/`.max`, and
+    /// `.brand()` hands back the very same instance rather than a wrapper that could — so a
+    /// branded newtype constraining one of its own parameters is refused, through the opaque arm
+    /// of `non_string_inner_shape` this erasure puts it in front of.
     ///
     /// Recurses through `SiblingType` generics, `Map` keys/values, and `Tuple` elements.
-    #[cfg(feature = "jsonschema")]
+    #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
     pub fn erase_type_parameters(&mut self, parameters: &[String]) {
         if let FieldDefType::SiblingType(name, _) = &self.field_type
             && parameters.iter().any(|parameter| parameter == name)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,6 +225,13 @@ pub struct Document {
 /// A generic brand carries the requirement as a `Display` bound on each type parameter, so a
 /// non-`Display` type argument is rejected where the brand is used, not where it is declared.
 ///
+/// String constraints stop at the brand's own type parameters. TypeScript binds a parameter for
+/// real, but the two validating surfaces read it as the opaque value — one schema is written for
+/// every instantiation — and an opaque value takes no string checks: Zod 4's `z.unknown()` carries
+/// no `.min`/`.max`, and `.brand()` returns that same schema rather than a wrapper that could. So
+/// `#[model_schema(minLength = 3)] struct Slug<T>(pub T);` is refused at the inner field. Constrain
+/// a string-typed inner instead.
+///
 #[proc_macro_attribute]
 pub fn model_schema(args: TokenStream, input: TokenStream) -> TokenStream {
     exec_model_schema(args, input)

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -802,7 +802,8 @@ fn process_type_alias(item_type: ItemType, args: &ModelSchemaArgs) -> TokenStrea
     let ts_method = generate_alias_ts_definition_method(&alias, &export_name, &alias_field_def);
     let json_schema_method =
         generate_alias_json_schema_method(&alias, &export_name, &alias_field_def);
-    let zod_method = generate_alias_zod_method(&export_name, &rust_ident_str, &alias_field_def);
+    let zod_method =
+        generate_alias_zod_method(&alias, &export_name, &rust_ident_str, &alias_field_def);
 
     let output = quote! {
         #alias
@@ -1400,16 +1401,24 @@ fn branded_option_inner_error(
 /// number schema at all. A container inner never reaches that disagreement — it has no `Display`
 /// to render.
 ///
-/// A `SiblingType` inner — another brand, an unresolved user type, or a bare generic parameter —
-/// is admitted, because expansion cannot know its shape. That is why the constrained path asserts
-/// `Display` separately: the guard bounds the schema surfaces, the assertion bounds the Rust one.
-/// A sequence wrapper is the one `SiblingType` spelling that says its shape outright, and is
-/// refused as the array it is.
+/// A `SiblingType` inner — another brand, or an unresolved user type — is admitted, because
+/// expansion cannot know its shape. That is why the constrained path asserts `Display` separately:
+/// the guard bounds the schema surfaces, the assertion bounds the Rust one. A sequence wrapper is
+/// the one `SiblingType` spelling that says its shape outright, and is refused as the array it is.
+///
+/// One of the brand's *own* type parameters is not such a name: it says its shape outright too,
+/// because both validating surfaces have already settled that it has none. Reading the inner off
+/// [`value_surface_field_def`] puts it in front of the opaque arm, where it belongs — Zod 4's
+/// `z.unknown()` carries no `.min`/`.max` at all, and `.brand()` returns the same instance rather
+/// than a wrapper that could, so there is nothing for the checks to attach to; JSON Schema's
+/// string keywords go inert beside the `{}` a parameter describes as; and `validate()` still
+/// measures `Display`. Three surfaces, three answers — the disagreement this guard exists to stop.
 ///
 /// Resolved through the same `get_field_def` call the renderers make, so the guard and the
 /// contract cannot disagree about what a shape is.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn branded_constraint_inner_error(
+    generics: &syn::Generics,
     name: &Ident,
     inner_field: &Field,
     args: &ModelSchemaArgs,
@@ -1417,7 +1426,10 @@ fn branded_constraint_inner_error(
     if !args.has_string_constraints() {
         return None;
     }
-    let shape = non_string_inner_shape(&get_field_def("_inner", &inner_field.ty, ""))?;
+    let shape = non_string_inner_shape(&value_surface_field_def(
+        generics,
+        &get_field_def("_inner", &inner_field.ty, ""),
+    ))?;
     Some(
         syn::Error::new_spanned(
             inner_field,
@@ -1597,6 +1609,7 @@ fn branded_guard_errors(
         .into_iter()
         .chain(branded_option_inner_error(&item_struct.ident, inner_field))
         .chain(branded_constraint_inner_error(
+            &item_struct.generics,
             &item_struct.ident,
             inner_field,
             args,
@@ -2125,21 +2138,6 @@ fn process_tuple_struct(
     )
 }
 
-/// Processes a branded newtype (transparent single-field tuple struct) and generates
-/// TypeScript branded type definitions and Zod brand schemas.
-///
-/// A branded newtype is detected when a struct has **both** `#[serde(transparent)]` and exactly
-/// one unnamed field. The generated output depends on the active features:
-///
-/// - With `zod` + `typescript`: emits a Zod `.brand<"Name">()` schema and a
-///   `type Name<T> = T & z.$brand<"Name">` alias.
-/// - With `typescript` only (no `zod`): emits a `unique symbol` brand pattern and an
-///   `assertName()` type-assertion helper function.
-///
-/// Generic parameters on the struct are preserved in the TypeScript output. For non-generic
-/// newtypes, the inner field's Rust type is resolved to its TypeScript equivalent. For generic
-/// newtypes, the Zod schema always uses `z.string()` as the base because the generic parameter
-/// cannot be resolved at macro-expansion time.
 /// Builds the `validate_value`/`deserialize_value` functions for a constrained branded newtype.
 ///
 /// Returns `None` when the newtype has no string constraints. A path inner is measured by the
@@ -2457,20 +2455,61 @@ fn build_branded_json_schema_method(
     json_schema_methods(def_name, &body)
 }
 
-/// Extracts the generic type parameter names from a branded newtype's generics.
+/// The names an item's own declaration binds as type parameters.
+///
+/// This is the whole of what separates a name the expansion cannot resolve *because it is a
+/// parameter* from one it cannot resolve because the type lives elsewhere: the first is in scope
+/// here and names no type any emitted output can reference, the second names a type that publishes
+/// its own schema module. Every surface that has to draw that line draws it from this one list —
+/// see [`FieldDef::erase_type_parameters`].
+///
+/// Lifetimes and const parameters name no type a field position can be written out of, so they are
+/// left out.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-fn branded_generic_params(generics: &syn::Generics) -> Vec<String> {
+fn type_parameters_in_scope(generics: &syn::Generics) -> Vec<String> {
     generics
         .params
         .iter()
-        .filter_map(|p| {
-            if let syn::GenericParam::Type(tp) = p {
-                Some(tp.ident.to_string())
-            } else {
-                None
-            }
+        .filter_map(|param| match param {
+            syn::GenericParam::Type(tp) => Some(tp.ident.to_string()),
+            syn::GenericParam::Const(_) | syn::GenericParam::Lifetime(_) => None,
         })
         .collect()
+}
+
+/// The `FieldDef` a value-level surface renders from: the written one with every reference to the
+/// enclosing item's own type parameters replaced by the opaque type.
+///
+/// The one seam the Zod and JSON surfaces share for a parameter, and so the reason an alias and a
+/// brand cannot drift apart over one — see [`FieldDef::erase_type_parameters`] for the rule and
+/// for why TypeScript reads the written def instead.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn value_surface_field_def(generics: &syn::Generics, written: &FieldDef) -> FieldDef {
+    let mut erased = written.clone();
+    erased.erase_type_parameters(&type_parameters_in_scope(generics));
+    erased
+}
+
+/// The TypeScript argument list a generic item's own name takes where a Zod binding's annotation
+/// names it: one `unknown` per parameter, and nothing at all for an item that declares none.
+///
+/// The annotation states the type of the value beside it, and that value was composed with every
+/// parameter erased — so the name it is written under has to be filled in the same way. Naming the
+/// generic bare instead is a TypeScript error in its own right, the type requiring its arguments.
+#[cfg(feature = "zod")]
+fn erased_type_arguments(generics: &syn::Generics) -> String {
+    let parameters = type_parameters_in_scope(generics);
+    if parameters.is_empty() {
+        return String::new();
+    }
+    format!("<{}>", vec!["unknown"; parameters.len()].join(", "))
+}
+
+/// The one def both validating surfaces read a branded newtype's inner off, so neither can render
+/// a type parameter the other has erased — see [`value_surface_field_def`].
+#[cfg(any(feature = "zod", feature = "jsonschema"))]
+fn branded_value_inner(generics: &syn::Generics, inner_ty: &syn::Type) -> FieldDef {
+    value_surface_field_def(generics, &get_field_def("_inner", inner_ty, ""))
 }
 
 /// Resolves the TypeScript inner type name and generic parameter list for a branded newtype.
@@ -2498,15 +2537,13 @@ fn branded_ts_type_and_generics(
     (ts_inner_type, ts_generics)
 }
 
-/// Resolves the JSON schema shape for a branded newtype's inner field.
+/// Resolves the JSON schema shape for a branded newtype's inner field, read off the def
+/// [`value_surface_field_def`] has already erased the brand's own type parameters out of.
 ///
-/// The brand's own type parameters are replaced by the opaque type before the inner is classified,
-/// exactly as [`alias_json_schema_field_def`] replaces an alias's: a parameter names no type until
-/// the brand is instantiated, and the schema is written once for every instantiation. So the
-/// parameter admits any value while the shape it sits in — an array, a map's keys, a tuple's arity
-/// — is still described, which is what `#[serde(transparent)]` puts on the wire.
+/// So a parameter admits any value while the shape it sits in — an array, a map's keys, a tuple's
+/// arity — is still described, which is what `#[serde(transparent)]` puts on the wire.
 ///
-/// An `ObjectId`, a composite and a named type are then read off their own `FieldDef`, because none
+/// An `ObjectId`, a composite and a named type are then read off that same `FieldDef`, because none
 /// of them writes a value one `"type"` keyword describes; a chrono type writes a string one keyword
 /// names but not the only one it carries. Every remaining inner maps from the resolved TypeScript
 /// type name.
@@ -2515,15 +2552,13 @@ fn branded_ts_type_and_generics(
 /// answers for the array around whatever it holds — which is what `#[serde(transparent)]` puts on
 /// the wire — rather than for the item.
 #[cfg(feature = "jsonschema")]
-fn branded_json_inner(generic_params: &[String], inner_ty: &syn::Type) -> BrandedJsonInner {
-    let mut inner = get_field_def("_inner", inner_ty, "");
-    inner.erase_type_parameters(generic_params);
+fn branded_json_inner(inner: &FieldDef) -> BrandedJsonInner {
     #[cfg(feature = "object_id")]
-    if branded_inner_is_object_id(&inner) {
+    if branded_inner_is_object_id(inner) {
         return BrandedJsonInner::ObjectId;
     }
-    if branded_inner_composite(&inner).is_some() {
-        return BrandedJsonInner::Slot(Box::new(inner));
+    if branded_inner_composite(inner).is_some() {
+        return BrandedJsonInner::Slot(Box::new(inner.clone()));
     }
     #[cfg(feature = "chrono")]
     if let Some(format) = chrono_json_schema_format(&inner.field_type) {
@@ -2533,7 +2568,7 @@ fn branded_json_inner(generic_params: &[String], inner_ty: &syn::Type) -> Brande
     // names, through the reference every other position defers it through — which is what makes a
     // forward declaration and a cycle behave for a brand as they behave for a field.
     if matches!(inner.field_type, FieldDefType::SiblingType(..)) {
-        return BrandedJsonInner::Slot(Box::new(inner));
+        return BrandedJsonInner::Slot(Box::new(inner.clone()));
     }
     BrandedJsonInner::Scalar(match inner.typescript_typename().as_str() {
         "number" => "number".to_owned(),
@@ -2628,15 +2663,15 @@ fn branded_inner_composite(inner: &FieldDef) -> Option<BrandedComposite> {
 /// `ObjectId` is the value the schema itself describes. An `ObjectId` writes `{"$oid": hex}`, so
 /// its `Display` is the `$oid` member and the checks land there.
 ///
-/// A brand's own type parameters are rendered here as they are anywhere else the value expression
-/// reaches one: through the `Name$Schema` binding `zod_array_base` names every unresolved type
-/// after, which is what a generic alias's value already publishes for a parameter.
+/// The inner is the def [`value_surface_field_def`] has already erased the brand's own type
+/// parameters out of, so a parameter composes into the value as `z.unknown()` rather than as a
+/// binding nothing declares. The checks never land on one: an opaque inner carries no string for
+/// them to measure and is refused by [`branded_constraint_inner_error`] before this.
 #[cfg(feature = "zod")]
-fn branded_zod_inner(args: &ModelSchemaArgs, inner_ty: &syn::Type) -> String {
+fn branded_zod_inner(args: &ModelSchemaArgs, inner: &FieldDef) -> String {
     let checks = branded_zod_string_checks(args);
-    let inner = get_field_def("_inner", inner_ty, "");
     #[cfg(feature = "object_id")]
-    if branded_inner_is_object_id(&inner) {
+    if branded_inner_is_object_id(inner) {
         return get_object_id_zod_schema_with(&checks);
     }
     format!("{}{checks}", inner.zod_type())
@@ -2658,17 +2693,15 @@ fn branded_zod_inner(args: &ModelSchemaArgs, inner_ty: &syn::Type) -> String {
 /// was called on, so the binding's type is the base schema's type whether or not the brand
 /// constrains it.
 ///
-/// A type parameter is a name like any other, so it is annotated through that same named-inner arm
-/// — the type of the binding the value was composed from — and the two surfaces cannot disagree
-/// about what the brand wraps.
+/// A type parameter reaches this off the erased def, as `z.unknown()` — the opaque arm — so the
+/// annotation follows the value rather than naming a binding the value no longer composes from.
 #[cfg(all(feature = "zod", feature = "typescript"))]
-fn branded_zod_type_name(inner_ty: &syn::Type) -> String {
-    let inner = get_field_def("_inner", inner_ty, "");
+fn branded_zod_type_name(inner: &FieldDef) -> String {
     #[cfg(feature = "object_id")]
-    if branded_inner_is_object_id(&inner) {
+    if branded_inner_is_object_id(inner) {
         return "ZodObject".to_owned();
     }
-    if let Some(composite) = branded_inner_composite(&inner) {
+    if let Some(composite) = branded_inner_composite(inner) {
         return match composite {
             BrandedComposite::Array => "ZodArray".to_owned(),
             BrandedComposite::Map => "ZodRecord".to_owned(),
@@ -2723,18 +2756,22 @@ fn build_branded_ts_definition_method(
 }
 
 /// Builds the `zod_schema()` method for a branded newtype's schema module.
+///
+/// The value and the annotation are both read off the one erased inner, so the type the binding
+/// claims and the schema it holds cannot describe different things.
 #[cfg(feature = "zod")]
 fn build_branded_zod_schema_method(
+    args: &ModelSchemaArgs,
     item_name: &str,
     rust_ident: &str,
-    inner_ty: &syn::Type,
-    zod_inner: &str,
+    inner: &FieldDef,
     plain_description: &str,
 ) -> proc_macro2::TokenStream {
+    let zod_inner = branded_zod_inner(args, inner);
     let reexport = ident_reexport_zod(rust_ident, item_name);
     #[cfg(feature = "typescript")]
     {
-        let zod_type_name = branded_zod_type_name(inner_ty);
+        let zod_type_name = branded_zod_type_name(inner);
         let zod_type_annotation = format!("$ZodBranded<{zod_type_name}, \"{item_name}\">");
         quote! {
             pub fn zod_schema() -> String {
@@ -2747,7 +2784,7 @@ fn build_branded_zod_schema_method(
     }
     #[cfg(not(feature = "typescript"))]
     {
-        let _: &_ = &inner_ty;
+        let _: &_ = &inner;
         quote! {
             pub fn zod_schema() -> String {
                 format!(
@@ -3106,6 +3143,21 @@ fn branded_guard_failure_output(
     )
 }
 
+/// Processes a branded newtype (transparent single-field tuple struct) and generates
+/// TypeScript branded type definitions and Zod brand schemas.
+///
+/// A branded newtype is detected when a struct has **both** `#[serde(transparent)]` and exactly
+/// one unnamed field. The generated output depends on the active features:
+///
+/// - With `zod` + `typescript`: emits a Zod `.brand<"Name">()` schema and a
+///   `type Name<T> = T & z.$brand<"Name">` alias.
+/// - With `typescript` only (no `zod`): emits a `unique symbol` brand pattern and an
+///   `assertName()` type-assertion helper function.
+///
+/// Generic parameters on the struct are preserved in the TypeScript output, whose declaration
+/// binds them. The two validating surfaces read the inner off the erased def instead, so a
+/// parameter reaching either of them describes as the opaque value — see
+/// [`FieldDef::erase_type_parameters`].
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn process_branded_newtype(item_struct: syn::ItemStruct, args: &ModelSchemaArgs) -> TokenStream {
     if let Some(output) = branded_guard_failure_output(&item_struct, args) {
@@ -3138,7 +3190,7 @@ fn process_branded_newtype(item_struct: syn::ItemStruct, args: &ModelSchemaArgs)
     let plain_description = item_description(docs_vec.as_deref(), &item_name);
 
     // Get generic type parameters from the struct
-    let generic_params = branded_generic_params(&item_struct.generics);
+    let generic_params = type_parameters_in_scope(&item_struct.generics);
     let is_generic = !generic_params.is_empty();
 
     // Get inner field type info
@@ -3152,11 +3204,11 @@ fn process_branded_newtype(item_struct: syn::ItemStruct, args: &ModelSchemaArgs)
     #[cfg(not(any(feature = "typescript", feature = "zod")))]
     let _: &_ = &inner_ty;
 
-    #[cfg(feature = "jsonschema")]
-    let json_inner = branded_json_inner(&generic_params, inner_ty);
+    #[cfg(any(feature = "zod", feature = "jsonschema"))]
+    let value_inner = branded_value_inner(&item_struct.generics, inner_ty);
 
-    #[cfg(feature = "zod")]
-    let zod_inner = branded_zod_inner(args, inner_ty);
+    #[cfg(feature = "jsonschema")]
+    let json_inner = branded_json_inner(&value_inner);
 
     // --- Generate ts_definition method ---
     #[cfg(feature = "typescript")]
@@ -3166,10 +3218,10 @@ fn process_branded_newtype(item_struct: syn::ItemStruct, args: &ModelSchemaArgs)
     // --- Generate zod_schema method ---
     #[cfg(feature = "zod")]
     let zod_schema_method = build_branded_zod_schema_method(
+        args,
         &item_name,
         &rust_ident,
-        inner_ty,
-        &zod_inner,
+        &value_inner,
         &plain_description,
     );
 
@@ -8652,29 +8704,6 @@ fn generate_ts_alias_method(
     }
 }
 
-/// The alias target as the JSON mapping reads it: every reference to one of the alias's own type
-/// parameters replaced by the opaque type.
-///
-/// A parameter names no type until the alias is instantiated, and every position that references an
-/// alias references it uninstantiated — a field written as `Pair<A, B>` carries the alias module's
-/// one schema. So a parameter admits any value, as an opaque field does, while the shape around it
-/// — arity, array-ness, a map's keys — is still described.
-#[cfg(feature = "jsonschema")]
-fn alias_json_schema_field_def(alias: &ItemType, field_def: &FieldDef) -> FieldDef {
-    let parameters: Vec<String> = alias
-        .generics
-        .params
-        .iter()
-        .filter_map(|param| match param {
-            syn::GenericParam::Type(tp) => Some(tp.ident.to_string()),
-            syn::GenericParam::Const(_) | syn::GenericParam::Lifetime(_) => None,
-        })
-        .collect();
-    let mut erased = field_def.clone();
-    erased.erase_type_parameters(&parameters);
-    erased
-}
-
 /// The diagnostic an alias whose target the dispatch cannot render emits, in place of the whole
 /// `json_schema()` body.
 ///
@@ -8708,8 +8737,9 @@ fn generate_alias_json_schema_method(
 ) -> proc_macro2::TokenStream {
     #[cfg(feature = "jsonschema")]
     {
-        let body = build_tuple_element_json_schema(&alias_json_schema_field_def(alias, field_def))
-            .unwrap_or_else(|rejection| alias_json_schema_rejection(export_name, &rejection));
+        let body =
+            build_tuple_element_json_schema(&value_surface_field_def(&alias.generics, field_def))
+                .unwrap_or_else(|rejection| alias_json_schema_rejection(export_name, &rejection));
         json_schema_methods(export_name, &body)
     }
     #[cfg(not(feature = "jsonschema"))]
@@ -8721,8 +8751,17 @@ fn generate_alias_json_schema_method(
     }
 }
 
+/// Builds the alias module's `zod_schema()`, or nothing when `zod` is off.
+///
+/// The value is rendered from the target read through [`value_surface_field_def`], for the reason
+/// [`FieldDef::erase_type_parameters`] records: a `const` cannot be parameterised, so a parameter
+/// left as the `Name$Schema` binding an unresolved type is named after would reference a binding
+/// no emitted module declares. The exported binding's annotation then follows the value, taking
+/// the same opaque argument the value was composed with — a generic alias named bare in it would
+/// be a TypeScript error of its own.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn generate_alias_zod_method(
+    alias: &ItemType,
     export_name: &str,
     rust_ident: &str,
     field_def: &FieldDef,
@@ -8733,13 +8772,14 @@ fn generate_alias_zod_method(
         // the null-flavored `z.tuple([...])`, a scalar yields `z.string()`, a sibling
         // yields `Name$Schema`). Bind it to `$RawSchema` and re-export the annotated
         // `$Schema`, mirroring how struct/enum schemas expose their const.
-        let schema_code = field_def.zod_type();
+        let schema_code = value_surface_field_def(&alias.generics, field_def).zod_type();
+        let annotated_name = format!("{export_name}{}", erased_type_arguments(&alias.generics));
         let reexport = ident_reexport_zod(rust_ident, export_name);
         quote! {
             pub fn zod_schema() -> String {
                 format!(
                     "const {}$RawSchema = {};\n\nexport const {}$Schema: ZodType<{}> = {}$RawSchema;{}",
-                    #export_name, #schema_code, #export_name, #export_name, #export_name, #reexport
+                    #export_name, #schema_code, #export_name, #annotated_name, #export_name, #reexport
                 )
             }
         }
@@ -8748,7 +8788,7 @@ fn generate_alias_zod_method(
     {
         // Without the `zod` feature, `FieldDef::zod_type` does not exist; nothing in
         // this build has zod enabled, so the schema method would be cfg'd out anyway.
-        let _: &_ = &(export_name, rust_ident, field_def);
+        let _: &_ = &(alias, export_name, rust_ident, field_def);
         quote! {}
     }
 }

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -2236,6 +2236,37 @@ fn an_alias_type_parameter_is_erased_at_every_depth() {
     }
 }
 
+/// The same erasure at the same depths on the value surface, where the consequence of skipping it
+/// is louder: a Zod `const` cannot be parameterised, so a parameter left to render names a
+/// `$Schema` binding no emitted module declares and the pasted output throws before a payload is
+/// read. Asserted over the identical alias list the JSON test walks, so the two surfaces cannot
+/// erase at different depths.
+#[cfg(feature = "zod")]
+#[test]
+fn an_alias_type_parameter_is_erased_at_every_depth_on_the_value_surface() {
+    for alias_source in [
+        "pub type Holder<V> = V;",
+        "pub type Holder<V> = Vec<V>;",
+        "pub type Holder<V> = Option<V>;",
+        "pub type Holder<V> = (String, V);",
+        "pub type Holder<V> = HashMap<String, V>;",
+        "pub type Holder<V> = HashMap<String, Vec<V>>;",
+    ] {
+        let alias: syn::ItemType = syn::parse_str(alias_source).unwrap();
+        let field_def = super::get_field_def("HolderType", &alias.ty, "");
+        let tokens = super::generate_alias_zod_method(&alias, "HolderType", "Holder", &field_def)
+            .to_string();
+        assert!(
+            !tokens.contains("V$Schema"),
+            "for {alias_source}, got: {tokens}"
+        );
+        assert!(
+            tokens.contains("\"HolderType<unknown>\""),
+            "for {alias_source}, got: {tokens}"
+        );
+    }
+}
+
 /// The stub this replaced answered every alias with an object carrying a lone `warning` key, which
 /// under JSON Schema constrains nothing — every slot naming an alias accepted every payload. No
 /// emission may carry one again.
@@ -2255,9 +2286,12 @@ fn no_json_schema_emission_carries_a_warning_key() {
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
 fn alias_zod_method_carries_no_cfg_attribute() {
+    let alias: syn::ItemType = syn::parse_quote!(
+        pub type Alias = String;
+    );
     let ty: syn::Type = syn::parse_quote!(String);
     let field_def = super::get_field_def("AliasType", &ty, "");
-    let tokens = super::generate_alias_zod_method("AliasType", "Alias", &field_def);
+    let tokens = super::generate_alias_zod_method(&alias, "AliasType", "Alias", &field_def);
     assert_no_cfg_attribute(&tokens, "generate_alias_zod_method");
 }
 
@@ -2496,10 +2530,14 @@ fn string_constraints_over_a_non_string_inner_are_rejected() {
     }
 }
 
-/// The inners that carry the constraints faithfully. A `SiblingType` — another brand, an
-/// unresolved user type, or a bare generic parameter — is admitted because expansion cannot know
-/// its shape; the constrained path's `Display` assertion is what covers it. A name carrying one
-/// argument that is not a sequence wrapper is such a name too, and stays admitted.
+/// The inners that carry the constraints faithfully. A `SiblingType` — another brand, or an
+/// unresolved user type — is admitted because expansion cannot know its shape; the constrained
+/// path's `Display` assertion is what covers it. A name carrying one argument that is not a
+/// sequence wrapper is such a name too, and stays admitted.
+///
+/// `U` is written where the brand declares no such parameter, so it is one of those unresolved
+/// names rather than a parameter: that is the whole of the line the classifier draws, and the
+/// brand's own `T` is on the other side of it in the test below.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
 fn string_constraints_over_a_string_shaped_inner_pass() {
@@ -2508,7 +2546,7 @@ fn string_constraints_over_a_string_shaped_inner_pass() {
         "PathBuf",
         "ObjectId",
         "SomeOtherBrand",
-        "T",
+        "U",
         "SomeWrapper<String>",
     ] {
         let ty: syn::Type = syn::parse_str(inner).unwrap();
@@ -2520,6 +2558,36 @@ fn string_constraints_over_a_string_shaped_inner_pass() {
             &pattern_args(),
         );
         assert!(errors.is_empty(), "for {inner}, got: {errors:?}");
+    }
+}
+
+/// A brand constraining one of its own type parameters has nothing to hang the checks on.
+///
+/// Both validating surfaces read a parameter as the opaque value, and an opaque value takes no
+/// string checks: Zod 4's `z.unknown()` carries no `.min`/`.max`, and `.brand()` hands back that
+/// same instance rather than a wrapper that could; JSON Schema's string keywords go inert beside
+/// the `{}` a parameter describes as; and `validate()` still measures `Display`. So the parameter
+/// reaches the same refusal `serde_json::Value` reaches, through the same opaque arm — the erasure
+/// is what puts it there, and is why the guard does not have to name parameters itself.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn string_constraints_over_the_brands_own_type_parameter_are_rejected() {
+    for inner in ["T", "U"] {
+        let ty: syn::Type = syn::parse_str(inner).unwrap();
+        let errors = branded_errors_with(
+            &syn::parse_quote! {
+                #[serde(transparent)]
+                struct Branded<T, U>(pub #ty);
+            },
+            &pattern_args(),
+        );
+        assert_eq!(errors.len(), 1, "for {inner}, got: {errors:?}");
+        assert!(errors[0].contains("`Branded`"), "got: {}", errors[0]);
+        assert!(
+            errors[0].contains("opaque"),
+            "for {inner}, got: {}",
+            errors[0]
+        );
     }
 }
 
@@ -4478,7 +4546,7 @@ fn a_sibling_slot_carries_the_schema_module_reference() {
 fn brand_json_schema_over(inner_ty: &syn::Type) -> String {
     super::build_branded_json_schema_method(
         &super::ModelSchemaArgs::default(),
-        &super::branded_json_inner(&[], inner_ty),
+        &super::branded_json_inner(&super::get_field_def("_inner", inner_ty, "")),
         "Wrapped",
     )
     .to_string()

--- a/tests/branded_newtype_tests/tests.rs
+++ b/tests/branded_newtype_tests/tests.rs
@@ -49,17 +49,19 @@ mod zod_ts_tests {
         );
     }
 
-    /// The parameter is what the brand wraps, so the value is composed from the binding named
-    /// after it and the annotation is that binding's own type — the pair a named inner publishes,
-    /// and the same `$Schema` reference a generic alias's value publishes for a parameter.
+    /// The parameter is what the brand wraps, and on a value surface that is the opaque value:
+    /// a `const` cannot be parameterised, so a binding named after the parameter would be one
+    /// nothing declares. The annotation follows the value, as it does for every other inner. The
+    /// TypeScript type beside it keeps `IdType`, its own declaration binding it for real.
     #[test]
     fn test_branded_newtype_zod_schema() {
         let zod = RoleId::<String>::zod_schema();
-        assert!(zod.contains("IdType$Schema.brand"), "Got: {zod}");
+        assert!(zod.contains("z.unknown().brand"), "Got: {zod}");
         assert!(
-            zod.contains("$ZodBranded<typeof IdType$Schema, \"RoleId\">"),
+            zod.contains("$ZodBranded<ZodUnknown, \"RoleId\">"),
             "Got: {zod}"
         );
+        assert!(!zod.contains("IdType"), "Got: {zod}");
     }
 
     #[test]
@@ -183,12 +185,6 @@ mod zod_ts_tests {
 mod constrained_branded_tests {
     use super::*;
 
-    // Generic branded newtype with constraints — validates via ToString
-    #[model_schema(pattern = "^[a-z0-9_]+$", minLength = 3, maxLength = 50)]
-    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-    #[serde(transparent)]
-    pub struct GenericSlug<T>(pub T);
-
     // Pattern-only constraint
     #[model_schema(pattern = "^[0-9a-fA-F]{24}$")]
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -291,51 +287,6 @@ mod constrained_branded_tests {
 
         let invalid = ObjectIdStr("not-a-hex-id".to_owned());
         assert!(invalid.validate().is_err());
-    }
-
-    #[test]
-    fn test_generic_constrained_branded_validate_pass() {
-        let valid = GenericSlug("hello_world".to_owned());
-        valid.validate().unwrap();
-    }
-
-    #[test]
-    fn test_generic_constrained_branded_validate_too_short() {
-        let short = GenericSlug("ab".to_owned());
-        let result = short.validate();
-        assert!(result.is_err());
-        assert!(result.unwrap_err()[0].contains("too short"));
-    }
-
-    #[test]
-    fn test_generic_constrained_branded_validate_bad_pattern() {
-        let bad = GenericSlug("UPPERCASE".to_owned());
-        let result = bad.validate();
-        assert!(result.is_err());
-        assert!(result.unwrap_err()[0].contains("pattern"));
-    }
-
-    #[test]
-    fn test_generic_constrained_branded_serde_rejects_invalid() {
-        let result: Result<GenericSlug<String>, _> = serde_json::from_str("\"ab\"");
-        assert!(result.is_err(), "Should reject too-short value via serde");
-    }
-
-    #[test]
-    fn test_generic_constrained_branded_serde_accepts_valid() {
-        let result: Result<GenericSlug<String>, _> = serde_json::from_str("\"hello_world\"");
-        assert!(result.is_ok(), "Should accept valid value via serde");
-    }
-
-    #[test]
-    fn test_generic_constrained_branded_zod_has_constraints() {
-        let zod = GenericSlug::<String>::zod_schema();
-        assert!(zod.contains(".min(3)"), "Got:\n{zod}");
-        assert!(zod.contains(".max(50)"), "Got:\n{zod}");
-        assert!(
-            zod.contains(".check(z.regex(/^[a-z0-9_]+$/))"),
-            "Got:\n{zod}"
-        );
     }
 }
 
@@ -820,32 +771,25 @@ mod branded_constrained_json_schema_tests {
     #[model_schema(minLength = 24, maxLength = 24, pattern = "^[a-f\\d]{24}$")]
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     #[serde(transparent)]
-    pub struct ConstrainedId<T>(pub T);
+    pub struct ConstrainedId(pub String);
 
     #[model_schema(minLength = 3, maxLength = 50)]
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     #[serde(transparent)]
     pub struct ShortId(pub String);
 
-    /// A bare parameter names no type to describe, so the brand's own constraints narrow it from
-    /// inside the `allOf` every inner without a `"type"` of its own is layered under, rather than
-    /// asserting a `"string"` the parameter was never held to.
     #[test]
     fn test_constrained_branded_json_schema() {
         // The `\d` the brand is declared with reaches the schema as the members it stands for: a
         // JSON Schema `pattern` is an ECMA-262 regex, which reads `\d` as ASCII, while the Rust
         // validator beside it reads the Unicode class. Written out, both read the one set.
         assert_eq!(
-            ConstrainedId::<String>::json_schema(),
+            ConstrainedId::json_schema(),
             serde_json::json!({
-                "allOf": [
-                    {},
-                    {
-                        "minLength": 24_u32,
-                        "maxLength": 24_u32,
-                        "pattern": "^[a-f0-9]{24}$"
-                    }
-                ]
+                "type": "string",
+                "minLength": 24_u32,
+                "maxLength": 24_u32,
+                "pattern": "^[a-f0-9]{24}$"
             })
         );
     }
@@ -1261,8 +1205,9 @@ mod branded_composite_inner_tests {
 /// carry the same rendering it does.
 ///
 /// The parameter itself carries what an uninstantiated parameter carries in every other position:
-/// its own name in TypeScript, the `$Schema` binding named after it in Zod, and the permissive
-/// empty schema in JSON, where a parameter names no type to describe.
+/// its own name in TypeScript, where the declaration binds it for real, and the opaque value on
+/// both validating surfaces — `z.unknown()` in Zod and the permissive empty schema in JSON — where
+/// a parameter names no type to describe and nothing declares a binding for it.
 #[cfg(all(
     feature = "jsonschema",
     feature = "serde",
@@ -1337,7 +1282,7 @@ mod branded_generic_inner_tests {
         );
         let zod = TagList::<String>::zod_schema();
         assert!(
-            zod.contains(r#"const TagList$RawSchema = z.array(T$Schema).brand<"TagList">()"#),
+            zod.contains(r#"const TagList$RawSchema = z.array(z.unknown()).brand<"TagList">()"#),
             "Got:\n{zod}"
         );
         assert!(
@@ -1359,7 +1304,7 @@ mod branded_generic_inner_tests {
         let zod = WeightIndex::<u32>::zod_schema();
         assert!(
             zod.contains(
-                r#"const WeightIndex$RawSchema = z.record(z.string(), T$Schema).brand<"WeightIndex">()"#
+                r#"const WeightIndex$RawSchema = z.record(z.string(), z.unknown()).brand<"WeightIndex">()"#
             ),
             "Got:\n{zod}"
         );
@@ -1383,11 +1328,11 @@ mod branded_generic_inner_tests {
         );
         let zod = BareTag::<String>::zod_schema();
         assert!(
-            zod.contains(r#"const BareTag$RawSchema = T$Schema.brand<"BareTag">()"#),
+            zod.contains(r#"const BareTag$RawSchema = z.unknown().brand<"BareTag">()"#),
             "Got:\n{zod}"
         );
         assert!(
-            zod.contains(r#"BareTag$Schema: $ZodBranded<typeof T$Schema, "BareTag">"#),
+            zod.contains(r#"BareTag$Schema: $ZodBranded<ZodUnknown, "BareTag">"#),
             "Got:\n{zod}"
         );
         assert_eq!(BareTag::<String>::json_schema(), serde_json::json!({}));
@@ -1420,7 +1365,7 @@ mod branded_generic_inner_tests {
             (
                 TagList::<String>::zod_schema(),
                 tag_seq_schema::Schema::zod_schema(),
-                "z.array(T$Schema)",
+                "z.array(z.unknown())",
             ),
             (
                 WeightIndex::<u32>::ts_definition(),
@@ -1430,7 +1375,7 @@ mod branded_generic_inner_tests {
             (
                 WeightIndex::<u32>::zod_schema(),
                 weight_seq_schema::Schema::zod_schema(),
-                "z.record(z.string(), T$Schema)",
+                "z.record(z.string(), z.unknown())",
             ),
             (
                 BareTag::<String>::ts_definition(),
@@ -1440,11 +1385,58 @@ mod branded_generic_inner_tests {
             (
                 BareTag::<String>::zod_schema(),
                 bare_seq_schema::Schema::zod_schema(),
-                "= T$Schema",
+                "= z.unknown()",
             ),
         ] {
             assert!(brand.contains(shared), "brand got:\n{brand}");
             assert!(alias.contains(shared), "alias got:\n{alias}");
+        }
+    }
+
+    /// Zod publishes values, and a value-level surface has no generic a `const` can be declared
+    /// over: a parameter rendered as the `Name$Schema` binding every unresolved type is named
+    /// after would reference a binding no emitted module ever declares, and the consumer that
+    /// pastes the output gets a `ReferenceError` before any payload is read.
+    ///
+    /// Asserted over the brand and the alias together, because both compose their value from the
+    /// same rendering and so would drift apart one landing at a time.
+    #[test]
+    fn no_emitted_zod_value_references_a_binding_named_after_a_parameter() {
+        for zod in [
+            TagList::<String>::zod_schema(),
+            WeightIndex::<u32>::zod_schema(),
+            BareTag::<String>::zod_schema(),
+            tag_seq_schema::Schema::zod_schema(),
+            weight_seq_schema::Schema::zod_schema(),
+            bare_seq_schema::Schema::zod_schema(),
+        ] {
+            assert!(!zod.contains("T$Schema"), "Got:\n{zod}");
+        }
+    }
+
+    /// The exported binding's annotation is read off the value it annotates, so the alias's
+    /// erasure has to reach it too: `ZodType<TagSeqType>` names a type TypeScript refuses without
+    /// its argument, and the argument the value was composed with is the opaque one.
+    #[test]
+    fn a_generic_alias_annotation_carries_the_argument_its_value_was_composed_with() {
+        for (zod, annotation) in [
+            (
+                tag_seq_schema::Schema::zod_schema(),
+                "export const TagSeqType$Schema: ZodType<TagSeqType<unknown>> = \
+                 TagSeqType$RawSchema;",
+            ),
+            (
+                weight_seq_schema::Schema::zod_schema(),
+                "export const WeightSeqType$Schema: ZodType<WeightSeqType<unknown>> = \
+                 WeightSeqType$RawSchema;",
+            ),
+            (
+                bare_seq_schema::Schema::zod_schema(),
+                "export const BareSeqType$Schema: ZodType<BareSeqType<unknown>> = \
+                 BareSeqType$RawSchema;",
+            ),
+        ] {
+            assert!(zod.contains(annotation), "Got:\n{zod}");
         }
     }
 }


### PR DESCRIPTION
A Zod `const` cannot be parameterised, so a type parameter rendered as `T$Schema` named a binding nothing emits (ReferenceError on paste; `tsc` errors on the annotation). An item's OWN parameters — classified by `type_parameters_in_scope`, which is what separates a parameter from a genuinely unresolved sibling type that does publish its binding — now erase to the opaque value on both validating surfaces: `z.unknown()` in Zod, `{}` in JSON (the rule the JSON surface already applied, now documented once at `FieldDef::erase_type_parameters` and cited by every consumer). TypeScript is untouched — its declaration binds the parameter for real. The alias and brand arms read one shared seam; the annotation follows the value (`ZodUnknown`, with alias exports filled as `Name<unknown>`).

A constrained brand over a bare parameter is now refused by the existing opaque-inner guard rather than emitting `.min()` calls on a binding that carries none — `z.unknown()` has no string checks and `.brand()` returns the same instance (verified on zod 4.4.3), so the checks had nowhere real to land. Non-generic aliases and brands proven byte-identical against a baseline archive.