### PR TITLE
carry an item's generics into the emitted impl and the TypeScript declaration, rendering a parameter as itself

### DIFF
--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -126,6 +126,14 @@ pub enum FieldDefType {
     StringLiteral(String), // For string literal types like "Tixena"
     /// Tuple type - generates anonymous object in TS/Zod.
     Tuple(Vec<FieldDef>),
+    /// One of the enclosing item's own type parameters — `IdType` in `struct Wrapper<IdType>`.
+    ///
+    /// Held apart from [`FieldDefType::SiblingType`] because the three surfaces answer for it
+    /// differently, and only one of them can name it: TypeScript binds the parameter for real, so
+    /// it renders as the name it was written with, while the two validating surfaces render the
+    /// opaque value. [`FieldDef::erase_type_parameters`] is where that rule is written down and
+    /// where a written name becomes this.
+    TypeParam(String),
     U16,
     U32,
     U64,
@@ -259,6 +267,7 @@ impl FieldDef {
             | FieldDefType::NaiveDateTime
             | FieldDefType::DateTime => None,
             FieldDefType::SiblingType(_, _)
+            | FieldDefType::TypeParam(_)
             | FieldDefType::Unknown
             | FieldDefType::StringLiteral(_)
             | FieldDefType::Boolean
@@ -317,7 +326,8 @@ impl FieldDef {
                 .iter()
                 .any(|e| e.contains_type_reference(type_name)),
             // Primitive and leaf types can't contain recursive references
-            FieldDefType::Unknown
+            FieldDefType::TypeParam(_)
+            | FieldDefType::Unknown
             | FieldDefType::StringLiteral(_)
             | FieldDefType::Boolean
             | FieldDefType::String
@@ -343,20 +353,35 @@ impl FieldDef {
         }
     }
 
-    /// Replaces every reference to one of the enclosing item's type parameters with the opaque
-    /// type.
+    /// Rewrites every name that is one of the enclosing item's own type parameters into
+    /// [`FieldDefType::TypeParam`], so the surfaces stop reading it as a reference to another
+    /// generated type.
     ///
-    /// A parameter names no type at expansion — the instantiation names one, and the schema is
-    /// written once for every instantiation. So a parameter describes as an opaque value does,
-    /// which leaves the shape it sits in — a tuple's arity, an array, a map's keys — described.
+    /// This is the one rule the two validating surfaces read a type parameter under, and the one
+    /// place they part company with TypeScript over it. A parameter names no type at expansion —
+    /// the instantiation names one, and one schema is written for every instantiation. So on those
+    /// two surfaces a parameter describes as an opaque value does (`{}` in JSON Schema,
+    /// `z.unknown()` in Zod), which leaves the shape it sits in — a tuple's arity, an array, a
+    /// map's keys — described. TypeScript needs no such rule: it is a type surface, and
+    /// `export type Wrapper<IdType> = { id: IdType }` binds the parameter for real, so it renders
+    /// the name.
     ///
-    /// Recurses through `SiblingType` generics, `Map` keys/values, and `Tuple` elements.
-    #[cfg(feature = "jsonschema")]
+    /// Zod is why the rule cannot stop at JSON. Zod publishes *values*, and a `const` cannot be
+    /// parameterised, so a parameter left to render as the `Name$Schema` binding every unresolved
+    /// type is named after would reference a binding no emitted module declares — the consumer
+    /// pasting the output gets a `ReferenceError` before a payload is read. That is why only the
+    /// enclosing item's *own* parameters are rewritten: a genuinely unresolved sibling type keeps
+    /// its `$Schema` reference, because the type it names does publish that binding.
+    ///
+    /// Recurses through `SiblingType` generics, `Map` keys/values, and `Tuple` elements. Applied
+    /// after the field guards have read the field, so every guard asks its question of the type
+    /// the author wrote — and in every build, features or none, because which of the two a name is
+    /// is a fact about the declaration rather than about the surfaces reading it.
     pub fn erase_type_parameters(&mut self, parameters: &[String]) {
         if let FieldDefType::SiblingType(name, _) = &self.field_type
             && parameters.iter().any(|parameter| parameter == name)
         {
-            self.field_type = FieldDefType::Unknown;
+            self.field_type = FieldDefType::TypeParam(name.clone());
             return;
         }
         match &mut self.field_type {
@@ -375,7 +400,8 @@ impl FieldDef {
                 }
             }
             // Leaf types name no parameter.
-            FieldDefType::Unknown
+            FieldDefType::TypeParam(_)
+            | FieldDefType::Unknown
             | FieldDefType::StringLiteral(_)
             | FieldDefType::Boolean
             | FieldDefType::String
@@ -439,6 +465,7 @@ impl FieldDef {
             FieldDefType::SiblingType(_, _)
             | FieldDefType::Map(_, _)
             | FieldDefType::Tuple(_)
+            | FieldDefType::TypeParam(_)
             | FieldDefType::Unknown
             | FieldDefType::StringLiteral(_)
             | FieldDefType::Boolean
@@ -530,7 +557,8 @@ impl FieldDef {
                 key.os_string_name().or_else(|| value.os_string_name())
             }
             FieldDefType::Tuple(elements) => elements.iter().find_map(Self::os_string_name),
-            FieldDefType::Unknown
+            FieldDefType::TypeParam(_)
+            | FieldDefType::Unknown
             | FieldDefType::StringLiteral(_)
             | FieldDefType::Boolean
             | FieldDefType::String
@@ -586,7 +614,8 @@ impl FieldDef {
                 }
             }
             // Leaf types cannot contain nested references.
-            FieldDefType::Unknown
+            FieldDefType::TypeParam(_)
+            | FieldDefType::Unknown
             | FieldDefType::StringLiteral(_)
             | FieldDefType::Boolean
             | FieldDefType::String
@@ -623,6 +652,8 @@ impl FieldDef {
     fn typescript_base(&self) -> String {
         let result = match &self.field_type {
             FieldDefType::Unknown => "unknown".to_owned(),
+            // The declaration binds this name, so the field is written under it.
+            FieldDefType::TypeParam(name) => name.clone(),
             FieldDefType::Tuple(lst) => {
                 let elements = lst
                     .iter()
@@ -803,7 +834,9 @@ impl FieldDef {
     #[cfg(feature = "zod")]
     fn zod_array_base(&self) -> String {
         let result = match &self.field_type {
-            FieldDefType::Unknown => "z.unknown()".to_owned(),
+            // A `const` cannot be parameterised, so the value a parameter composes into is the
+            // opaque one — see [`FieldDef::erase_type_parameters`].
+            FieldDefType::TypeParam(_) | FieldDefType::Unknown => "z.unknown()".to_owned(),
             FieldDefType::Tuple(lst) => {
                 let elements = lst
                     .iter()

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -6254,6 +6254,7 @@ const fn chrono_json_schema_format(field_type: &FieldDefType) -> Option<&'static
         | FieldDefType::String
         | FieldDefType::StringLiteral(_)
         | FieldDefType::Tuple(..)
+        | FieldDefType::TypeParam(_)
         | FieldDefType::U8
         | FieldDefType::U16
         | FieldDefType::U32

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -15,9 +15,6 @@ use quote::quote_spanned;
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 use syn::spanned::Spanned as _;
 
-#[cfg(feature = "typescript")]
-use syn::GenericParam;
-
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 use syn::Ident;
 
@@ -28,11 +25,9 @@ use crate::{
     utils::{get_field_docs, get_variant_docs, strip_examples_from_docs},
 };
 
-// The item paths take their exported name from `compute_item_export_name` and their module name
-// from `ident_schema_module_name`, both of which apply this themselves; what is left is the
-// parameter list a generic alias writes.
 #[cfg(feature = "typescript")]
-use crate::utils::safe_type_name;
+use crate::utils::ts_generic_params;
+use crate::utils::type_parameters_in_scope;
 
 #[cfg(feature = "zod")]
 use crate::utils::{escape_js_regex_literal, extract_example_from_docs};
@@ -82,8 +77,10 @@ use crate::features::jsonschema::{
 #[cfg(all(feature = "serde", feature = "jsonschema"))]
 use crate::features::jsonschema::{MergeDiagnostic, merged_object_value};
 
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+use crate::utils::get_enum_docs;
 #[cfg(any(feature = "typescript", feature = "zod"))]
-use crate::utils::{get_enum_docs, get_struct_docs};
+use crate::utils::get_struct_docs;
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 use crate::utils::{compute_alias_export_name, ident_schema_module_name};
@@ -906,6 +903,31 @@ fn build_jsdoc_body(docs_vec: Option<&[String]>, fallback_name: &str) -> String 
     }))
 }
 
+/// The `schema_example()` an enum's type publishes: the value its ` ```rust example ` block
+/// builds, or `None` where there is nothing to build one from — no example written, or no `zod`,
+/// which is the only surface that reads one.
+///
+/// One seam for all five enum shapes, which differ in how their variants are written and not in
+/// what the type beside them exposes.
+#[cfg(feature = "zod")]
+fn enum_schema_example_method(
+    docs_vec: Option<&[String]>,
+    name: &syn::Ident,
+) -> Option<proc_macro2::TokenStream> {
+    build_struct_schema_example(docs_vec.and_then(extract_example_from_docs).as_ref(), name)
+}
+
+#[cfg(all(
+    not(feature = "zod"),
+    any(feature = "typescript", feature = "jsonschema")
+))]
+const fn enum_schema_example_method(
+    _docs_vec: Option<&[String]>,
+    _name: &syn::Ident,
+) -> Option<proc_macro2::TokenStream> {
+    None
+}
+
 /// Builds the type-level `schema_example()` method from extracted example code, if present.
 #[cfg(feature = "zod")]
 fn build_struct_schema_example(
@@ -1005,9 +1027,15 @@ fn build_struct_delegate_items(
 
 /// Assembles the final macro output for a struct or enum: the item itself, its schema module
 /// (with the per-field validation functions), and the type's delegate impl.
+///
+/// The delegate impl carries the item's own generics through `split_for_impl`, the way
+/// [`assemble_branded_output`] already does: the block is written for the type as declared, so it
+/// has to repeat every parameter the declaration binds — a lifetime and a const included, neither
+/// of which reaches a schema — or it names a type that does not exist.
 #[cfg(any(feature = "zod", feature = "typescript", feature = "jsonschema"))]
 fn assemble_schema_output<T>(
     item: &T,
+    generics: &syn::Generics,
     module_ident: &Ident,
     name: &syn::Ident,
     schema_impl_items: &[proc_macro2::TokenStream],
@@ -1017,6 +1045,8 @@ fn assemble_schema_output<T>(
 where
     T: quote::ToTokens,
 {
+    let (impl_generics, type_generics, where_clause) = generics.split_for_impl();
+
     let output = quote! {
         #item
 
@@ -1033,7 +1063,7 @@ where
             #(#validation_fns)*
         }
 
-        impl #name {
+        impl #impl_generics #name #type_generics #where_clause {
             #(#delegate_impl_items)*
         }
     };
@@ -1041,6 +1071,31 @@ where
     log::trace!("{output}");
 
     TokenStream::from(output)
+}
+
+/// The type-level `validate()` a struct publishes: the aggregate of its per-field validators, or
+/// `None` where there is nothing to run — no constrained field, or no `serde` to have generated the
+/// validators from.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+fn struct_validate_method(
+    validate_bodies: &[proc_macro2::TokenStream],
+    module_ident: &Ident,
+) -> Option<proc_macro2::TokenStream> {
+    build_struct_validate_method(validate_bodies, module_ident)
+}
+
+#[cfg(all(
+    not(feature = "serde"),
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+const fn struct_validate_method(
+    _validate_bodies: &[proc_macro2::TokenStream],
+    _module_ident: &Ident,
+) -> Option<proc_macro2::TokenStream> {
+    None
 }
 
 /// Builds the type-level `validate()` method that aggregates per-field validators, or `None` when
@@ -1216,12 +1271,19 @@ fn struct_schema_impl_items(
     flattened_fields: &[FieldDef],
     item_name: &str,
     rust_ident: &str,
+    generics: &syn::Generics,
     docs: &str,
 ) -> Vec<proc_macro2::TokenStream> {
     #[cfg(not(feature = "typescript"))]
     let _: &str = docs;
     #[cfg(not(any(feature = "typescript", feature = "zod")))]
     let _: &str = rust_ident;
+    #[cfg(not(any(feature = "typescript", feature = "zod")))]
+    let _: &_ = &generics;
+    #[cfg(feature = "typescript")]
+    let ts_generics = ts_generic_params(generics);
+    #[cfg(feature = "zod")]
+    let ts_type_args = erased_type_arguments(generics);
     // bodies: (type_code, schema_code, json_schema_fields, fields_empty)
     let bodies = render_struct_field_bodies(field_defs, Some(item_name));
     // flatten: (ts_types, zod_schemas)
@@ -1235,9 +1297,24 @@ fn struct_schema_impl_items(
             item_name,
         ),
         #[cfg(feature = "typescript")]
-        generate_ts_definition_method(docs, item_name, rust_ident, &bodies.0, bodies.3, &flatten.0),
+        generate_ts_definition_method(
+            docs,
+            item_name,
+            rust_ident,
+            &ts_generics,
+            &bodies.0,
+            bodies.3,
+            &flatten.0,
+        ),
         #[cfg(feature = "zod")]
-        generate_zod_schema_method(item_name, rust_ident, &bodies.1, "", &flatten.1),
+        generate_zod_schema_method(
+            item_name,
+            rust_ident,
+            &ts_type_args,
+            &bodies.1,
+            "",
+            &flatten.1,
+        ),
     ]
 }
 
@@ -1594,7 +1671,7 @@ fn non_string_inner_shape(inner: &FieldDef) -> Option<&'static str> {
         | FieldDefType::Isize
         | FieldDefType::F32
         | FieldDefType::F64 => Some("numeric"),
-        FieldDefType::Unknown => Some("opaque"),
+        FieldDefType::TypeParam(_) | FieldDefType::Unknown => Some("opaque"),
         FieldDefType::String | FieldDefType::StringLiteral(_) | FieldDefType::SiblingType(..) => {
             None
         }
@@ -1778,7 +1855,9 @@ fn collect_struct_fields(
     rename_all: Option<&str>,
     module_name_opt: Option<&str>,
     type_name: &str,
+    generics: &syn::Generics,
 ) -> StructFieldData {
+    let type_parameters = type_parameters_in_scope(generics);
     let mut field_defs = Vec::new();
     let mut flattened_fields: Vec<FieldDef> = Vec::new();
     let mut validation_fns: Vec<proc_macro2::TokenStream> = Vec::new();
@@ -1800,8 +1879,14 @@ fn collect_struct_fields(
             guard_errors.extend(flattened_field_guard_error(field, type_name));
         }
 
-        let (f_def, validation_fn, validate_body, field_guard_errors) =
-            process_field(rename_all, field, module_name_opt, None, type_name);
+        let (f_def, validation_fn, validate_body, field_guard_errors) = process_field(
+            rename_all,
+            field,
+            module_name_opt,
+            None,
+            type_name,
+            &type_parameters,
+        );
 
         guard_errors.extend(field_guard_errors);
 
@@ -1969,6 +2054,7 @@ fn process_struct(mut item_struct: syn::ItemStruct, args: &ModelSchemaArgs) -> T
         rename_all.as_deref(),
         module_name_opt,
         &rust_ident,
+        &item_struct.generics,
     );
     #[cfg(not(any(feature = "typescript", feature = "zod", feature = "jsonschema")))]
     let _: &_ = &&collected;
@@ -1989,8 +2075,14 @@ fn process_struct(mut item_struct: syn::ItemStruct, args: &ModelSchemaArgs) -> T
     let docs = String::new();
 
     #[cfg(any(feature = "zod", feature = "typescript", feature = "jsonschema"))]
-    let schema_impl_items =
-        struct_schema_impl_items(collected.0, &collected.1, &item_name, &rust_ident, &docs);
+    let schema_impl_items = struct_schema_impl_items(
+        collected.0,
+        &collected.1,
+        &item_name,
+        &rust_ident,
+        &item_struct.generics,
+        &docs,
+    );
 
     // schema_example must be directly on the type (not in the module) because the example code
     // uses type names that may not be accessible from the nested module.
@@ -2002,17 +2094,8 @@ fn process_struct(mut item_struct: syn::ItemStruct, args: &ModelSchemaArgs) -> T
     ))]
     let schema_example_method: Option<proc_macro2::TokenStream> = None;
 
-    // Generate the type-level validate() method if there are constrained fields.
-    #[cfg(all(
-        feature = "serde",
-        any(feature = "typescript", feature = "zod", feature = "jsonschema")
-    ))]
-    let validate_method = build_struct_validate_method(&collected.3, &module_ident);
-    #[cfg(all(
-        not(feature = "serde"),
-        any(feature = "typescript", feature = "zod", feature = "jsonschema")
-    ))]
-    let validate_method: Option<proc_macro2::TokenStream> = None;
+    #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+    let validate_method = struct_validate_method(&collected.3, &module_ident);
 
     // Build delegating impl items (schema_example is added directly, not as a delegate).
     #[cfg(any(feature = "zod", feature = "typescript", feature = "jsonschema"))]
@@ -2028,6 +2111,7 @@ fn process_struct(mut item_struct: syn::ItemStruct, args: &ModelSchemaArgs) -> T
     {
         assemble_schema_output(
             &item_struct,
+            &item_struct.generics,
             &module_ident,
             &name,
             &schema_impl_items,
@@ -2066,12 +2150,20 @@ fn collect_tuple_slots(
     rename_all: Option<&str>,
     module_name: &str,
     type_name: &str,
+    generics: &syn::Generics,
 ) -> (Vec<FieldDef>, Vec<proc_macro2::TokenStream>) {
+    let type_parameters = type_parameters_in_scope(generics);
     let mut slots: Vec<FieldDef> = Vec::new();
     let mut guard_errors: Vec<proc_macro2::TokenStream> = Vec::new();
     for field in fields.iter_mut() {
-        let (slot, _, _, slot_guard_errors) =
-            process_field(rename_all, field, Some(module_name), None, type_name);
+        let (slot, _, _, slot_guard_errors) = process_field(
+            rename_all,
+            field,
+            Some(module_name),
+            None,
+            type_name,
+            &type_parameters,
+        );
         guard_errors.extend(slot_guard_errors);
         slots.push(slot);
     }
@@ -2139,10 +2231,12 @@ fn build_tuple_struct_ts_definition_method(
     docs: &str,
     item_name: &str,
     rust_ident: &str,
+    ts_generics: &str,
     ts_body: &str,
 ) -> proc_macro2::TokenStream {
-    let reexport = ident_reexport_ts(rust_ident, item_name, "");
-    let type_str = format!("/**\n{docs}\n **/\nexport type {item_name} = {ts_body};{reexport}");
+    let reexport = ident_reexport_ts(rust_ident, item_name, ts_generics);
+    let type_str =
+        format!("/**\n{docs}\n **/\nexport type {item_name}{ts_generics} = {ts_body};{reexport}");
     quote! {
         pub fn ts_definition() -> String {
             #type_str.to_owned()
@@ -2157,13 +2251,18 @@ fn build_tuple_struct_ts_definition_method(
 fn build_tuple_struct_zod_schema_method(
     item_name: &str,
     rust_ident: &str,
+    ts_type_args: &str,
     zod_body: &str,
 ) -> proc_macro2::TokenStream {
     let reexport = ident_reexport_zod(rust_ident, item_name);
     #[cfg(feature = "typescript")]
     let schema_str = format!(
-        "const {item_name}$RawSchema = {zod_body};\n\nexport const {item_name}$Schema: ZodType<{item_name}> = {item_name}$RawSchema;{reexport}"
+        "const {item_name}$RawSchema = {zod_body};\n\nexport const {item_name}$Schema: ZodType<{item_name}{ts_type_args}> = {item_name}$RawSchema;{reexport}"
     );
+    // The annotation is the only place the arguments are written, and a zod-only build has no
+    // `ZodType` to annotate with.
+    #[cfg(not(feature = "typescript"))]
+    let _: &_ = &ts_type_args;
     #[cfg(not(feature = "typescript"))]
     let schema_str = format!("export const {item_name}$Schema = {zod_body};{reexport}");
     quote! {
@@ -2195,6 +2294,7 @@ fn process_tuple_struct(
         rename_all,
         &module_name,
         &name.to_string(),
+        &item_struct.generics,
     );
 
     // A violated slot guard makes the whole contract unsound, so the schema surface is dropped and
@@ -2216,12 +2316,14 @@ fn process_tuple_struct(
             &build_jsdoc_body(docs_and_example.0.as_deref(), &item_name),
             &item_name,
             &name.to_string(),
+            &ts_generic_params(&item_struct.generics),
             &tuple_struct_ts_body(&slots),
         ),
         #[cfg(feature = "zod")]
         build_tuple_struct_zod_schema_method(
             &item_name,
             &name.to_string(),
+            &erased_type_arguments(&item_struct.generics),
             &tuple_struct_zod_body(&slots),
         ),
     ];
@@ -2243,6 +2345,7 @@ fn process_tuple_struct(
 
     assemble_schema_output(
         &item_struct,
+        &item_struct.generics,
         &module_ident,
         &name,
         &schema_impl_items,
@@ -2577,20 +2680,20 @@ fn build_branded_json_schema_method(
     json_schema_methods(def_name, &body)
 }
 
-/// Extracts the generic type parameter names from a branded newtype's generics.
-#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-fn branded_generic_params(generics: &syn::Generics) -> Vec<String> {
-    generics
-        .params
-        .iter()
-        .filter_map(|p| {
-            if let syn::GenericParam::Type(tp) = p {
-                Some(tp.ident.to_string())
-            } else {
-                None
-            }
-        })
-        .collect()
+/// The TypeScript argument list a generic item's own name takes where a Zod binding's annotation
+/// names it: one `unknown` per parameter, and nothing at all for an item that declares none.
+///
+/// The annotation states the type of the value beside it, and that value was composed with every
+/// parameter rendered opaque — so the name it is written under has to be filled in the same way.
+/// Naming the generic bare instead is a TypeScript error in its own right, the type requiring its
+/// arguments.
+#[cfg(feature = "zod")]
+fn erased_type_arguments(generics: &syn::Generics) -> String {
+    let parameters = type_parameters_in_scope(generics);
+    if parameters.is_empty() {
+        return String::new();
+    }
+    format!("<{}>", vec!["unknown"; parameters.len()].join(", "))
 }
 
 /// Resolves the TypeScript inner type name and generic parameter list for a branded newtype.
@@ -2715,7 +2818,7 @@ fn branded_inner_composite(inner: &FieldDef) -> Option<BrandedComposite> {
     match &inner.field_type {
         FieldDefType::Map(..) => Some(BrandedComposite::Map),
         FieldDefType::Tuple(..) => Some(BrandedComposite::Tuple),
-        FieldDefType::Unknown => Some(BrandedComposite::Opaque),
+        FieldDefType::TypeParam(_) | FieldDefType::Unknown => Some(BrandedComposite::Opaque),
         FieldDefType::Boolean
         | FieldDefType::F32
         | FieldDefType::F64
@@ -3255,7 +3358,7 @@ fn process_branded_newtype(item_struct: syn::ItemStruct, args: &ModelSchemaArgs)
     let plain_description = item_description(docs_vec.as_deref(), &item_name);
 
     // Get generic type parameters from the struct
-    let generic_params = branded_generic_params(&item_struct.generics);
+    let generic_params = type_parameters_in_scope(&item_struct.generics);
     let is_generic = !generic_params.is_empty();
 
     // Get inner field type info
@@ -3682,13 +3785,8 @@ fn process_plain_enum(
     let rust_ident = name.to_string();
 
     // Extract docs early for example extraction
-    #[cfg(any(feature = "typescript", feature = "zod"))]
+    #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
     let docs_vec = get_enum_docs(&item_enum);
-
-    #[cfg(feature = "zod")]
-    let example_code = docs_vec
-        .as_ref()
-        .and_then(|docs| extract_example_from_docs(docs));
 
     let (enum_options, enum_variant_docs) = collect_plain_enum_options(&mut item_enum, rename_all);
     #[cfg(not(feature = "typescript"))]
@@ -3719,6 +3817,7 @@ fn process_plain_enum(
         &docs_and_description.0,
         item_name,
         &rust_ident,
+        &ts_generic_params(&item_enum.generics),
         &type_code,
     );
 
@@ -3737,13 +3836,8 @@ fn process_plain_enum(
 
     // schema_example must be directly on the type (not in the module) because the example code
     // uses type names that may not be accessible from the nested module.
-    #[cfg(feature = "zod")]
-    let schema_example_method = build_struct_schema_example(example_code.as_ref(), name);
-    #[cfg(all(
-        not(feature = "zod"),
-        any(feature = "typescript", feature = "jsonschema")
-    ))]
-    let schema_example_method: Option<proc_macro2::TokenStream> = None;
+    #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+    let schema_example_method = enum_schema_example_method(docs_vec.as_deref(), name);
 
     // Build schema module impl items (without schema_example)
     #[cfg(any(feature = "zod", feature = "typescript", feature = "jsonschema"))]
@@ -3768,6 +3862,13 @@ fn process_plain_enum(
     // Use the enumerated values in the quote! macro
     let enum_values = &enumerated;
 
+    // A plain enum publishes `enum_members()` from an `impl` of its own rather than through
+    // `assemble_schema_output`, so it repeats the declaration's parameters itself. A type
+    // parameter it cannot bind — Rust refuses an all-unit enum that leaves one unused — but a
+    // const or a lifetime it can, and either has to be carried here or the block names a type
+    // that does not exist.
+    let (impl_generics, type_generics, where_clause) = item_enum.generics.split_for_impl();
+
     #[cfg(any(feature = "zod", feature = "typescript", feature = "jsonschema"))]
     let output = quote! {
         #item_enum
@@ -3783,7 +3884,7 @@ fn process_plain_enum(
             }
         }
 
-        impl #name {
+        impl #impl_generics #name #type_generics #where_clause {
             #(#delegate_impl_items)*
 
             pub fn enum_members() -> Vec<String> {
@@ -3798,7 +3899,7 @@ fn process_plain_enum(
     let output = quote! {
         #item_enum
 
-        impl #name {
+        impl #impl_generics #name #type_generics #where_clause {
             pub fn enum_members() -> Vec<String> {
                 [
                     #(#enum_values),*
@@ -3824,6 +3925,7 @@ fn collect_discriminated_variants(
     rename_all: Option<&str>,
     enum_module_name_opt: Option<&str>,
 ) -> DiscriminatedVariantData {
+    let type_parameters = type_parameters_in_scope(&item_enum.generics);
     let mut variants: Vec<DiscriminatedVariant> = Vec::new();
     let mut enum_validation_fns: Vec<proc_macro2::TokenStream> = Vec::new();
     let mut guard_errors: Vec<proc_macro2::TokenStream> = Vec::new();
@@ -3853,6 +3955,7 @@ fn collect_discriminated_variants(
                 enum_module_name_opt,
                 Some(&variant_ident),
                 &enum_type_name,
+                &type_parameters,
             );
             if let Some(vfn) = validation_fn {
                 enum_validation_fns.push(vfn);
@@ -3955,13 +4058,8 @@ fn process_discriminated_enum(
     let (module_name, module_ident) = enum_module_idents(name, item_name, AliasKind::NoEnumMembers);
 
     // Extract docs early for example extraction
-    #[cfg(any(feature = "typescript", feature = "zod"))]
+    #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
     let docs_vec = get_enum_docs(&item_enum);
-
-    #[cfg(feature = "zod")]
-    let example_code = docs_vec
-        .as_ref()
-        .and_then(|docs| extract_example_from_docs(docs));
 
     // Process each variant in the enum.
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
@@ -4011,27 +4109,27 @@ fn process_discriminated_enum(
         &docs,
         item_name,
         &name.to_string(),
+        &ts_generic_params(&item_enum.generics),
         &type_code,
     );
 
     // Schema module emits zod_schema without examples; example injection happens in the delegating
     // method on the type to avoid `super::` resolution issues.
     #[cfg(feature = "zod")]
-    let zod_schema_method =
-        generate_discriminated_enum_zod_schema_method(item_name, &name.to_string(), &schema_code);
+    let zod_schema_method = generate_discriminated_enum_zod_schema_method(
+        item_name,
+        &name.to_string(),
+        &erased_type_arguments(&item_enum.generics),
+        &schema_code,
+    );
 
     #[cfg(not(any(feature = "typescript", feature = "zod")))]
     let _: &_ = &item_name;
 
     // schema_example must be directly on the type (not in the module) because the example code
     // uses type names that may not be accessible from the nested module.
-    #[cfg(feature = "zod")]
-    let schema_example_method = build_struct_schema_example(example_code.as_ref(), name);
-    #[cfg(all(
-        not(feature = "zod"),
-        any(feature = "typescript", feature = "jsonschema")
-    ))]
-    let schema_example_method: Option<proc_macro2::TokenStream> = None;
+    #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+    let schema_example_method = enum_schema_example_method(docs_vec.as_deref(), name);
 
     // Build schema module impl items (without schema_example)
     #[cfg(any(feature = "zod", feature = "typescript", feature = "jsonschema"))]
@@ -4059,6 +4157,7 @@ fn process_discriminated_enum(
     {
         assemble_schema_output(
             &item_enum,
+            &item_enum.generics,
             &module_ident,
             name,
             &schema_impl_items,
@@ -4371,13 +4470,8 @@ fn process_externally_tagged_enum(
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
     let (module_name, module_ident) = enum_module_idents(name, item_name, AliasKind::NoEnumMembers);
 
-    #[cfg(any(feature = "typescript", feature = "zod"))]
+    #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
     let docs_vec = get_enum_docs(&item_enum);
-
-    #[cfg(feature = "zod")]
-    let example_code = docs_vec
-        .as_ref()
-        .and_then(|docs| extract_example_from_docs(docs));
 
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
     let enum_module_name_opt = Some(module_name.as_str());
@@ -4418,23 +4512,23 @@ fn process_externally_tagged_enum(
         &docs,
         item_name,
         &name.to_string(),
+        &ts_generic_params(&item_enum.generics),
         &type_code,
     );
 
     #[cfg(feature = "zod")]
-    let zod_schema_method =
-        generate_discriminated_enum_zod_schema_method(item_name, &name.to_string(), &schema_code);
+    let zod_schema_method = generate_discriminated_enum_zod_schema_method(
+        item_name,
+        &name.to_string(),
+        &erased_type_arguments(&item_enum.generics),
+        &schema_code,
+    );
 
     #[cfg(not(any(feature = "typescript", feature = "zod")))]
     let _: &_ = &item_name;
 
-    #[cfg(feature = "zod")]
-    let schema_example_method = build_struct_schema_example(example_code.as_ref(), name);
-    #[cfg(all(
-        not(feature = "zod"),
-        any(feature = "typescript", feature = "jsonschema")
-    ))]
-    let schema_example_method: Option<proc_macro2::TokenStream> = None;
+    #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+    let schema_example_method = enum_schema_example_method(docs_vec.as_deref(), name);
 
     #[cfg(any(feature = "zod", feature = "typescript", feature = "jsonschema"))]
     let schema_impl_items: Vec<proc_macro2::TokenStream> = vec![
@@ -4459,6 +4553,7 @@ fn process_externally_tagged_enum(
     {
         assemble_schema_output(
             &item_enum,
+            &item_enum.generics,
             &module_ident,
             name,
             &schema_impl_items,
@@ -4520,6 +4615,7 @@ fn tagged_content(inner: &FieldDef) -> TaggedContent {
         FieldDefType::Map(..) => TaggedContent::Unnameable("a map"),
         #[cfg(feature = "object_id")]
         FieldDefType::ObjectId => TaggedContent::Unnameable("an ObjectId"),
+        FieldDefType::TypeParam(_) => TaggedContent::Unnameable("a type parameter"),
         FieldDefType::Unknown => TaggedContent::Unnameable("a type the expansion cannot resolve"),
     }
 }
@@ -4769,13 +4865,8 @@ fn process_internally_tagged_enum(
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
     let (module_name, module_ident) = enum_module_idents(name, item_name, AliasKind::NoEnumMembers);
 
-    #[cfg(any(feature = "typescript", feature = "zod"))]
+    #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
     let docs_vec = get_enum_docs(&item_enum);
-
-    #[cfg(feature = "zod")]
-    let example_code = docs_vec
-        .as_ref()
-        .and_then(|docs| extract_example_from_docs(docs));
 
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
     let enum_module_name_opt = Some(module_name.as_str());
@@ -4824,23 +4915,23 @@ fn process_internally_tagged_enum(
         &docs,
         item_name,
         &name.to_string(),
+        &ts_generic_params(&item_enum.generics),
         &type_code,
     );
 
     #[cfg(feature = "zod")]
-    let zod_schema_method =
-        generate_discriminated_enum_zod_schema_method(item_name, &name.to_string(), &schema_code);
+    let zod_schema_method = generate_discriminated_enum_zod_schema_method(
+        item_name,
+        &name.to_string(),
+        &erased_type_arguments(&item_enum.generics),
+        &schema_code,
+    );
 
     #[cfg(not(any(feature = "typescript", feature = "zod")))]
     let _: &_ = &item_name;
 
-    #[cfg(feature = "zod")]
-    let schema_example_method = build_struct_schema_example(example_code.as_ref(), name);
-    #[cfg(all(
-        not(feature = "zod"),
-        any(feature = "typescript", feature = "jsonschema")
-    ))]
-    let schema_example_method: Option<proc_macro2::TokenStream> = None;
+    #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+    let schema_example_method = enum_schema_example_method(docs_vec.as_deref(), name);
 
     #[cfg(any(feature = "zod", feature = "typescript", feature = "jsonschema"))]
     let schema_impl_items: Vec<proc_macro2::TokenStream> = vec![
@@ -4865,6 +4956,7 @@ fn process_internally_tagged_enum(
     {
         assemble_schema_output(
             &item_enum,
+            &item_enum.generics,
             &module_ident,
             name,
             &schema_impl_items,
@@ -5170,7 +5262,7 @@ fn field_json_schema_value(fld: &FieldDef) -> proc_macro2::TokenStream {
         },
         // An opaque value carries no type name to narrow with, so the member admits any value: the
         // permissive empty schema, as in field position.
-        FieldDefType::Unknown => quote! { serde_json::json!({}) },
+        FieldDefType::TypeParam(_) | FieldDefType::Unknown => quote! { serde_json::json!({}) },
     };
 
     arrayed_json_schema_value(fld, inner)
@@ -5223,6 +5315,7 @@ fn collect_untagged_members(
     schema_module_name: Option<&str>,
 ) -> UntaggedMemberData {
     let enum_type_name = item_enum.ident.to_string();
+    let type_parameters = type_parameters_in_scope(&item_enum.generics);
     let mut ts_parts: Vec<String> = Vec::new();
     let mut zod_parts: Vec<String> = Vec::new();
     #[cfg(feature = "zod")]
@@ -5292,6 +5385,8 @@ fn collect_untagged_members(
 
             field_def.resolve_self_references(&enum_type_name);
             apply_model_schema_prop_meta(&mut field_def, prop_meta, &field_name);
+            // Applied where `process_field` applies it: after every guard has read the field.
+            field_def.erase_type_parameters(&type_parameters);
             field_defs.push(field_def);
         }
 
@@ -5358,12 +5453,13 @@ fn build_untagged_schema_impl_items(
     name: &syn::Ident,
     item_name: &str,
     docs_vec: Option<&[String]>,
+    generics: &syn::Generics,
     ts_parts: &[String],
     zod_parts: &[String],
     json_parts: &[proc_macro2::TokenStream],
 ) -> Vec<proc_macro2::TokenStream> {
     #[cfg(not(any(feature = "typescript", feature = "zod")))]
-    let _: &_ = &name;
+    let _: &_ = &(name, generics);
     #[cfg(not(feature = "typescript"))]
     let _: &_ = &(ts_parts, docs_vec);
     #[cfg(not(feature = "zod"))]
@@ -5403,12 +5499,17 @@ fn build_untagged_schema_impl_items(
         &docs,
         item_name,
         &name.to_string(),
+        &ts_generic_params(generics),
         &type_code,
     );
 
     #[cfg(feature = "zod")]
-    let zod_schema_method =
-        generate_discriminated_enum_zod_schema_method(item_name, &name.to_string(), &schema_code);
+    let zod_schema_method = generate_discriminated_enum_zod_schema_method(
+        item_name,
+        &name.to_string(),
+        &erased_type_arguments(generics),
+        &schema_code,
+    );
 
     vec![
         #[cfg(feature = "jsonschema")]
@@ -5435,21 +5536,8 @@ fn process_untagged_enum(
     let (module_name, module_ident) = enum_module_idents(name, item_name, AliasKind::NoEnumMembers);
 
     // Extract docs early for example extraction
-    #[cfg(any(feature = "typescript", feature = "zod"))]
+    #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
     let docs_vec = get_enum_docs(&item_enum);
-    // The schema module is built under a wider gate than the one that reads docs, so the binding
-    // it takes has to exist on that gate's own terms.
-    #[cfg(all(
-        not(feature = "typescript"),
-        not(feature = "zod"),
-        feature = "jsonschema"
-    ))]
-    let docs_vec: Option<Vec<String>> = None;
-
-    #[cfg(feature = "zod")]
-    let example_code = docs_vec
-        .as_ref()
-        .and_then(|docs| extract_example_from_docs(docs));
 
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
     let enum_module_name_opt = Some(module_name.as_str());
@@ -5482,13 +5570,8 @@ fn process_untagged_enum(
     #[cfg(not(any(feature = "typescript", feature = "zod", feature = "jsonschema")))]
     let _: &_ = &(name, item_name, &ts_parts, &zod_parts, &json_parts);
 
-    #[cfg(feature = "zod")]
-    let schema_example_method = build_struct_schema_example(example_code.as_ref(), name);
-    #[cfg(all(
-        not(feature = "zod"),
-        any(feature = "typescript", feature = "jsonschema")
-    ))]
-    let schema_example_method: Option<proc_macro2::TokenStream> = None;
+    #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+    let schema_example_method = enum_schema_example_method(docs_vec.as_deref(), name);
 
     // Build schema module impl items (without schema_example)
     #[cfg(any(feature = "zod", feature = "typescript", feature = "jsonschema"))]
@@ -5496,6 +5579,7 @@ fn process_untagged_enum(
         name,
         item_name,
         docs_vec.as_deref(),
+        &item_enum.generics,
         &ts_parts,
         &zod_parts,
         &json_parts,
@@ -5518,6 +5602,7 @@ fn process_untagged_enum(
     {
         assemble_schema_output(
             &item_enum,
+            &item_enum.generics,
             &module_ident,
             name,
             &schema_impl_items,
@@ -6052,7 +6137,8 @@ fn scalar_field_json_schema_item(fld: &FieldDef) -> Option<proc_macro2::TokenStr
         | FieldDefType::DateTime => chrono_json_schema_item(&fld.field_type)?,
         #[cfg(feature = "object_id")]
         FieldDefType::ObjectId => object_id_json_schema_item(&object_id_hex_json_schema()),
-        FieldDefType::Unknown
+        FieldDefType::TypeParam(_)
+        | FieldDefType::Unknown
         | FieldDefType::SiblingType(..)
         | FieldDefType::Map(..)
         | FieldDefType::Tuple(..) => return None,
@@ -6280,6 +6366,7 @@ fn map_key_path(key: &FieldDef) -> MapKeyPath<'_> {
         #[cfg(feature = "object_id")]
         FieldDefType::ObjectId => MapKeyPath::Refused(unwritable_key(key, WRITTEN_AS_OBJECT)),
         FieldDefType::SiblingType(..)
+        | FieldDefType::TypeParam(_)
         | FieldDefType::Unknown
         | FieldDefType::Boolean
         | FieldDefType::StringLiteral(_)
@@ -6342,7 +6429,9 @@ fn map_key_element_name(key: &FieldDef) -> String {
         return map_key_element_name(element);
     }
     match &key.field_type {
-        FieldDefType::SiblingType(key_type_name, _) => key_type_name.clone(),
+        FieldDefType::SiblingType(key_type_name, _) | FieldDefType::TypeParam(key_type_name) => {
+            key_type_name.clone()
+        }
         FieldDefType::String | FieldDefType::StringLiteral(_) => "String".to_owned(),
         FieldDefType::Boolean => "bool".to_owned(),
         FieldDefType::U8 => "u8".to_owned(),
@@ -6413,7 +6502,8 @@ fn map_key_rejection(fld: &FieldDef) -> Option<MapKeyRejection> {
             .or_else(|| map_key_rejection(value)),
         FieldDefType::SiblingType(_, generics) => generics.iter().find_map(map_key_rejection),
         FieldDefType::Tuple(elements) => elements.iter().find_map(map_key_rejection),
-        FieldDefType::Unknown
+        FieldDefType::TypeParam(_)
+        | FieldDefType::Unknown
         | FieldDefType::StringLiteral(_)
         | FieldDefType::Boolean
         | FieldDefType::String
@@ -6651,7 +6741,9 @@ fn build_map_member_item(value: &FieldDef) -> Result<MapMemberItem, MapMemberRej
         }
         // An opaque value carries no type name to narrow with, so a member admits any value: the
         // permissive empty schema, as in field position.
-        FieldDefType::Unknown => MapMemberItem::Fragment(quote! { {} }),
+        FieldDefType::TypeParam(_) | FieldDefType::Unknown => {
+            MapMemberItem::Fragment(quote! { {} })
+        }
         // The shared mapping renders every type named here except a tuple, which is the lone
         // `None`. Named exhaustively rather than caught by a wildcard: a new variant must be given
         // a member schema, not silently widened into an open object.
@@ -7124,7 +7216,9 @@ fn build_field_type_schema(fld: &FieldDef, field_name_str: &str) -> proc_macro2:
         FieldDefType::Tuple(lst) => build_tuple_field_schema(fld, field_name_str, lst),
         // Named exhaustively rather than caught by a wildcard: a new variant must be given a
         // schema here, not silently routed to whatever the last arm happens to emit.
-        FieldDefType::Unknown => build_unknown_field_schema(fld, field_name_str),
+        FieldDefType::TypeParam(_) | FieldDefType::Unknown => {
+            build_unknown_field_schema(fld, field_name_str)
+        }
     }
 }
 
@@ -8132,6 +8226,7 @@ fn process_field(
     schema_module_name: Option<&str>,
     variant_ident: Option<&str>,
     type_name: &str,
+    type_parameters: &[String],
 ) -> (
     FieldDef,
     Option<proc_macro2::TokenStream>,
@@ -8218,6 +8313,10 @@ fn process_field(
     );
 
     apply_model_schema_prop_meta(&mut field_def, model_schema_prop_meta, &final_name);
+
+    // Last, so every guard above asked its question of the type the author wrote, and so an
+    // `as = Type` override is read for a parameter too.
+    field_def.erase_type_parameters(type_parameters);
 
     (field_def, validation_fn, validate_body, guard_errors)
 }
@@ -8515,11 +8614,12 @@ fn generate_ts_definition_method(
     docs: &str,
     item_name: &str,
     rust_ident: &str,
+    ts_generics: &str,
     type_code: &str,
     fields_empty: bool,
     flatten_types: &[MergedOperand],
 ) -> proc_macro2::TokenStream {
-    let reexport = ident_reexport_ts(rust_ident, item_name, "");
+    let reexport = ident_reexport_ts(rust_ident, item_name, ts_generics);
     let has_flatten = !flatten_types.is_empty();
     let operands: Vec<String> = flatten_types.iter().map(ts_merged_operand).collect();
     let intersection_only = operands.join(" & ");
@@ -8532,20 +8632,20 @@ fn generate_ts_definition_method(
     let typescript_type_gen = if fields_empty {
         if has_flatten {
             quote::quote! {
-                format!("{}\n\nexport type {} = {};{}", docs, #item_name, #intersection_only, #reexport)
+                format!("{}\n\nexport type {}{} = {};{}", docs, #item_name, #ts_generics, #intersection_only, #reexport)
             }
         } else {
             quote::quote! {
-                format!(r#"/**\n{}\n**/\nexport type {} = Record<string, never>;{}"#, docs, #item_name, #reexport)
+                format!(r#"/**\n{}\n**/\nexport type {}{} = Record<string, never>;{}"#, docs, #item_name, #ts_generics, #reexport)
             }
         }
     } else if has_flatten {
         quote::quote! {
-            format!("{}\n\nexport type {} = {{\n{}\n}}{};{}", docs, #item_name, #type_code, #intersection_suffix, #reexport)
+            format!("{}\n\nexport type {}{} = {{\n{}\n}}{};{}", docs, #item_name, #ts_generics, #type_code, #intersection_suffix, #reexport)
         }
     } else {
         quote::quote! {
-            format!("{}\n\nexport type {} = {{\n{}\n}};{}", docs, #item_name, #type_code, #reexport)
+            format!("{}\n\nexport type {}{} = {{\n{}\n}};{}", docs, #item_name, #ts_generics, #type_code, #reexport)
         }
     };
 
@@ -8666,6 +8766,7 @@ fn zod_merged_statements(
 fn generate_zod_schema_method(
     item_name: &str,
     rust_ident: &str,
+    ts_type_args: &str,
     schema_code: &str,
     show_opts: &str,
     flatten_schemas: &[MergedOperand],
@@ -8680,10 +8781,13 @@ fn generate_zod_schema_method(
         #[cfg(feature = "typescript")]
         let body = format!(
             "{preamble}const {item_name}$RawSchema = {expression};\n\nexport const \
-             {item_name}$Schema: ZodType<{item_name}> = {item_name}$RawSchema;{reexport}"
+             {item_name}$Schema: ZodType<{item_name}{ts_type_args}> = {item_name}$RawSchema;{reexport}"
         );
 
-        // When typescript feature is disabled, generate JavaScript-style Zod schema
+        // When typescript feature is disabled, generate JavaScript-style Zod schema, which
+        // carries no annotation for the arguments to fill in.
+        #[cfg(not(feature = "typescript"))]
+        let _: &_ = &ts_type_args;
         #[cfg(not(feature = "typescript"))]
         let body = format!("{preamble}export const {item_name}$Schema = {expression};{reexport}");
 
@@ -8699,6 +8803,7 @@ fn generate_zod_schema_method(
         let _: &_ = &(
             item_name,
             rust_ident,
+            ts_type_args,
             schema_code,
             show_opts,
             flatten_schemas,
@@ -8771,16 +8876,17 @@ fn generate_plain_enum_ts_definition_method(
     docs: &str,
     item_name: &str,
     rust_ident: &str,
+    ts_generics: &str,
     type_code: &str,
 ) -> proc_macro2::TokenStream {
     #[cfg(feature = "typescript")]
     {
         let json_docs_gen = generate_enum_json_docs_part(docs);
-        let reexport = ident_reexport_ts(rust_ident, item_name, "");
+        let reexport = ident_reexport_ts(rust_ident, item_name, ts_generics);
 
         // TypeScript type generation (only available when typescript feature is enabled)
         let typescript_type_gen = quote::quote! {
-            format!("{}export type {} =\n{};{}", docs, #item_name, #type_code, #reexport)
+            format!("{}export type {}{} =\n{};{}", docs, #item_name, #ts_generics, #type_code, #reexport)
         };
 
         quote::quote! {
@@ -8860,18 +8966,19 @@ fn generate_discriminated_enum_ts_definition_method(
     docs: &str,
     item_name: &str,
     rust_ident: &str,
+    ts_generics: &str,
     type_code: &str,
 ) -> proc_macro2::TokenStream {
     #[cfg(feature = "typescript")]
     {
         let json_docs_gen = generate_enum_json_docs_part(docs);
-        let reexport = ident_reexport_ts(rust_ident, item_name, "");
+        let reexport = ident_reexport_ts(rust_ident, item_name, ts_generics);
 
         quote::quote! {
             pub fn ts_definition() -> String {
                 #json_docs_gen
                 let bundled_docs = docs;
-                format!(r#"{bundled_docs}export type {} = {};{}"#, #item_name, #type_code, #reexport)
+                format!(r#"{bundled_docs}export type {}{} = {};{}"#, #item_name, #ts_generics, #type_code, #reexport)
             }
         }
     }
@@ -8892,6 +8999,7 @@ fn generate_discriminated_enum_ts_definition_method(
 fn generate_discriminated_enum_zod_schema_method(
     item_name: &str,
     rust_ident: &str,
+    ts_type_args: &str,
     schema_code: &str,
 ) -> proc_macro2::TokenStream {
     #[cfg(feature = "zod")]
@@ -8902,7 +9010,7 @@ fn generate_discriminated_enum_zod_schema_method(
         {
             quote::quote! {
                 pub fn zod_schema() -> String {
-                    format!("const {}$RawSchema = {};\n\nexport const {}$Schema: ZodType<{}> = {}$RawSchema;{}", #item_name, #schema_code, #item_name, #item_name, #item_name, #reexport)
+                    format!("const {}$RawSchema = {};\n\nexport const {}$Schema: ZodType<{}{}> = {}$RawSchema;{}", #item_name, #schema_code, #item_name, #item_name, #ts_type_args, #item_name, #reexport)
                 }
             }
         }
@@ -8910,6 +9018,7 @@ fn generate_discriminated_enum_zod_schema_method(
         // When typescript feature is disabled, generate JavaScript-style Zod schema
         #[cfg(not(feature = "typescript"))]
         {
+            let _: &_ = &ts_type_args;
             quote::quote! {
                 pub fn zod_schema() -> String {
                     format!(r#"export const {}$Schema = {};{}"#, #item_name, #schema_code, #reexport)
@@ -8920,7 +9029,7 @@ fn generate_discriminated_enum_zod_schema_method(
 
     #[cfg(not(feature = "zod"))]
     {
-        let _: &_ = &(item_name, rust_ident, schema_code);
+        let _: &_ = &(item_name, rust_ident, ts_type_args, schema_code);
         quote::quote! {
             // Zod schema method not available - zod feature disabled
             // To enable: add "zod" to your features
@@ -8942,24 +9051,11 @@ fn generate_alias_ts_definition_method(
     {
         let docs_formatted = alias_jsdoc_body(get_item_docs(&alias.attrs).as_deref(), export_name);
 
-        let generics: Vec<String> = alias
-            .generics
-            .params
-            .iter()
-            .filter_map(|param| {
-                if let GenericParam::Type(tp) = param {
-                    Some(safe_type_name(&tp.ident.to_string()))
-                } else {
-                    None
-                }
-            })
-            .collect();
-
         generate_ts_alias_method(
             &docs_formatted,
             export_name,
             &alias.ident.to_string(),
-            &generics,
+            &ts_generic_params(&alias.generics),
             field_def,
         )
     }
@@ -8975,18 +9071,12 @@ fn generate_ts_alias_method(
     docs: &str,
     export_name: &str,
     rust_ident: &str,
-    generics: &[String],
+    ts_generics: &str,
     field_def: &FieldDef,
 ) -> proc_macro2::TokenStream {
-    let ts_generics = if generics.is_empty() {
-        String::new()
-    } else {
-        format!("<{}>", generics.join(", "))
-    };
-
     let alias_name_ts = format!("{export_name}{ts_generics}");
     let target_ts = field_def.typescript_typename();
-    let reexport = ident_reexport_ts(rust_ident, export_name, &ts_generics);
+    let reexport = ident_reexport_ts(rust_ident, export_name, ts_generics);
 
     let docs_block = docs.to_owned();
 

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -2182,8 +2182,13 @@ fn branded_schema_example_instantiates_every_parameter() {
 #[cfg(feature = "typescript")]
 #[test]
 fn plain_enum_ts_definition_carries_no_cfg_attribute() {
-    let tokens =
-        super::generate_plain_enum_ts_definition_method(" * Status", "Status", "Status", "  'a'");
+    let tokens = super::generate_plain_enum_ts_definition_method(
+        " * Status",
+        "Status",
+        "Status",
+        "",
+        "  'a'",
+    );
     assert_no_cfg_attribute(&tokens, "generate_plain_enum_ts_definition_method");
 }
 
@@ -2191,7 +2196,7 @@ fn plain_enum_ts_definition_carries_no_cfg_attribute() {
 #[test]
 fn discriminated_enum_ts_definition_carries_no_cfg_attribute() {
     let tokens = super::generate_discriminated_enum_ts_definition_method(
-        " * Shape", "Shape", "Shape", "  'a'",
+        " * Shape", "Shape", "Shape", "", "  'a'",
     );
     assert_no_cfg_attribute(&tokens, "generate_discriminated_enum_ts_definition_method");
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -11,10 +11,12 @@ use regex_syntax::ast::{
 #[cfg(feature = "serde")]
 use regex_syntax::hir;
 use std::collections::HashMap;
-use syn::{Attribute, Expr, Field, Lit, LitStr, Meta, Variant};
+use syn::{Attribute, Expr, Field, GenericParam, Generics, Lit, LitStr, Meta, Variant};
 
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+use syn::ItemEnum;
 #[cfg(any(feature = "typescript", feature = "zod"))]
-use syn::{ItemEnum, ItemStruct};
+use syn::ItemStruct;
 
 /// The JavaScript engine generation the emitted Zod regex literals and JSON Schema `pattern`
 /// keywords are written for, and therefore the line the guard admits and refuses along.
@@ -616,6 +618,50 @@ fn ident_reexport_name(rust_ident: &str, export_name: &str) -> Option<String> {
     (referenced != export_name).then_some(referenced)
 }
 
+/// The names an item's own declaration binds as type parameters.
+///
+/// This is the whole of what separates a name the expansion cannot resolve *because it is a
+/// parameter* from one it cannot resolve because the type lives elsewhere: the first is in scope
+/// at the declaration and names no type any emitted output can reference, the second names a type
+/// that publishes its own schema module. Every surface that has to draw that line draws it here —
+/// see [`crate::field_type::FieldDef::erase_type_parameters`] for what each of them then does with
+/// it.
+///
+/// Lifetimes and const parameters name no type a field position can be written out of, so they are
+/// left out. That is also why an emitted `impl` block is spelled from `split_for_impl` instead of
+/// from this list: the block has to carry every parameter the declaration binds, lifetimes and
+/// consts included, while only these can reach a schema.
+pub fn type_parameters_in_scope(generics: &Generics) -> Vec<String> {
+    generics
+        .params
+        .iter()
+        .filter_map(|param| match param {
+            GenericParam::Type(type_param) => Some(type_param.ident.to_string()),
+            GenericParam::Const(_) | GenericParam::Lifetime(_) => None,
+        })
+        .collect()
+}
+
+/// The parameter list a generic item's `TypeScript` declaration is written under — `<IdType>`,
+/// `<IdType, DateType>` — or the empty string for an item that binds none.
+///
+/// Spelled once for the alias, the struct and every enum shape, so the three cannot come to write
+/// the same declaration differently. The names are written as declared, which is what a field
+/// typed with one already renders as: the declaration and the fields it binds have to spell a
+/// parameter the same way or the type does not close.
+///
+/// A lifetime and a const parameter never reach here — they name no type `TypeScript` has a
+/// declaration slot for — so `struct Label<'a>` publishes a plain `export type Label`.
+#[cfg(feature = "typescript")]
+pub fn ts_generic_params(generics: &Generics) -> String {
+    let parameters = type_parameters_in_scope(generics);
+    if parameters.is_empty() {
+        String::new()
+    } else {
+        format!("<{}>", parameters.join(", "))
+    }
+}
+
 /// The `TypeScript` line an item publishes under its own Rust ident, or nothing when it is already
 /// exported under it. The parameter list is repeated on both sides so a generic item stays generic
 /// through the re-export.
@@ -663,7 +709,9 @@ pub fn get_struct_docs(item_struct: &ItemStruct) -> Option<Vec<String>> {
     collect_doc_lines(&item_struct.attrs)
 }
 
-#[cfg(any(feature = "typescript", feature = "zod"))]
+/// An enum's doc lines. Reachable in every schema build, not just the two that publish prose: the
+/// `schema_example()` an item's ` ```rust example ` block earns is read off these too.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 pub fn get_enum_docs(item_enum: &ItemEnum) -> Option<Vec<String>> {
     collect_doc_lines(&item_enum.attrs)
 }

--- a/tests/generic_types_tests.rs
+++ b/tests/generic_types_tests.rs
@@ -1,0 +1,11 @@
+//! Tests for `#[model_schema()]` on items that declare type parameters.
+//!
+//! Deliberately **not** feature-gated at the harness level: the fixtures below must expand in
+//! every feature combination of the powerset, because the emitted impl block is what carries the
+//! item's generics and nothing about it is feature-dependent.
+
+extern crate alloc;
+
+#[cfg(test)]
+#[path = "generic_types_tests/tests.rs"]
+mod tests;

--- a/tests/generic_types_tests/tests.rs
+++ b/tests/generic_types_tests/tests.rs
@@ -1,0 +1,424 @@
+//! `#[model_schema()]` on an item that declares parameters.
+//!
+//! Three questions run through every fixture here. Does the emitted `impl` still name the type the
+//! author declared — every parameter it binds, lifetimes and consts included. Does the TypeScript
+//! declaration bind the parameters its fields are written under. And does a field typed with one
+//! render as that parameter on the type surface while describing as the opaque value on the two
+//! validating ones, which publish one schema for every instantiation and so can say nothing else
+//! about it.
+//!
+//! A plain enum — all unit variants — cannot bind a *type* parameter at all: Rust refuses the
+//! declaration for an unused parameter before the attribute is reached. What it can bind is a
+//! const, which `PlainConst` carries, and that is the plain-enum shape of the same question: the
+//! `impl` has to repeat the const while the declaration names nothing.
+
+#[cfg(feature = "typescript")]
+mod typescript {
+    use super::{
+        Adjacent, External, Holder, Internal, LifetimeStruct, Pair, PlainConst, Positional,
+        Untagged, Wrapper,
+    };
+
+    /// The declaration binds what the fields under it are written with, so a field typed with a
+    /// parameter is that parameter and not a reference to a generated type of the same name.
+    #[test]
+    fn a_struct_declaration_binds_its_parameters() {
+        let ts = Wrapper::<String>::ts_definition();
+        assert!(ts.contains("export type Wrapper<IdType> = {"), "Got: {ts}");
+        assert!(ts.contains("  id: IdType;"), "Got: {ts}");
+        assert!(ts.contains("  children: Array<IdType>;"), "Got: {ts}");
+        assert!(ts.contains("  name: string;"), "Got: {ts}");
+        assert!(!ts.contains("IdType$Schema"), "Got: {ts}");
+    }
+
+    /// Every parameter is bound, in declaration order, and each is reached through whatever shape
+    /// the field was written around it.
+    #[test]
+    fn a_parameter_is_reached_through_the_shape_it_was_written_under() {
+        let ts = Pair::<String, u32>::ts_definition();
+        assert!(
+            ts.contains("export type Pair<KeyType, ValueType> = {"),
+            "Got: {ts}"
+        );
+        assert!(ts.contains("  key: KeyType;"), "Got: {ts}");
+        assert!(
+            ts.contains("  by_key: Partial<Record<string, ValueType>>;"),
+            "Got: {ts}"
+        );
+        assert!(ts.contains("  maybe: ValueType | undefined;"), "Got: {ts}");
+        assert!(ts.contains("  tuple: [KeyType, ValueType];"), "Got: {ts}");
+    }
+
+    #[test]
+    fn a_tuple_struct_declaration_binds_its_parameters() {
+        let ts = Positional::<String>::ts_definition();
+        assert!(
+            ts.contains("export type Positional<IdType> = [IdType, string];"),
+            "Got: {ts}"
+        );
+    }
+
+    /// Which shape an enum's members are written in is what the tagging attributes decide, and
+    /// only `serde` reads those; what the declaration binds is decided by the declaration, so it
+    /// is asked of every flavour in every build.
+    #[test]
+    fn every_enum_flavour_declaration_binds_its_parameters() {
+        for (flavour, ts) in [
+            ("Adjacent", Adjacent::<String>::ts_definition()),
+            ("Internal", Internal::<String>::ts_definition()),
+            ("External", External::<String>::ts_definition()),
+            ("Untagged", Untagged::<String>::ts_definition()),
+        ] {
+            assert!(
+                ts.contains(&format!("export type {flavour}<IdType> = ")),
+                "Got: {ts}"
+            );
+            assert!(ts.contains("id: IdType"), "Got: {ts}");
+            assert!(!ts.contains("IdType$Schema"), "Got: {ts}");
+        }
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn each_tagged_shape_reaches_its_parameter_where_that_shape_puts_it() {
+        let adjacent = Adjacent::<String>::ts_definition();
+        assert!(adjacent.contains("  id: IdType;"), "Got: {adjacent}");
+        assert!(adjacent.contains("  payload: IdType;"), "Got: {adjacent}");
+
+        let internal = Internal::<String>::ts_definition();
+        assert!(internal.contains("  id: IdType;"), "Got: {internal}");
+
+        let external = External::<String>::ts_definition();
+        assert!(external.contains("  id: IdType;"), "Got: {external}");
+        assert!(external.contains("\"Single\": IdType;"), "Got: {external}");
+
+        let untagged = Untagged::<String>::ts_definition();
+        assert!(
+            untagged.contains("export type Untagged<IdType> = { id: IdType } | { count: number };"),
+            "Got: {untagged}"
+        );
+    }
+
+    /// A const parameter names no type, so there is nothing for the declaration to bind — the
+    /// `impl` still has to repeat it, which is what makes the fixture compile at all.
+    #[test]
+    fn a_const_parameter_reaches_no_declaration() {
+        let ts = PlainConst::<4>::ts_definition();
+        assert!(ts.contains("export type PlainConst =\n"), "Got: {ts}");
+        assert!(!ts.contains("PlainConst<"), "Got: {ts}");
+    }
+
+    /// A lifetime names no type either, for the same reason and with the same outcome.
+    #[test]
+    fn a_lifetime_reaches_no_declaration() {
+        let ts = LifetimeStruct::ts_definition();
+        assert!(ts.contains("export type LifetimeStruct = {"), "Got: {ts}");
+        assert!(ts.contains("  label: string;"), "Got: {ts}");
+    }
+
+    /// The line an item publishes under its own Rust ident is written after the declaration it
+    /// refers to, and repeats the parameter list on both sides — a generic type named bare on
+    /// either would be a TypeScript error of its own.
+    #[test]
+    fn the_reexport_lands_after_the_parameterised_declaration() {
+        let ts = Holder::<String>::ts_definition();
+        let declaration = ts.find("export type RenamedHolder<IdType> = {");
+        let reexport = ts.find("export type Holder<IdType> = RenamedHolder<IdType>;");
+        assert!(
+            matches!((declaration, reexport), (Some(at), Some(after)) if at < after),
+            "Got: {ts}"
+        );
+    }
+}
+
+#[cfg(feature = "zod")]
+mod zod {
+    use super::{Pair, Wrapper};
+
+    /// A `const` cannot be parameterised, so a parameter composes into the value as the opaque
+    /// schema rather than as a `$Schema` binding no emitted module declares.
+    #[test]
+    fn a_parameter_composes_into_the_value_as_the_opaque_schema() {
+        let zod = Wrapper::<String>::zod_schema();
+        assert!(zod.contains("id: z.unknown()"), "Got: {zod}");
+        assert!(zod.contains("children: z.array(z.unknown())"), "Got: {zod}");
+        assert!(zod.contains("name: z.string()"), "Got: {zod}");
+        assert!(!zod.contains("IdType"), "Got: {zod}");
+    }
+
+    #[test]
+    fn a_parameter_is_opaque_at_every_depth_it_is_written_at() {
+        let zod = Pair::<String, u32>::zod_schema();
+        assert!(zod.contains("key: z.unknown()"), "Got: {zod}");
+        assert!(
+            zod.contains("by_key: z.record(z.string(), z.unknown())"),
+            "Got: {zod}"
+        );
+        assert!(
+            zod.contains("tuple: z.tuple([z.unknown(), z.unknown()])"),
+            "Got: {zod}"
+        );
+        assert!(!zod.contains("KeyType"), "Got: {zod}");
+        assert!(!zod.contains("ValueType"), "Got: {zod}");
+    }
+
+    /// The annotation states the type of the value beside it, and that value was composed with
+    /// every parameter opaque — so the name it is written under is filled in the same way.
+    #[cfg(feature = "typescript")]
+    #[test]
+    fn the_exported_binding_is_annotated_with_the_erased_arguments() {
+        use super::{Holder, Positional};
+
+        for (expected, zod) in [
+            (
+                "export const Wrapper$Schema: ZodType<Wrapper<unknown>> =",
+                Wrapper::<String>::zod_schema(),
+            ),
+            (
+                "export const Pair$Schema: ZodType<Pair<unknown, unknown>> =",
+                Pair::<String, u32>::zod_schema(),
+            ),
+            (
+                "export const Positional$Schema: ZodType<Positional<unknown>> =",
+                Positional::<String>::zod_schema(),
+            ),
+            (
+                "export const RenamedHolder$Schema: ZodType<RenamedHolder<unknown>> =",
+                Holder::<String>::zod_schema(),
+            ),
+        ] {
+            assert!(zod.contains(expected), "Got: {zod}");
+        }
+    }
+
+    #[cfg(feature = "typescript")]
+    #[test]
+    fn every_enum_flavour_annotates_its_binding_the_same_way() {
+        use super::{Adjacent, External, Internal, Untagged};
+
+        for (flavour, zod) in [
+            ("Adjacent", Adjacent::<String>::zod_schema()),
+            ("Internal", Internal::<String>::zod_schema()),
+            ("External", External::<String>::zod_schema()),
+            ("Untagged", Untagged::<String>::zod_schema()),
+        ] {
+            assert!(
+                zod.contains(&format!(
+                    "export const {flavour}$Schema: ZodType<{flavour}<unknown>> ="
+                )),
+                "Got: {zod}"
+            );
+            assert!(zod.contains("z.unknown()"), "Got: {zod}");
+            assert!(!zod.contains("IdType"), "Got: {zod}");
+        }
+    }
+}
+
+#[cfg(feature = "jsonschema")]
+mod jsonschema {
+    use super::{Pair, Wrapper};
+
+    /// One schema is written for every instantiation, so a parameter admits any value while the
+    /// shape it sits in stays described.
+    #[test]
+    fn a_parameter_describes_as_the_open_schema() {
+        let schema = Wrapper::<String>::json_schema();
+        let properties = &schema["properties"];
+        assert_eq!(properties["id"], serde_json::json!({}));
+        assert_eq!(
+            properties["children"],
+            serde_json::json!({ "type": "array", "items": {} })
+        );
+        assert_eq!(properties["name"], serde_json::json!({ "type": "string" }));
+    }
+
+    #[test]
+    fn the_shape_around_a_parameter_is_still_described() {
+        let schema = Pair::<String, u32>::json_schema();
+        let properties = &schema["properties"];
+        assert_eq!(
+            properties["by_key"],
+            serde_json::json!({ "type": "object", "additionalProperties": {} })
+        );
+        assert_eq!(
+            properties["tuple"],
+            serde_json::json!({
+                "type": "array",
+                "prefixItems": [{}, {}],
+                "items": false,
+                "minItems": 2_u64,
+                "maxItems": 2_u64
+            })
+        );
+    }
+
+    /// The `anyOf` an untagged enum describes as is what `#[serde(untagged)]` earns it, and only
+    /// `serde` reads that attribute.
+    #[cfg(feature = "serde")]
+    #[test]
+    fn an_untagged_member_describes_its_parameter_the_same_way() {
+        let schema = super::Untagged::<String>::json_schema();
+        assert_eq!(
+            schema["anyOf"][0]["properties"]["id"],
+            serde_json::json!({})
+        );
+    }
+}
+
+use alloc::borrow::Cow;
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use tixschema::model_schema;
+
+#[model_schema()]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Wrapper<IdType> {
+    pub children: Vec<IdType>,
+    pub id: IdType,
+    pub name: String,
+}
+
+#[model_schema()]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Pair<KeyType, ValueType> {
+    pub by_key: HashMap<String, ValueType>,
+    pub key: KeyType,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub maybe: Option<ValueType>,
+    pub tuple: (KeyType, ValueType),
+}
+
+#[model_schema()]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "payload")]
+pub enum Adjacent<IdType> {
+    Named { id: IdType },
+    Nothing,
+    Single(IdType),
+}
+
+#[model_schema()]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind")]
+pub enum Internal<IdType> {
+    Named { id: IdType },
+    Nothing,
+}
+
+#[model_schema()]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum External<IdType> {
+    Named { id: IdType },
+    Nothing,
+    Single(IdType),
+}
+
+#[model_schema()]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum Untagged<IdType> {
+    Named { id: IdType },
+    Numbered { count: u32 },
+}
+
+/// The one enum shape a parameter can reach without a variant carrying it.
+#[model_schema()]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum PlainConst<const WIDTH: usize> {
+    Narrow,
+    Wide,
+}
+
+#[model_schema(name = "RenamedHolder")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Holder<IdType> {
+    pub id: IdType,
+}
+
+#[model_schema()]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Positional<IdType>(pub IdType, pub String);
+
+#[model_schema()]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LifetimeStruct<'label> {
+    #[model_schema_prop(minLength = 1)]
+    pub label: Cow<'label, str>,
+}
+
+/// The pair the attribute used to produce on any generic item: `E0107` on the emitted `impl`,
+/// which dropped the parameters the declaration binds, and `E0433` on a module named after a
+/// parameter, which names no type and so publishes none. Both are compile errors, so the suite
+/// compiling is the assertion; this names an instance of each declaration shape so no build can
+/// drop one silently.
+#[test]
+fn a_generic_item_expands_to_rust_that_compiles() {
+    let wrapper = Wrapper {
+        children: vec!["a".to_owned()],
+        id: "b".to_owned(),
+        name: "c".to_owned(),
+    };
+    assert_eq!(wrapper.children.len(), 1);
+    assert_eq!(wrapper.id, "b");
+    assert_eq!(wrapper.name, "c");
+
+    let pair = Pair {
+        by_key: HashMap::from([("k".to_owned(), 1_u32)]),
+        key: "k".to_owned(),
+        maybe: None,
+        tuple: ("k".to_owned(), 1_u32),
+    };
+    assert_eq!(pair.by_key.len(), 1);
+    assert_eq!(pair.key, "k");
+    assert_eq!(pair.maybe, None);
+    assert_eq!(pair.tuple.1, 1);
+
+    let positional = Positional("id".to_owned(), "name".to_owned());
+    assert_eq!(positional.0, "id");
+    assert_eq!(positional.1, "name");
+
+    assert!(matches!(Adjacent::<String>::Nothing, Adjacent::Nothing));
+    assert!(matches!(Internal::<String>::Nothing, Internal::Nothing));
+    assert!(matches!(External::<String>::Nothing, External::Nothing));
+    assert!(matches!(
+        Untagged::<String>::Numbered { count: 1 },
+        Untagged::Numbered { .. }
+    ));
+    assert!(matches!(PlainConst::<4>::Wide, PlainConst::Wide));
+    assert_eq!(Holder { id: 1_u32 }.id, 1);
+    assert_eq!(LifetimeStruct { label: "x".into() }.label, "x");
+}
+
+/// A lifetime is the half of the `impl` fix no schema surface can show: nothing renders it, and
+/// the only evidence it was carried through is that the constrained field still reaches both gates
+/// its bound is held at.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn a_lifetime_struct_still_holds_its_field_to_its_bound() {
+    let rejected = serde_json::from_str::<LifetimeStruct<'_>>(r#"{"label":""}"#).unwrap_err();
+    assert!(
+        rejected
+            .to_string()
+            .contains("'label' is too short: minimum length is 1, got 0"),
+        "Unexpected error: {rejected}"
+    );
+
+    let accepted = serde_json::from_str::<LifetimeStruct<'_>>(r#"{"label":"x"}"#).unwrap();
+    assert!(
+        accepted.validate().is_ok(),
+        "A payload the wire admits must be one validate() admits: {:?}",
+        accepted.validate().err()
+    );
+
+    let empty = LifetimeStruct {
+        label: Cow::Borrowed(""),
+    };
+    assert_eq!(
+        empty.validate().unwrap_err(),
+        vec!["'label' is too short: minimum length is 1, got 0"]
+    );
+}


### PR DESCRIPTION
#[model_schema()] on a generic struct or enum now expands to compiling Rust and a parameterized TypeScript declaration:

- `assemble_schema_output` takes the item's generics and emits `impl #impl_generics #name #type_generics #where_clause` (the branded assembler's split_for_impl pattern); all six call sites thread them, including the plain-enum path's own `enum_members()` impl, which was dropping them too.
- Every TypeScript arm writes the parameter list right after the item name — struct, tuple struct, plain enum, and the shared data-enum emitter — with the re-export suffix still landing after the parameterized declaration.
- A field typed as a parameter carries a new `FieldDefType::TypeParam`: TypeScript renders the name the declaration binds; the validating surfaces keep the opaque rule (`z.unknown()` / `{}`) documented at the erasure seam, which now runs in every build since which names are parameters is a fact about the declaration. The Zod binding's annotation fills one `unknown` per parameter.
- Const-parameter and lifetime fixtures pin the impl threading where a type parameter cannot exist; non-generic output proven byte-identical across eight feature sets by archive diff.

One observable alias change: parameter names are written as declared (no `Json`-suffix stripping), matching the brand arm and field rendering.