### PR TITLE
refuse a pattern that admits every value, where taking it would claim a check nothing performs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1089,6 +1089,23 @@ Some constructs are **refused**, because no spelling makes the readers agree:
 - `\x{...}`, `\u{...}`, `\U...` and octal escapes -- code point escapes JavaScript reads differently or not at all. Write the character.
 - An unescaped `]` opening a class, as in `[]-a]`. This one is refused rather than escaped because escaping it changes the meaning: `[]-a]` is the three members `]`, `-` and `a`, and `[\]-a]` is a range.
 
+#### A `pattern` has to turn some value away
+
+A pattern every string satisfies is refused too, for a different reason: it is a constraint that constrains nothing. `""`, `^`, `$`, `|`, `a*` and `^a*` all match at some position of every string, so the generated validator would reject no value and the Zod and JSON schemas would publish a check every payload passes -- an attribute that reads as a guarantee and is not one. The derive fails at expansion, naming the field or the brand.
+
+The verdict is read off the parsed pattern rather than off its text, so the same shape written any way gets the same answer -- and the near misses keep theirs:
+
+| Pattern | Verdict |
+|---|---|
+| `""`, `^`, `$`, `\|`, `()`, `(^)` | Refused -- matches at a position every string has |
+| `a*`, `a?`, `a\|`, `^a*`, `a*$` | Refused -- the repeated part may run zero times, or the alternative may be skipped |
+| `^$` | Accepted -- both ends at one position, which only the empty string has |
+| `^a*$` | Accepted -- both ends pinned around a run of `a` |
+| `\b`, `\B` | Accepted -- the empty string holds no word boundary |
+| `a+`, `^[a-z]+$` | Accepted -- a character has to be there |
+
+One case is left standing. `clippy::trivial_regex`, which a consumer denying `clippy::nursery` gets, also flags `\b` -- as "the regex is unlikely to be useful as it is", naming no replacement -- and reports it against the `#[model_schema]` attribute, where there is no edit available. `\b` keeps its regex anyway: it is a real constraint, and answering the lint would mean dropping a check the author asked for.
+
 ### Numeric Constraints (minimum, maximum)
 
 ```rust

--- a/src/features/model_schema_prop.rs
+++ b/src/features/model_schema_prop.rs
@@ -6,7 +6,7 @@
 use syn::meta::ParseNestedMeta;
 use syn::{Attribute, LitStr, Type};
 
-use crate::utils::portable_pattern;
+use crate::utils::{constraining_pattern, portable_pattern};
 
 /// Every key the parser reads, in the order it tries them, as the unknown-key rejection names them.
 ///
@@ -38,7 +38,9 @@ const KNOWN_KEYS: &[&str] = &[
 ///
 /// - `pattern = "regex"` — validates the string matches the regex pattern. Must be a regex all
 ///   three engines read the same way; see [`crate::utils::portable_pattern`] for what that rules
-///   out and what it rewrites.
+///   out and what it rewrites. It must also turn some value away: a pattern every string satisfies
+///   is refused where it is written rather than published as a check that checks nothing — see
+///   [`crate::utils::constraining_pattern`].
 ///   - Zod: `.check(z.regex(/regex/))`
 ///   - JSON Schema: `"pattern"`
 ///   - Rust: auto-generates a `deserialize_{field}` serde hook and a `validate_{field}_value()` static function
@@ -115,8 +117,8 @@ pub struct ModelSchemaPropMeta {
     /// earned a [`Self::pattern_rejection`].
     pub pattern: Option<String>, // e.g., "^[0-9a-fA-F]{24}$" from pattern = "^[0-9a-fA-F]{24}$"
     /// What keeps `pattern` off the surfaces it was written for -- a regex the `regex` crate
-    /// cannot parse, or a construct a JavaScript regex literal cannot carry -- spanned on the
-    /// literal it was written as.
+    /// cannot parse, a construct a JavaScript regex literal cannot carry, or a shape that admits
+    /// every value and so says nothing on any of them -- spanned on the literal it was written as.
     pub pattern_rejection: Option<syn::Error>,
     pub preprocess: Vec<String>, // e.g., ["epoch_to_date", "trim"] from preprocess = ["epoch_to_date", "trim"]
     pub ts_optional: bool,
@@ -162,7 +164,7 @@ fn parse_prop_key(nested: &ParseNestedMeta, meta: &mut ModelSchemaPropMeta) -> s
         let lit: LitStr = nested.value()?.parse()?;
         // A refused pattern is recorded as written: the guards that answer for what a `pattern`
         // may sit on read that one was given, not what it says.
-        match portable_pattern(&lit) {
+        match portable_pattern(&lit).and_then(|portable| constraining_pattern(&lit, portable)) {
             Ok(pattern) => meta.pattern = Some(pattern),
             Err(rejection) => {
                 meta.pattern_rejection = Some(rejection);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,6 +273,11 @@ pub fn model_schema(args: TokenStream, input: TokenStream) -> TokenStream {
 /// and inline flag directives (`(?i)`). `(?P<name>...)` is accepted and emitted as the
 /// `(?<name>...)` both grammars read.
 ///
+/// It also has to turn some value away. A pattern every string satisfies — `""`, `^`, `$`, `|`,
+/// `a*` — constrains nothing, and is refused at expansion rather than published as a check that
+/// checks nothing. `^$` is not one of them: it pins both ends of the value to one position, which
+/// only the empty string has.
+///
 /// A `PathBuf` field carries these too, as does the `Path` borrow behind a wrapper: serde writes a
 /// path as a JSON string, and the checks measure that string — the path's `to_string_lossy`
 /// rendering, which is the exact wire value for every path serde can write.

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -47,7 +47,7 @@ use crate::features::object_id::get_object_id_zod_schema_with;
 use crate::features::object_id::OBJECT_ID_HEX_PATTERN;
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-use crate::utils::{AliasKind, lookup_alias_info, portable_pattern};
+use crate::utils::{AliasKind, constraining_pattern, lookup_alias_info, portable_pattern};
 
 #[cfg(feature = "serde")]
 use crate::utils::{TrivialPattern, trivial_pattern};
@@ -439,10 +439,10 @@ struct ModelSchemaArgs {
     /// earned a `pattern_rejection`.
     pattern: Option<String>,
     /// What keeps `pattern` off the surfaces it was written for -- a regex the `regex` crate
-    /// cannot parse, or a construct a JavaScript regex literal cannot carry -- spanned on the
-    /// literal it was written as. Only the brand path splices the argument, and only a schema
-    /// feature builds that path; without one, a type-level constraint never reaches a surface at
-    /// all.
+    /// cannot parse, a construct a JavaScript regex literal cannot carry, or a shape that admits
+    /// every value and so says nothing on any of them -- spanned on the literal it was written as.
+    /// Only the brand path splices the argument, and only a schema feature builds that path;
+    /// without one, a type-level constraint never reaches a surface at all.
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
     pattern_rejection: Option<syn::Error>,
 }
@@ -662,7 +662,7 @@ fn unknown_arg_rejection(meta: &Meta) -> syn::Error {
 /// read that one was given, not what it says.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn record_pattern(result: &mut ModelSchemaArgs, lit_str: &syn::LitStr) {
-    match portable_pattern(lit_str) {
+    match portable_pattern(lit_str).and_then(|portable| constraining_pattern(lit_str, portable)) {
         Ok(pattern) => result.pattern = Some(pattern),
         Err(rejection) => {
             result.pattern_rejection = Some(rejection);
@@ -1368,8 +1368,10 @@ fn cfg_attr_guard_error(rejection: &syn::Error, item: &str) -> proc_macro2::Toke
 /// Turns a rejected `pattern` into `compile_error!` tokens naming what carries it, keeping the
 /// literal's span so the diagnostic points at the pattern as written.
 ///
-/// Why a pattern is refused is [`crate::utils::portable_pattern`]'s to say — the crate cannot parse
-/// it, or JavaScript reads it as something else — so the refusal is quoted rather than restated.
+/// Why a pattern is refused is the guard that refused it's to say — [`crate::utils::portable_pattern`]
+/// where the crate cannot parse it or JavaScript reads it as something else,
+/// [`crate::utils::constraining_pattern`] where it admits every value — so the refusal is quoted
+/// rather than restated.
 fn pattern_guard_error(rejection: &syn::Error, subject: &str) -> proc_macro2::TokenStream {
     syn::Error::new(
         rejection.span(),
@@ -1627,8 +1629,8 @@ const fn branded_cfg_attr_guard_errors(
     Vec::new()
 }
 
-/// The `compile_error!` tokens for a brand whose `pattern` argument the `regex` crate rejects, or
-/// `None` when it carries none or it parses.
+/// The `compile_error!` tokens for a brand whose `pattern` argument a guard refuses, or `None`
+/// when it carries none or it clears them.
 ///
 /// The brand is the only shape that reads a type-level `pattern`, and it splices the string into
 /// the Rust validator, the Zod literal and the JSON schema alike; every other shape is refused the

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -1695,6 +1695,51 @@ fn a_field_pattern_naming_a_group_the_rust_way_clears_the_guard() {
     assert!(errors.is_empty(), "got: {errors:?}");
 }
 
+/// A pattern every string satisfies is refused where it is written, naming the field, the way a
+/// bound written where no surface reads one is. The alternative — taking it and emitting no check
+/// — would leave the author a contract nothing enforces, and would leave the emitted
+/// `validate_..._value(value: &str)` with `value` unread, which the consumer's own deny set turns
+/// into a second failure it has no edit for.
+#[test]
+fn a_field_pattern_admitting_every_value_names_the_field_and_says_so() {
+    for pattern in ["", "^", "$", "|", "a*", "^a*"] {
+        let errors = field_prop_guard_errors(&syn::parse_quote! {
+            struct Report {
+                #[model_schema_prop(pattern = #pattern)]
+                name: String,
+            }
+        });
+        assert_eq!(errors.len(), 1, "for {pattern:?}, got: {errors:?}");
+        for needle in [
+            "compile_error",
+            "field `name`",
+            "admits every value",
+            "constrains nothing",
+        ] {
+            assert!(
+                errors[0].contains(needle),
+                "{needle} missing for {pattern:?}: {}",
+                errors[0]
+            );
+        }
+    }
+}
+
+/// The shapes written out of the same pieces that still turn a value away clear the guard: `^$`
+/// asks for the empty string, `^a*$` for a run of `a`, and `\b` for a word boundary.
+#[test]
+fn a_field_pattern_written_out_of_the_same_pieces_that_still_constrains_clears_the_guard() {
+    for pattern in ["^$", "^a*$", r"\b"] {
+        let errors = field_prop_guard_errors(&syn::parse_quote! {
+            struct Report {
+                #[model_schema_prop(pattern = #pattern)]
+                name: String,
+            }
+        });
+        assert!(errors.is_empty(), "for {pattern:?}, got: {errors:?}");
+    }
+}
+
 /// A field carrying no `pattern` at all must not acquire one of these errors.
 #[test]
 fn an_unpatterned_field_is_left_alone() {
@@ -2368,6 +2413,39 @@ fn a_brand_pattern_javascript_cannot_carry_names_the_type_and_the_construct() {
 fn a_brand_pattern_naming_a_group_the_rust_way_clears_the_guard() {
     let errors = brand_pattern_errors("^(?P<word>[a-z]+)$");
     assert!(errors.is_empty(), "got: {errors:?}");
+}
+
+/// The brand carries the same `pattern` to the same three surfaces a field does, so a pattern that
+/// says nothing has to be refused here too — and it is the only string constraint the brand has,
+/// so taking it would publish a `validate()` that turns nothing away.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn a_brand_pattern_admitting_every_value_names_the_type_and_says_so() {
+    for pattern in ["", "^", "$", "|", "a*", "^a*"] {
+        let errors = brand_pattern_errors(pattern);
+        assert_eq!(errors.len(), 1, "for {pattern:?}, got: {errors:?}");
+        for needle in [
+            "compile_error",
+            "type `UserId`",
+            "admits every value",
+            "constrains nothing",
+        ] {
+            assert!(
+                errors[0].contains(needle),
+                "{needle} missing for {pattern:?}: {}",
+                errors[0]
+            );
+        }
+    }
+}
+
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn a_brand_pattern_that_still_constrains_clears_the_guard() {
+    for pattern in ["^$", "^a*$", r"\b"] {
+        let errors = brand_pattern_errors(pattern);
+        assert!(errors.is_empty(), "for {pattern:?}, got: {errors:?}");
+    }
 }
 
 /// The brand renders its inner into the brand rather than walking it as a field, so the map-key
@@ -5454,5 +5532,41 @@ fn a_pattern_of_any_real_shape_keeps_its_regex() {
          static RE : LazyLock < regex :: Regex > = LazyLock :: new (|| { regex :: Regex :: new (\"^[a-z]+$\") . unwrap () }) ; \
          if ! RE . is_match (value) { \
          return Err (format ! (\"'{}' does not match pattern '{}'\" , \"field\" , \"^[a-z]+$\")) ; } } Ok (()) } "
+    );
+}
+
+/// `^$` is the empty-string check, not a degenerate pattern: it pins both ends of the value to one
+/// position. It keeps the `is_empty()` call it has been emitted as, byte for byte, now that the
+/// shapes written out of the same two anchors are refused.
+#[cfg(feature = "serde")]
+#[test]
+fn the_empty_string_pattern_keeps_the_call_it_was_already_emitted_as() {
+    assert_eq!(
+        emitted_pattern_validator("^$"),
+        "pub fn validate_field_value (value : & str) -> Result < () , String > \
+         { if ! value . is_empty () { \
+         return Err (format ! (\"'{}' does not match pattern '{}'\" , \"field\" , \"^$\")) ; } Ok (()) } "
+    );
+}
+
+/// `\b` is trivial to `clippy::trivial_regex` and names no `str` call, so it keeps the regex — and
+/// the lint keeps firing on it in the consumer, which is the one case left standing here.
+///
+/// The verdict is from a probe, not an assumption: `#[model_schema_prop(pattern = r"\b")]` run
+/// through `cargo clippy --all-targets -- -D warnings` in a crate denying `clippy::nursery`
+/// reported `error: trivial regex ... the regex is unlikely to be useful as it is`, against the
+/// `#[model_schema()]` attribute. It is left standing because `\b` turns a value away — the empty
+/// string holds no word boundary — so there is a check here to keep, and answering the lint would
+/// mean dropping it.
+#[cfg(feature = "serde")]
+#[test]
+fn a_word_boundary_pattern_keeps_its_regex() {
+    assert_eq!(
+        emitted_pattern_validator(r"\b"),
+        "pub fn validate_field_value (value : & str) -> Result < () , String > \
+         { { use std :: sync :: LazyLock ; \
+         static RE : LazyLock < regex :: Regex > = LazyLock :: new (|| { regex :: Regex :: new (\"\\\\b\") . unwrap () }) ; \
+         if ! RE . is_match (value) { \
+         return Err (format ! (\"'{}' does not match pattern '{}'\" , \"field\" , \"\\\\b\")) ; } } Ok (()) } "
     );
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,7 +8,6 @@ use regex_syntax::ast::{
     ClassSetBinaryOpKind, ClassSetItem, Flag, FlagsItemKind, Group, GroupKind, HexLiteralKind,
     Literal, LiteralKind, SpecialLiteralKind,
 };
-#[cfg(feature = "serde")]
 use regex_syntax::hir;
 use std::collections::HashMap;
 use syn::{Attribute, Expr, Field, Lit, LitStr, Meta, Variant};
@@ -935,6 +934,125 @@ fn js_spelling(pattern: &str) -> Result<String, String> {
     Ok(walk.rewritten(pattern))
 }
 
+/// The `pattern` handed back when it turns some value away, or the refusal it earns for admitting
+/// every value -- spanned on the literal the author wrote.
+///
+/// A `pattern` that matches at some position of every string is a constraint that constrains
+/// nothing. Nothing downstream can make it say anything: the generated validator would reject no
+/// value, and the Zod and JSON Schema surfaces would publish a check every payload passes. Taking
+/// it silently leaves the author holding a contract that says the value is checked when nothing
+/// checks it -- the same claim a bound written where no surface reads one is refused for, so it is
+/// refused the same way, where it is written.
+///
+/// It also settles what such a pattern would have been emitted as. The `str` call
+/// [`trivial_pattern`] names for a simple pattern does not exist here -- there is no call for "and
+/// then check nothing" -- and dropping the check from a validator whose only constraint is that
+/// pattern leaves `value` unread in the emitted `pub fn validate_..._value(value: &str)`, which is
+/// a fresh `-D warnings` failure in the consumer crate the validator is written into. Refusing at
+/// expansion means no such validator is ever emitted.
+///
+/// What stays on the regex path is every pattern that turns some value away, `\b` included. That
+/// one is the residual: `clippy::trivial_regex` flags it and names no replacement -- a probe of
+/// `#[model_schema_prop(pattern = r"\b")]` under `cargo clippy --all-targets -- -D warnings` in a
+/// crate denying `clippy::nursery` reports `trivial regex ... the regex is unlikely to be useful
+/// as it is` against the `#[model_schema]` attribute -- and it is left standing, because `\b` is a
+/// real constraint: the empty string holds no word boundary, so a value is turned away by it, and
+/// refusing it would drop a check the author is owed.
+pub fn constraining_pattern(lit: &LitStr, pattern: String) -> Result<String, syn::Error> {
+    if admits_every_value(&pattern) {
+        return Err(syn::Error::new_spanned(
+            lit,
+            "`pattern` admits every value, so it constrains nothing: every string has a position \
+             this matches at, which leaves the generated validator turning no value away and the \
+             Zod and JSON schemas publishing a check every payload passes. Taking it would leave a \
+             contract that says the value is checked when nothing checks it -- the same silent \
+             claim a bound written where no surface reads one is refused for. Write the pattern \
+             the value has to match, or drop it.",
+        ));
+    }
+    Ok(pattern)
+}
+
+/// Whether a search for `pattern` succeeds in every haystack, read off the HIR rather than off the
+/// pattern text: `^` and `(^)` and `^|a` are one verdict written three ways, and `^$` is written
+/// out of the same two anchors as `^` and `$` yet admits only the empty string.
+///
+/// The rule is one sentence with one exception. A pattern admits every value when nothing in it
+/// asks the haystack for anything -- when it matches the empty string wherever it is tried
+/// ([`matches_at_every_position`]) -- and the exception is that a single whole-text anchor asks
+/// for nothing either, since every haystack has a start and an end. Two of them do ask: `^$` pins
+/// both to one position, which only the empty string has.
+///
+/// It errs toward `false` everywhere the reading is not certain, and everything it declines keeps
+/// its `regex::Regex`, where being conservative costs nothing. `^^` and `(?:^)+` are both admit-
+/// everything shapes it does not classify, and a pattern the parser cannot read is not classified
+/// at all -- that one is [`portable_pattern`]'s refusal to make, ahead of this one.
+fn admits_every_value(pattern: &str) -> bool {
+    regex_syntax::ParserBuilder::new()
+        .unicode(true)
+        .utf8(true)
+        .build()
+        .parse(pattern)
+        .is_ok_and(|parsed| matches_every_haystack(&parsed))
+}
+
+/// Whether a search for this sub-expression succeeds in every haystack.
+fn matches_every_haystack(hir: &hir::Hir) -> bool {
+    match hir.kind() {
+        hir::HirKind::Look(_) => is_text_anchor(hir),
+        hir::HirKind::Capture(capture) => matches_every_haystack(&capture.sub),
+        hir::HirKind::Alternation(branches) => branches.iter().any(matches_every_haystack),
+        hir::HirKind::Concat(parts) => concat_matches_every_haystack(parts),
+        hir::HirKind::Empty
+        | hir::HirKind::Literal(_)
+        | hir::HirKind::Class(_)
+        | hir::HirKind::Repetition(_) => matches_at_every_position(hir),
+    }
+}
+
+/// Whether a concatenation matches at a position every haystack has.
+///
+/// Every part that asks the haystack for nothing can be tried anywhere, so a run of them matches
+/// anywhere; one whole-text anchor among them fixes that anywhere to a position every haystack
+/// still has. A second anchor is what breaks it -- `^$` requires the start and the end to be the
+/// same position -- and so is any part that consumes a character.
+fn concat_matches_every_haystack(parts: &[hir::Hir]) -> bool {
+    parts.iter().filter(|part| is_text_anchor(part)).count() <= 1
+        && parts
+            .iter()
+            .filter(|part| !is_text_anchor(part))
+            .all(matches_at_every_position)
+}
+
+/// Whether this sub-expression matches the empty string at every position of every haystack, and
+/// so asks the haystack for nothing at all.
+///
+/// A repetition that may run zero times is such a match wherever it is tried, whatever it repeats;
+/// an alternation is one as soon as any single branch is. A literal or a class consumes a
+/// character, and a look-around holds only where the haystack has the property it names -- `^` at
+/// the start, `\b` at a word boundary — so neither asks for nothing.
+fn matches_at_every_position(hir: &hir::Hir) -> bool {
+    match hir.kind() {
+        hir::HirKind::Empty => true,
+        hir::HirKind::Repetition(repetition) => repetition.min == 0,
+        hir::HirKind::Capture(capture) => matches_at_every_position(&capture.sub),
+        hir::HirKind::Concat(parts) => parts.iter().all(matches_at_every_position),
+        hir::HirKind::Alternation(branches) => branches.iter().any(matches_at_every_position),
+        hir::HirKind::Literal(_) | hir::HirKind::Class(_) | hir::HirKind::Look(_) => false,
+    }
+}
+
+/// Whether a sub-expression is one of the two whole-text anchors, the only assertions a search
+/// finds in every haystack. The line anchors `(?m)` turns these into never reach this crate --
+/// [`portable_pattern`] refuses an inline flag first -- and every word-boundary flavour asks the
+/// haystack for something the empty string does not have.
+fn is_text_anchor(hir: &hir::Hir) -> bool {
+    matches!(
+        *hir.kind(),
+        hir::HirKind::Look(hir::Look::Start | hir::Look::End)
+    )
+}
+
 /// What a `pattern` accepts stated without a regex, for exactly the patterns
 /// `clippy::trivial_regex` proves one is unnecessary for -- and `None` for every other pattern,
 /// which keeps its `regex::Regex` and is the only thing that reads a pattern of any real shape.
@@ -952,9 +1070,11 @@ fn js_spelling(pattern: &str) -> Result<String, String> {
 /// than that. A shape the lint does not name is left on the regex path, where it costs nothing;
 /// a shape misread as trivial would silently change which values a constraint admits.
 ///
-/// The two shapes the lint calls trivial and offers no replacement for -- a pattern that matches
-/// everything (`""`, `^`, `$`), and one whose alternatives are all empty (`|`) -- are not
-/// classified here: there is no call to emit for them, only the absence of a check.
+/// Two of the shapes the lint calls trivial and offers no replacement for -- a pattern that
+/// matches everything (`""`, `^`, `$`), and one whose alternatives are all empty (`|`) -- never
+/// reach here at all: [`constraining_pattern`] refuses them where they are written, since there is
+/// no call to emit for them, only the absence of a check. The third, a bare `\b`, does reach here
+/// and keeps its regex, because it turns a value away and so has a check worth keeping.
 ///
 /// The HIR walked is the one the lint reads, parsed with the options it parses with, so what is
 /// classified here is what it classifies. Anchors are the whole-haystack `Look::Start` and

--- a/src/utils/tests.rs
+++ b/src/utils/tests.rs
@@ -318,6 +318,25 @@ const NON_TRIVIAL_PATTERNS: [&str; 16] = [
     "a|b",
 ];
 
+/// Every shape the guard proves admits every value, written the ways an author reaches one: the
+/// four the report names, then the same emptiness reached through a capture, a repetition that may
+/// run zero times, an alternative that may be skipped, and a single text anchor with nothing but
+/// those beside it.
+const UNCONSTRAINING_PATTERNS: [&str; 12] = [
+    "", "^", "$", "|", "()", "(^)", "a*", "a?", "a|", "^a*", "a*$", "(?:ab)*",
+];
+
+/// Patterns that turn some value away, kept beside [`UNCONSTRAINING_PATTERNS`] as the near misses
+/// that decide where the line sits.
+///
+/// `^$` and `^a*$` pin both ends of the value to one position, which is a constraint however
+/// little sits between them. `\b` and `\B` ask the value for a word boundary, or for the absence
+/// of one at every position, and the empty string has neither. `a+` and `(?:ab)+` demand the run
+/// they repeat at least once.
+const CONSTRAINING_PATTERNS: [&str; 8] = [
+    "^$", "^a*$", r"\b", r"\B", "a+", "(?:ab)+", "^[a-z]+$", r"^\s*$",
+];
+
 /// The negated classes the verdict was decided over: a single member, the ranges an author reaches
 /// for to bound one to ASCII, an escape, and the `\d` the guard writes out to `0-9` on its way in.
 /// The last is the one that shows rewriting cannot help — its members come out ASCII and the
@@ -339,6 +358,16 @@ const NEGATED_CLASS_PATTERNS: [&str; 6] = [
 /// are two contracts and only one of them is enforced.
 #[cfg(feature = "object_id")]
 const CRATE_EMITTED_PATTERNS: [&str; 1] = [OBJECT_ID_HEX_PATTERN];
+
+/// The strings a classification is proved against — every character the equalised classes are
+/// compared over, plus the delimiters and near-miss prefixes the rewrite tests carry.
+fn classification_haystacks() -> Vec<&'static str> {
+    CROSS_ENGINE_HAYSTACKS
+        .into_iter()
+        .chain(REWRITE_HAYSTACKS)
+        .chain(["ab", "abab", "xay", "word boundary", "  "])
+        .collect()
+}
 
 #[cfg(feature = "serde")]
 /// The haystacks a classified pattern is held to, in the two senses that matter: every character
@@ -1088,5 +1117,86 @@ fn test_trivial_pattern_accepts_exactly_what_its_regex_accepts() {
                 "{pattern} and the call it was classified as part ways over {haystack:?}"
             );
         }
+    }
+}
+
+/// Runs both `pattern` guards the way the attribute parsers run them, and hands back the refusal
+/// as the author reads it.
+fn constraining(pattern: &str) -> Result<String, String> {
+    let lit = LitStr::new(pattern, proc_macro2::Span::call_site());
+    portable_pattern(&lit)
+        .and_then(|portable| constraining_pattern(&lit, portable))
+        .map_err(|rejection| rejection.to_string())
+}
+
+/// The verdict is proved against the regex the pattern would have been checked by, not asserted
+/// beside it: a pattern the guard calls unconstraining has to match every haystack in the corpus,
+/// and one it lets through has to turn at least one of them away.
+#[test]
+fn test_the_unconstraining_verdict_is_the_regex_crate_s_own() {
+    let haystacks = classification_haystacks();
+    for pattern in UNCONSTRAINING_PATTERNS {
+        let regex = regex::Regex::new(pattern).unwrap();
+        for haystack in &haystacks {
+            assert!(
+                regex.is_match(haystack),
+                "{pattern} is called unconstraining and turns {haystack:?} away"
+            );
+        }
+    }
+    for pattern in CONSTRAINING_PATTERNS {
+        let regex = regex::Regex::new(pattern).unwrap();
+        assert!(
+            haystacks.iter().any(|haystack| !regex.is_match(haystack)),
+            "{pattern} is left on the regex path and turns nothing in the corpus away"
+        );
+    }
+}
+
+/// A pattern that matches at some position of every string is refused where it is written, and the
+/// refusal says what is wrong with it rather than naming a construct.
+#[test]
+fn test_a_pattern_admitting_every_value_is_refused() {
+    for pattern in UNCONSTRAINING_PATTERNS {
+        let rejection = constraining(pattern).unwrap_err();
+        for needle in ["pattern", "admits every value", "constrains nothing"] {
+            assert!(
+                rejection.contains(needle),
+                "{needle} missing for {pattern}: {rejection}"
+            );
+        }
+    }
+}
+
+/// A pattern that turns some value away keeps its place, `\b` included.
+///
+/// `\b` is the one shape `clippy::trivial_regex` flags that this guard deliberately does not
+/// answer for. A probe run before this guard existed put `#[model_schema_prop(pattern = r"\b")]`
+/// through `cargo clippy --all-targets -- -D warnings` in a crate denying `clippy::nursery`, and
+/// the lint fired — `error: trivial regex ... the regex is unlikely to be useful as it is`, landing
+/// on the `#[model_schema()]` attribute. It fires anyway, and refusing `\b` here would be refusing
+/// a real constraint: the empty string holds no word boundary, so the pattern turns a value away.
+#[test]
+fn test_a_pattern_turning_some_value_away_clears_the_guard() {
+    for pattern in CONSTRAINING_PATTERNS {
+        assert!(
+            constraining(pattern).is_ok(),
+            "{pattern} constrains something and was refused: {:?}",
+            constraining(pattern)
+        );
+    }
+}
+
+/// The patterns the shipped tests and the report write all say something, so none of them changes
+/// verdict under the new guard — the classified trivial shapes above all.
+#[cfg(feature = "serde")]
+#[test]
+fn test_the_shapes_already_classified_still_clear_the_guard() {
+    for pattern in TRIVIAL_PATTERNS.into_iter().chain(PORTABLE_PATTERNS) {
+        assert_eq!(
+            constraining(pattern).as_deref(),
+            Ok(pattern),
+            "{pattern} was refused, or came back in a different spelling"
+        );
     }
 }

--- a/tests/validation_tests/tests.rs
+++ b/tests/validation_tests/tests.rs
@@ -1198,6 +1198,39 @@ fn test_pattern_anchored_single_character_prefix() {
     );
 }
 
+/// `^$` is written out of the two anchors a pattern admitting every value is written out of, and
+/// it is the one arrangement of them that still says something: both ends of the value at one
+/// position, which only the empty string has. It keeps validating, and it keeps compiling under a
+/// deny set that has no edit available at the attribute.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn test_pattern_pinning_both_ends_to_one_position() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug)]
+    pub struct PatternBlankSlot {
+        #[model_schema_prop(pattern = "^$")]
+        pub slot: String,
+    }
+
+    PatternBlankSlot {
+        slot: String::new(),
+    }
+    .validate()
+    .unwrap();
+
+    let rejected = PatternBlankSlot {
+        slot: "x".to_owned(),
+    };
+    let errors = rejected.validate().unwrap_err();
+    assert_eq!(
+        errors[0], "'slot' does not match pattern '^$'",
+        "Rejection should read exactly as the regex path words it: {errors:?}"
+    );
+}
+
 // ==================== Constraints under Option / wrappers / sequences ====================
 
 #[cfg(all(


### PR DESCRIPTION
The shapes clippy calls trivial while naming no str replacement split two ways, and each gets its honest answer:

- A pattern that admits every value (``, `^`, `$`, `|`, `a*`, `(^)`, …) is refused at expansion, spanned on the literal with the placement-contract framing: every string has a position it matches at, so the validator would turn nothing away and the schemas would publish a check every payload passes. Classified from the parsed HIR, never text — zero-min repetitions, lone text anchors, captures/alternations/concats by their parts, with the anchor count keeping `^$` (a real emptiness check) out. Conservative by construction: anything it declines keeps its regex. Soundness proven against the regex crate itself over a corpus (every refused pattern matches all 37 strings; every accepted one turns at least one away). The refusal also removes the unread-`value` validator the always-true shapes would otherwise emit.
- `\b` keeps its regex byte-identically — it is a real constraint — and the capture shows clippy still fires on it in a nursery-denying consumer; that residual is documented and tracked as its own decision.