### PR TITLE
refuse flattening a union member serde writes as no object, in the words the other surface already uses

### DIFF
--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -12,7 +12,7 @@ use crate::features::model_schema_prop::ModelSchemaPropMeta;
 use crate::utils::{lookup_alias_info, safe_type_name};
 
 #[cfg(feature = "zod")]
-use crate::utils::escape_js_regex_literal;
+use crate::utils::{ZodUnionMember, escape_js_regex_literal};
 
 #[cfg(feature = "chrono")]
 use crate::features::chrono;
@@ -1009,7 +1009,7 @@ impl FieldDef {
     /// in the name's place would drop it. The outermost `Option` is not one of those: it is what
     /// [`Self::zod_merged_schema`] already leaves to the merge.
     #[cfg(feature = "zod")]
-    pub fn zod_union_members(&self) -> Vec<String> {
+    pub fn zod_union_members(&self) -> Vec<ZodUnionMember> {
         let wrapped = self
             .model_schema_prop_meta
             .as_ref()

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -97,7 +97,7 @@ use crate::utils::{get_item_docs, ident_reexport_ts};
 use crate::utils::ident_reexport_zod;
 
 #[cfg(feature = "zod")]
-use crate::utils::record_zod_union_members;
+use crate::utils::{ZodUnionMember, record_zod_union_members};
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 use crate::utils::register_alias_info;
@@ -161,6 +161,14 @@ type RenderedVariants = (
     Vec<proc_macro2::TokenStream>,
 );
 
+/// What an untagged enum's members contribute to an object that merges it, which only the Zod
+/// surface multiplies out and so only it has a member type for. The other tables carry the same
+/// slot spelled as what they never read.
+#[cfg(all(feature = "serde", feature = "zod"))]
+type ZodMergeParts = Vec<ZodUnionMember>;
+#[cfg(all(feature = "serde", not(feature = "zod")))]
+type ZodMergeParts = Vec<String>;
+
 /// Per-member data collected from an untagged enum: the TypeScript member types, the Zod member
 /// schemas, what those Zod members contribute to an object that merges the enum, the JSON-schema
 /// value tokens, the `compile_error!` tokens for any field-level guard violations, the per-member
@@ -169,7 +177,7 @@ type RenderedVariants = (
 type UntaggedMemberData = (
     Vec<String>,
     Vec<String>,
-    Vec<String>,
+    ZodMergeParts,
     Vec<proc_macro2::TokenStream>,
     Vec<proc_macro2::TokenStream>,
     Vec<proc_macro2::TokenStream>,
@@ -466,7 +474,7 @@ struct MergedOperand {
     /// `spelling`. Zod only: TypeScript distributes an intersection over a union on its own, so
     /// there the union is spelled as the one operand it is.
     #[cfg(feature = "zod")]
-    members: Vec<String>,
+    members: Vec<ZodUnionMember>,
     optional: bool,
     spelling: String,
 }
@@ -1770,6 +1778,48 @@ fn flattened_field_guard_error(
     )
 }
 
+/// The `compile_error!` tokens for a `#[serde(flatten)]` field naming an untagged union one of
+/// whose recorded members serde does not write as an object, or `None` for every other field.
+///
+/// The union itself is left alone — an untagged enum may hold a scalar, and it is only the merge
+/// that has no object to join one to. What the multiplication would write for such a member is the
+/// object intersected with the scalar, a branch no payload satisfies and nothing reports; serde
+/// refuses the value outright, and the JSON-schema merge refuses the declaration in the words
+/// repeated here. Refused at expansion because that is the only place holding the field the author
+/// would have to change.
+///
+/// A union declared below the object has recorded nothing, so this answers for no member of it —
+/// the same bound the multiplication itself has, and the same one the merge's fallback documents.
+#[cfg(all(feature = "serde", feature = "zod"))]
+fn flattened_union_member_guard_error(
+    field: &syn::Field,
+    type_name: &str,
+) -> Option<proc_macro2::TokenStream> {
+    let inner = get_field_def("_flattened", &field.ty, "");
+    let FieldDefType::SiblingType(inner_name, _) = &inner.field_type else {
+        return None;
+    };
+    let member = inner
+        .zod_union_members()
+        .into_iter()
+        .find(|member| member.non_object.is_some())?;
+    let named = member.non_object?;
+    let branch = member.branch_path();
+    Some(
+        syn::Error::new_spanned(
+            &field.ty,
+            format!(
+                "model_schema: `{type_name}`: `#[serde(flatten)]` of `{inner_name}` writes a \
+                 union member that is not an object — its branch {branch} describes a `{named}`, \
+                 which has no members to merge, and what serde writes for that member does not \
+                 join the object being written; write the field as a named member so the value \
+                 gets a key of its own."
+            ),
+        )
+        .to_compile_error(),
+    )
+}
+
 /// Processes every field of a struct, returning the regular field defs, the `#[serde(flatten)]`
 /// field defs, the per-field serde validation functions and `validate()` body fragments, and the
 /// `compile_error!` tokens for any field-level guard violations.
@@ -1798,6 +1848,11 @@ fn collect_struct_fields(
         ))]
         if is_flatten {
             guard_errors.extend(flattened_field_guard_error(field, type_name));
+        }
+
+        #[cfg(all(feature = "serde", feature = "zod"))]
+        if is_flatten {
+            guard_errors.extend(flattened_union_member_guard_error(field, type_name));
         }
 
         let (f_def, validation_fn, validate_body, field_guard_errors) =
@@ -5226,9 +5281,9 @@ fn collect_untagged_members(
     let mut ts_parts: Vec<String> = Vec::new();
     let mut zod_parts: Vec<String> = Vec::new();
     #[cfg(feature = "zod")]
-    let mut zod_merge_parts: Vec<String> = Vec::new();
+    let mut zod_merge_parts: ZodMergeParts = Vec::new();
     #[cfg(not(feature = "zod"))]
-    let zod_merge_parts: Vec<String> = Vec::new();
+    let zod_merge_parts: ZodMergeParts = Vec::new();
     let mut json_parts: Vec<proc_macro2::TokenStream> = Vec::new();
     let mut guard_errors: Vec<proc_macro2::TokenStream> = Vec::new();
     let mut validation_fns: Vec<proc_macro2::TokenStream> = Vec::new();
@@ -5303,7 +5358,12 @@ fn collect_untagged_members(
         match render_untagged_variant(&kind, variant, &field_defs, &enum_type_name) {
             Ok((ts, zod, json_val)) => {
                 #[cfg(feature = "zod")]
-                zod_merge_parts.extend(zod_merge_branches(&kind, &field_defs, &zod));
+                zod_merge_parts.extend(zod_merge_branches(
+                    &kind,
+                    &field_defs,
+                    &zod,
+                    ts_parts.len() + 1,
+                ));
                 ts_parts.push(ts);
                 zod_parts.push(zod);
                 json_parts.push(json_val);
@@ -5329,16 +5389,83 @@ fn collect_untagged_members(
 /// This is where the recorded member list is multiplied out, so what the registry hands a merge is
 /// the leaf set rather than a chain to walk. A member reached through an `Option` is left as it was
 /// rendered: its absence is a bare `null` on the wire, which is not a key set and joins no object.
+///
+/// `branch` is the member's own one-based position, which the leaves of a nested union are reached
+/// through and so keep as the head of theirs — the multiplication flattens the chain and the trail
+/// is what still says where a leaf was written.
 #[cfg(all(feature = "serde", feature = "zod"))]
-fn zod_merge_branches(kind: &VariantKind, field_defs: &[FieldDef], rendered: &str) -> Vec<String> {
-    let members = match (kind, field_defs) {
+fn zod_merge_branches(
+    kind: &VariantKind,
+    field_defs: &[FieldDef],
+    rendered: &str,
+    branch: usize,
+) -> Vec<ZodUnionMember> {
+    let nested = match (kind, field_defs) {
         (VariantKind::TupleSingle, [fld]) if !fld.is_optional() => fld.zod_union_members(),
         _ => Vec::new(),
     };
-    if members.is_empty() {
-        vec![rendered.to_owned()]
-    } else {
-        members
+    if nested.is_empty() {
+        let non_object = match (kind, field_defs) {
+            (VariantKind::TupleSingle, [fld]) => zod_member_non_object(fld),
+            _ => None,
+        };
+        return vec![ZodUnionMember {
+            branch: vec![branch],
+            non_object,
+            spelling: rendered.to_owned(),
+        }];
+    }
+    nested
+        .into_iter()
+        .map(|leaf| {
+            let mut trail = vec![branch];
+            trail.extend(leaf.branch);
+            ZodUnionMember {
+                branch: trail,
+                non_object: leaf.non_object,
+                spelling: leaf.spelling,
+            }
+        })
+        .collect()
+}
+
+/// What serde writes an untagged union's member as, when the member's own written type proves that
+/// is not an object, and `None` when nothing here proves it.
+///
+/// Named by the JSON type keyword the JSON-schema surface writes for the same member, so the two
+/// merges refuse the same member in the same words. That surface reads the keyword off a document
+/// it has already built; here there is only the type, so the answer is a partial one by
+/// construction — a name the registry stands for and a map are left to the merge that does read
+/// them, and a union member is not asked at all, its own leaves having already been recorded.
+#[cfg(all(feature = "serde", feature = "zod"))]
+fn zod_member_non_object(fld: &FieldDef) -> Option<&'static str> {
+    if fld.is_array() {
+        return Some("array");
+    }
+    match &fld.field_type {
+        FieldDefType::Boolean => Some("boolean"),
+        FieldDefType::F32 | FieldDefType::F64 => Some("number"),
+        FieldDefType::I8
+        | FieldDefType::I16
+        | FieldDefType::I32
+        | FieldDefType::I64
+        | FieldDefType::Isize
+        | FieldDefType::U8
+        | FieldDefType::U16
+        | FieldDefType::U32
+        | FieldDefType::U64
+        | FieldDefType::Usize => Some("integer"),
+        FieldDefType::String | FieldDefType::StringLiteral(_) => Some("string"),
+        #[cfg(feature = "chrono")]
+        FieldDefType::DateTime
+        | FieldDefType::NaiveDate
+        | FieldDefType::NaiveDateTime
+        | FieldDefType::NaiveTime => Some("string"),
+        FieldDefType::Tuple(_) => Some("array"),
+        FieldDefType::SiblingType(name, _) => is_sequence_wrapper(name).then_some("array"),
+        #[cfg(feature = "object_id")]
+        FieldDefType::ObjectId => None,
+        FieldDefType::Map(_, _) | FieldDefType::Unknown => None,
     }
 }
 
@@ -8587,7 +8714,11 @@ fn zod_operand_contributions(operand: &MergedOperand) -> Vec<&str> {
     if operand.members.is_empty() {
         vec![operand.spelling.as_str()]
     } else {
-        operand.members.iter().map(String::as_str).collect()
+        operand
+            .members
+            .iter()
+            .map(|member| member.spelling.as_str())
+            .collect()
     }
 }
 

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -20,6 +20,9 @@ use super::{
     ident_schema_module_name, register_alias_info,
 };
 
+#[cfg(all(feature = "serde", feature = "zod"))]
+use super::{flattened_union_member_guard_error, record_zod_union_members};
+
 #[cfg(feature = "typescript")]
 use super::tuple_struct_ts_body;
 
@@ -5506,4 +5509,146 @@ fn a_pattern_of_any_real_shape_keeps_its_regex() {
          if ! RE . is_match (value) { \
          return Err (format ! (\"'{}' does not match pattern '{}'\" , \"field\" , \"^[a-z]+$\")) ; } } Ok (()) } "
     );
+}
+
+/// The recording a merge reads the union's members off says which of them serde writes as something
+/// other than an object, that being the one thing the spelling does not carry and the one thing a
+/// merge has to know: an intersection built on such a member is an object joined to a scalar, which
+/// no payload satisfies.
+#[cfg(all(feature = "serde", feature = "zod"))]
+#[test]
+fn a_scalar_union_member_is_recorded_as_the_type_serde_writes_it_as() {
+    let mut item: syn::ItemEnum = syn::parse_quote! {
+        enum Choice {
+            Obj(Holder),
+            Text(String),
+            Count(u32),
+            Many(Vec<Holder>),
+        }
+    };
+    let (_, _, merge_parts, _, errors, _, _) = collect_untagged_members(&mut item, UNTAGGED_MODULE);
+    assert!(errors.is_empty(), "got: {errors:?}");
+    let recorded: Vec<(String, Option<&str>)> = merge_parts
+        .iter()
+        .map(|member| (member.branch_path(), member.non_object))
+        .collect();
+    assert_eq!(
+        recorded,
+        vec![
+            ("1".to_owned(), None),
+            ("2".to_owned(), Some("string")),
+            ("3".to_owned(), Some("integer")),
+            ("4".to_owned(), Some("array")),
+        ]
+    );
+}
+
+/// So an object flattening that union is refused where the field was written, in the words the
+/// JSON-schema merge refuses the same declaration with. Before, the branch for the scalar member
+/// was emitted as the object intersected with it and nothing said so.
+#[cfg(all(feature = "serde", feature = "zod"))]
+#[test]
+fn flattening_a_union_with_a_scalar_member_is_refused_naming_the_branch() {
+    let error = recorded_union_flatten_error(
+        "ScalarChoice",
+        syn::parse_quote! {
+            enum ScalarChoice {
+                Obj(Holder),
+                Text(String),
+            }
+        },
+        &syn::parse_quote! { #[serde(flatten)] either: ScalarChoice },
+    )
+    .unwrap();
+    assert!(error.contains("compile_error"), "got: {error}");
+    assert!(
+        error.contains(
+            "`#[serde(flatten)]` of `ScalarChoice` writes a union member that is not an object"
+        ),
+        "got: {error}"
+    );
+    assert!(
+        error.contains("its branch 2 describes a `string`"),
+        "got: {error}"
+    );
+    assert!(
+        error.contains("write the field as a named member so the value gets a key of its own"),
+        "got: {error}"
+    );
+}
+
+/// A member reached through a nesting is named by the trail that reaches it, which is the position
+/// the JSON-schema merge names the same member by — the recording is multiplied out where that
+/// merge descends, so the trail is what keeps the two answers the same sentence.
+#[cfg(all(feature = "serde", feature = "zod"))]
+#[test]
+fn a_nested_scalar_union_member_is_refused_by_its_trail() {
+    recorded_union_flatten_error(
+        "NestedInner",
+        syn::parse_quote! {
+            enum NestedInner {
+                Obj(Holder),
+                Text(String),
+            }
+        },
+        &syn::parse_quote! { #[serde(flatten)] either: NestedInner },
+    );
+    let error = recorded_union_flatten_error(
+        "NestedOuter",
+        syn::parse_quote! {
+            enum NestedOuter {
+                Inner(NestedInner),
+                Other(Holder),
+            }
+        },
+        &syn::parse_quote! { #[serde(flatten)] either: NestedOuter },
+    )
+    .unwrap();
+    assert!(
+        error.contains("its branch 1.2 describes a `string`"),
+        "got: {error}"
+    );
+}
+
+/// An object flattening a union every member of which serde writes as an object is untouched, and
+/// so is one naming a type the recording holds nothing for.
+#[cfg(all(feature = "serde", feature = "zod"))]
+#[test]
+fn flattening_a_union_of_objects_is_not_refused() {
+    assert!(
+        recorded_union_flatten_error(
+            "ObjectChoice",
+            syn::parse_quote! {
+                enum ObjectChoice {
+                    First(Holder),
+                    Second(Other),
+                }
+            },
+            &syn::parse_quote! { #[serde(flatten)] either: ObjectChoice },
+        )
+        .is_none()
+    );
+    let unrecorded: syn::Field = syn::parse_quote! { #[serde(flatten)] base: NeverRecorded };
+    assert!(flattened_union_member_guard_error(&unrecorded, "Host").is_none());
+}
+
+/// Records an untagged enum's members the way its own expansion does, then asks the flatten guard
+/// what an object naming it would be told. Returns the rendered `compile_error!`, or `None` where
+/// the merge has nothing to refuse.
+#[cfg(all(feature = "serde", feature = "zod"))]
+fn recorded_union_flatten_error(
+    rust_ident: &str,
+    mut item: syn::ItemEnum,
+    field: &syn::Field,
+) -> Option<String> {
+    let (_, _, merge_parts, _, errors, _, _) = collect_untagged_members(&mut item, UNTAGGED_MODULE);
+    assert!(errors.is_empty(), "got: {errors:?}");
+    register_alias_info(
+        rust_ident,
+        rust_ident,
+        &ident_schema_module_name(rust_ident),
+        AliasKind::NoEnumMembers,
+    );
+    record_zod_union_members(rust_ident, &merge_parts);
+    flattened_union_member_guard_error(field, "Host").map(|error| error.to_string())
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -128,6 +128,42 @@ pub enum TrivialPattern {
     StartsWith(String),
 }
 
+/// One member of an untagged union as the Zod surface writes it, beside the two things a merge
+/// that flattens the union has to know about it and cannot recover from the spelling.
+///
+/// `branch` is the trail of one-based choices the member sits at, so a member of a nested union is
+/// named `1.2` rather than twice as `2` — the position the JSON-schema merge names the same member
+/// by, the recording being already multiplied out where that merge descends.
+///
+/// `non_object` is what serde writes the member as when that is provably not an object, named by
+/// the JSON type keyword the other surface writes for it. serde flattens structs and maps and
+/// nothing else, so such a member is one no object can be merged with, on any surface.
+///
+/// Both travel under `serde` alone, which is the feature that reads `#[serde(untagged)]` and
+/// `#[serde(flatten)]` at all: without it nothing records a member and nothing merges one, and the
+/// spelling is all the Zod surface still writes.
+#[cfg(feature = "zod")]
+#[derive(Clone)]
+pub struct ZodUnionMember {
+    #[cfg(feature = "serde")]
+    pub branch: Vec<usize>,
+    #[cfg(feature = "serde")]
+    pub non_object: Option<&'static str>,
+    pub spelling: String,
+}
+
+#[cfg(all(feature = "serde", feature = "zod"))]
+impl ZodUnionMember {
+    /// The member's position, spelled the way the JSON-schema merge spells the same one.
+    pub fn branch_path(&self) -> String {
+        self.branch
+            .iter()
+            .map(usize::to_string)
+            .collect::<Vec<String>>()
+            .join(".")
+    }
+}
+
 #[derive(Clone)]
 pub struct AliasInfo {
     pub export_name: String,
@@ -139,7 +175,7 @@ pub struct AliasInfo {
     /// item. Filled by [`record_zod_union_members`] once the enum's own expansion has rendered
     /// them.
     #[cfg(feature = "zod")]
-    pub zod_union_members: Vec<String>,
+    pub zod_union_members: Vec<ZodUnionMember>,
 }
 
 /// The walk over a parsed `pattern` that collects the rewrites its JavaScript spelling needs and
@@ -522,8 +558,13 @@ pub fn register_alias_info(
 /// walk is what could not be made to terminate — two unions naming each other is a shape a merge is
 /// free to reach. The recording cannot hold such a cycle, because an entry is only ever built from
 /// entries registered before it.
+///
+/// Each member carries where it sits and whether serde writes it as an object, because the merge is
+/// the position that has to answer for both and the spelling tells it neither. The member itself is
+/// left alone: an untagged enum may hold a scalar, and it is joining that scalar to an object that
+/// no value satisfies.
 #[cfg(feature = "zod")]
-pub fn record_zod_union_members(rust_ident: &str, members: &[String]) {
+pub fn record_zod_union_members(rust_ident: &str, members: &[ZodUnionMember]) {
     ALIAS_INFO.with(|map| {
         if let Some(info) = map.borrow_mut().get_mut(rust_ident) {
             info.zod_union_members = members.to_vec();

--- a/tests/flatten_tests/tests.rs
+++ b/tests/flatten_tests/tests.rs
@@ -249,8 +249,9 @@ enum LaterEither {
     Second(FlatSecond),
 }
 
-/// The same shape with one member serde writes as a string rather than an object. The union names
-/// no type of its own, so nothing before the merge can tell the two apart.
+/// The same shape with one member serde writes as a string rather than an object. Standing on its
+/// own it is an ordinary union — an untagged enum may hold a scalar — and every surface describes
+/// it.
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(untagged)]
@@ -259,12 +260,39 @@ enum FlatScalarEither {
     Text(String),
 }
 
+/// Flattening it is what no value satisfies, and the Zod surface refuses the declaration once the
+/// members it multiplies over say which of them serde writes as a scalar. So the struct exists
+/// only where nothing records those members, which is where the JSON-schema merge answers for the
+/// same declaration at run time instead.
+#[cfg(not(feature = "zod"))]
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct FlatOverScalarUntagged {
     #[serde(flatten)]
     either: FlatScalarEither,
     own: String,
+}
+
+/// The same union declared *below* the object that flattens it. The recording holds what has
+/// already expanded, so this one carries no members and the Zod merge names it as the one operand
+/// it is — the fallback a forward reference already takes — while the JSON-schema merge, which
+/// reads the members back at run time, refuses it wherever it is declared.
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct FlatOverLaterScalarUntagged {
+    #[serde(flatten)]
+    either: LaterScalarEither,
+    own: String,
+}
+
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(untagged)]
+enum LaterScalarEither {
+    Obj(FlatFirst),
+    Text(String),
 }
 
 /// A union member that names itself, and the struct that flattens the union. The member describes
@@ -1038,6 +1066,7 @@ fn test_the_untagged_flatten_schema_accepts_every_payload_serde_writes() {
 
 /// A union member serde writes as a string is a member serde cannot flatten at all.
 #[test]
+#[cfg(not(feature = "zod"))]
 fn test_flattening_an_untagged_enum_over_a_string_member_is_unserializable() {
     let refusal = serde_json::to_value(FlatOverScalarUntagged {
         own: "o".to_owned(),
@@ -1051,9 +1080,26 @@ fn test_flattening_an_untagged_enum_over_a_string_member_is_unserializable() {
     );
 }
 
+/// The same value written for the union declared below the object, which every table holds: what
+/// serde refuses is the declaration, not the spelling any one surface gave it.
+#[test]
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+fn test_flattening_a_later_untagged_enum_over_a_string_member_is_unserializable() {
+    let refusal = serde_json::to_value(FlatOverLaterScalarUntagged {
+        own: "o".to_owned(),
+        either: LaterScalarEither::Text("t".to_owned()),
+    })
+    .unwrap_err()
+    .to_string();
+    assert!(
+        refusal.contains("can only flatten structs and maps"),
+        "Got: {refusal}"
+    );
+}
+
 /// So the merge refuses the whole union, naming the branch that cannot join the object.
 #[test]
-#[cfg(feature = "jsonschema")]
+#[cfg(all(feature = "jsonschema", not(feature = "zod")))]
 #[should_panic(
     expected = "`FlatOverScalarUntagged`: `#[serde(flatten)]` of `FlatScalarEither` writes a union member that is not an object — its branch 2 describes a `string`"
 )]
@@ -1061,12 +1107,23 @@ fn test_a_string_member_of_a_flattened_untagged_enum_is_refused_by_the_merge() {
     assert!(FlatOverScalarUntagged::json_schema().is_object());
 }
 
+/// And it refuses it in those same words wherever the union was declared, which is the one reading
+/// of the declaration that survives the Zod surface refusing it at expansion.
+#[test]
+#[cfg(feature = "jsonschema")]
+#[should_panic(
+    expected = "`FlatOverLaterScalarUntagged`: `#[serde(flatten)]` of `LaterScalarEither` writes a union member that is not an object — its branch 2 describes a `string`"
+)]
+fn test_a_string_member_of_a_later_flattened_untagged_enum_is_refused_by_the_merge() {
+    assert!(FlatOverLaterScalarUntagged::json_schema().is_object());
+}
+
 /// The remedy that refusal names is the same one every flattened non-object gets.
 #[test]
 #[cfg(feature = "jsonschema")]
 #[should_panic(expected = "write the field as a named member so the value gets a key of its own")]
 fn test_the_untagged_branch_refusal_names_the_remedy() {
-    assert!(FlatOverScalarUntagged::json_schema().is_object());
+    assert!(FlatOverLaterScalarUntagged::json_schema().is_object());
 }
 
 /// A union member that names itself writes its own keys beside the struct's, the same as any other
@@ -1781,4 +1838,40 @@ fn test_an_internally_tagged_flatten_schema_is_byte_identical() {
     const EXPECTED: &str = "export const DataElementSampleValueEntry$Schema = z.strictObject({\n  dataElementId: z.string(),\n\n}).and(z.lazy(() => DataElementSampleValueVariant$Schema));";
 
     assert_eq!(DataElementSampleValueEntry::zod_schema(), EXPECTED);
+}
+
+/// A union holding a member serde writes as a scalar is a union like any other while nothing
+/// flattens it: the member is a branch of the choice, where a scalar is exactly what a payload may
+/// be, and the schema is spelled byte for byte as it was before the merge could tell the two apart.
+#[test]
+#[cfg(feature = "zod")]
+fn test_a_standalone_union_with_a_scalar_member_is_byte_identical() {
+    #[cfg(feature = "typescript")]
+    const EXPECTED: &str = "const FlatScalarEither$RawSchema = z.union([FlatFirst$Schema, z.string()]);\n\nexport const FlatScalarEither$Schema: ZodType<FlatScalarEither> = FlatScalarEither$RawSchema;";
+    #[cfg(not(feature = "typescript"))]
+    const EXPECTED: &str =
+        "export const FlatScalarEither$Schema = z.union([FlatFirst$Schema, z.string()]);";
+
+    assert_eq!(FlatScalarEither::zod_schema(), EXPECTED);
+}
+
+/// And flattening one is refused at expansion rather than emitted — the branch that used to be
+/// written for the scalar member was the object intersected with it, which no payload satisfies and
+/// which nothing reported. The declaration that would carry it does not exist under this feature,
+/// so what the refusal is pinned against is the field it names.
+///
+/// The reach is the recording's: a union declared below the object records nothing for the merge to
+/// read, so that one is still named as the one operand it is.
+#[test]
+#[cfg(feature = "zod")]
+fn test_a_union_with_a_scalar_member_declared_below_is_still_named_as_one_operand() {
+    let zod = FlatOverLaterScalarUntagged::zod_schema();
+    assert!(
+        zod.contains("}).and(z.lazy(() => LaterScalarEither$Schema));"),
+        "expected the union named as one operand, got: {zod}"
+    );
+    assert!(
+        !zod.contains(".and(z.lazy(() => z.string()))"),
+        "the scalar member reached the intersection in: {zod}"
+    );
 }


### PR DESCRIPTION
The Zod flatten multiplication read recorded union members as bare spellings, so an object intersected with a scalar member (`$OwnSchema.and(z.lazy(() => z.string()))`) was emitted silently — a branch no payload satisfies, where serde errors at run time and the JSON-schema merge panics naming the branch. The recording now carries what the spelling cannot: `ZodUnionMember { branch, non_object, spelling }`, the branch trail being the same position the JSON merge names (`1.2` for a nested leaf), and `non_object` proven from the member's own written type (string/integer/number/boolean/array) with `None` where nothing proves it — the recording never refuses more than it can prove. The flatten site refuses with a spanned error in the JSON surface's own sentence, naming the branch and the remedy.

The enum itself stays legal everywhere (a standalone scalar-member union pinned byte-identical). A declared-below twin keeps the documented fallback reachable under every feature table. All-object flattens byte-identical.