### PR TITLE
show the emissions the landing-page examples actually generate, pinned per block

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,32 +36,104 @@ use proc_macro::TokenStream;
 /// #[serde(rename_all = "camelCase")]
 /// #[model_schema()]
 /// pub struct User {
-///     pub id: String,
-///     pub first_name: String,
-///     pub last_name: String,
 ///     #[serde(skip_serializing_if = "Option::is_none")]
 ///     pub age: Option<u32>,
+///     pub first_name: String,
+///     pub id: String,
+///     pub last_name: String,
 ///     pub roles: Vec<String>,
 /// }
-///
-/// // This will generate a ts_definition() method that returns:
-/// //
-/// // export type User = {
-/// //   id: string,
-/// //   firstName: string,
-/// //   lastName: string,
-/// //   age: number | undefined,
-/// //   roles: Array<string>,
-/// // };
-/// //
-/// // export const User$Schema: ZodType<User> = z.strictObject({
-/// //   id: z.string(),
-/// //   firstName: z.string(),
-/// //   lastName: z.string(),
-/// //   age: z.union([z.number(), z.undefined()]).prefault(undefined),
-/// //   roles: z.array(z.string()),
-/// // });
 /// ```
+///
+/// Each output block below is a run of the declaration above it under the default features, pasted
+/// verbatim. The two methods answer separately -- `ts_definition()` returns the TypeScript alone,
+/// `zod_schema()` the Zod alone -- and the JSON Schema carried by each leading `JSDoc` block is
+/// written only while the `jsonschema` feature is on.
+///
+/// `User::ts_definition()`:
+///
+#[doc = r#"```typescript
+/**
+ * User
+ * 
+ * JSON Schema:
+ * {
+ *   "type": "object",
+ *   "additionalProperties": false,
+ *   "properties": {
+ *     "age": {
+ *       "type": "integer"
+ *     },
+ *     "firstName": {
+ *       "type": "string"
+ *     },
+ *     "id": {
+ *       "type": "string"
+ *     },
+ *     "lastName": {
+ *       "type": "string"
+ *     },
+ *     "roles": {
+ *       "type": "array",
+ *       "items": {
+ *         "type": "string"
+ *       }
+ *     }
+ *   },
+ *   "required": [
+ *     "firstName",
+ *     "id",
+ *     "lastName",
+ *     "roles"
+ *   ]
+ * }
+ **/
+
+
+export type User = {
+  /**
+ * age
+ * 
+**/
+  age: number | undefined;
+  /**
+ * firstName
+ * 
+**/
+  firstName: string;
+  /**
+ * id
+ * 
+**/
+  id: string;
+  /**
+ * lastName
+ * 
+**/
+  lastName: string;
+  /**
+ * roles
+ * 
+**/
+  roles: Array<string>;
+
+};
+```"#]
+///
+/// `User::zod_schema()`:
+///
+#[doc = "```typescript
+const User$RawSchema = z.strictObject({
+  age: z.union([z.number().int(), z.undefined()]).prefault(undefined),
+  firstName: z.string(),
+  id: z.string(),
+  lastName: z.string(),
+  roles: z.array(z.string()),
+
+});
+
+export const User$Schema: ZodType<User> = User$RawSchema;
+```"]
 ///
 /// ## Enum Support
 ///
@@ -75,14 +147,42 @@ use proc_macro::TokenStream;
 /// #[model_schema()]
 /// pub enum Status {
 ///     Active,
-///     Pending,
 ///     Inactive,
+///     Pending,
 /// }
-///
-/// // Generates:
-/// // export type Status = "active" | "pending" | "inactive";
-/// // export const Status$Schema: ZodType<Status> = z.enum(["active", "pending", "inactive"]);
 /// ```
+///
+/// `Status::ts_definition()`:
+///
+#[doc = r#"```typescript
+/**
+ * Status
+ * 
+ * JSON Schema:
+ * {
+ *   "type": "string",
+ *   "enum": [
+ *     "active",
+ *     "inactive",
+ *     "pending"
+ *   ]
+ * }
+ **/
+export type Status =
+  | "active"
+  | "inactive"
+  | "pending";
+```"#]
+///
+/// `Status::zod_schema()`:
+///
+#[doc = r#"```typescript
+const Status$RawSchema = z.enum(["active", "inactive", "pending"]).meta({
+  description: "Status",
+});
+
+export const Status$Schema: ZodType<Status> = Status$RawSchema;
+```"#]
 ///
 /// ## Tagged Unions (Discriminated Unions)
 ///
@@ -96,27 +196,117 @@ use proc_macro::TokenStream;
 /// #[model_schema()]
 /// pub enum Event {
 ///     UserCreated {
-///         user_id: String,
 ///         timestamp: String,
+///         user_id: String,
 ///     },
 ///     UserDeleted {
-///         user_id: String,
 ///         #[serde(skip_serializing_if = "Option::is_none")]
 ///         reason: Option<String>,
-///     }
+///         user_id: String,
+///     },
 /// }
-///
-/// // Generates a discriminated union in TypeScript:
-/// // export type Event = {
-/// //   type: "userCreated";
-/// //   userId: string;
-/// //   timestamp: string;
-/// // } | {
-/// //   type: "userDeleted";
-/// //   userId: string;
-/// //   reason: string | undefined;
-/// // };
 /// ```
+///
+/// `Event::ts_definition()`, a discriminated union:
+///
+#[doc = r#"```typescript
+/**
+ * Event
+ * 
+ * JSON Schema:
+ * {
+ *   "type": "object",
+ *   "oneOf": [
+ *     {
+ *       "additionalProperties": false,
+ *       "properties": {
+ *         "type": {
+ *           "type": "string",
+ *           "const": "userCreated"
+ *         },
+ *         "timestamp": {
+ *           "type": "string"
+ *         },
+ *         "userId": {
+ *           "type": "string"
+ *         }
+ *       },
+ *       "required": [
+ *         "type",
+ *         "timestamp",
+ *         "userId"
+ *       ]
+ *     },
+ *     {
+ *       "additionalProperties": false,
+ *       "properties": {
+ *         "type": {
+ *           "type": "string",
+ *           "const": "userDeleted"
+ *         },
+ *         "reason": {
+ *           "type": "string"
+ *         },
+ *         "userId": {
+ *           "type": "string"
+ *         }
+ *       },
+ *       "required": [
+ *         "type",
+ *         "userId"
+ *       ]
+ *     }
+ *   ]
+ * }
+ **/
+export type Event = {  /**
+ * userCreated
+ * 
+**/
+  type: "userCreated";
+  /**
+ * timestamp
+ * 
+**/
+  timestamp: string;
+  /**
+ * userId
+ * 
+**/
+  userId: string;
+} | {  /**
+ * userDeleted
+ * 
+**/
+  type: "userDeleted";
+  /**
+ * reason
+ * 
+**/
+  reason: string | undefined;
+  /**
+ * userId
+ * 
+**/
+  userId: string;
+};
+```"#]
+///
+/// `Event::zod_schema()`:
+///
+#[doc = r#"```typescript
+const Event$RawSchema = z.discriminatedUnion("type", [z.strictObject({
+  type: z.literal("userCreated"),
+  timestamp: z.string(),
+  userId: z.string(),
+}), z.strictObject({
+  type: z.literal("userDeleted"),
+  reason: z.union([z.string(), z.undefined()]).prefault(undefined),
+  userId: z.string(),
+})]);
+
+export const Event$Schema: ZodType<Event> = Event$RawSchema;
+```"#]
 ///
 /// ## `MongoDB` `ObjectId` Support
 ///
@@ -131,39 +321,168 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 // Dummy ObjectId for doc test (in real usage, use mongodb::bson::oid::ObjectId)
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-struct ObjectId(String);
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ObjectId(pub String);
 
 #[derive(Serialize, Deserialize)]
 #[model_schema()]
 pub struct Document {
-    pub id: ObjectId,
-    pub title: String,
     pub author_id: ObjectId,
-    pub tags: Vec<ObjectId>,
+    pub id: ObjectId,
     pub metadata: HashMap<String, ObjectId>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parent_id: Option<ObjectId>,
+    pub tags: Vec<ObjectId>,
+    pub title: String,
 }
+```
 
-// Generates:
-// export type Document = {
-//   id: ObjectId;
-//   title: string;
-//   author_id: ObjectId;
-//   tags: Array<ObjectId>;
-//   metadata: Partial<Record<string, ObjectId>>;
-//   parent_id: ObjectId | undefined;
-// };
-//
-// export const Document$Schema = z.strictObject({
-//   id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) }),
-//   title: z.string(),
-//   author_id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) }),
-//   tags: z.array(z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) })),
-//   metadata: z.record(z.string(), z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) })),
-//   parent_id: z.union([z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) }), z.undefined()]).prefault(undefined),
-// });
+`Document::ts_definition()`:
+
+```typescript
+/**
+ * Document
+ * 
+ * JSON Schema:
+ * {
+ *   "type": "object",
+ *   "additionalProperties": false,
+ *   "properties": {
+ *     "author_id": {
+ *       "type": "object",
+ *       "properties": {
+ *         "$oid": {
+ *           "type": "string",
+ *           "pattern": "^[a-f0-9]{24}$"
+ *         }
+ *       },
+ *       "required": [
+ *         "$oid"
+ *       ],
+ *       "additionalProperties": false
+ *     },
+ *     "id": {
+ *       "type": "object",
+ *       "properties": {
+ *         "$oid": {
+ *           "type": "string",
+ *           "pattern": "^[a-f0-9]{24}$"
+ *         }
+ *       },
+ *       "required": [
+ *         "$oid"
+ *       ],
+ *       "additionalProperties": false
+ *     },
+ *     "metadata": {
+ *       "type": "object",
+ *       "additionalProperties": {
+ *         "type": "object",
+ *         "properties": {
+ *           "$oid": {
+ *             "type": "string",
+ *             "pattern": "^[a-f0-9]{24}$"
+ *           }
+ *         },
+ *         "required": [
+ *           "$oid"
+ *         ],
+ *         "additionalProperties": false
+ *       }
+ *     },
+ *     "parent_id": {
+ *       "type": "object",
+ *       "properties": {
+ *         "$oid": {
+ *           "type": "string",
+ *           "pattern": "^[a-f0-9]{24}$"
+ *         }
+ *       },
+ *       "required": [
+ *         "$oid"
+ *       ],
+ *       "additionalProperties": false
+ *     },
+ *     "tags": {
+ *       "type": "array",
+ *       "items": {
+ *         "type": "object",
+ *         "properties": {
+ *           "$oid": {
+ *             "type": "string",
+ *             "pattern": "^[a-f0-9]{24}$"
+ *           }
+ *         },
+ *         "required": [
+ *           "$oid"
+ *         ],
+ *         "additionalProperties": false
+ *       }
+ *     },
+ *     "title": {
+ *       "type": "string"
+ *     }
+ *   },
+ *   "required": [
+ *     "author_id",
+ *     "id",
+ *     "metadata",
+ *     "tags",
+ *     "title"
+ *   ]
+ * }
+ **/
+
+
+export type Document = {
+  /**
+ * author_id
+ * 
+**/
+  author_id: ObjectId;
+  /**
+ * id
+ * 
+**/
+  id: ObjectId;
+  /**
+ * metadata
+ * 
+**/
+  metadata: Partial<Record<string, ObjectId>>;
+  /**
+ * parent_id
+ * 
+**/
+  parent_id: ObjectId | undefined;
+  /**
+ * tags
+ * 
+**/
+  tags: Array<ObjectId>;
+  /**
+ * title
+ * 
+**/
+  title: string;
+
+};
+```
+
+`Document::zod_schema()`:
+
+```typescript
+const Document$RawSchema = z.strictObject({
+  author_id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) }),
+  id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) }),
+  metadata: z.record(z.string(), z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) })),
+  parent_id: z.union([z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) }), z.undefined()]).prefault(undefined),
+  tags: z.array(z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) })),
+  title: z.string(),
+
+});
+
+export const Document$Schema: ZodType<Document> = Document$RawSchema;
 ```
 "#
 )]

--- a/tests/crate_rustdoc_tests.rs
+++ b/tests/crate_rustdoc_tests.rs
@@ -1,0 +1,3 @@
+#[cfg(test)]
+#[path = "crate_rustdoc_tests/tests.rs"]
+mod tests;

--- a/tests/crate_rustdoc_tests/tests.rs
+++ b/tests/crate_rustdoc_tests/tests.rs
@@ -1,0 +1,149 @@
+//! The crate rustdoc opens with four declarations and prints, beside each, what that declaration
+//! emits. A reader takes those blocks for the crate's output — so each one is expanded here as
+//! written and held to the run: the emission the generator answers with has to still appear in
+//! `src/lib.rs` verbatim. Drift on either side fails here rather than on the docs page.
+//!
+//! Field and variant order is load-bearing, every surface being written in declaration order, so
+//! each type is declared exactly as the rustdoc declares it.
+
+#[cfg(all(
+    feature = "jsonschema",
+    feature = "serde",
+    feature = "typescript",
+    feature = "zod"
+))]
+use serde::{Deserialize, Serialize};
+#[cfg(all(
+    feature = "jsonschema",
+    feature = "object_id",
+    feature = "serde",
+    feature = "typescript",
+    feature = "zod"
+))]
+use std::collections::HashMap;
+#[cfg(all(
+    feature = "jsonschema",
+    feature = "serde",
+    feature = "typescript",
+    feature = "zod"
+))]
+use tixschema::model_schema;
+
+/// The JSON Schema each emission carries in its leading `JSDoc` block is written only while
+/// `jsonschema` is on, so every pin here reads the rustdoc under the feature set the shown blocks
+/// were taken from.
+#[cfg(all(
+    feature = "jsonschema",
+    feature = "serde",
+    feature = "typescript",
+    feature = "zod"
+))]
+fn assert_rustdoc_shows(surface: &str) {
+    let rustdoc = include_str!("../../src/lib.rs");
+    assert!(
+        rustdoc.contains(surface),
+        "src/lib.rs no longer shows this emission verbatim:\n{surface}"
+    );
+}
+
+#[cfg(all(
+    feature = "jsonschema",
+    feature = "serde",
+    feature = "typescript",
+    feature = "zod"
+))]
+#[test]
+fn test_usage_section_shows_what_the_struct_emits() {
+    #[derive(Serialize, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    #[model_schema()]
+    pub struct User {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub age: Option<u32>,
+        pub first_name: String,
+        pub id: String,
+        pub last_name: String,
+        pub roles: Vec<String>,
+    }
+
+    assert_rustdoc_shows(&User::ts_definition());
+    assert_rustdoc_shows(&User::zod_schema());
+}
+
+#[cfg(all(
+    feature = "jsonschema",
+    feature = "serde",
+    feature = "typescript",
+    feature = "zod"
+))]
+#[test]
+fn test_enum_section_shows_what_the_enum_emits() {
+    #[derive(Serialize, Deserialize)]
+    #[serde(rename_all = "lowercase")]
+    #[model_schema()]
+    pub enum Status {
+        Active,
+        Inactive,
+        Pending,
+    }
+
+    assert_rustdoc_shows(&Status::ts_definition());
+    assert_rustdoc_shows(&Status::zod_schema());
+}
+
+#[cfg(all(
+    feature = "jsonschema",
+    feature = "serde",
+    feature = "typescript",
+    feature = "zod"
+))]
+#[test]
+fn test_tagged_union_section_shows_what_the_tagged_enum_emits() {
+    #[derive(Serialize, Deserialize)]
+    #[serde(tag = "type", rename_all = "camelCase")]
+    #[model_schema()]
+    pub enum Event {
+        UserCreated {
+            timestamp: String,
+            user_id: String,
+        },
+        UserDeleted {
+            #[serde(skip_serializing_if = "Option::is_none")]
+            reason: Option<String>,
+            user_id: String,
+        },
+    }
+
+    assert_rustdoc_shows(&Event::ts_definition());
+    assert_rustdoc_shows(&Event::zod_schema());
+}
+
+/// The rustdoc block this pins stands in a dummy `ObjectId` rather than pulling `mongodb` in, the
+/// type being recognised by name, and so does this.
+#[cfg(all(
+    feature = "jsonschema",
+    feature = "object_id",
+    feature = "serde",
+    feature = "typescript",
+    feature = "zod"
+))]
+#[test]
+fn test_object_id_section_shows_what_the_object_id_struct_emits() {
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    pub struct ObjectId(pub String);
+
+    #[derive(Serialize, Deserialize)]
+    #[model_schema()]
+    pub struct Document {
+        pub author_id: ObjectId,
+        pub id: ObjectId,
+        pub metadata: HashMap<String, ObjectId>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub parent_id: Option<ObjectId>,
+        pub tags: Vec<ObjectId>,
+        pub title: String,
+    }
+
+    assert_rustdoc_shows(&Document::ts_definition());
+    assert_rustdoc_shows(&Document::zod_schema());
+}


### PR DESCRIPTION
The crate rustdoc's four '// Generates:' blocks (User, Status, Event, Document — the docs.rs landing page) stated TypeScript and Zod the crate does not emit: wrong member separators, no JSDoc, an inlined export where the crate splits a `$RawSchema` binding, `z.number()` for a `u32`, and the Event/Document blocks had never been run at all (Event's Zod — `z.discriminatedUnion` — was missing entirely). All four are replaced by captured emissions, moved into their own typescript fences via `#[doc]` attributes so the file holds the emission with no comment prefix, and each block is pinned by a test that renders the block's own declaration and asserts `include_str!(lib.rs)` still shows it — verified to bite on a one-space mutation. The example declarations went alphabetical so the re-declaration pins can be byte-exact under the repo's ordering lint.