### PR TITLE
give the brand processor its own accurate doc and quote the validator's real sentences in the crate rustdoc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -299,8 +299,10 @@ pub fn model_schema(args: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// ### The `validate()` Method
 ///
-/// When any field has constraints, the macro also generates a `validate(&self) -> Result<(), Vec<String>>`
-/// method for validating instances constructed in code. Serde deserialization validates automatically.
+/// With `serde` and a schema output feature (`zod`, `typescript`, or `jsonschema`) both active, a
+/// type carrying at least one constrained field also gets a
+/// `validate(&self) -> Result<(), Vec<String>>` method for validating instances constructed in
+/// code. Serde deserialization validates automatically.
 ///
 /// ```rust
 /// use tixschema::{model_schema, model_schema_prop};
@@ -317,8 +319,8 @@ pub fn model_schema(args: TokenStream, input: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// When a schema output feature is active (`zod`, `typescript`, or `jsonschema`), the macro also
-/// generates a `validate(&self) -> Result<(), Vec<String>>` method:
+/// Every constrained field that fails contributes its own message, each naming the field it came
+/// from:
 ///
 /// ```text
 /// let reg = RegistrationJson { username: "ab".to_string(), age: 150 };
@@ -328,8 +330,8 @@ pub fn model_schema(args: TokenStream, input: TokenStream) -> TokenStream {
 ///         for e in &errors {
 ///             println!("Error: {e}");
 ///         }
-///         // "username: too short (minimum length 3, got 2)"
-///         // "age: too large (maximum 120, got 150)"
+///         // "'username' is too short: minimum length is 3, got 2"
+///         // "'age' is too large: maximum is 120, got 150"
 ///     }
 /// }
 /// ```

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -2234,21 +2234,6 @@ fn process_tuple_struct(
     )
 }
 
-/// Processes a branded newtype (transparent single-field tuple struct) and generates
-/// TypeScript branded type definitions and Zod brand schemas.
-///
-/// A branded newtype is detected when a struct has **both** `#[serde(transparent)]` and exactly
-/// one unnamed field. The generated output depends on the active features:
-///
-/// - With `zod` + `typescript`: emits a Zod `.brand<"Name">()` schema and a
-///   `type Name<T> = T & z.$brand<"Name">` alias.
-/// - With `typescript` only (no `zod`): emits a `unique symbol` brand pattern and an
-///   `assertName()` type-assertion helper function.
-///
-/// Generic parameters on the struct are preserved in the TypeScript output. For non-generic
-/// newtypes, the inner field's Rust type is resolved to its TypeScript equivalent. For generic
-/// newtypes, the Zod schema always uses `z.string()` as the base because the generic parameter
-/// cannot be resolved at macro-expansion time.
 /// Builds the `validate_value`/`deserialize_value` functions for a constrained branded newtype.
 ///
 /// Returns `None` when the newtype has no string constraints. A path inner is measured by the
@@ -3206,6 +3191,23 @@ fn branded_guard_failure_output(
     )
 }
 
+/// Processes a branded newtype — a `#[serde(transparent)]` struct holding exactly one unnamed
+/// field — into the parts [`assemble_branded_output`] joins: the struct itself, the `Display` impl
+/// it earns, its schema module, and the delegate impl forwarding to that module.
+///
+/// A brand adds its own name to what its inner already writes, and each surface says so in the
+/// spelling that surface has for the marker. TypeScript intersects the inner's rendering with
+/// `$brand<"Name">`, the marker the `zod` runtime supplies; without `zod` there is no such marker
+/// to name, so the intersection is written against a `unique symbol` declared beside the type, and
+/// those two lines are the whole emission. Zod brands the inner's own schema with
+/// `.brand<"Name">()`, carries the item's description in the `.meta({ description })` every item
+/// carries it in, and annotates the exported binding `$ZodBranded<Class, "Name">` for the `Class`
+/// read off the very inner that rendering was built from.
+///
+/// The brand's own type parameters are inners like any other: TypeScript renders a parameter as
+/// the name it was written with, and Zod reaches it through that parameter's `Name$Schema`
+/// binding, so a generic brand describes whatever its argument publishes rather than a base of its
+/// own.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn process_branded_newtype(item_struct: syn::ItemStruct, args: &ModelSchemaArgs) -> TokenStream {
     if let Some(output) = branded_guard_failure_output(&item_struct, args) {

--- a/tests/validation_tests/tests.rs
+++ b/tests/validation_tests/tests.rs
@@ -2197,3 +2197,47 @@ fn test_every_variant_shape_reaches_the_accessor() {
         .unwrap();
     EveryShape::Nothing.validate().unwrap();
 }
+
+/// The shipped rustdoc quotes the messages a failed `validate()` prints, so the block is checked
+/// against a run of the very type it declares rather than against memory. It sits in a `text` fence
+/// no doctest reaches, which is why the check lives out here.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn test_crate_rustdoc_quotes_the_messages_the_generator_writes() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize)]
+    pub struct RegistrationJson {
+        #[model_schema_prop(minimum = 0, maximum = 120)]
+        pub age: u32,
+
+        #[model_schema_prop(minLength = 3, maxLength = 30)]
+        pub username: String,
+    }
+
+    let errors = RegistrationJson {
+        age: 150,
+        username: "ab".to_owned(),
+    }
+    .validate()
+    .unwrap_err();
+
+    assert_eq!(
+        errors,
+        vec![
+            "'age' is too large: maximum is 120, got 150".to_owned(),
+            "'username' is too short: minimum length is 3, got 2".to_owned(),
+        ]
+    );
+
+    let rustdoc = include_str!("../../src/lib.rs");
+    for message in &errors {
+        let shown = format!("// \"{message}\"");
+        assert!(
+            rustdoc.contains(&shown),
+            "src/lib.rs no longer shows {shown}"
+        );
+    }
+}


### PR DESCRIPTION
Two rustdoc corrections, both checked against runs rather than memory:

- The stale block that sat with no separating item above `build_branded_validation` — claiming `z.$brand`, an `assertName()` helper nothing emits, and the retracted always-`z.string()` generic rule — is gone; `build_branded_validation` keeps only its own doc, and `process_branded_newtype` gets an accurate one (the parts the assembler joins, each surface's marker spelling, the `$ZodBranded` annotation, and the parameter-erasure rule). Attachment verified via cargo doc output pages; `grep` for the retracted claims returns zero in src/.
- The crate-level rustdoc's `validate()` example now quotes the generator's exact sentences, with the contradictory feature-gate prose merged into one statement matching the emitter's actual cfg. Pinned by a test that runs the doc's own type, asserts the Err contents, and asserts `include_str!(lib.rs)` still shows each sentence — generator drift and doc drift both fail the build.