### PR TITLE
publish a memoized schema factory for a generic item, its parameters typed and required

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,14 @@ item, computed expression) records nothing and describes as an unbounded array.
 **FieldDefType** (type categories):
 - Primitives: `Boolean`, `String`, `U8-U64`, `I8-I64`, `F32`, `F64`, `Usize`, `Isize`
 - Complex: `SiblingType` (custom types), `Map` (HashMap), `Tuple`
-- Special: `ObjectId` (MongoDB, feature-gated), `StringLiteral`, `Unknown`
+- Special: `ObjectId` (MongoDB, feature-gated), `StringLiteral`, `TypeParam`, `Unknown`
+
+`TypeParam` is one of the enclosing item's own type parameters, which `erase_type_parameters`
+rewrites a written name into. The three surfaces answer for it differently: TypeScript renders the
+name it was written with, JSON Schema describes it as `{}`, and Zod composes the argument the
+enclosing factory binds for it (`idType` for `IdType`). A surface with no factory to bind an
+argument — an alias, a branded newtype — calls `with_opaque_type_parameters` first and writes
+`z.unknown()`.
 
 ### Feature Flag System
 
@@ -355,8 +362,32 @@ export type UserId<ID_TYPE> = ID_TYPE & { readonly [__brand_UserId]: true };
 Rules:
 - Generic parameter names are preserved exactly (`ID_TYPE` stays `ID_TYPE` in TypeScript)
 - Non-generic: `struct CorrelationId(pub String)` generates `string & z.$brand<"CorrelationId">`
-- Generic newtypes always use `z.string()` as the Zod base (inner type cannot be resolved at macro-expansion time)
+- A brand publishes a `const`, so a parameter in its inner has no argument to name and renders as
+  the opaque `z.unknown()`
 - Serde transparent serialization works normally — the newtype is invisible in JSON
+
+### Generic Types and Zod Factories
+
+A Zod schema is a runtime value and TypeScript generics do not exist at runtime, so a generic
+struct, tuple struct or enum has no one schema to publish. It exports `X$SchemaFactory` instead —
+a function taking one required schema argument per parameter — while a type that binds no type
+parameter keeps exporting `X$Schema` exactly as before. `zod_binding_suffix` is the one seam that
+decides which, and `zod_published_binding` the one seam that writes either.
+
+Each factory memoizes on the identity of its arguments, one cache level per parameter, so two
+calls with the same argument objects return the identical schema and no two argument lists
+collide. The levels are written out to the exact depth the type declares rather than looped over:
+a loop needs a key type it cannot name and a value it cannot type, which means `unknown` and a
+cast at every level, while the written-out form comes back already typed.
+
+Every parameter is a real TypeScript type parameter (`<IdType extends ZodType>`), never a bare
+`ZodType` annotation — `ZodType` defaults its own parameters, so an argument annotated with it
+infers every field as `unknown`.
+
+`typescript_preamble!()` returns the one helper the factories share, `createSchemaCache`, which
+every generated module carries once above its per-type definitions. It holds the only assertion
+anywhere in the output: a cache's value type depends on its key type, which TypeScript can declare
+but cannot construct.
 
 ### Adding Examples to Types
 

--- a/README.md
+++ b/README.md
@@ -757,11 +757,95 @@ export type DocumentRecord = {
 
 ### Type Parameters
 
-A generic alias and a generic branded newtype are the two items that can name their own type parameters, and every surface reads such a name under one rule.
+A struct, a tuple struct, an enum, an alias and a branded newtype can each name their own type parameters, and every surface reads such a name under one rule.
 
-**TypeScript binds the parameter for real.** It is a type surface, and the declaration it emits carries the parameter list: `export type WrapperType<T> = Array<T>` is a generic type, and a use site fills `T` in.
+**TypeScript binds the parameter for real.** It is a type surface, and the declaration it emits carries the parameter list: `export type Wrapper<T> = { id: T }` is a generic type, and a use site fills `T` in.
 
-**Zod and JSON Schema erase it to the opaque value** -- `z.unknown()` and `{}`. A parameter names no type until the item is instantiated, and one schema is written for every instantiation, so the parameter admits any value while the shape around it -- an array, a map's keys, a tuple's arity -- stays described. Zod could not do otherwise even in principle: it publishes *values*, and a `const` takes no type parameters, so a parameter left to render would name a `$Schema` binding no emitted module declares, and the pasted output would throw a `ReferenceError` before reading a payload. The exported binding's annotation follows its value, taking the same opaque argument the value was composed with.
+**JSON Schema describes it as the open schema** -- `{}`. A parameter names no type until the item is instantiated, and one JSON schema is written for every instantiation, so the parameter admits any value while the shape around it -- an array, a map's keys, a tuple's arity -- stays described.
+
+**Zod publishes a factory rather than a schema.** A Zod schema is a runtime value and TypeScript generics do not exist at runtime, so there is no one value a generic type could publish: the caller has to say what fills each parameter before anything can validate. A generic type therefore exports `X$SchemaFactory`, a function taking one required schema argument per parameter, and a field written with a parameter composes the argument bound for it.
+
+```rust
+#[model_schema()]
+pub struct Wrapper<IdType> {
+    pub children: Vec<IdType>,
+    pub id: IdType,
+    pub name: String,
+}
+```
+
+```typescript
+export type Wrapper<IdType> = {
+  children: Array<IdType>;
+  id: IdType;
+  name: string;
+};
+
+const buildWrapper$Schema = <IdType extends ZodType>(
+  idType: IdType,
+) =>
+  z.strictObject({
+  children: z.array(idType),
+  id: idType,
+  name: z.string(),
+
+});
+
+type Wrapper$SchemaOf<IdType extends ZodType> = ReturnType<
+  typeof buildWrapper$Schema<IdType>
+>;
+
+interface Wrapper$SchemaFactoryCache {
+  get<IdType extends ZodType>(key: IdType): Wrapper$SchemaOf<IdType> | undefined;
+  set<IdType extends ZodType>(key: IdType, value: Wrapper$SchemaOf<IdType>): this;
+}
+
+const Wrapper$SchemaFactoryCache = createSchemaCache<Wrapper$SchemaFactoryCache>();
+
+export const Wrapper$SchemaFactory = <IdType extends ZodType>(
+  idType: IdType,
+): Wrapper$SchemaOf<IdType> => {
+  const hit = Wrapper$SchemaFactoryCache.get(idType);
+  if (hit) return hit;
+
+  const schema = buildWrapper$Schema(idType);
+  Wrapper$SchemaFactoryCache.set(idType, schema);
+  return schema;
+};
+```
+
+Every parameter is a real TypeScript type parameter, never a bare `ZodType` annotation: `ZodType` defaults its own parameters, so an argument annotated with it would infer every field it validates as `unknown` and the caller would learn nothing from the schema handed back. Arguments are required -- a default would let a call site say nothing about a filling and still be handed a schema, which is exactly the silent mis-validation the factory exists to prevent.
+
+Each factory memoizes on the *identity* of the arguments it was handed, one cache level per parameter. Two calls with the same argument objects return the identical schema, and no two argument lists collide -- a change in the first argument and a change in the last each key a different level:
+
+```typescript
+const wireDocument = EcmDocument$SchemaFactory(z.string(), z.number());
+const storedDocument = EcmDocument$SchemaFactory(objectIdSchema, z.date());
+
+EcmDocument$SchemaFactory(z.string(), z.number()) === wireDocument;  // false -- fresh arguments, new key
+```
+
+A generic type that also flattens keeps the deferred read of its base, so declaration order stays irrelevant: `.and(z.lazy(() => Envelope$Schema))` composes inside the factory unchanged.
+
+#### The module preamble
+
+The factories share one helper, which every generated module carries once above its per-type definitions:
+
+```rust
+use tixschema::typescript_preamble;
+
+const PREAMBLE: &str = typescript_preamble!();
+```
+
+```typescript
+const createSchemaCache = <Cache extends object>(): Cache => new WeakMap() as unknown as Cache;
+```
+
+A cache maps an argument to the schema built from *that* argument, so its value type depends on its key type. TypeScript can declare that dependency -- each factory writes it out, one interface per parameter -- but cannot construct a map that satisfies it, since a `WeakMap` fixes both of its own parameters at construction. So the dependency is declared where it does the work and asserted exactly once, in the preamble: that line is the only assertion anywhere in the output. A module holding no generic type needs no preamble; one holding any needs it exactly once.
+
+#### The two items that still publish a `const`
+
+A generic alias and a generic branded newtype publish a plain `const`, so a parameter inside either has no argument to name and still renders as the opaque value -- `z.unknown()`, the same answer JSON Schema gives:
 
 ```rust
 #[model_schema()]
@@ -776,11 +860,7 @@ const WrapperType$RawSchema = z.array(z.unknown());
 export const WrapperType$Schema: ZodType<WrapperType<unknown>> = WrapperType$RawSchema;
 ```
 
-```json
-{ "type": "array", "items": {} }
-```
-
-Only the item's *own* parameters erase. A name the expansion cannot resolve because the type lives elsewhere keeps its `Name$Schema` reference, since that type publishes the binding.
+Only the item's *own* parameters are read this way. A name the expansion cannot resolve because the type lives elsewhere keeps its `Name$Schema` reference, since that type publishes the binding.
 
 One consequence is worth stating outright: an opaque value carries no string checks, so a branded newtype cannot apply `pattern`, `minLength`, or `maxLength` to one of its own type parameters. See [Branded Newtype Validation Constraints](#branded-newtype-validation-constraints).
 

--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -12,7 +12,7 @@ use crate::features::model_schema_prop::ModelSchemaPropMeta;
 use crate::utils::{lookup_alias_info, safe_type_name};
 
 #[cfg(feature = "zod")]
-use crate::utils::{ZodUnionMember, escape_js_regex_literal};
+use crate::utils::{ZodUnionMember, escape_js_regex_literal, zod_factory_argument};
 
 #[cfg(feature = "chrono")]
 use crate::features::chrono;
@@ -390,46 +390,8 @@ impl FieldDef {
             self.field_type = FieldDefType::TypeParam(name.clone());
             return;
         }
-        match &mut self.field_type {
-            FieldDefType::SiblingType(_, generics) => {
-                for generic in generics.iter_mut() {
-                    generic.erase_type_parameters(parameters);
-                }
-            }
-            FieldDefType::Map(key, value) => {
-                key.erase_type_parameters(parameters);
-                value.erase_type_parameters(parameters);
-            }
-            FieldDefType::Tuple(elements) => {
-                for element in elements.iter_mut() {
-                    element.erase_type_parameters(parameters);
-                }
-            }
-            // Leaf types name no parameter.
-            FieldDefType::TypeParam(_)
-            | FieldDefType::Unknown
-            | FieldDefType::StringLiteral(_)
-            | FieldDefType::Boolean
-            | FieldDefType::String
-            | FieldDefType::U8
-            | FieldDefType::U16
-            | FieldDefType::U32
-            | FieldDefType::U64
-            | FieldDefType::I8
-            | FieldDefType::I16
-            | FieldDefType::I32
-            | FieldDefType::I64
-            | FieldDefType::Usize
-            | FieldDefType::Isize
-            | FieldDefType::F32
-            | FieldDefType::F64 => {}
-            #[cfg(feature = "object_id")]
-            FieldDefType::ObjectId => {}
-            #[cfg(feature = "chrono")]
-            FieldDefType::NaiveDate
-            | FieldDefType::NaiveTime
-            | FieldDefType::NaiveDateTime
-            | FieldDefType::DateTime => {}
+        for nested in self.nested_type_positions() {
+            nested.erase_type_parameters(parameters);
         }
     }
 
@@ -538,6 +500,56 @@ impl FieldDef {
     fn mark_nullable_at(&mut self, level: u8) {
         if !self.nullable_levels.contains(&level) {
             self.nullable_levels.push(level);
+        }
+    }
+
+    /// The defs written inside this one, which is every position a type parameter can be reached
+    /// at below the top: a `SiblingType`'s generic arguments, a `Map`'s key and value, a `Tuple`'s
+    /// elements. Every other variant names a type outright and holds no def.
+    ///
+    /// Listed exhaustively and in one place, so a variant that grows a nested position has to be
+    /// classified here rather than silently escaping every walk that reads a parameter.
+    fn nested_type_positions(&mut self) -> Vec<&mut Self> {
+        match &mut self.field_type {
+            FieldDefType::SiblingType(_, generics) => generics.iter_mut().collect(),
+            FieldDefType::Map(key, value) => vec![key, value],
+            FieldDefType::Tuple(elements) => elements.iter_mut().collect(),
+            // Leaf types hold no def.
+            FieldDefType::TypeParam(_)
+            | FieldDefType::Unknown
+            | FieldDefType::StringLiteral(_)
+            | FieldDefType::Boolean
+            | FieldDefType::String
+            | FieldDefType::U8
+            | FieldDefType::U16
+            | FieldDefType::U32
+            | FieldDefType::U64
+            | FieldDefType::I8
+            | FieldDefType::I16
+            | FieldDefType::I32
+            | FieldDefType::I64
+            | FieldDefType::Usize
+            | FieldDefType::Isize
+            | FieldDefType::F32
+            | FieldDefType::F64 => Vec::new(),
+            #[cfg(feature = "object_id")]
+            FieldDefType::ObjectId => Vec::new(),
+            #[cfg(feature = "chrono")]
+            FieldDefType::NaiveDate
+            | FieldDefType::NaiveTime
+            | FieldDefType::NaiveDateTime
+            | FieldDefType::DateTime => Vec::new(),
+        }
+    }
+
+    #[cfg(feature = "zod")]
+    fn opaque_type_parameters(&mut self) {
+        if matches!(self.field_type, FieldDefType::TypeParam(_)) {
+            self.field_type = FieldDefType::Unknown;
+            return;
+        }
+        for nested in self.nested_type_positions() {
+            nested.opaque_type_parameters();
         }
     }
 
@@ -826,6 +838,20 @@ impl FieldDef {
         value
     }
 
+    /// The same def with every [`FieldDefType::TypeParam`] written back as the opaque value.
+    ///
+    /// Zod names a parameter through the argument the enclosing factory binds for it, which only a
+    /// type that publishes a factory has. An alias and a branded newtype publish a plain `const`,
+    /// so there is no argument for a parameter inside either to name and the opaque value is still
+    /// all either can write — the answer [`Self::erase_type_parameters`] describes, kept for the
+    /// two surfaces that have not moved off it.
+    #[cfg(feature = "zod")]
+    #[must_use]
+    pub fn with_opaque_type_parameters(mut self) -> Self {
+        self.opaque_type_parameters();
+        self
+    }
+
     /// The type match plus one `z.array(…)` per array level, each carrying the `z.nullable(…)` of
     /// the level it wraps and the `.length(N)` of a level written as a fixed-size `[T; N]`, before
     /// the preprocess wrap.
@@ -840,9 +866,12 @@ impl FieldDef {
     #[cfg(feature = "zod")]
     fn zod_array_base(&self) -> String {
         let result = match &self.field_type {
-            // A `const` cannot be parameterised, so the value a parameter composes into is the
-            // opaque one — see [`FieldDef::erase_type_parameters`].
-            FieldDefType::TypeParam(_) | FieldDefType::Unknown => "z.unknown()".to_owned(),
+            FieldDefType::Unknown => "z.unknown()".to_owned(),
+            // A `const` cannot be parameterised, so a generic type publishes a factory and a
+            // parameter composes the argument that factory binds for it — see
+            // [`zod_factory_argument`]. A surface with no factory to bind one opaques the
+            // parameter first, through [`FieldDef::with_opaque_type_parameters`].
+            FieldDefType::TypeParam(name) => zod_factory_argument(name),
             FieldDefType::Tuple(lst) => {
                 let elements = lst
                     .iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -712,3 +712,45 @@ pub fn model_schema_prop(_args: TokenStream, input: TokenStream) -> TokenStream 
     // For now, simply pass through the input
     input
 }
+
+/// # `typescript_preamble`
+///
+/// The `TypeScript` a generated module carries once, above the per-type definitions it is
+/// assembled from. Expands to a string literal and takes no arguments.
+///
+/// ```rust
+/// const PREAMBLE: &str = tixschema::typescript_preamble!();
+/// ```
+///
+/// A generic type publishes `X$SchemaFactory` rather than `X$Schema`, because a Zod schema is a
+/// runtime value and one value cannot stand for every filling of a parameter. Each factory
+/// memoizes on the identity of the arguments it was handed, and `createSchemaCache` is the helper
+/// they all build those caches with:
+///
+#[cfg_attr(
+    feature = "typescript",
+    doc = "```typescript
+const createSchemaCache = <Cache extends object>(): Cache => new WeakMap() as unknown as Cache;
+```"
+)]
+#[cfg_attr(
+    not(feature = "typescript"),
+    doc = "```javascript
+const createSchemaCache = () => new WeakMap();
+```"
+)]
+///
+/// A cache maps an argument to the schema built from *that* argument, so its value type depends on
+/// its key type. `TypeScript` can declare that dependency — each factory writes it out, one
+/// interface per parameter — but cannot construct a map that satisfies it, since a `WeakMap` fixes
+/// both of its own parameters at construction. So the dependency is declared where it does the
+/// work and asserted exactly once, here: this line is the only assertion anywhere in the generated
+/// output.
+///
+/// Emit it once per module, ahead of every `zod_schema()` the module carries. A module with no
+/// generic type in it needs no preamble, and one that has any needs it exactly once.
+#[cfg(feature = "zod")]
+#[proc_macro]
+pub fn typescript_preamble(input: TokenStream) -> TokenStream {
+    model_schema::typescript_preamble_tokens(input.into()).into()
+}

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -29,8 +29,11 @@ use crate::{
 use crate::utils::ts_generic_params;
 use crate::utils::type_parameters_in_scope;
 
+#[cfg(all(feature = "zod", feature = "typescript"))]
+use core::iter::once;
+
 #[cfg(feature = "zod")]
-use crate::utils::{escape_js_regex_literal, extract_example_from_docs};
+use crate::utils::{escape_js_regex_literal, extract_example_from_docs, zod_factory_argument};
 
 #[cfg(all(feature = "zod", feature = "object_id"))]
 use crate::features::object_id::get_object_id_zod_schema_with;
@@ -122,6 +125,26 @@ const FLATTENED_PLAIN_ENUM_SCOPE: &str = "Only a type the registry has already c
 
 /// The two shapes a map key can write that `serde_json` will not use as an object key, as
 /// [`MapKeyRejection::Unwritable`] names them.
+/// The one helper every generated module carries above its per-type definitions, and the only
+/// assertion anything here writes.
+///
+/// A factory's cache maps an argument to the schema built from *that* argument, so the value type
+/// depends on the key type. TypeScript can declare that dependency — each level's `get` and `set`
+/// are written generic over the key — but cannot construct a map that satisfies it, since a
+/// `WeakMap`'s two parameters are fixed at construction. So the dependency is declared in the
+/// interfaces, where it does the work, and asserted exactly once here, where a reader can see the
+/// whole of what was asserted.
+///
+/// A `WeakMap` is what makes an argument nobody else holds collectable rather than pinned for the
+/// life of the module.
+#[cfg(all(feature = "zod", feature = "typescript"))]
+const TYPESCRIPT_PREAMBLE: &str = "const createSchemaCache = <Cache extends object>(): Cache => new WeakMap() as unknown as Cache;";
+
+/// The JavaScript flavour of [`TYPESCRIPT_PREAMBLE`]: a build with no `typescript` writes plain
+/// JavaScript, which declares no types and so has nothing to assert.
+#[cfg(all(feature = "zod", not(feature = "typescript")))]
+const TYPESCRIPT_PREAMBLE: &str = "const createSchemaCache = () => new WeakMap();";
+
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 const WRITTEN_AS_ARRAY: &str = "a JSON array";
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
@@ -970,6 +993,7 @@ fn build_struct_delegate_items(
     module_ident: &Ident,
     item_name: &str,
     rust_ident: &str,
+    parameters: &[String],
     schema_example_method: Option<&proc_macro2::TokenStream>,
     validate_method: Option<proc_macro2::TokenStream>,
 ) -> Vec<proc_macro2::TokenStream> {
@@ -977,9 +1001,9 @@ fn build_struct_delegate_items(
     #[cfg(feature = "zod")]
     let has_example = schema_example_method.is_some();
     #[cfg(feature = "zod")]
-    let reexport = ident_reexport_zod(rust_ident, item_name);
+    let reexport = ident_reexport_zod(rust_ident, item_name, zod_binding_suffix(parameters));
     #[cfg(not(feature = "zod"))]
-    let _: &_ = &(item_name, rust_ident);
+    let _: &_ = &(item_name, rust_ident, parameters);
     #[cfg(not(feature = "zod"))]
     let _: Option<&proc_macro2::TokenStream> = schema_example_method;
 
@@ -1292,7 +1316,7 @@ fn struct_schema_impl_items(
     #[cfg(feature = "typescript")]
     let ts_generics = ts_generic_params(generics);
     #[cfg(feature = "zod")]
-    let ts_type_args = erased_type_arguments(generics);
+    let type_parameters = type_parameters_in_scope(generics);
     // bodies: (type_code, schema_code, json_schema_fields, fields_empty)
     let bodies = render_struct_field_bodies(field_defs, Some(item_name));
     // flatten: (ts_types, zod_schemas)
@@ -1319,7 +1343,7 @@ fn struct_schema_impl_items(
         generate_zod_schema_method(
             item_name,
             rust_ident,
-            &ts_type_args,
+            &type_parameters,
             &bodies.1,
             "",
             &flatten.1,
@@ -2173,6 +2197,7 @@ fn process_struct(mut item_struct: syn::ItemStruct, args: &ModelSchemaArgs) -> T
         &module_ident,
         &item_name,
         &rust_ident,
+        &type_parameters_in_scope(&item_struct.generics),
         schema_example_method.as_ref(),
         validate_method,
     );
@@ -2315,26 +2340,17 @@ fn build_tuple_struct_ts_definition_method(
 }
 
 /// Builds the `zod_schema()` method for a tuple struct's schema module, in the same framing every
-/// unbranded type publishes: the raw schema, then the exported binding annotated with the
-/// TypeScript type the module's own `ts_definition()` writes.
+/// unbranded type publishes: the annotated binding, or the factory when the tuple struct declares
+/// parameters.
 #[cfg(feature = "zod")]
 fn build_tuple_struct_zod_schema_method(
     item_name: &str,
     rust_ident: &str,
-    ts_type_args: &str,
+    parameters: &[String],
     zod_body: &str,
 ) -> proc_macro2::TokenStream {
-    let reexport = ident_reexport_zod(rust_ident, item_name);
-    #[cfg(feature = "typescript")]
-    let schema_str = format!(
-        "const {item_name}$RawSchema = {zod_body};\n\nexport const {item_name}$Schema: ZodType<{item_name}{ts_type_args}> = {item_name}$RawSchema;{reexport}"
-    );
-    // The annotation is the only place the arguments are written, and a zod-only build has no
-    // `ZodType` to annotate with.
-    #[cfg(not(feature = "typescript"))]
-    let _: &_ = &ts_type_args;
-    #[cfg(not(feature = "typescript"))]
-    let schema_str = format!("export const {item_name}$Schema = {zod_body};{reexport}");
+    let reexport = ident_reexport_zod(rust_ident, item_name, zod_binding_suffix(parameters));
+    let schema_str = zod_published_binding(item_name, parameters, "", zod_body, &reexport);
     quote! {
         pub fn zod_schema() -> String {
             #schema_str.to_owned()
@@ -2393,7 +2409,7 @@ fn process_tuple_struct(
         build_tuple_struct_zod_schema_method(
             &item_name,
             &name.to_string(),
-            &erased_type_arguments(&item_struct.generics),
+            &type_parameters_in_scope(&item_struct.generics),
             &tuple_struct_zod_body(&slots),
         ),
     ];
@@ -2409,6 +2425,7 @@ fn process_tuple_struct(
         &module_ident,
         &item_name,
         &name.to_string(),
+        &type_parameters_in_scope(&item_struct.generics),
         schema_example_method.as_ref(),
         None,
     );
@@ -2754,9 +2771,12 @@ fn value_surface_field_def(generics: &syn::Generics, written: &FieldDef) -> Fiel
 /// The annotation states the type of the value beside it, and that value was composed with every
 /// parameter erased — so the name it is written under has to be filled in the same way. Naming the
 /// generic bare instead is a TypeScript error in its own right, the type requiring its arguments.
+///
+/// Only an alias reaches this with parameters now: every other generic item publishes a factory,
+/// whose return type is read off the arguments the caller supplied rather than declared ahead of
+/// them.
 #[cfg(feature = "zod")]
-fn erased_type_arguments(generics: &syn::Generics) -> String {
-    let parameters = type_parameters_in_scope(generics);
+fn erased_type_arguments(parameters: &[String]) -> String {
     if parameters.is_empty() {
         return String::new();
     }
@@ -3017,6 +3037,10 @@ fn build_branded_ts_definition_method(
 ///
 /// The value and the annotation are both read off the one erased inner, so the type the binding
 /// claims and the schema it holds cannot describe different things.
+///
+/// A brand publishes a `const` rather than a factory, so a parameter inside its inner has no
+/// argument to name and is opaqued before either is rendered — see
+/// [`FieldDef::with_opaque_type_parameters`].
 #[cfg(feature = "zod")]
 fn build_branded_zod_schema_method(
     args: &ModelSchemaArgs,
@@ -3025,11 +3049,12 @@ fn build_branded_zod_schema_method(
     inner: &FieldDef,
     plain_description: &str,
 ) -> proc_macro2::TokenStream {
-    let zod_inner = branded_zod_inner(args, inner);
-    let reexport = ident_reexport_zod(rust_ident, item_name);
+    let opaque_inner = &inner.clone().with_opaque_type_parameters();
+    let zod_inner = branded_zod_inner(args, opaque_inner);
+    let reexport = ident_reexport_zod(rust_ident, item_name, "$Schema");
     #[cfg(feature = "typescript")]
     {
-        let zod_type_name = branded_zod_type_name(inner);
+        let zod_type_name = branded_zod_type_name(opaque_inner);
         let zod_type_annotation = format!("$ZodBranded<{zod_type_name}, \"{item_name}\">");
         quote! {
             pub fn zod_schema() -> String {
@@ -4208,7 +4233,7 @@ fn process_discriminated_enum(
     let zod_schema_method = generate_discriminated_enum_zod_schema_method(
         item_name,
         &name.to_string(),
-        &erased_type_arguments(&item_enum.generics),
+        &type_parameters_in_scope(&item_enum.generics),
         &schema_code,
     );
 
@@ -4238,6 +4263,7 @@ fn process_discriminated_enum(
         &module_ident,
         item_name,
         &name.to_string(),
+        &type_parameters_in_scope(&item_enum.generics),
         schema_example_method.as_ref(),
         build_enum_validate_method(&variants.3, &module_ident),
     );
@@ -4609,7 +4635,7 @@ fn process_externally_tagged_enum(
     let zod_schema_method = generate_discriminated_enum_zod_schema_method(
         item_name,
         &name.to_string(),
-        &erased_type_arguments(&item_enum.generics),
+        &type_parameters_in_scope(&item_enum.generics),
         &schema_code,
     );
 
@@ -4634,6 +4660,7 @@ fn process_externally_tagged_enum(
         &module_ident,
         item_name,
         &name.to_string(),
+        &type_parameters_in_scope(&item_enum.generics),
         schema_example_method.as_ref(),
         build_enum_validate_method(&variants.3, &module_ident),
     );
@@ -5012,7 +5039,7 @@ fn process_internally_tagged_enum(
     let zod_schema_method = generate_discriminated_enum_zod_schema_method(
         item_name,
         &name.to_string(),
-        &erased_type_arguments(&item_enum.generics),
+        &type_parameters_in_scope(&item_enum.generics),
         &schema_code,
     );
 
@@ -5037,6 +5064,7 @@ fn process_internally_tagged_enum(
         &module_ident,
         item_name,
         &name.to_string(),
+        &type_parameters_in_scope(&item_enum.generics),
         schema_example_method.as_ref(),
         build_enum_validate_method(&variants.3, &module_ident),
     );
@@ -5675,7 +5703,7 @@ fn build_untagged_schema_impl_items(
     let zod_schema_method = generate_discriminated_enum_zod_schema_method(
         item_name,
         &name.to_string(),
-        &erased_type_arguments(generics),
+        &type_parameters_in_scope(generics),
         &schema_code,
     );
 
@@ -5762,6 +5790,7 @@ fn process_untagged_enum(
         &module_ident,
         item_name,
         &name.to_string(),
+        &type_parameters_in_scope(&item_enum.generics),
         schema_example_method.as_ref(),
         build_enum_validate_method(&validate_arms, &module_ident),
     );
@@ -8851,6 +8880,277 @@ fn deferred_zod_operand(schema: &str) -> String {
     format!("z.lazy(() => {schema})")
 }
 
+/// The tokens `typescript_preamble!()` expands to — the preamble as a string literal, or the
+/// `compile_error!` for a call that was handed arguments it has none of.
+#[cfg(feature = "zod")]
+pub fn typescript_preamble_tokens(input: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
+    if !input.is_empty() {
+        return syn::Error::new_spanned(
+            input,
+            "tixschema: `typescript_preamble!()` takes no arguments",
+        )
+        .to_compile_error();
+    }
+    quote! { #TYPESCRIPT_PREAMBLE }
+}
+
+/// The suffix the binding an item publishes is named with. A generic type publishes a factory —
+/// one schema per filling, built on demand — where a type that declares no parameter publishes the
+/// one schema it has.
+#[cfg(feature = "zod")]
+const fn zod_binding_suffix(parameters: &[String]) -> &'static str {
+    if parameters.is_empty() {
+        "$Schema"
+    } else {
+        "$SchemaFactory"
+    }
+}
+
+/// The identifier holding the expression a factory's arguments compose into. Bound beside the
+/// factory rather than inlined in it, so the factory's return type can be read back off it and
+/// neither can drift from the other.
+#[cfg(feature = "zod")]
+fn zod_factory_builder_name(item_name: &str) -> String {
+    format!("build{item_name}$Schema")
+}
+
+/// The `TypeScript` parameter list a factory and everything written around it are declared under —
+/// `<IdType extends ZodType, DateType extends ZodType>`.
+///
+/// Every parameter is a parameter of the function for real. A bare `ZodType` annotation compiles
+/// and infers nothing: `ZodType` defaults its own parameters, so a field validated by such an
+/// argument comes back as `unknown` and the caller learns nothing from the schema it was handed.
+#[cfg(all(feature = "zod", feature = "typescript"))]
+fn zod_factory_bounds(parameters: &[String]) -> String {
+    format!(
+        "<{}>",
+        parameters
+            .iter()
+            .map(|parameter| format!("{parameter} extends ZodType"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
+}
+
+/// The argument list a factory and its builder are written with, one line per parameter. Required,
+/// every one of them: a default would let a call site say nothing about a filling and still get a
+/// schema back, which is the silent mis-validation the factory exists to prevent.
+#[cfg(feature = "zod")]
+fn zod_factory_arguments(parameters: &[String]) -> String {
+    parameters.iter().fold(String::new(), |mut acc, parameter| {
+        let argument = zod_factory_argument(parameter);
+        #[cfg(feature = "typescript")]
+        let _ = write!(acc, "\n  {argument}: {parameter},");
+        #[cfg(not(feature = "typescript"))]
+        let _ = write!(acc, "\n  {argument},");
+        acc
+    })
+}
+
+/// The cache interface keying on the parameter at `depth`, named for how many parameters it has
+/// already resolved: the root resolves none, and each level below carries the ones above it.
+#[cfg(all(feature = "zod", feature = "typescript"))]
+fn zod_cache_level_name(item_name: &str, depth: usize) -> String {
+    if depth == 0 {
+        format!("{item_name}$SchemaFactoryCache")
+    } else {
+        format!("{item_name}$SchemaFactoryCacheL{depth}")
+    }
+}
+
+/// What a lookup at `depth` hands back: the level below it while parameters remain, and the schema
+/// itself once the last one is resolved.
+#[cfg(all(feature = "zod", feature = "typescript"))]
+fn zod_cache_level_value(item_name: &str, parameters: &[String], depth: usize) -> String {
+    if depth + 1 == parameters.len() {
+        format!("{item_name}$SchemaOf<{}>", parameters.join(", "))
+    } else {
+        format!(
+            "{}<{}>",
+            zod_cache_level_name(item_name, depth + 1),
+            parameters[..=depth].join(", ")
+        )
+    }
+}
+
+/// One cache interface per parameter, each written generic over the key it is about to resolve and
+/// carrying the parameters resolved above it.
+///
+/// Nesting spelled to the exact depth the type declares rather than looped over: a loop needs a
+/// key type it cannot name and a value it cannot type, which is `unknown` and a cast at every
+/// level. Written out, a lookup comes back already typed and the factory body asserts nothing.
+#[cfg(all(feature = "zod", feature = "typescript"))]
+fn zod_cache_interfaces(item_name: &str, parameters: &[String]) -> String {
+    let mut written = String::new();
+    for depth in (1..parameters.len()).chain(once(0)) {
+        let key = &parameters[depth];
+        let value = zod_cache_level_value(item_name, parameters, depth);
+        let held = if depth == 0 {
+            String::new()
+        } else {
+            zod_factory_bounds(&parameters[..depth])
+        };
+        let _ = write!(
+            written,
+            "interface {}{held} {{\n  get<{key} extends ZodType>(key: {key}): {value} | \
+             undefined;\n  set<{key} extends ZodType>(key: {key}, value: {value}): this;\n}}\n\n",
+            zod_cache_level_name(item_name, depth)
+        );
+    }
+    written
+}
+
+/// The factory's body: walk down to the map the last argument keys, hand back what is already
+/// there, and otherwise build once, store, and return the very schema that was stored — which is
+/// what makes two calls with the same arguments the same schema rather than two that agree.
+///
+/// Every argument is read on the way down, so no two argument lists share a slot: a change in the
+/// first re-keys the outermost map and a change in the last re-keys the one the schema sits in.
+#[cfg(feature = "zod")]
+fn zod_factory_body(item_name: &str, parameters: &[String]) -> String {
+    let arguments: Vec<String> = parameters.iter().map(|p| zod_factory_argument(p)).collect();
+    let mut body = String::new();
+    let mut holder = format!("{item_name}$SchemaFactoryCache");
+    for depth in 1..parameters.len() {
+        let below = format!("by{}", parameters[depth]);
+        let key = &arguments[depth - 1];
+        #[cfg(feature = "typescript")]
+        let fresh = format!(
+            "createSchemaCache<{}<{}>>()",
+            zod_cache_level_name(item_name, depth),
+            parameters[..depth].join(", ")
+        );
+        #[cfg(not(feature = "typescript"))]
+        let fresh = "createSchemaCache()".to_owned();
+        let _ = write!(
+            body,
+            "  let {below} = {holder}.get({key});\n  if (!{below}) {{\n    {below} = \
+             {fresh};\n    {holder}.set({key}, {below});\n  }}\n\n"
+        );
+        holder = below;
+    }
+    let last = arguments.last().map_or_else(String::new, Clone::clone);
+    let _ = write!(
+        body,
+        "  const hit = {holder}.get({last});\n  if (hit) return hit;\n\n  const schema = \
+         {}({});\n  {holder}.set({last}, schema);\n  return schema;",
+        zod_factory_builder_name(item_name),
+        arguments.join(", ")
+    );
+    body
+}
+
+/// What a generic type's Zod surface is written as: the builder holding the schema its arguments
+/// compose into, the return type read back off it, the cache interfaces, and the exported factory.
+///
+/// A Zod schema is a runtime value and TypeScript generics do not exist at runtime, so a generic
+/// type has no one schema to publish — the caller has to say what fills each parameter before
+/// anything can validate. What it publishes instead is the function that answers that, and the
+/// cache is what keeps a filling asked for twice from becoming two schemas.
+#[cfg(feature = "zod")]
+fn zod_factory_block(
+    item_name: &str,
+    parameters: &[String],
+    preamble: &str,
+    expression: &str,
+    reexport: &str,
+) -> String {
+    let builder = zod_factory_builder_name(item_name);
+    let arguments = zod_factory_arguments(parameters);
+    let body = zod_factory_body(item_name, parameters);
+
+    #[cfg(feature = "typescript")]
+    let bounds = zod_factory_bounds(parameters);
+    #[cfg(not(feature = "typescript"))]
+    let bounds = String::new();
+
+    // A merged object binds its own keys ahead of the branches that read them, and those keys are
+    // composed from the arguments — so the binding belongs inside the builder, where the arguments
+    // are in scope, rather than beside it at module level.
+    let built = if preamble.is_empty() {
+        format!("const {builder} = {bounds}({arguments}\n) =>\n  {expression};")
+    } else {
+        format!(
+            "const {builder} = {bounds}({arguments}\n) => {{\n  {preamble}  return {expression};\n}};"
+        )
+    };
+
+    #[cfg(feature = "typescript")]
+    let declarations = format!(
+        "type {item_name}$SchemaOf{bounds} = ReturnType<\n  typeof {builder}<{}>\n>;\n\n{}const \
+         {item_name}$SchemaFactoryCache = \
+         createSchemaCache<{item_name}$SchemaFactoryCache>();\n\n",
+        parameters.join(", "),
+        zod_cache_interfaces(item_name, parameters)
+    );
+    #[cfg(not(feature = "typescript"))]
+    let declarations = format!("const {item_name}$SchemaFactoryCache = createSchemaCache();\n\n");
+
+    #[cfg(feature = "typescript")]
+    let returns = format!(": {item_name}$SchemaOf<{}>", parameters.join(", "));
+    #[cfg(not(feature = "typescript"))]
+    let returns = String::new();
+
+    format!(
+        "{built}\n\n{declarations}export const {item_name}$SchemaFactory = \
+         {bounds}({arguments}\n){returns} => {{\n{body}\n}};{reexport}"
+    )
+}
+
+/// The binding a type that declares no parameter publishes: the raw schema, then the exported
+/// `const` annotated with the type it validates.
+///
+/// The annotation is the only place a TypeScript type is named, so a build without `typescript`
+/// writes the same value under a bare `const`.
+#[cfg(feature = "zod")]
+fn zod_const_block(
+    item_name: &str,
+    ts_type_args: &str,
+    preamble: &str,
+    expression: &str,
+    reexport: &str,
+) -> String {
+    #[cfg(feature = "typescript")]
+    {
+        format!(
+            "{preamble}const {item_name}$RawSchema = {expression};\n\nexport const \
+             {item_name}$Schema: ZodType<{item_name}{ts_type_args}> = \
+             {item_name}$RawSchema;{reexport}"
+        )
+    }
+    #[cfg(not(feature = "typescript"))]
+    {
+        let _: &str = ts_type_args;
+        format!("{preamble}export const {item_name}$Schema = {expression};{reexport}")
+    }
+}
+
+/// The whole of what a type publishes on the Zod surface: a factory when it declares parameters,
+/// and the annotated `const` when it declares none.
+///
+/// The one seam every declared item takes that decision at, so a struct, a tuple struct and an
+/// enum cannot come to answer it differently.
+#[cfg(feature = "zod")]
+fn zod_published_binding(
+    item_name: &str,
+    parameters: &[String],
+    preamble: &str,
+    expression: &str,
+    reexport: &str,
+) -> String {
+    if parameters.is_empty() {
+        zod_const_block(
+            item_name,
+            &erased_type_arguments(parameters),
+            preamble,
+            expression,
+            reexport,
+        )
+    } else {
+        zod_factory_block(item_name, parameters, preamble, expression, reexport)
+    }
+}
+
 /// What one merged source contributes to each branch: one schema per member of the untagged union
 /// it names, and the source itself when it names none.
 #[cfg(feature = "zod")]
@@ -8941,30 +9241,18 @@ fn zod_merged_statements(
 fn generate_zod_schema_method(
     item_name: &str,
     rust_ident: &str,
-    ts_type_args: &str,
+    parameters: &[String],
     schema_code: &str,
     show_opts: &str,
     flatten_schemas: &[MergedOperand],
 ) -> proc_macro2::TokenStream {
     #[cfg(feature = "zod")]
     {
-        let reexport = ident_reexport_zod(rust_ident, item_name);
+        let reexport = ident_reexport_zod(rust_ident, item_name, zod_binding_suffix(parameters));
         let own = format!("z.strictObject({{\n{schema_code}\n}}){show_opts}");
         let (preamble, expression) = zod_merged_statements(item_name, &own, flatten_schemas);
-        // When typescript feature is enabled, generate TypeScript-style Zod schema
-        // Note: Example injection is handled by the delegating method on the type itself
-        #[cfg(feature = "typescript")]
-        let body = format!(
-            "{preamble}const {item_name}$RawSchema = {expression};\n\nexport const \
-             {item_name}$Schema: ZodType<{item_name}{ts_type_args}> = {item_name}$RawSchema;{reexport}"
-        );
-
-        // When typescript feature is disabled, generate JavaScript-style Zod schema, which
-        // carries no annotation for the arguments to fill in.
-        #[cfg(not(feature = "typescript"))]
-        let _: &_ = &ts_type_args;
-        #[cfg(not(feature = "typescript"))]
-        let body = format!("{preamble}export const {item_name}$Schema = {expression};{reexport}");
+        // Note: Example injection is handled by the delegating method on the type itself.
+        let body = zod_published_binding(item_name, parameters, &preamble, &expression, &reexport);
 
         quote::quote! {
             pub fn zod_schema() -> String {
@@ -8978,7 +9266,7 @@ fn generate_zod_schema_method(
         let _: &_ = &(
             item_name,
             rust_ident,
-            ts_type_args,
+            parameters,
             schema_code,
             show_opts,
             flatten_schemas,
@@ -9085,6 +9373,10 @@ fn generate_plain_enum_ts_definition_method(
 #[cfg(feature = "zod")]
 /// Generates the Zod schema method for plain enums (Zod schemas only)
 /// Note: Example injection is handled by the delegating method on the type itself.
+///
+/// A plain enum publishes the one schema it has whatever it declares: Rust refuses a *type*
+/// parameter no variant uses, and every variant of a plain enum is a unit, so there is never a
+/// parameter here for a factory to bind.
 fn generate_plain_enum_zod_schema_method(
     item_name: &str,
     rust_ident: &str,
@@ -9093,7 +9385,7 @@ fn generate_plain_enum_zod_schema_method(
 ) -> proc_macro2::TokenStream {
     #[cfg(feature = "zod")]
     {
-        let reexport = ident_reexport_zod(rust_ident, item_name);
+        let reexport = ident_reexport_zod(rust_ident, item_name, "$Schema");
         // When typescript feature is enabled, generate TypeScript-style Zod schema
         #[cfg(feature = "typescript")]
         {
@@ -9174,37 +9466,23 @@ fn generate_discriminated_enum_ts_definition_method(
 fn generate_discriminated_enum_zod_schema_method(
     item_name: &str,
     rust_ident: &str,
-    ts_type_args: &str,
+    parameters: &[String],
     schema_code: &str,
 ) -> proc_macro2::TokenStream {
     #[cfg(feature = "zod")]
     {
-        let reexport = ident_reexport_zod(rust_ident, item_name);
-        // When typescript feature is enabled, generate TypeScript-style Zod schema
-        #[cfg(feature = "typescript")]
-        {
-            quote::quote! {
-                pub fn zod_schema() -> String {
-                    format!("const {}$RawSchema = {};\n\nexport const {}$Schema: ZodType<{}{}> = {}$RawSchema;{}", #item_name, #schema_code, #item_name, #item_name, #ts_type_args, #item_name, #reexport)
-                }
-            }
-        }
-
-        // When typescript feature is disabled, generate JavaScript-style Zod schema
-        #[cfg(not(feature = "typescript"))]
-        {
-            let _: &_ = &ts_type_args;
-            quote::quote! {
-                pub fn zod_schema() -> String {
-                    format!(r#"export const {}$Schema = {};{}"#, #item_name, #schema_code, #reexport)
-                }
+        let reexport = ident_reexport_zod(rust_ident, item_name, zod_binding_suffix(parameters));
+        let schema_str = zod_published_binding(item_name, parameters, "", schema_code, &reexport);
+        quote::quote! {
+            pub fn zod_schema() -> String {
+                #schema_str.to_owned()
             }
         }
     }
 
     #[cfg(not(feature = "zod"))]
     {
-        let _: &_ = &(item_name, rust_ident, ts_type_args, schema_code);
+        let _: &_ = &(item_name, rust_ident, parameters, schema_code);
         quote::quote! {
             // Zod schema method not available - zod feature disabled
             // To enable: add "zod" to your features
@@ -9336,9 +9614,14 @@ fn generate_alias_zod_method(
         // the null-flavored `z.tuple([...])`, a scalar yields `z.string()`, a sibling
         // yields `Name$Schema`). Bind it to `$RawSchema` and re-export the annotated
         // `$Schema`, mirroring how struct/enum schemas expose their const.
-        let schema_code = value_surface_field_def(&alias.generics, field_def).zod_type();
-        let annotated_name = format!("{export_name}{}", erased_type_arguments(&alias.generics));
-        let reexport = ident_reexport_zod(rust_ident, export_name);
+        let schema_code = value_surface_field_def(&alias.generics, field_def)
+            .with_opaque_type_parameters()
+            .zod_type();
+        let annotated_name = format!(
+            "{export_name}{}",
+            erased_type_arguments(&type_parameters_in_scope(&alias.generics))
+        );
+        let reexport = ident_reexport_zod(rust_ident, export_name, "$Schema");
         quote! {
             pub fn zod_schema() -> String {
                 format!(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -715,10 +715,28 @@ pub fn ident_reexport_ts(rust_ident: &str, export_name: &str, ts_generics: &str)
 /// The zod counterpart of [`ident_reexport_ts`] — a binding, not a second schema, so the two names
 /// carry the one schema the item published. It is written unannotated because a zod-only build has
 /// no `ZodType` to annotate it with, and the binding's own type is the exported schema's.
+///
+/// `binding_suffix` is what the item's own binding is named with, and the two names have to agree
+/// on it: a generic type publishes a factory rather than a schema, so both spellings end in
+/// `$SchemaFactory` there and in `$Schema` everywhere else.
 #[cfg(feature = "zod")]
-pub fn ident_reexport_zod(rust_ident: &str, export_name: &str) -> String {
+pub fn ident_reexport_zod(rust_ident: &str, export_name: &str, binding_suffix: &str) -> String {
     ident_reexport_name(rust_ident, export_name).map_or_else(String::new, |referenced| {
-        format!("\n\nexport const {referenced}$Schema = {export_name}$Schema;")
+        format!("\n\nexport const {referenced}{binding_suffix} = {export_name}{binding_suffix};")
+    })
+}
+
+/// The identifier a factory binds one type parameter's schema argument to — `idType` for `IdType`.
+///
+/// A Zod schema is a value and a `const` cannot be parameterised, so a generic type publishes a
+/// function of one argument per parameter rather than a schema, and a field written with a
+/// parameter composes that argument. Lower-camel of the declared name, so the argument reads as
+/// the parameter it fills while staying a name of its own beside it.
+#[cfg(feature = "zod")]
+pub fn zod_factory_argument(parameter: &str) -> String {
+    let mut characters = parameter.chars();
+    characters.next().map_or_else(String::new, |first| {
+        format!("{}{}", first.to_lowercase(), characters.as_str())
     })
 }
 

--- a/src/utils/tests.rs
+++ b/src/utils/tests.rs
@@ -739,11 +739,45 @@ fn a_ts_reexport_is_written_only_where_the_export_moved_off_the_ident() {
 #[test]
 fn a_zod_reexport_is_written_only_where_the_export_moved_off_the_ident() {
     assert_eq!(
-        ident_reexport_zod("LaterAlias", "LaterAliasType"),
+        ident_reexport_zod("LaterAlias", "LaterAliasType", "$Schema"),
         "\n\nexport const LaterAlias$Schema = LaterAliasType$Schema;"
     );
     for (ident, export) in [("PlainItem", "PlainItem"), ("PlainItemJson", "PlainItem")] {
-        assert_eq!(ident_reexport_zod(ident, export), "", "for: {ident}");
+        assert_eq!(
+            ident_reexport_zod(ident, export, "$Schema"),
+            "",
+            "for: {ident}"
+        );
+    }
+}
+
+/// A generic type publishes a factory, so both names it is reached by have to name that factory:
+/// a re-export written to `$Schema` would bind a name no emitted module declares.
+#[cfg(feature = "zod")]
+#[test]
+fn a_zod_reexport_carries_the_suffix_the_item_published_under() {
+    assert_eq!(
+        ident_reexport_zod("Holder", "RenamedHolder", "$SchemaFactory"),
+        "\n\nexport const Holder$SchemaFactory = RenamedHolder$SchemaFactory;"
+    );
+}
+
+/// The argument a factory binds for a parameter reads as the parameter it fills while staying a
+/// name of its own beside it.
+#[cfg(feature = "zod")]
+#[test]
+fn a_factory_argument_is_the_lower_camel_of_its_parameter() {
+    for (parameter, argument) in [
+        ("IdType", "idType"),
+        ("T", "t"),
+        ("DateType", "dateType"),
+        ("", ""),
+    ] {
+        assert_eq!(
+            zod_factory_argument(parameter),
+            argument,
+            "for: {parameter}"
+        );
     }
 }
 

--- a/tests/generic_types_tests/tests.rs
+++ b/tests/generic_types_tests/tests.rs
@@ -133,69 +133,78 @@ mod typescript {
 
 #[cfg(feature = "zod")]
 mod zod {
-    use super::{Pair, Wrapper};
+    use super::{
+        Adjacent, Carried, Envelope, External, Holder, Internal, LifetimeStruct, Pair, PlainConst,
+        Positional, Quintet, Tagged, Untagged, Wrapper,
+    };
 
-    /// A `const` cannot be parameterised, so a parameter composes into the value as the opaque
-    /// schema rather than as a `$Schema` binding no emitted module declares.
+    /// Whether the output publishes `name` as a plain exported `const` — the binding a type that
+    /// declares no parameter writes, in either build flavour. Asked this way because
+    /// `{name}$SchemaFactory` carries `{name}$Schema` inside it, so the two names cannot be told
+    /// apart by the prefix alone.
+    fn publishes_a_schema_const(zod: &str, name: &str) -> bool {
+        zod.contains(&format!("export const {name}$Schema:"))
+            || zod.contains(&format!("export const {name}$Schema ="))
+    }
+
+    /// A Zod schema is a runtime value and a `const` cannot be parameterised, so a generic type has
+    /// no one schema to publish — what it publishes is the function that builds one per filling.
     #[test]
-    fn a_parameter_composes_into_the_value_as_the_opaque_schema() {
+    fn a_generic_type_publishes_a_factory_where_a_plain_type_publishes_a_schema() {
+        let generic = Wrapper::<String>::zod_schema();
+        assert!(
+            generic.contains("export const Wrapper$SchemaFactory = "),
+            "Got: {generic}"
+        );
+        assert!(
+            !publishes_a_schema_const(&generic, "Wrapper"),
+            "Got: {generic}"
+        );
+
+        let plain = Envelope::zod_schema();
+        assert!(publishes_a_schema_const(&plain, "Envelope"), "Got: {plain}");
+        assert!(!plain.contains("$SchemaFactory"), "Got: {plain}");
+    }
+
+    /// The argument the factory binds is what a field written with a parameter composes, so the
+    /// caller's filling is what validates rather than a value that admits anything.
+    #[test]
+    fn a_parameter_composes_into_the_value_as_the_argument_bound_for_it() {
         let zod = Wrapper::<String>::zod_schema();
-        assert!(zod.contains("id: z.unknown()"), "Got: {zod}");
-        assert!(zod.contains("children: z.array(z.unknown())"), "Got: {zod}");
-        assert!(zod.contains("name: z.string()"), "Got: {zod}");
-        assert!(!zod.contains("IdType"), "Got: {zod}");
+        assert!(zod.contains("id: idType,"), "Got: {zod}");
+        assert!(zod.contains("children: z.array(idType),"), "Got: {zod}");
+        assert!(zod.contains("name: z.string(),"), "Got: {zod}");
     }
 
     #[test]
-    fn a_parameter_is_opaque_at_every_depth_it_is_written_at() {
+    fn a_parameter_is_the_argument_at_every_depth_it_is_written_at() {
         let zod = Pair::<String, u32>::zod_schema();
-        assert!(zod.contains("key: z.unknown()"), "Got: {zod}");
+        assert!(zod.contains("key: keyType,"), "Got: {zod}");
         assert!(
-            zod.contains("by_key: z.record(z.string(), z.unknown())"),
+            zod.contains("by_key: z.record(z.string(), valueType),"),
             "Got: {zod}"
         );
         assert!(
-            zod.contains("tuple: z.tuple([z.unknown(), z.unknown()])"),
+            zod.contains("tuple: z.tuple([keyType, valueType]),"),
             "Got: {zod}"
         );
-        assert!(!zod.contains("KeyType"), "Got: {zod}");
-        assert!(!zod.contains("ValueType"), "Got: {zod}");
     }
 
-    /// The annotation states the type of the value beside it, and that value was composed with
-    /// every parameter opaque — so the name it is written under is filled in the same way.
-    #[cfg(feature = "typescript")]
     #[test]
-    fn the_exported_binding_is_annotated_with_the_erased_arguments() {
-        use super::{Holder, Positional};
-
-        for (expected, zod) in [
-            (
-                "export const Wrapper$Schema: ZodType<Wrapper<unknown>> =",
-                Wrapper::<String>::zod_schema(),
-            ),
-            (
-                "export const Pair$Schema: ZodType<Pair<unknown, unknown>> =",
-                Pair::<String, u32>::zod_schema(),
-            ),
-            (
-                "export const Positional$Schema: ZodType<Positional<unknown>> =",
-                Positional::<String>::zod_schema(),
-            ),
-            (
-                "export const RenamedHolder$Schema: ZodType<RenamedHolder<unknown>> =",
-                Holder::<String>::zod_schema(),
-            ),
-        ] {
-            assert!(zod.contains(expected), "Got: {zod}");
-        }
+    fn a_generic_tuple_struct_publishes_a_factory_too() {
+        let zod = Positional::<String>::zod_schema();
+        assert!(
+            zod.contains("export const Positional$SchemaFactory = "),
+            "Got: {zod}"
+        );
+        assert!(zod.contains("z.tuple([idType, z.string()])"), "Got: {zod}");
     }
 
-    #[cfg(feature = "typescript")]
+    /// Which shape an enum's members are written in is what the tagging attributes decide, and only
+    /// `serde` reads those; that the parameter is bound by a factory is decided by the declaration,
+    /// so it is asked of every flavour in every build.
     #[test]
-    fn every_enum_flavour_annotates_its_binding_the_same_way() {
-        use super::{Adjacent, External, Internal, Untagged};
-
+    fn every_enum_flavour_publishes_a_factory() {
         for (flavour, zod) in [
             ("Adjacent", Adjacent::<String>::zod_schema()),
             ("Internal", Internal::<String>::zod_schema()),
@@ -203,14 +212,254 @@ mod zod {
             ("Untagged", Untagged::<String>::zod_schema()),
         ] {
             assert!(
-                zod.contains(&format!(
-                    "export const {flavour}$Schema: ZodType<{flavour}<unknown>> ="
-                )),
+                zod.contains(&format!("export const {flavour}$SchemaFactory = ")),
                 "Got: {zod}"
             );
-            assert!(zod.contains("z.unknown()"), "Got: {zod}");
-            assert!(!zod.contains("IdType"), "Got: {zod}");
+            assert!(zod.contains("idType"), "Got: {zod}");
+            assert!(!publishes_a_schema_const(&zod, flavour), "Got: {zod}");
         }
+    }
+
+    /// A const parameter and a lifetime name no type, so neither reaches a schema and there is
+    /// nothing for a factory to bind — the item publishes the one schema it has.
+    #[test]
+    fn an_item_binding_no_type_parameter_still_publishes_a_schema() {
+        for (name, zod) in [
+            ("PlainConst", PlainConst::<4>::zod_schema()),
+            ("LifetimeStruct", LifetimeStruct::zod_schema()),
+        ] {
+            assert!(publishes_a_schema_const(&zod, name), "Got: {zod}");
+            assert!(!zod.contains("$SchemaFactory"), "Got: {zod}");
+        }
+    }
+
+    /// Both names an item is published under carry the one binding it has, so a generic type's
+    /// re-export names the factory rather than a schema no module declares.
+    #[test]
+    fn the_ident_reexport_names_the_factory() {
+        let zod = Holder::<String>::zod_schema();
+        assert!(
+            zod.contains("export const Holder$SchemaFactory = RenamedHolder$SchemaFactory;"),
+            "Got: {zod}"
+        );
+        assert!(!publishes_a_schema_const(&zod, "Holder"), "Got: {zod}");
+    }
+
+    /// A base is read when the intersection is used rather than while the value holding it is
+    /// built, which is what leaves declaration order irrelevant. The arguments are in scope for the
+    /// whole of the builder, so the deferral composes inside the factory unchanged.
+    #[cfg(feature = "serde")]
+    #[test]
+    fn a_generic_type_that_flattens_still_defers_its_base() {
+        let zod = Carried::<String>::zod_schema();
+        assert!(
+            zod.contains("export const Carried$SchemaFactory = "),
+            "Got: {zod}"
+        );
+        assert!(zod.contains("id: idType,"), "Got: {zod}");
+        assert!(
+            zod.contains(".and(z.lazy(() => Envelope$Schema))"),
+            "Got: {zod}"
+        );
+    }
+
+    /// Two calls with the same arguments reach the one schema: the miss path returns the very
+    /// value it stored, and the hit path returns what was stored.
+    #[test]
+    fn a_factory_returns_what_it_stored_rather_than_building_again() {
+        let zod = Wrapper::<String>::zod_schema();
+        assert!(
+            zod.contains(
+                "  const hit = Wrapper$SchemaFactoryCache.get(idType);\n  if (hit) return \
+                 hit;\n\n  const schema = buildWrapper$Schema(idType);\n  \
+                 Wrapper$SchemaFactoryCache.set(idType, schema);\n  return schema;\n};"
+            ),
+            "Got: {zod}"
+        );
+    }
+
+    /// Every argument keys a level of its own, so no two argument lists meet in one slot: a change
+    /// in the first re-keys the outermost map, and a change in the last re-keys the one the schema
+    /// is stored in.
+    #[test]
+    fn every_argument_keys_a_level_of_its_own() {
+        let zod = Quintet::<u32, u32, u32, u32, u32>::zod_schema();
+        for lookup in [
+            "  let byBType = Quintet$SchemaFactoryCache.get(aType);",
+            "  let byCType = byBType.get(bType);",
+            "  let byDType = byCType.get(cType);",
+            "  let byEType = byDType.get(dType);",
+            "  const hit = byEType.get(eType);",
+            "  const schema = buildQuintet$Schema(aType, bType, cType, dType, eType);",
+            "  byEType.set(eType, schema);",
+        ] {
+            assert!(zod.contains(lookup), "Missing {lookup:?} in: {zod}");
+        }
+    }
+
+    /// The builder holds the expression the arguments compose into and the factory's return type is
+    /// read back off it, so the two cannot come to claim different shapes.
+    #[cfg(feature = "typescript")]
+    #[test]
+    fn the_factory_return_type_is_read_back_off_the_builder() {
+        let zod = Wrapper::<String>::zod_schema();
+        assert!(
+            zod.contains(
+                "const buildWrapper$Schema = <IdType extends ZodType>(\n  idType: IdType,\n) =>"
+            ),
+            "Got: {zod}"
+        );
+        assert!(
+            zod.contains(
+                "type Wrapper$SchemaOf<IdType extends ZodType> = ReturnType<\n  typeof \
+                 buildWrapper$Schema<IdType>\n>;"
+            ),
+            "Got: {zod}"
+        );
+        assert!(
+            zod.contains(
+                "export const Wrapper$SchemaFactory = <IdType extends ZodType>(\n  idType: \
+                 IdType,\n): Wrapper$SchemaOf<IdType> => {"
+            ),
+            "Got: {zod}"
+        );
+    }
+
+    /// Each parameter is a parameter of the function for real. A bare `ZodType` annotation compiles
+    /// and infers nothing — `ZodType` defaults its own parameters — so a field validated through
+    /// one would come back as the opaque value whatever the caller supplied.
+    #[cfg(feature = "typescript")]
+    #[test]
+    fn every_parameter_is_a_type_parameter_rather_than_a_bare_annotation() {
+        let zod = Pair::<String, u32>::zod_schema();
+        assert!(
+            zod.contains("<KeyType extends ZodType, ValueType extends ZodType>"),
+            "Got: {zod}"
+        );
+        assert!(
+            zod.contains("\n  keyType: KeyType,\n  valueType: ValueType,\n)"),
+            "Got: {zod}"
+        );
+        assert!(!zod.contains("keyType: ZodType"), "Got: {zod}");
+        assert!(!zod.contains("valueType: ZodType"), "Got: {zod}");
+    }
+
+    /// One parameter collapses to a single interface and a single lookup.
+    #[cfg(feature = "typescript")]
+    #[test]
+    fn one_parameter_writes_one_cache_interface() {
+        let zod = Wrapper::<String>::zod_schema();
+        assert!(
+            zod.contains(
+                "interface Wrapper$SchemaFactoryCache {\n  get<IdType extends ZodType>(key: \
+                 IdType): Wrapper$SchemaOf<IdType> | undefined;\n  set<IdType extends \
+                 ZodType>(key: IdType, value: Wrapper$SchemaOf<IdType>): this;\n}"
+            ),
+            "Got: {zod}"
+        );
+        assert!(
+            zod.contains(
+                "const Wrapper$SchemaFactoryCache = createSchemaCache<Wrapper$SchemaFactoryCache>();"
+            ),
+            "Got: {zod}"
+        );
+        assert!(!zod.contains("Wrapper$SchemaFactoryCacheL1"), "Got: {zod}");
+    }
+
+    /// One level per parameter, each carrying the parameters resolved above it — which is what lets
+    /// a lookup come back already typed and keeps the factory body free of assertions.
+    #[cfg(feature = "typescript")]
+    #[test]
+    fn each_cache_level_carries_the_parameters_resolved_above_it() {
+        let zod = Quintet::<u32, u32, u32, u32, u32>::zod_schema();
+        for level in [
+            "interface Quintet$SchemaFactoryCacheL1<AType extends ZodType> {\n  get<BType extends \
+             ZodType>(key: BType): Quintet$SchemaFactoryCacheL2<AType, BType> | undefined;",
+            "interface Quintet$SchemaFactoryCacheL4<AType extends ZodType, BType extends ZodType, \
+             CType extends ZodType, DType extends ZodType> {\n  get<EType extends ZodType>(key: \
+             EType): Quintet$SchemaOf<AType, BType, CType, DType, EType> | undefined;",
+            "interface Quintet$SchemaFactoryCache {\n  get<AType extends ZodType>(key: AType): \
+             Quintet$SchemaFactoryCacheL1<AType> | undefined;",
+            "    byCType = createSchemaCache<Quintet$SchemaFactoryCacheL2<AType, BType>>();",
+        ] {
+            assert!(zod.contains(level), "Missing {level:?} in: {zod}");
+        }
+        assert!(!zod.contains("Quintet$SchemaFactoryCacheL5"), "Got: {zod}");
+    }
+
+    /// The one assertion the output carries lives in the shared preamble, so nothing a type
+    /// publishes for itself needs `as`, `any`, or `unknown` to say what it validates.
+    #[test]
+    fn a_generic_type_publishes_no_assertion_and_no_opaque_value() {
+        for zod in [
+            Wrapper::<String>::zod_schema(),
+            Pair::<String, u32>::zod_schema(),
+            Positional::<String>::zod_schema(),
+            Quintet::<u32, u32, u32, u32, u32>::zod_schema(),
+            Carried::<String>::zod_schema(),
+            Adjacent::<String>::zod_schema(),
+        ] {
+            assert!(!zod.contains(" as "), "Got: {zod}");
+            assert!(!zod.contains("any"), "Got: {zod}");
+            assert!(!zod.contains("unknown"), "Got: {zod}");
+        }
+    }
+
+    /// A build with no `typescript` writes plain JavaScript: the same function and the same cache,
+    /// with nothing to declare either to.
+    #[cfg(not(feature = "typescript"))]
+    #[test]
+    fn a_javascript_build_writes_the_factory_untyped() {
+        let zod = Wrapper::<String>::zod_schema();
+        assert!(
+            zod.contains("const buildWrapper$Schema = (\n  idType,\n) =>"),
+            "Got: {zod}"
+        );
+        assert!(
+            zod.contains("const Wrapper$SchemaFactoryCache = createSchemaCache();"),
+            "Got: {zod}"
+        );
+        assert!(
+            zod.contains("export const Wrapper$SchemaFactory = (\n  idType,\n) => {"),
+            "Got: {zod}"
+        );
+        assert!(!zod.contains("interface "), "Got: {zod}");
+        assert!(!zod.contains("ZodType"), "Got: {zod}");
+    }
+
+    /// The two surfaces that publish a `const` rather than a factory have no argument for a
+    /// parameter inside them to name, so both still write the opaque value there.
+    #[test]
+    fn a_surface_publishing_no_factory_keeps_the_opaque_value() {
+        let alias = super::boxed_schema::Schema::zod_schema();
+        assert!(alias.contains("z.array(z.unknown())"), "Got: {alias}");
+        assert!(!alias.contains("$SchemaFactory"), "Got: {alias}");
+
+        let brand = Tagged::<String>::zod_schema();
+        assert!(
+            brand.contains("z.unknown().brand<\"Tagged\">()"),
+            "Got: {brand}"
+        );
+        assert!(!brand.contains("$SchemaFactory"), "Got: {brand}");
+    }
+
+    /// The one helper every factory builds its cache with, and the only assertion in the output.
+    #[cfg(feature = "typescript")]
+    #[test]
+    fn the_preamble_carries_the_shared_cache_helper() {
+        assert_eq!(
+            tixschema::typescript_preamble!(),
+            "const createSchemaCache = <Cache extends object>(): Cache => new WeakMap() as unknown as Cache;"
+        );
+    }
+
+    #[cfg(not(feature = "typescript"))]
+    #[test]
+    fn the_preamble_carries_the_shared_cache_helper() {
+        assert_eq!(
+            tixschema::typescript_preamble!(),
+            "const createSchemaCache = () => new WeakMap();"
+        );
     }
 }
 
@@ -347,6 +596,45 @@ pub struct LifetimeStruct<'label> {
     pub label: Cow<'label, str>,
 }
 
+/// Enough parameters that every level of the lookup is a level with two neighbours: the first
+/// argument keys the outermost map, the last keys the one the schema is stored in, and the three
+/// between are only reached through the two.
+#[model_schema()]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Quintet<AType, BType, CType, DType, EType> {
+    pub alpha: AType,
+    pub bravo: BType,
+    pub charlie: CType,
+    pub delta: DType,
+    pub echo: EType,
+}
+
+#[model_schema()]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Envelope {
+    pub trace: String,
+}
+
+/// A generic alias, and a generic branded newtype: the two surfaces that publish a `const` rather
+/// than a factory, and so the two a parameter inside still reaches as the opaque value.
+#[model_schema(name = "Boxed")]
+pub type Boxed<ValueType> = Vec<ValueType>;
+
+#[model_schema()]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Tagged<ValueType>(pub ValueType);
+
+/// A generic type that also flattens, which is the one shape where the parameters and the deferred
+/// read of another type's binding have to hold at once.
+#[model_schema()]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Carried<IdType> {
+    #[serde(flatten)]
+    pub envelope: Envelope,
+    pub id: IdType,
+}
+
 /// The pair the attribute used to produce on any generic item: `E0107` on the emitted `impl`,
 /// which dropped the parameters the declaration binds, and `E0433` on a module named after a
 /// parameter, which names no type and so publishes none. Both are compile errors, so the suite
@@ -378,6 +666,40 @@ fn a_generic_item_expands_to_rust_that_compiles() {
     assert_eq!(positional.0, "id");
     assert_eq!(positional.1, "name");
 
+    assert_eq!(Holder { id: 1_u32 }.id, 1);
+    assert_eq!(LifetimeStruct { label: "x".into() }.label, "x");
+
+    let carried = Carried {
+        envelope: Envelope {
+            trace: "t".to_owned(),
+        },
+        id: "i".to_owned(),
+    };
+    assert_eq!(carried.envelope.trace, "t");
+    assert_eq!(carried.id, "i");
+
+    let boxed: Boxed<u32> = vec![1_u32];
+    assert_eq!(boxed.len(), 1);
+    assert_eq!(Tagged("t".to_owned()).0, "t");
+
+    let quintet = Quintet {
+        alpha: 1_u32,
+        bravo: "b".to_owned(),
+        charlie: 3_u32,
+        delta: "d".to_owned(),
+        echo: 5_u32,
+    };
+    assert_eq!(quintet.alpha, 1);
+    assert_eq!(quintet.bravo, "b");
+    assert_eq!(quintet.charlie, 3);
+    assert_eq!(quintet.delta, "d");
+    assert_eq!(quintet.echo, 5);
+}
+
+/// The enum half of the same question, in every shape the tagging attributes reach — plus the one
+/// a plain enum can bind, which is a const rather than a type.
+#[test]
+fn a_generic_enum_expands_to_rust_that_compiles() {
     assert!(matches!(Adjacent::<String>::Nothing, Adjacent::Nothing));
     assert!(matches!(Internal::<String>::Nothing, Internal::Nothing));
     assert!(matches!(External::<String>::Nothing, External::Nothing));
@@ -386,8 +708,6 @@ fn a_generic_item_expands_to_rust_that_compiles() {
         Untagged::Numbered { .. }
     ));
     assert!(matches!(PlainConst::<4>::Wide, PlainConst::Wide));
-    assert_eq!(Holder { id: 1_u32 }.id, 1);
-    assert_eq!(LifetimeStruct { label: "x".into() }.label, "x");
 }
 
 /// A lifetime is the half of the `impl` fix no schema surface can show: nothing renders it, and


### PR DESCRIPTION
A Zod schema is a runtime value and a `const` cannot be parameterised, so a generic item now publishes `X$SchemaFactory` — an arrow function taking one required, `ZodType`-bounded argument per declared parameter, memoized one cache level per parameter (same arguments → the identical schema object, verified at runtime under node at arity 2 and 5). Non-generic items keep `X$Schema` byte-identically; the plain-enum emitter is pinned to `$Schema` since Rust refuses an unused type parameter. A field typed with a parameter renders the factory argument in the builder; flattened bases keep their deferred `z.lazy` operands inside it. No `as`/`any`/`unknown` in per-type code, asserted across six fixtures.

Two recorded deviations from the task's original anchors: phase 1's landed `z.unknown()` rendering replaces the never-landed `compile_error!` arm, and `typescript_preamble` ships as a function-like macro because a proc-macro crate cannot export plain functions (rustc's own refusal captured). Generic aliases and brands still publish consts with opaque parameters — brands become factories in their own task.