### PR TITLE
let the guards see a type parameter, refusing bounds that reach nothing and opening the map its key already writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,8 @@ All of them are covered under [Compilation Errors](#compilation-errors), with th
 
 Every other key is neither open nor enumerable, and none of them is refused: serde stringifies each one into a key for you. The JSON schema describes such a map as an object and says nothing about its members — `{"type": "object", "additionalProperties": true}` — while TypeScript and Zod keep the key's own type, so a `HashMap<u32, String>` is `Partial<Record<number, string>>` and `z.record(z.number().int(), z.string())`. serde writes the object with the key's string form for its keys: `7` becomes `"7"`, `true` becomes `"true"`, a chrono `NaiveDate` its ISO rendering. A brand over one of those writes the same object and describes as the same one, under the brand's name. Only the narrowing is missing, not the object. The rule the refusals apply is refuse-what-serde-refuses, never refuse-what-is-not-a-`String`.
 
+A key written as one of the enclosing item's own type parameters is the open case, read off that same rule. The expansion cannot see which type the instantiation will supply, but serde has already settled what any of them may write: an instantiation whose key writes as a string keys the map, and one whose key does not fails the whole map at serialization with `key must be a string` — so string keys hold for every instantiation that serializes at all. The two validating surfaces say exactly that and nothing more, `{"type": "object", "additionalProperties": V}` and `z.record(z.string(), V)`, the pair a `String` key earns; the value side stays described, being no parameter's business. TypeScript keeps the parameter in the key position the way it keeps a parameter anywhere — see [Type Parameters](#type-parameters).
+
 ### Pointers and Borrowed Values
 
 `Box<T>`, `Rc<T>`, `Arc<T>` and `Cow<'_, T>` describe as `T`. serde writes each of them as the value it holds, with nothing of its own around it, so a field written under one is the field its inner type is — on every surface, and wherever the wrapper was written: `Box<Option<T>>` is the `Option<T>` field, optional; `Vec<Rc<T>>` is the `Vec<T>` field; `Box<str>`, `Rc<str>` and `Cow<'_, str>` are `String` fields, `str` being what a `String` writes.
@@ -782,7 +784,17 @@ export const WrapperType$Schema: ZodType<WrapperType<unknown>> = WrapperType$Raw
 
 Only the item's *own* parameters erase. A name the expansion cannot resolve because the type lives elsewhere keeps its `Name$Schema` reference, since that type publishes the binding.
 
-One consequence is worth stating outright: an opaque value carries no string checks, so a branded newtype cannot apply `pattern`, `minLength`, or `maxLength` to one of its own type parameters. See [Branded Newtype Validation Constraints](#branded-newtype-validation-constraints).
+One consequence is worth stating outright: an opaque value carries no checks, so no `model_schema_prop` bound may be spelled against a type parameter. A branded newtype cannot apply `pattern`, `minLength`, or `maxLength` to one of its own — see [Branded Newtype Validation Constraints](#branded-newtype-validation-constraints) — and a *field* typed with one is refused for the same reason, at every depth the parameter is reached through:
+
+```rust
+#[model_schema()]
+pub struct Constrained<IdType> {
+    #[model_schema_prop(minLength = 3)] // refused, and so is it on `Option<IdType>` or `Vec<IdType>`
+    pub id: IdType,
+}
+```
+
+The value's type is whatever the instantiation supplies, so nothing here holds it to anything: Zod and the JSON schema describe the value as the opaque one, the generated validator emits no check for it, and serde reads the payload back untouched. Constrain the argument instead — declare the type the instantiation supplies as a branded newtype carrying the bound — or drop the key. The JSDoc says nothing about a bound the refusal turns away either, the sentence being written only where something holds the value to it.
 
 ### Branded Newtypes
 

--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -290,8 +290,10 @@ impl FieldDef {
     /// Whether a length, a pattern or a range written on this field reaches no surface at all —
     /// the one question both the refusal and the docs are written from, so neither can come to
     /// answer it differently from the other.
-    pub const fn constraints_reach_nothing(&self) -> bool {
-        self.fixed_shape_name().is_some() || self.composite_shape_name().is_some()
+    pub fn constraints_reach_nothing(&self) -> bool {
+        self.fixed_shape_name().is_some()
+            || self.composite_shape_name().is_some()
+            || self.parameter_shape_name().is_some()
     }
 
     #[cfg(feature = "zod")]
@@ -564,6 +566,51 @@ impl FieldDef {
             }
             FieldDefType::Tuple(elements) => elements.iter().find_map(Self::os_string_name),
             FieldDefType::TypeParam(_)
+            | FieldDefType::Unknown
+            | FieldDefType::StringLiteral(_)
+            | FieldDefType::Boolean
+            | FieldDefType::String
+            | FieldDefType::U8
+            | FieldDefType::U16
+            | FieldDefType::U32
+            | FieldDefType::U64
+            | FieldDefType::I8
+            | FieldDefType::I16
+            | FieldDefType::I32
+            | FieldDefType::I64
+            | FieldDefType::Usize
+            | FieldDefType::Isize
+            | FieldDefType::F32
+            | FieldDefType::F64 => None,
+            #[cfg(feature = "object_id")]
+            FieldDefType::ObjectId => None,
+            #[cfg(feature = "chrono")]
+            FieldDefType::NaiveDate
+            | FieldDefType::NaiveTime
+            | FieldDefType::NaiveDateTime
+            | FieldDefType::DateTime => None,
+        }
+    }
+
+    /// The enclosing item's own type parameter this field renders as, when a bound spelled against
+    /// it names a value whose type the expansion never sees.
+    ///
+    /// A parameter names no type at expansion — the instantiation names one, and one schema is
+    /// written for every instantiation. So the two validating surfaces describe the value as the
+    /// opaque one, which takes no length, no pattern and no range, while the generated validator
+    /// and serde read whatever type the instantiation supplied and hold it to nothing written here.
+    /// A bound therefore reaches nothing on any surface, exactly as one written beside a map's
+    /// members does; the caller turns that into a guard error naming the parameter.
+    ///
+    /// Only a field already read through [`Self::erase_type_parameters`] answers here: which of
+    /// the two a written name is — the item's own parameter or a reference to another type — is
+    /// that rewrite's question, and asking it twice is how the two answers come to differ.
+    pub fn parameter_shape_name(&self) -> Option<&str> {
+        match &self.field_type {
+            FieldDefType::TypeParam(name) => Some(name),
+            FieldDefType::SiblingType(_, _)
+            | FieldDefType::Map(_, _)
+            | FieldDefType::Tuple(_)
             | FieldDefType::Unknown
             | FieldDefType::StringLiteral(_)
             | FieldDefType::Boolean
@@ -875,7 +922,7 @@ impl FieldDef {
                 }
             }
             FieldDefType::Map(k, v) => {
-                format!("z.record({}, {})", k.zod_type(), v.zod_slot_type())
+                format!("z.record({}, {})", k.zod_map_key_type(), v.zod_slot_type())
             }
             FieldDefType::Boolean => "z.boolean()".to_owned(),
             FieldDefType::String => self.zod_string_type(),
@@ -940,6 +987,27 @@ impl FieldDef {
         } else {
             array_result
         }
+    }
+
+    /// The key schema a `z.record(…)` is written with: the key's own, except where the key is one
+    /// of the enclosing item's type parameters.
+    ///
+    /// A record key has to produce string keys, and the opaque value a parameter describes as
+    /// everywhere else declines to say anything at all about them — the one position where saying
+    /// nothing says less than the wire already guarantees. serde is what guarantees it: an
+    /// instantiation either writes this map's object keys as strings or refuses the whole map at
+    /// serialization with `key must be a string`, with no fallback form, so `z.string()` holds for
+    /// every instantiation that serializes at all. It is also the answer the JSON surface reads off
+    /// the same key through its own classification, which is what keeps the two saying one thing.
+    ///
+    /// Only a bare key reaches the parameter arm: a key written under a sequence or an `Option`
+    /// wrapper is refused before any surface renders the map.
+    #[cfg(feature = "zod")]
+    fn zod_map_key_type(&self) -> String {
+        if self.parameter_shape_name().is_some() {
+            return "z.string()".to_owned();
+        }
+        self.zod_type()
     }
 
     /// The same value on the Zod surface, for the same reason: what a merged source validates, with

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -5557,6 +5557,21 @@ fn member_rejection_value(
     quote! { compile_error!(#message) }
 }
 
+/// One untagged member's field def in the two readings the guards need: as the surfaces will
+/// render it, every reference to one of the enclosing item's own parameters already the opaque
+/// value, and as the author spelled it. [`process_field`] reads the same pair off the same erase.
+#[cfg(feature = "serde")]
+fn untagged_member_field_defs(
+    field: &Field,
+    field_name: &str,
+    type_parameters: &[String],
+) -> (FieldDef, FieldDef) {
+    let written = get_field_def(field_name, &field.ty, "");
+    let mut rendered = written.clone();
+    rendered.erase_type_parameters(type_parameters);
+    (rendered, written)
+}
+
 /// The guard verdicts one untagged member earns, serde's and this crate's own combined — the
 /// checks [`process_field`] runs through its own channels, asked here by the walk that builds its
 /// field defs directly.
@@ -5564,6 +5579,7 @@ fn member_rejection_value(
 fn untagged_member_guard_errors(
     field: &Field,
     field_def: &FieldDef,
+    written_def: &FieldDef,
     field_name: &str,
     prop_meta: &ModelSchemaPropMeta,
     serde_field_meta: &SerdeFieldMeta,
@@ -5576,7 +5592,14 @@ fn untagged_member_guard_errors(
         serde_field_meta,
         positional_constraint_error,
     );
-    collect_field_guard_errors(field, field_def, field_name, prop_meta, serde_guard_errors)
+    collect_field_guard_errors(
+        field,
+        field_def,
+        written_def,
+        field_name,
+        prop_meta,
+        serde_guard_errors,
+    )
 }
 
 /// Collects each untagged variant's union-member parts: the TypeScript member type, the Zod member
@@ -5660,10 +5683,12 @@ fn collect_untagged_members(
                 checks.push(body);
             }
 
-            let mut field_def = get_field_def(&field_name, &field.ty, "");
+            let (mut field_def, written_def) =
+                untagged_member_field_defs(field, &field_name, &type_parameters);
             guard_errors.extend(untagged_member_guard_errors(
                 field,
                 &field_def,
+                &written_def,
                 &field_name,
                 &prop_meta,
                 &serde_field_meta,
@@ -5672,8 +5697,6 @@ fn collect_untagged_members(
 
             field_def.resolve_self_references(&enum_type_name);
             apply_model_schema_prop_meta(&mut field_def, prop_meta, &field_name);
-            // Applied where `process_field` applies it: after every guard has read the field.
-            field_def.erase_type_parameters(&type_parameters);
             field_defs.push(field_def);
         }
 
@@ -6727,7 +6750,11 @@ fn map_key_path(key: &FieldDef) -> MapKeyPath<'_> {
         return MapKeyPath::Refused(MapKeyRejection::Optional(map_key_element_name(key)));
     }
     match &key.field_type {
-        FieldDefType::String => MapKeyPath::Open,
+        // A parameter names no type here, so nothing about the key can be enumerated or narrowed —
+        // but serde has already said the one thing an object key needs: every instantiation this
+        // map has either writes its keys as strings or refuses the whole map at serialization, so
+        // the open member set is true of every instantiation that serializes at all.
+        FieldDefType::String | FieldDefType::TypeParam(_) => MapKeyPath::Open,
         FieldDefType::SiblingType(key_type_name, args) if args.is_empty() => {
             match registered_key_kind(key_type_name) {
                 Some(AliasKind::StringWire) => MapKeyPath::Open,
@@ -6740,7 +6767,6 @@ fn map_key_path(key: &FieldDef) -> MapKeyPath<'_> {
         #[cfg(feature = "object_id")]
         FieldDefType::ObjectId => MapKeyPath::Refused(unwritable_key(key, WRITTEN_AS_OBJECT)),
         FieldDefType::SiblingType(..)
-        | FieldDefType::TypeParam(_)
         | FieldDefType::Unknown
         | FieldDefType::Boolean
         | FieldDefType::StringLiteral(_)
@@ -8346,15 +8372,22 @@ fn field_guard_errors(
         .collect()
 }
 
-/// Every guard error the field violates: the two the written type earns — the `OsString` guard and
-/// the map-key guard, neither of which any attribute can hide — then everything the
+/// Every guard error the field violates: the two the type earns — the `OsString` guard and the
+/// map-key guard, neither of which any attribute can hide — then everything the
 /// `model_schema_prop` attribute earned, then the serde-side guards when any fired.
+///
+/// `field_def` is the field as the surfaces will render it, every reference to one of the enclosing
+/// item's own parameters already the opaque value: a guard and the renderer standing behind it read
+/// one def, so neither can answer for a parameter the other has not. `written_def` is the same
+/// field as the author spelled it, which only [`check_as_type_override`] reads — `as` names a type,
+/// and a parameter is one of the names it may name.
 ///
 /// The map-key guard stands under every subset that emits a schema at all, which is the same set
 /// the registry it reads is populated under.
 fn collect_field_guard_errors(
     field: &Field,
     field_def: &FieldDef,
+    written_def: &FieldDef,
     raw_field_ident: &str,
     prop_meta: &ModelSchemaPropMeta,
     serde_guard_errors: Vec<proc_macro2::TokenStream>,
@@ -8374,7 +8407,11 @@ fn collect_field_guard_errors(
         .into_iter()
         .chain(map_key_error)
         .chain(model_schema_prop_guard_errors(
-            field, field_def, &label, prop_meta,
+            field,
+            field_def,
+            written_def,
+            &label,
+            prop_meta,
         ))
         .chain(serde_guard_errors)
         .collect()
@@ -8391,12 +8428,13 @@ fn collect_field_guard_errors(
 fn model_schema_prop_guard_errors(
     field: &Field,
     field_def: &FieldDef,
+    written_def: &FieldDef,
     label: &str,
     prop_meta: &ModelSchemaPropMeta,
 ) -> Vec<proc_macro2::TokenStream> {
     let refusals = [
         check_fixed_shape_constraints(field, field_def, prop_meta, label).err(),
-        check_as_type_override(field, field_def, prop_meta, label).err(),
+        check_as_type_override(field, written_def, prop_meta, label).err(),
         check_as_preprocess_conflict(field, prop_meta, label).err(),
         flag_guard_error(
             field,
@@ -8459,12 +8497,13 @@ fn written_constraint_keys(prop_meta: &ModelSchemaPropMeta) -> Vec<&'static str>
 
 /// Rejects a length, pattern or range written on a field no surface reads one beside.
 ///
-/// Two shapes earn it. The types [`FieldDef::fixed_shape_name`] answers for render a shape fixed in
-/// this crate rather than the plain string or number a bound is spelled against; the ones
+/// Three shapes earn it. The types [`FieldDef::fixed_shape_name`] answers for render a shape fixed
+/// in this crate rather than the plain string or number a bound is spelled against; the ones
 /// [`FieldDef::composite_shape_name`] answers for render their members, which are built from inner
-/// field defs that carry no meta. Either way every surface writes the field without ever reading the
-/// bound — so it is accepted at expansion and reaches nothing, which leaves the author holding a
-/// contract that says the value is checked when nothing checks it.
+/// field defs that carry no meta; and the one [`FieldDef::parameter_shape_name`] answers for
+/// renders a value whose type no instantiation has yet supplied. Every one of them writes the field
+/// without ever reading the bound — so it is accepted at expansion and reaches nothing, which
+/// leaves the author holding a contract that says the value is checked when nothing checks it.
 fn check_fixed_shape_constraints(
     field: &Field,
     field_def: &FieldDef,
@@ -8488,17 +8527,31 @@ fn check_fixed_shape_constraints(
             ),
         ));
     }
-    let Some(shape) = field_def.composite_shape_name() else {
+    if let Some(shape) = field_def.composite_shape_name() {
+        return Err(syn::Error::new_spanned(
+            field,
+            format!(
+                "model_schema: {label}: `{keys}` cannot apply to {shape} — a map renders its keys \
+                 and its values, a tuple renders each of its elements, and every surface builds \
+                 those from the members: the bound names no value here, and `model_schema_prop` \
+                 has no way to say which member it meant, so the constraint would reach neither \
+                 Zod, nor the JSON schema, nor the generated validator. Constrain the member \
+                 instead — declare its type as a branded newtype carrying the bound — or drop it."
+            ),
+        ));
+    }
+    let Some(parameter) = field_def.parameter_shape_name() else {
         return Ok(());
     };
     Err(syn::Error::new_spanned(
         field,
         format!(
-            "model_schema: {label}: `{keys}` cannot apply to {shape} — a map renders its keys and \
-             its values, a tuple renders each of its elements, and every surface builds those from \
-             the members: the bound names no value here, and `model_schema_prop` has no way to say \
-             which member it meant, so the constraint would reach neither Zod, nor the JSON schema, \
-             nor the generated validator. Constrain the member instead — declare its type as a \
+            "model_schema: {label}: `{keys}` cannot apply to the type parameter `{parameter}` — \
+             the value's type is whatever the instantiation supplies, and one schema is written \
+             for every instantiation: Zod and the JSON schema describe the value as the opaque one \
+             a bound cannot be spelled against, and neither the generated validator nor serde \
+             holds it to anything written here, so the constraint would reach none of them. \
+             Constrain the argument instead — declare the type the instantiation supplies as a \
              branded newtype carrying the bound — or drop it."
         ),
     ))
@@ -8675,6 +8728,16 @@ fn process_field(
     // read the field so each one asks its question of the type the surfaces will render.
     field_def.resolve_self_references(type_name);
 
+    // The field as the author spelled it, kept for the one guard that reads a written *name*: an
+    // `as = Type` may name one of the item's own parameters, and the target it is compared against
+    // is built from the written type too.
+    let written_def = field_def.clone();
+
+    // Every other guard, and the constraint docs below, ask what the surfaces will render — where
+    // one of the item's own parameters is the opaque value rather than a reference to a type of
+    // that name. Erased here so a guard and the renderer standing behind it read one def.
+    field_def.erase_type_parameters(type_parameters);
+
     #[cfg(feature = "serde")]
     let serde_guard_errors = field_guard_errors(
         field,
@@ -8689,16 +8752,13 @@ fn process_field(
     let guard_errors = collect_field_guard_errors(
         field,
         &field_def,
+        &written_def,
         &raw_field_ident,
         &model_schema_prop_meta,
         serde_guard_errors,
     );
 
     apply_model_schema_prop_meta(&mut field_def, model_schema_prop_meta, &final_name);
-
-    // Last, so every guard above asked its question of the type the author wrote, and so an
-    // `as = Type` override is read for a parameter too.
-    field_def.erase_type_parameters(type_parameters);
 
     (field_def, validation_fn, validate_body, guard_errors)
 }

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -1736,19 +1736,29 @@ fn a_container_short_of_its_wire_arity_still_falls_through_as_a_sibling() {
 /// Runs the field walk the way [`super::process_field`] does and renders the guard failures its
 /// `model_schema_prop` attributes earn, so a refused key and an unparseable `pattern` are read off
 /// the same channel that carries them to the emitted item.
-fn field_prop_guard_errors(item: &syn::ItemStruct) -> Vec<String> {
+///
+/// `parameters` names what the enclosing item declares, which is what decides whether a name the
+/// field is written with is a reference to another type or one of the item's own parameters — the
+/// same list [`super::process_field`] hands the walk.
+fn field_prop_guard_errors_in_scope(item: &syn::ItemStruct, parameters: &[String]) -> Vec<String> {
     let field = item.fields.iter().next().unwrap();
     let name = field
         .ident
         .as_ref()
         .map(ToString::to_string)
         .unwrap_or_default();
-    let field_def = get_field_def(&name, &field.ty, "");
+    let written = get_field_def(&name, &field.ty, "");
+    let mut rendered = written.clone();
+    rendered.erase_type_parameters(parameters);
     let meta = super::parse_model_schema_prop_attributes(&field.attrs);
-    super::collect_field_guard_errors(field, &field_def, &name, &meta, Vec::new())
+    super::collect_field_guard_errors(field, &rendered, &written, &name, &meta, Vec::new())
         .iter()
         .map(ToString::to_string)
         .collect()
+}
+
+fn field_prop_guard_errors(item: &syn::ItemStruct) -> Vec<String> {
+    field_prop_guard_errors_in_scope(item, &[])
 }
 
 /// The guard's verdict is the `regex` crate's verdict: the parse the generated validator's
@@ -2087,8 +2097,91 @@ fn a_map_or_tuple_field_without_a_bound_is_left_alone() {
     }
 }
 
-/// The docs a field's meta earns, read off the walk that writes them.
-fn field_docs_after_meta(item: &syn::ItemStruct) -> String {
+/// A parameter names no type until the item is instantiated, so a bound written on a field typed
+/// with one is held by nothing at all: the two validating surfaces describe the value as opaque,
+/// which takes no length, no pattern and no range, and the generated validator and serde read
+/// whatever type the instantiation supplied. That is the map's and the tuple's loss under another
+/// spelling, and it is refused where it is written for the same reason — at every depth the
+/// parameter can be reached through, the wrappers collapsing onto the value a bound would measure.
+#[test]
+fn a_bound_on_a_parameter_typed_field_is_refused() {
+    for (constraint, key) in [
+        (quote::quote! { minLength = 30 }, "minLength"),
+        (quote::quote! { maxLength = 30 }, "maxLength"),
+        (quote::quote! { pattern = "^[a-z]+$" }, "pattern"),
+        (quote::quote! { minimum = 5 }, "minimum"),
+        (quote::quote! { maximum = 5 }, "maximum"),
+    ] {
+        for field_type in [
+            quote::quote! { IdType },
+            quote::quote! { Option<IdType> },
+            quote::quote! { Vec<IdType> },
+            quote::quote! { Option<Vec<IdType>> },
+        ] {
+            let errors = field_prop_guard_errors_in_scope(
+                &syn::parse_quote! {
+                    struct Report {
+                        #[model_schema_prop(#constraint)]
+                        labels: #field_type,
+                    }
+                },
+                &["IdType".to_owned()],
+            );
+            assert_eq!(errors.len(), 1, "for {key} on {field_type}: {errors:?}");
+            for needle in [
+                "compile_error",
+                "field `labels`",
+                key,
+                "type parameter",
+                "IdType",
+                "brand",
+            ] {
+                assert!(
+                    errors[0].contains(needle),
+                    "{needle} missing for {key} on {field_type}: {}",
+                    errors[0]
+                );
+            }
+        }
+    }
+}
+
+/// The refusal turns on the bound and on the name being the item's own, so a parameter-typed field
+/// carrying none clears it — and so does the same bound on a concrete field standing beside the
+/// parameter, which every surface still reads it for. A name the item does not declare is a
+/// reference to another type and keeps whatever that type's own rendering earns.
+#[test]
+fn a_parameter_in_scope_only_refuses_the_field_that_carries_a_bound() {
+    for (field, parameters) in [
+        (quote::quote! { labels: IdType }, &["IdType".to_owned()][..]),
+        (
+            quote::quote! { #[model_schema_prop(preprocess = ["trim"])] labels: IdType },
+            &["IdType".to_owned()][..],
+        ),
+        (
+            quote::quote! { #[model_schema_prop(minLength = 30)] labels: String },
+            &["IdType".to_owned()][..],
+        ),
+        (
+            quote::quote! { #[model_schema_prop(minLength = 30)] labels: IdType },
+            &[][..],
+        ),
+    ] {
+        let errors = field_prop_guard_errors_in_scope(
+            &syn::parse_quote! {
+                struct Report {
+                    #field
+                }
+            },
+            parameters,
+        );
+        assert!(errors.is_empty(), "for {field}: {errors:?}");
+    }
+}
+
+/// The docs a field's meta earns, read off the walk that writes them, inside an item declaring
+/// `parameters`.
+fn field_docs_after_meta_in_scope(item: &syn::ItemStruct, parameters: &[String]) -> String {
     let field = item.fields.iter().next().unwrap();
     let name = field
         .ident
@@ -2096,9 +2189,14 @@ fn field_docs_after_meta(item: &syn::ItemStruct) -> String {
         .map(ToString::to_string)
         .unwrap_or_default();
     let mut field_def = get_field_def(&name, &field.ty, "");
+    field_def.erase_type_parameters(parameters);
     let meta = super::parse_model_schema_prop_attributes(&field.attrs);
     super::apply_model_schema_prop_meta(&mut field_def, meta, &name);
     field_def.docs
+}
+
+fn field_docs_after_meta(item: &syn::ItemStruct) -> String {
+    field_docs_after_meta_in_scope(item, &[])
 }
 
 /// The `JSDoc` states the bound as a rule the value is held to, so it is written only where
@@ -2127,6 +2225,43 @@ fn the_constraint_docs_are_written_only_where_the_bound_is_kept() {
         });
         assert!(docs.is_empty(), "for {field}, got: {docs}");
     }
+}
+
+/// The `JSDoc` was the one place a bound on a parameter-typed field appeared at all — every gate it
+/// named was silent — so the sentence goes where the refusal does, off the same question both are
+/// written from. A concrete field standing in the same generic item keeps its own.
+#[test]
+fn the_constraint_docs_are_silent_for_a_parameter_typed_field() {
+    let parameters = ["IdType".to_owned()];
+    for field in [
+        quote::quote! { #[model_schema_prop(minLength = 30)] id: IdType },
+        quote::quote! { #[model_schema_prop(maximum = 5)] id: Option<IdType> },
+        quote::quote! { #[model_schema_prop(minimum = 5)] id: Vec<IdType> },
+    ] {
+        let docs = field_docs_after_meta_in_scope(
+            &syn::parse_quote! {
+                struct Report {
+                    #field
+                }
+            },
+            &parameters,
+        );
+        assert!(docs.is_empty(), "for {field}, got: {docs}");
+    }
+
+    assert!(
+        field_docs_after_meta_in_scope(
+            &syn::parse_quote! {
+                struct Report {
+                    #[model_schema_prop(minLength = 30)]
+                    id: String,
+                }
+            },
+            &parameters,
+        )
+        .contains("Minimum length: 30"),
+        "a bound the surfaces render says so in the docs, parameters in scope or not"
+    );
 }
 
 /// `as` names the type the field already renders or it names nothing the expansion can honor: the

--- a/tests/generic_types_tests/tests.rs
+++ b/tests/generic_types_tests/tests.rs
@@ -183,8 +183,10 @@ mod zod {
             zod.contains("parameter_keyed: z.record(z.string(), z.string())"),
             "Got: {zod}"
         );
+        // The value parameter is the factory's own argument since the factories landing; only
+        // the KEY position is this rule's — it states the string keys serde writes.
         assert!(
-            zod.contains("both_parameters: z.record(z.string(), z.unknown())"),
+            zod.contains("both_parameters: z.record(z.string(), valueType)"),
             "Got: {zod}"
         );
         assert!(!zod.contains("z.record(z.unknown()"), "Got: {zod}");

--- a/tests/generic_types_tests/tests.rs
+++ b/tests/generic_types_tests/tests.rs
@@ -620,7 +620,12 @@ mod jsonschema {
 }
 
 use alloc::borrow::Cow;
-#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[cfg(any(
+    feature = "serde",
+    feature = "typescript",
+    feature = "zod",
+    feature = "jsonschema"
+))]
 use core::hash::Hash;
 use std::collections::HashMap;
 
@@ -698,8 +703,13 @@ pub struct Positional<IdType>(pub IdType, pub String);
 
 /// A map keyed by one of the item's own parameters, beside the concrete-keyed members the two
 /// validating surfaces must keep answering for exactly as before. Consumed only by the surface
-/// modules, so it exists only where one of them compiles.
-#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+/// modules and the serde wire tests, so it exists only where one of them compiles.
+#[cfg(any(
+    feature = "serde",
+    feature = "typescript",
+    feature = "zod",
+    feature = "jsonschema"
+))]
 #[model_schema()]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct KeyedByParameter<KeyType: Eq + Hash, ValueType> {

--- a/tests/generic_types_tests/tests.rs
+++ b/tests/generic_types_tests/tests.rs
@@ -620,6 +620,7 @@ mod jsonschema {
 }
 
 use alloc::borrow::Cow;
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 use core::hash::Hash;
 use std::collections::HashMap;
 
@@ -696,7 +697,9 @@ pub struct Holder<IdType> {
 pub struct Positional<IdType>(pub IdType, pub String);
 
 /// A map keyed by one of the item's own parameters, beside the concrete-keyed members the two
-/// validating surfaces must keep answering for exactly as before.
+/// validating surfaces must keep answering for exactly as before. Consumed only by the surface
+/// modules, so it exists only where one of them compiles.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[model_schema()]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct KeyedByParameter<KeyType: Eq + Hash, ValueType> {

--- a/tests/generic_types_tests/tests.rs
+++ b/tests/generic_types_tests/tests.rs
@@ -15,9 +15,36 @@
 #[cfg(feature = "typescript")]
 mod typescript {
     use super::{
-        Adjacent, External, Holder, Internal, LifetimeStruct, Pair, PlainConst, Positional,
-        Untagged, Wrapper,
+        Adjacent, External, Holder, Internal, KeyedByParameter, LifetimeStruct, Pair, PlainConst,
+        Positional, Untagged, Wrapper,
     };
+
+    /// TypeScript is a type surface and the declaration binds the parameter for real, so the key
+    /// stays the name the author wrote where the two validating surfaces erase it.
+    #[test]
+    fn a_parameter_keyed_map_keeps_the_parameter_on_the_type_surface() {
+        let ts = KeyedByParameter::<String, u32>::ts_definition();
+        assert!(
+            ts.contains("export type KeyedByParameter<KeyType, ValueType> = {"),
+            "Got: {ts}"
+        );
+        assert!(
+            ts.contains("  parameter_keyed: Partial<Record<KeyType, string>>;"),
+            "Got: {ts}"
+        );
+        assert!(
+            ts.contains("  both_parameters: Partial<Record<KeyType, ValueType>>;"),
+            "Got: {ts}"
+        );
+        assert!(
+            ts.contains("  concrete_string_key: Partial<Record<string, string>>;"),
+            "Got: {ts}"
+        );
+        assert!(
+            ts.contains("  stringified_number_key: Partial<Record<number, string>>;"),
+            "Got: {ts}"
+        );
+    }
 
     /// The declaration binds what the fields under it are written with, so a field typed with a
     /// parameter is that parameter and not a reference to a generated type of the same name.
@@ -133,7 +160,41 @@ mod typescript {
 
 #[cfg(feature = "zod")]
 mod zod {
-    use super::{Pair, Wrapper};
+    use super::{KeyedByParameter, Pair, Wrapper};
+
+    /// A record key has to produce string keys, and serde says every instantiation this map has
+    /// does: it writes a JSON object key as a string or refuses the map outright at serialization.
+    /// So the key states that guarantee rather than declining to state anything, and the member
+    /// comes out byte-identical to the concrete `String`-keyed one beside it.
+    #[test]
+    fn a_parameter_keyed_map_states_the_string_keys_serde_writes() {
+        let zod = KeyedByParameter::<String, u32>::zod_schema();
+        assert!(
+            zod.contains("parameter_keyed: z.record(z.string(), z.string())"),
+            "Got: {zod}"
+        );
+        assert!(
+            zod.contains("both_parameters: z.record(z.string(), z.unknown())"),
+            "Got: {zod}"
+        );
+        assert!(!zod.contains("z.record(z.unknown()"), "Got: {zod}");
+        assert!(!zod.contains("KeyType"), "Got: {zod}");
+    }
+
+    /// A concrete key keeps its own answer: a bare string opens the object, and a key serde
+    /// stringifies for the author keeps the narrowing it has always described as.
+    #[test]
+    fn a_concrete_key_beside_a_parameter_one_renders_as_it_always_did() {
+        let zod = KeyedByParameter::<String, u32>::zod_schema();
+        assert!(
+            zod.contains("concrete_string_key: z.record(z.string(), z.string())"),
+            "Got: {zod}"
+        );
+        assert!(
+            zod.contains("stringified_number_key: z.record(z.number().int(), z.string())"),
+            "Got: {zod}"
+        );
+    }
 
     /// A `const` cannot be parameterised, so a parameter composes into the value as the opaque
     /// schema rather than as a `$Schema` binding no emitted module declares.
@@ -216,7 +277,39 @@ mod zod {
 
 #[cfg(feature = "jsonschema")]
 mod jsonschema {
-    use super::{Pair, Wrapper};
+    use super::{KeyedByParameter, Pair, Wrapper};
+
+    /// A key every instantiation writes as a string leaves the value side describable, so the
+    /// object says what it holds instead of opening entirely — the answer the concrete
+    /// `String`-keyed member beside it already gave.
+    #[test]
+    fn a_parameter_keyed_map_still_describes_its_values() {
+        let schema = KeyedByParameter::<String, u32>::json_schema();
+        let properties = &schema["properties"];
+        assert_eq!(
+            properties["parameter_keyed"],
+            serde_json::json!({ "type": "object", "additionalProperties": { "type": "string" } })
+        );
+        assert_eq!(
+            properties["both_parameters"],
+            serde_json::json!({ "type": "object", "additionalProperties": {} })
+        );
+        assert_eq!(
+            properties["parameter_keyed"],
+            properties["concrete_string_key"]
+        );
+    }
+
+    /// A key serde stringifies for the author is not the same question, and keeps the open object
+    /// it has always described as.
+    #[test]
+    fn a_stringified_concrete_key_keeps_its_open_object() {
+        let schema = KeyedByParameter::<String, u32>::json_schema();
+        assert_eq!(
+            schema["properties"]["stringified_number_key"],
+            serde_json::json!({ "type": "object", "additionalProperties": true })
+        );
+    }
 
     /// One schema is written for every instantiation, so a parameter admits any value while the
     /// shape it sits in stays described.
@@ -266,6 +359,7 @@ mod jsonschema {
 }
 
 use alloc::borrow::Cow;
+use core::hash::Hash;
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
@@ -340,6 +434,17 @@ pub struct Holder<IdType> {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Positional<IdType>(pub IdType, pub String);
 
+/// A map keyed by one of the item's own parameters, beside the concrete-keyed members the two
+/// validating surfaces must keep answering for exactly as before.
+#[model_schema()]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KeyedByParameter<KeyType: Eq + Hash, ValueType> {
+    pub both_parameters: HashMap<KeyType, ValueType>,
+    pub concrete_string_key: HashMap<String, String>,
+    pub parameter_keyed: HashMap<KeyType, String>,
+    pub stringified_number_key: HashMap<u32, String>,
+}
+
 #[model_schema()]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LifetimeStruct<'label> {
@@ -388,6 +493,69 @@ fn a_generic_item_expands_to_rust_that_compiles() {
     assert!(matches!(PlainConst::<4>::Wide, PlainConst::Wide));
     assert_eq!(Holder { id: 1_u32 }.id, 1);
     assert_eq!(LifetimeStruct { label: "x".into() }.label, "x");
+}
+
+/// The evidence the string-keyed rendering rests on: serde writes a JSON object key as a string
+/// for every instantiation it accepts at all, and refuses the whole map at serialization for the
+/// ones it does not — there is no instantiation whose keys reach the wire as anything else.
+#[cfg(feature = "serde")]
+#[test]
+fn every_instantiation_the_wire_accepts_writes_string_keys() {
+    let string_instantiation = KeyedByParameter::<String, u32> {
+        parameter_keyed: HashMap::from([("a".to_owned(), "one".to_owned())]),
+        both_parameters: HashMap::from([("a".to_owned(), 1_u32)]),
+        concrete_string_key: HashMap::new(),
+        stringified_number_key: HashMap::new(),
+    };
+    let written = serde_json::to_value(&string_instantiation).unwrap();
+    assert_eq!(
+        written["parameter_keyed"],
+        serde_json::json!({ "a": "one" })
+    );
+
+    let by_number = KeyedByParameter::<u32, u32> {
+        parameter_keyed: HashMap::from([(7_u32, "seven".to_owned())]),
+        both_parameters: HashMap::new(),
+        concrete_string_key: HashMap::new(),
+        stringified_number_key: HashMap::new(),
+    };
+    assert_eq!(
+        serde_json::to_value(&by_number).unwrap()["parameter_keyed"],
+        serde_json::json!({ "7": "seven" }),
+        "a key serde stringifies still reaches the wire as a string"
+    );
+
+    let by_bool = KeyedByParameter::<bool, u32> {
+        parameter_keyed: HashMap::from([(true, "yes".to_owned())]),
+        both_parameters: HashMap::new(),
+        concrete_string_key: HashMap::new(),
+        stringified_number_key: HashMap::new(),
+    };
+    assert_eq!(
+        serde_json::to_value(&by_bool).unwrap()["parameter_keyed"],
+        serde_json::json!({ "true": "yes" })
+    );
+
+    let by_sequence = KeyedByParameter::<Vec<u32>, u32> {
+        parameter_keyed: HashMap::from([(vec![1_u32], "no".to_owned())]),
+        both_parameters: HashMap::new(),
+        concrete_string_key: HashMap::new(),
+        stringified_number_key: HashMap::new(),
+    };
+    let refused = serde_json::to_value(&by_sequence).unwrap_err();
+    assert!(
+        refused.to_string().contains("key must be a string"),
+        "an instantiation whose key is no string fails the whole map: {refused}"
+    );
+
+    let read_back = serde_json::from_value::<KeyedByParameter<u32, u32>>(serde_json::json!({
+        "parameter_keyed": { "7": "seven" },
+        "both_parameters": {},
+        "concrete_string_key": {},
+        "stringified_number_key": {},
+    }))
+    .unwrap();
+    assert_eq!(read_back.parameter_keyed[&7], "seven");
 }
 
 /// A lifetime is the half of the `impl` fix no schema surface can show: nothing renders it, and

--- a/tests/generic_types_tests/tests.rs
+++ b/tests/generic_types_tests/tests.rs
@@ -190,7 +190,10 @@ mod zod {
             "Got: {zod}"
         );
         assert!(!zod.contains("z.record(z.unknown()"), "Got: {zod}");
-        assert!(!zod.contains("KeyType"), "Got: {zod}");
+        // The factory legitimately names the parameter in its own signature; what must never
+        // appear is the parameter standing where the KEY schema goes.
+        assert!(!zod.contains("z.record(keyType"), "Got: {zod}");
+        assert!(!zod.contains("KeyType$Schema"), "Got: {zod}");
     }
 
     /// A concrete key keeps its own answer: a bare string opens the object, and a key serde


### PR DESCRIPTION
Two classification gaps left by the generics landing, one root: the parameter erasure ran LAST in `process_field`, so every guard read a bare parameter as an unresolved sibling type. It now runs before the guards, with the written def kept for exactly the one check that wants the author's spelling (`as` overrides); for a non-generic item the erase is identity, proven byte-identical.

- A length/pattern/range on a parameter-typed field reached no gate on any surface while the JSDoc claimed it. `parameter_shape_name` joins the placement contract's one question, so the bound is refused at expansion naming the parameter and the remedy, and the constraint-docs seam silences the claim with no second rule — five keys by four spellings pinned.
- A map keyed by the item's own parameter rendered `z.record(z.unknown(), …)` and stated nothing. The parameter key now joins `MapKeyPath::Open` — serde writes a JSON object key as a string or refuses the map outright, which is a guarantee, not an absence — so Zod states `z.record(z.string(), …)` and JSON `additionalProperties` with the value's schema, byte-identical to the concrete String-keyed member; stringified concrete keys keep their narrowing. The zod 4.4.3 verdict (unknown-vs-string key schemas parse identically; they differ in what they state) is recorded.

The TypeScript declaration's own type-check failure for `Record<K, …>` is tracked separately with the tsc evidence.