### PR TITLE
model the absence a member's Option carries as a document level, and resolve named members through the registry

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -122,6 +122,16 @@ const KNOWN_ARGS: &[&str] = &["name", "pattern", "minLength", "maxLength", "no_d
 const FLATTENED_PLAIN_ENUM_SCOPE: &str = "Only a type the registry has already classified reaches this guard; one it has not keeps its \
      TypeScript and Zod intersection, and is refused by the JSON surface when the merge runs.";
 
+/// The two shapes [`crate::utils::record_value_shape`] records that a second reader matches on
+/// rather than merely prints: each names one JSON type keyword and only one, so the flatten guard
+/// can repeat the JSON-schema merge's words off the recorded shape alone. Written once so a rename
+/// moves both the recording and the reading.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+const VALUE_SHAPE_BOOLEAN: &str = "boolean";
+
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+const VALUE_SHAPE_ENUMERATED: &str = "enumerated";
+
 /// The two shapes a map key can write that `serde_json` will not use as an object key, as
 /// [`MapKeyRejection::Unwritable`] names them.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
@@ -1699,7 +1709,7 @@ fn non_string_inner_shape(inner: &FieldDef) -> Option<&'static str> {
     match &inner.field_type {
         FieldDefType::SiblingType(inner_name, _) => registered_value_shape(inner_name),
         FieldDefType::Map(..) | FieldDefType::Tuple(..) => Some("container"),
-        FieldDefType::Boolean => Some("boolean"),
+        FieldDefType::Boolean => Some(VALUE_SHAPE_BOOLEAN),
         FieldDefType::U8
         | FieldDefType::U16
         | FieldDefType::U32
@@ -1735,6 +1745,39 @@ fn non_string_inner_shape(inner: &FieldDef) -> Option<&'static str> {
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn registered_value_shape(rust_ident: &str) -> Option<&'static str> {
     lookup_alias_info(rust_ident)?.value_shape
+}
+
+/// The JSON type keyword a registered name's wire describes as, when the registry proves that wire
+/// is no object, and `None` for every name it cannot prove one way or the other.
+///
+/// The same entry the constrained-brand guard reads, asked the merge's question instead of the
+/// brand's, in one lookup: `value_shape` is what the named item published as a value, and `kind` is
+/// what serde writes it as. The shape answers wherever it names something no object can be — a
+/// `boolean`, and the `string` an `enumerated` unit enum writes its member name as. Where the shape
+/// is `None`, which the brand's vocabulary uses for exactly the surfaces a string check lands on,
+/// the kind is what separates a proven bare string from a name nothing has classified.
+///
+/// `numeric` is deliberately not an answer. The one recorded word covers two published documents —
+/// a one-slot tuple struct over a `u32` publishes `{"type": "integer"}` and a
+/// `#[serde(transparent)]` brand over the same `u32` publishes `{"type": "number"}` — so naming
+/// either keyword would put this refusal into disagreement with the merge whose words it repeats,
+/// which is the disagreement it exists to remove. A `container`, which bundles the array with the
+/// map, and a `nullable`, whose absence sits a level below the name rather than at it, are
+/// unprovable here for the same reason. `Stringified` is likewise not read on its own: the map-key
+/// dispatch answers it for a generic spelling it has not resolved, so a brand over an unregistered
+/// `Foreign<T>` carries it with nothing recorded behind it.
+///
+/// A name the registry has no entry for keeps the emission it has always had — the fallback the
+/// merge already documents for a source declared below the object that flattens it.
+#[cfg(all(feature = "serde", feature = "zod"))]
+fn registered_non_object_wire(rust_ident: &str) -> Option<&'static str> {
+    let info = lookup_alias_info(rust_ident)?;
+    match info.value_shape {
+        Some(VALUE_SHAPE_BOOLEAN) => Some("boolean"),
+        Some(VALUE_SHAPE_ENUMERATED) => Some("string"),
+        Some(_) => None,
+        None => matches!(info.kind, AliasKind::StringWire).then_some("string"),
+    }
 }
 
 /// What the value surface a `#[model_schema()]` item publishes under a name is, as the
@@ -4027,8 +4070,12 @@ fn process_plain_enum(
     // Compute the schema module name and register the enum so other types can find it.
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
     // A plain enum is written as a `z.enum` of its variant names, which takes no string check.
-    let (_, module_ident) =
-        enum_module_idents(name, item_name, AliasKind::EnumMembers, Some("enumerated"));
+    let (_, module_ident) = enum_module_idents(
+        name,
+        item_name,
+        AliasKind::EnumMembers,
+        Some(VALUE_SHAPE_ENUMERATED),
+    );
     #[cfg(any(feature = "typescript", feature = "zod"))]
     let rust_ident = name.to_string();
 
@@ -5724,12 +5771,11 @@ fn collect_untagged_members(
 /// it names, when it names one the registry has recorded, and the member as rendered otherwise.
 ///
 /// This is where the recorded member list is multiplied out, so what the registry hands a merge is
-/// the leaf set rather than a chain to walk. A member reached through an `Option` is left as it was
-/// rendered: its absence is a bare `null` on the wire, which is not a key set and joins no object.
+/// the leaf set rather than a chain to walk.
 ///
-/// `branch` is the member's own one-based position, which the leaves of a nested union are reached
-/// through and so keep as the head of theirs — the multiplication flattens the chain and the trail
-/// is what still says where a leaf was written.
+/// `branch` is the member's own one-based position, which every leaf below it is reached through
+/// and so keeps as the head of its trail — the multiplication flattens the chain and the trail is
+/// what still says where a leaf was written.
 #[cfg(all(feature = "serde", feature = "zod"))]
 fn zod_merge_branches(
     kind: &VariantKind,
@@ -5737,22 +5783,15 @@ fn zod_merge_branches(
     rendered: &str,
     branch: usize,
 ) -> Vec<ZodUnionMember> {
-    let nested = match (kind, field_defs) {
-        (VariantKind::TupleSingle, [fld]) if !fld.is_optional() => fld.zod_union_members(),
-        _ => Vec::new(),
-    };
-    if nested.is_empty() {
-        let non_object = match (kind, field_defs) {
-            (VariantKind::TupleSingle, [fld]) => zod_member_non_object(fld),
-            _ => None,
-        };
-        return vec![ZodUnionMember {
-            branch: vec![branch],
-            non_object,
+    let leaves = match (kind, field_defs) {
+        (VariantKind::TupleSingle, [fld]) => zod_member_leaves(fld, rendered),
+        _ => vec![ZodUnionMember {
+            branch: Vec::new(),
+            non_object: None,
             spelling: rendered.to_owned(),
-        }];
-    }
-    nested
+        }],
+    };
+    leaves
         .into_iter()
         .map(|leaf| {
             let mut trail = vec![branch];
@@ -5766,14 +5805,57 @@ fn zod_merge_branches(
         .collect()
 }
 
+/// What one rendered member contributes below its own position: one entry for the member itself,
+/// the leaves of the union it names when it names one the registry has recorded, and — where it was
+/// written under an `Option` — those under the choice the value is, beside the choice the absence
+/// is.
+///
+/// An `Option` is a level of the document and not a decoration on one: the value's wire and a bare
+/// `null` are two branches, which is how the JSON-schema merge descends the same member and how it
+/// comes to name a leaf `n.2`. Recording them the same way is what keeps the two merges naming one
+/// member by one position.
+///
+/// The absence is proved to be no object outright. serde writes the flattened `None` as the object's
+/// own keys alone and then refuses to read those same keys back — the untagged enum matches no
+/// member for them — so the write side and the read side describe different payload sets, and no
+/// branch a multiplication could write is a description of the type. A merge that reads this is
+/// left with the refusal, which is what the JSON-schema merge already answers the same declaration
+/// with. The outer `Option` around a whole flattened source is the other case and keeps its
+/// multiplication: there the absence reads back as the absence.
+#[cfg(all(feature = "serde", feature = "zod"))]
+fn zod_member_leaves(fld: &FieldDef, rendered: &str) -> Vec<ZodUnionMember> {
+    let nested = fld.zod_union_members();
+    let mut leaves = if nested.is_empty() {
+        vec![ZodUnionMember {
+            branch: Vec::new(),
+            non_object: zod_member_non_object(fld),
+            spelling: rendered.to_owned(),
+        }]
+    } else {
+        nested
+    };
+    if fld.is_optional() {
+        for leaf in &mut leaves {
+            leaf.branch.insert(0, 1);
+        }
+        leaves.push(ZodUnionMember {
+            branch: vec![2],
+            non_object: Some("null"),
+            spelling: rendered.to_owned(),
+        });
+    }
+    leaves
+}
+
 /// What serde writes an untagged union's member as, when the member's own written type proves that
 /// is not an object, and `None` when nothing here proves it.
 ///
 /// Named by the JSON type keyword the JSON-schema surface writes for the same member, so the two
 /// merges refuse the same member in the same words. That surface reads the keyword off a document
-/// it has already built; here there is only the type, so the answer is a partial one by
-/// construction — a name the registry stands for and a map are left to the merge that does read
-/// them, and a union member is not asked at all, its own leaves having already been recorded.
+/// it has already built; here there is the type, and for a name the registry's answer for what the
+/// named item published — so the answer is still a partial one by construction, a map and a name
+/// nothing has classified being left to the merge that does read the document, and a union member
+/// not being asked at all, its own leaves having already been recorded.
 #[cfg(all(feature = "serde", feature = "zod"))]
 fn zod_member_non_object(fld: &FieldDef) -> Option<&'static str> {
     if fld.is_array() {
@@ -5799,7 +5881,9 @@ fn zod_member_non_object(fld: &FieldDef) -> Option<&'static str> {
         | FieldDefType::NaiveDateTime
         | FieldDefType::NaiveTime => Some("string"),
         FieldDefType::Tuple(_) => Some("array"),
-        FieldDefType::SiblingType(name, _) => is_sequence_wrapper(name).then_some("array"),
+        FieldDefType::SiblingType(name, _) => is_sequence_wrapper(name)
+            .then_some("array")
+            .or_else(|| registered_non_object_wire(name)),
         #[cfg(feature = "object_id")]
         FieldDefType::ObjectId => None,
         FieldDefType::Map(_, _) | FieldDefType::TypeParam(_) | FieldDefType::Unknown => None,

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -6166,6 +6166,253 @@ fn recorded_union_flatten_error(
     flattened_union_member_guard_error(field, "Host").map(|error| error.to_string())
 }
 
+/// The branch trails one untagged enum's members are recorded at, beside what each is proved to
+/// write, in declaration order.
+#[cfg(all(feature = "serde", feature = "zod"))]
+fn recorded_member_trails(mut item: syn::ItemEnum) -> Vec<(String, Option<&'static str>)> {
+    let (_, _, merge_parts, _, errors, _, _) = collect_untagged_members(&mut item, UNTAGGED_MODULE);
+    assert!(errors.is_empty(), "got: {errors:?}");
+    merge_parts
+        .iter()
+        .map(|member| (member.branch_path(), member.non_object))
+        .collect()
+}
+
+/// Registers a name carrying both answers a `#[model_schema()]` item's own expansion records for
+/// it: what serde writes it as, and what it published as a value.
+#[cfg(all(feature = "serde", feature = "zod"))]
+fn seed_registered_wire(rust_ident: &str, kind: AliasKind, shape: Option<&'static str>) {
+    register_alias_info(
+        rust_ident,
+        rust_ident,
+        &ident_schema_module_name(rust_ident),
+        kind,
+    );
+    record_value_shape(rust_ident, shape);
+}
+
+/// A member reached through an `Option` is two choices and not one: serde writes the value's own
+/// wire or writes nothing, and the JSON-schema merge descends into both — naming the value `n.1`
+/// and the absence `n.2`. The recording carries the same two, so the merge that reads it names a
+/// member by the position the other surface names the same member by.
+#[cfg(all(feature = "serde", feature = "zod"))]
+#[test]
+fn an_optional_union_member_is_recorded_as_its_value_beside_the_absence() {
+    assert_eq!(
+        recorded_member_trails(syn::parse_quote! {
+            enum Choice {
+                Obj(Holder),
+                Maybe(Option<Holder>),
+                Text(Option<String>),
+            }
+        }),
+        vec![
+            ("1".to_owned(), None),
+            ("2.1".to_owned(), None),
+            ("2.2".to_owned(), Some("null")),
+            ("3.1".to_owned(), Some("string")),
+            ("3.2".to_owned(), Some("null")),
+        ]
+    );
+}
+
+/// A member serde writes as an object is recorded exactly as it was: one entry at its own position,
+/// with no level below it. The `Option` is what adds a level, and nothing else does.
+#[cfg(all(feature = "serde", feature = "zod"))]
+#[test]
+fn a_member_written_without_an_option_keeps_the_one_position_it_had() {
+    assert_eq!(
+        recorded_member_trails(syn::parse_quote! {
+            enum Choice {
+                Obj(Holder),
+                Other(Second),
+            }
+        }),
+        vec![("1".to_owned(), None), ("2".to_owned(), None)]
+    );
+}
+
+/// So an object flattening a union with an optional member is refused where the field was written,
+/// naming the null leaf in the words the JSON-schema merge names it with. The absence is no key
+/// set: serde writes the object's own keys alone for it and then refuses to read those same keys
+/// back, so no branch a multiplication could write describes the type.
+#[cfg(all(feature = "serde", feature = "zod"))]
+#[test]
+fn flattening_a_union_with_an_optional_member_is_refused_naming_the_null_leaf() {
+    let error = recorded_union_flatten_error(
+        "NullableChoice",
+        syn::parse_quote! {
+            enum NullableChoice {
+                Obj(Holder),
+                Maybe(Option<Holder>),
+            }
+        },
+        &syn::parse_quote! { #[serde(flatten)] either: NullableChoice },
+    )
+    .unwrap();
+    assert!(
+        error.contains(
+            "`#[serde(flatten)]` of `NullableChoice` writes a union member that is not an object"
+        ),
+        "got: {error}"
+    );
+    assert!(
+        error.contains("its branch 2.2 describes a `null`"),
+        "got: {error}"
+    );
+}
+
+/// And an optional member whose value serde already writes as a scalar is named at the value's own
+/// trail — the choice below the `Option`, which is where the merge descending the same document
+/// stops first.
+#[cfg(all(feature = "serde", feature = "zod"))]
+#[test]
+fn an_optional_scalar_union_member_is_refused_below_the_option_it_was_written_under() {
+    let error = recorded_union_flatten_error(
+        "NullableScalarChoice",
+        syn::parse_quote! {
+            enum NullableScalarChoice {
+                Obj(Holder),
+                Maybe(Option<String>),
+            }
+        },
+        &syn::parse_quote! { #[serde(flatten)] either: NullableScalarChoice },
+    )
+    .unwrap();
+    assert!(
+        error.contains("its branch 2.1 describes a `string`"),
+        "got: {error}"
+    );
+}
+
+/// A member that names another item is asked of the registry rather than left unanswered: the
+/// named item recorded what serde writes it as and what it published as a value, and between them
+/// they name the JSON type keyword the other surface writes for the same member.
+///
+/// `numeric` is not among them on purpose — see the guard's own note — and a name the registry
+/// cannot rule out keeps the emission it has always had.
+#[cfg(all(feature = "serde", feature = "zod"))]
+#[test]
+fn a_union_member_naming_a_registered_non_object_wire_is_recorded_as_that_wire() {
+    seed_registered_wire("StringBrand", AliasKind::StringWire, None);
+    seed_registered_wire("SwitchBrand", AliasKind::Stringified, Some("boolean"));
+    seed_registered_wire("PlainEnum", AliasKind::EnumMembers, Some("enumerated"));
+    seed_registered_wire("NamedStruct", AliasKind::NoEnumMembers, Some("object"));
+    seed_registered_wire("TaggedEnum", AliasKind::NoEnumMembers, Some("union"));
+    seed_registered_wire("CountBrand", AliasKind::Stringified, Some("numeric"));
+    assert_eq!(
+        recorded_member_trails(syn::parse_quote! {
+            enum Choice {
+                Named(NamedStruct),
+                Slug(StringBrand),
+                Switch(SwitchBrand),
+                Hue(PlainEnum),
+                Tagged(TaggedEnum),
+                Count(CountBrand),
+                Foreign(NeverRegistered),
+            }
+        }),
+        vec![
+            ("1".to_owned(), None),
+            ("2".to_owned(), Some("string")),
+            ("3".to_owned(), Some("boolean")),
+            ("4".to_owned(), Some("string")),
+            ("5".to_owned(), None),
+            ("6".to_owned(), None),
+            ("7".to_owned(), None),
+        ]
+    );
+}
+
+/// So flattening a union whose member names a brand over a string is refused in the branch-naming
+/// words, where before it emitted the object intersected with that brand — a branch no payload
+/// satisfies, and one serde refuses to write for the same reason it refuses a directly flattened
+/// brand.
+#[cfg(all(feature = "serde", feature = "zod"))]
+#[test]
+fn flattening_a_union_with_a_named_string_wire_member_is_refused_naming_the_branch() {
+    seed_registered_wire("Slug", AliasKind::StringWire, None);
+    let error = recorded_union_flatten_error(
+        "SlugChoice",
+        syn::parse_quote! {
+            enum SlugChoice {
+                Obj(Holder),
+                Slug(Slug),
+            }
+        },
+        &syn::parse_quote! { #[serde(flatten)] either: SlugChoice },
+    )
+    .unwrap();
+    assert!(
+        error.contains("its branch 2 describes a `string`"),
+        "got: {error}"
+    );
+}
+
+/// The same for a brand serde stringifies and for a plain unit enum, each named by the keyword its
+/// own published document carries: a brand over a `bool` describes as a `boolean`, and a unit enum
+/// describes as the `string` its member name is written as.
+#[cfg(all(feature = "serde", feature = "zod"))]
+#[test]
+fn flattening_a_union_with_a_named_stringified_or_enumerated_member_is_refused() {
+    seed_registered_wire("Switch", AliasKind::Stringified, Some("boolean"));
+    let switch = recorded_union_flatten_error(
+        "SwitchChoice",
+        syn::parse_quote! {
+            enum SwitchChoice {
+                Obj(Holder),
+                Switch(Switch),
+            }
+        },
+        &syn::parse_quote! { #[serde(flatten)] either: SwitchChoice },
+    )
+    .unwrap();
+    assert!(
+        switch.contains("its branch 2 describes a `boolean`"),
+        "got: {switch}"
+    );
+
+    seed_registered_wire("Hue", AliasKind::EnumMembers, Some("enumerated"));
+    let hue = recorded_union_flatten_error(
+        "HueChoice",
+        syn::parse_quote! {
+            enum HueChoice {
+                Obj(Holder),
+                Hue(Hue),
+            }
+        },
+        &syn::parse_quote! { #[serde(flatten)] either: HueChoice },
+    )
+    .unwrap();
+    assert!(
+        hue.contains("its branch 2 describes a `string`"),
+        "got: {hue}"
+    );
+}
+
+/// A member naming an item the registry says publishes an object, and one naming a type the
+/// registry has never seen, are both left alone — the second being the declaration-order fallback,
+/// which answers for a name written above the union no differently than for a foreign type.
+#[cfg(all(feature = "serde", feature = "zod"))]
+#[test]
+fn a_union_member_naming_an_object_or_an_unregistered_type_stays_admitted() {
+    seed_registered_wire("Doc", AliasKind::NoEnumMembers, Some("object"));
+    assert!(
+        recorded_union_flatten_error(
+            "NamedChoice",
+            syn::parse_quote! {
+                enum NamedChoice {
+                    Obj(Holder),
+                    Doc(Doc),
+                    Foreign(NeverRegistered),
+                }
+            },
+            &syn::parse_quote! { #[serde(flatten)] either: NamedChoice },
+        )
+        .is_none()
+    );
+}
+
 /// `^$` is the empty-string check, not a degenerate pattern: it pins both ends of the value to one
 /// position. It keeps the `is_empty()` call it has been emitted as, byte for byte, now that the
 /// shapes written out of the same two anchors are refused.

--- a/tests/flatten_tests/tests.rs
+++ b/tests/flatten_tests/tests.rs
@@ -295,6 +295,147 @@ enum LaterScalarEither {
     Text(String),
 }
 
+/// The same shape with one member reached through an `Option`. Standing on its own it is an
+/// ordinary union — a member may be written as its value or as a bare `null`, and every surface
+/// describes the choice.
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(untagged)]
+enum FlatNullableEither {
+    Base(FlatFirst),
+    Maybe(Option<FlatSecond>),
+}
+
+/// Flattening it is what neither direction of serde agrees with the other on, so the Zod surface
+/// refuses the declaration and the struct exists only where nothing records the members — which is
+/// where the JSON-schema merge answers for the same declaration at run time instead.
+#[cfg(all(feature = "jsonschema", not(feature = "zod")))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct FlatOverNullableUntagged {
+    #[serde(flatten)]
+    either: FlatNullableEither,
+    own: String,
+}
+
+/// The same union declared *below* the object that flattens it, which every table holds: the
+/// recording carries nothing for it, so the Zod merge names it as the one operand it is while the
+/// JSON-schema merge refuses it wherever it was declared.
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct FlatOverLaterNullableUntagged {
+    #[serde(flatten)]
+    either: LaterNullableEither,
+    own: String,
+}
+
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(untagged)]
+enum LaterNullableEither {
+    Base(FlatFirst),
+    Maybe(Option<FlatSecond>),
+}
+
+/// Three members that name another item rather than spelling a type out: a brand over a string, a
+/// brand over a `bool`, and a plain unit enum. What serde writes each as lives on the named item,
+/// so the merge asks the registry rather than the spelling.
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(transparent)]
+struct MemberSlug(String);
+
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(transparent)]
+struct MemberSwitch(bool);
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+enum MemberHue {
+    Blue,
+    Red,
+}
+
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(untagged)]
+enum MemberSlugEither {
+    Base(FlatFirst),
+    Slug(MemberSlug),
+}
+
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(untagged)]
+enum MemberSwitchEither {
+    Base(FlatFirst),
+    Switch(MemberSwitch),
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(untagged)]
+enum MemberHueEither {
+    Base(FlatFirst),
+    Hue(MemberHue),
+}
+
+#[cfg(all(feature = "jsonschema", not(feature = "zod")))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct FlatOverMemberSlugUntagged {
+    #[serde(flatten)]
+    either: MemberSlugEither,
+    own: String,
+}
+
+#[cfg(all(feature = "jsonschema", not(feature = "zod")))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct FlatOverMemberSwitchUntagged {
+    #[serde(flatten)]
+    either: MemberSwitchEither,
+    own: String,
+}
+
+#[cfg(not(feature = "zod"))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct FlatOverMemberHueUntagged {
+    #[serde(flatten)]
+    either: MemberHueEither,
+    own: String,
+}
+
+/// And the same brand member in a union declared below the object, which keeps the fallback: a
+/// name the recording holds nothing for is named as the one operand it is, whatever the registry
+/// could have said about the members.
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct FlatOverLaterMemberSlugUntagged {
+    #[serde(flatten)]
+    either: LaterMemberSlugEither,
+    own: String,
+}
+
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(untagged)]
+enum LaterMemberSlugEither {
+    Base(FlatFirst),
+    Slug(MemberSlug),
+}
+
 /// A union member that names itself, and the struct that flattens the union. The member describes
 /// as a reference into the definitions, and the body it points at is written by the time the merge
 /// asks for it.
@@ -1118,6 +1259,142 @@ fn test_a_string_member_of_a_later_flattened_untagged_enum_is_refused_by_the_mer
     assert!(FlatOverLaterScalarUntagged::json_schema().is_object());
 }
 
+/// A member reached through an `Option` is the one shape where serde's two directions describe
+/// different payload sets. It writes the flattened `None` as the object's own keys alone, with no
+/// error, and then refuses to read those same keys back — the untagged enum matches no member for
+/// them. So there is no branch a multiplication could write: spelling the absence accepts a
+/// document `from_value` rejects, and omitting it rejects one `to_value` writes.
+#[test]
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+fn test_an_optional_flattened_union_member_is_written_and_then_not_read_back() {
+    let written = serde_json::to_value(FlatOverLaterNullableUntagged {
+        own: "o".to_owned(),
+        either: LaterNullableEither::Maybe(None),
+    })
+    .unwrap();
+    assert_eq!(written, serde_json::json!({ "own": "o" }));
+    let refusal = serde_json::from_value::<FlatOverLaterNullableUntagged>(written)
+        .unwrap_err()
+        .to_string();
+    assert!(
+        refusal.contains("did not match any variant"),
+        "Got: {refusal}"
+    );
+
+    let present = serde_json::to_value(FlatOverLaterNullableUntagged {
+        own: "o".to_owned(),
+        either: LaterNullableEither::Maybe(Some(FlatSecond { b: true })),
+    })
+    .unwrap();
+    assert_eq!(present, serde_json::json!({ "own": "o", "b": true }));
+    serde_json::from_value::<FlatOverLaterNullableUntagged>(present).unwrap();
+}
+
+/// So the merge refuses the whole union, naming the null the absence is described as and the leaf
+/// it sits at: an `Option` is a choice of its own below the member, so the absence is `2.2` rather
+/// than `2`.
+#[test]
+#[cfg(all(feature = "jsonschema", not(feature = "zod")))]
+#[should_panic(
+    expected = "`FlatOverNullableUntagged`: `#[serde(flatten)]` of `FlatNullableEither` writes a union member that is not an object — its branch 2.2 describes a `null`"
+)]
+fn test_an_optional_member_of_a_flattened_untagged_enum_is_refused_by_the_merge() {
+    assert!(FlatOverNullableUntagged::json_schema().is_object());
+}
+
+/// And in those same words wherever the union was declared, which is the one reading of the
+/// declaration that survives the Zod surface refusing it at expansion.
+#[test]
+#[cfg(feature = "jsonschema")]
+#[should_panic(
+    expected = "`FlatOverLaterNullableUntagged`: `#[serde(flatten)]` of `LaterNullableEither` writes a union member that is not an object — its branch 2.2 describes a `null`"
+)]
+fn test_an_optional_member_of_a_later_flattened_untagged_enum_is_refused_by_the_merge() {
+    assert!(FlatOverLaterNullableUntagged::json_schema().is_object());
+}
+
+/// A member that names a brand over a string is one serde refuses to flatten for the reason it
+/// refuses a directly flattened brand: what it writes is the bare string the brand's inner writes.
+#[test]
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+fn test_flattening_an_untagged_enum_over_a_named_string_member_is_unserializable() {
+    let refusal = serde_json::to_value(FlatOverLaterMemberSlugUntagged {
+        own: "o".to_owned(),
+        either: LaterMemberSlugEither::Slug(MemberSlug("s".to_owned())),
+    })
+    .unwrap_err()
+    .to_string();
+    assert!(
+        refusal.contains("can only flatten structs and maps"),
+        "Got: {refusal}"
+    );
+}
+
+/// So the merge refuses it, naming the branch and the string the brand publishes as — the answer
+/// the registry holds for the name, which the spelling of the member does not carry.
+#[test]
+#[cfg(feature = "jsonschema")]
+#[should_panic(
+    expected = "`FlatOverLaterMemberSlugUntagged`: `#[serde(flatten)]` of `LaterMemberSlugEither` writes a union member that is not an object — its branch 2 describes a `string`"
+)]
+fn test_a_named_string_member_of_a_flattened_untagged_enum_is_refused_by_the_merge() {
+    assert!(FlatOverLaterMemberSlugUntagged::json_schema().is_object());
+}
+
+/// In the same words wherever the union was declared, which is the reading that survives the Zod
+/// surface refusing the declared-above one at expansion.
+#[test]
+#[cfg(all(feature = "jsonschema", not(feature = "zod")))]
+#[should_panic(
+    expected = "`FlatOverMemberSlugUntagged`: `#[serde(flatten)]` of `MemberSlugEither` writes a union member that is not an object — its branch 2 describes a `string`"
+)]
+fn test_a_named_string_member_of_an_earlier_untagged_enum_is_refused_by_the_merge() {
+    assert!(FlatOverMemberSlugUntagged::json_schema().is_object());
+}
+
+/// The same for a brand serde stringifies and for a plain unit enum, each named by the keyword its
+/// own published document carries.
+#[test]
+#[cfg(all(feature = "jsonschema", not(feature = "zod")))]
+#[should_panic(
+    expected = "`FlatOverMemberSwitchUntagged`: `#[serde(flatten)]` of `MemberSwitchEither` writes a union member that is not an object — its branch 2 describes a `boolean`"
+)]
+fn test_a_named_boolean_member_of_a_flattened_untagged_enum_is_refused_by_the_merge() {
+    assert!(FlatOverMemberSwitchUntagged::json_schema().is_object());
+}
+
+#[test]
+#[cfg(all(feature = "jsonschema", not(feature = "zod")))]
+#[should_panic(
+    expected = "`FlatOverMemberHueUntagged`: `#[serde(flatten)]` of `MemberHueEither` writes a union member that is not an object — its branch 2 describes a `string`"
+)]
+fn test_a_named_enumerated_member_of_a_flattened_untagged_enum_is_refused_by_the_merge() {
+    assert!(FlatOverMemberHueUntagged::json_schema().is_object());
+}
+
+/// A plain enum is the one of the three serde does not refuse outright — the flatten serializer
+/// writes the variant name as a key of its own and reads it back. What refuses it is that both
+/// schema surfaces describe it as the string its member name is, and a string joins no object.
+#[test]
+#[cfg(not(feature = "zod"))]
+fn test_a_flattened_plain_enum_member_is_written_as_a_key_no_schema_describes() {
+    let holder = FlatOverMemberHueUntagged {
+        own: "o".to_owned(),
+        either: MemberHueEither::Hue(MemberHue::Red),
+    };
+    let written = serde_json::to_value(&holder).unwrap();
+    assert_eq!(written, serde_json::json!({ "own": "o", "Red": null }));
+    assert_eq!(
+        serde_json::from_value::<FlatOverMemberHueUntagged>(written).unwrap(),
+        holder
+    );
+    #[cfg(feature = "jsonschema")]
+    assert_eq!(
+        MemberHue::json_schema(),
+        serde_json::json!({ "type": "string", "enum": ["Blue", "Red"] })
+    );
+}
+
 /// The remedy that refusal names is the same one every flattened non-object gets.
 #[test]
 #[cfg(feature = "jsonschema")]
@@ -1853,6 +2130,65 @@ fn test_a_standalone_union_with_a_scalar_member_is_byte_identical() {
         "export const FlatScalarEither$Schema = z.union([FlatFirst$Schema, z.string()]);";
 
     assert_eq!(FlatScalarEither::zod_schema(), EXPECTED);
+}
+
+/// A union holding a member reached through an `Option`, and ones holding members that name a
+/// brand or a plain enum, are unions like any other while nothing flattens them: the member is a
+/// branch of the choice, and each is spelled byte for byte as it was before the merge could tell
+/// the shapes apart.
+#[test]
+#[cfg(feature = "zod")]
+fn test_standalone_unions_the_merge_now_refuses_are_byte_identical() {
+    #[cfg(feature = "typescript")]
+    const EXPECTED: [&str; 4] = [
+        "const FlatNullableEither$RawSchema = z.union([FlatFirst$Schema, z.nullable(FlatSecond$Schema)]);\n\nexport const FlatNullableEither$Schema: ZodType<FlatNullableEither> = FlatNullableEither$RawSchema;",
+        "const MemberSlugEither$RawSchema = z.union([FlatFirst$Schema, MemberSlug$Schema]);\n\nexport const MemberSlugEither$Schema: ZodType<MemberSlugEither> = MemberSlugEither$RawSchema;",
+        "const MemberSwitchEither$RawSchema = z.union([FlatFirst$Schema, MemberSwitch$Schema]);\n\nexport const MemberSwitchEither$Schema: ZodType<MemberSwitchEither> = MemberSwitchEither$RawSchema;",
+        "const MemberHueEither$RawSchema = z.union([FlatFirst$Schema, MemberHue$Schema]);\n\nexport const MemberHueEither$Schema: ZodType<MemberHueEither> = MemberHueEither$RawSchema;",
+    ];
+    #[cfg(not(feature = "typescript"))]
+    const EXPECTED: [&str; 4] = [
+        "export const FlatNullableEither$Schema = z.union([FlatFirst$Schema, z.nullable(FlatSecond$Schema)]);",
+        "export const MemberSlugEither$Schema = z.union([FlatFirst$Schema, MemberSlug$Schema]);",
+        "export const MemberSwitchEither$Schema = z.union([FlatFirst$Schema, MemberSwitch$Schema]);",
+        "export const MemberHueEither$Schema = z.union([FlatFirst$Schema, MemberHue$Schema]);",
+    ];
+
+    assert_eq!(
+        [
+            FlatNullableEither::zod_schema(),
+            MemberSlugEither::zod_schema(),
+            MemberSwitchEither::zod_schema(),
+            MemberHueEither::zod_schema(),
+        ],
+        EXPECTED.map(str::to_owned)
+    );
+}
+
+/// And the reach of both refusals is the recording's, exactly as the scalar one's is: a union
+/// declared below the object records nothing for the merge to read, so it is still named as the one
+/// operand it is and the fallback is unchanged.
+#[test]
+#[cfg(feature = "zod")]
+fn test_the_unions_declared_below_the_object_are_still_named_as_one_operand() {
+    let nullable = FlatOverLaterNullableUntagged::zod_schema();
+    assert!(
+        nullable.contains("}).and(z.lazy(() => LaterNullableEither$Schema));"),
+        "expected the union named as one operand, got: {nullable}"
+    );
+    assert!(
+        !nullable.contains("z.nullable("),
+        "the absence reached the intersection in: {nullable}"
+    );
+    let slug = FlatOverLaterMemberSlugUntagged::zod_schema();
+    assert!(
+        slug.contains("}).and(z.lazy(() => LaterMemberSlugEither$Schema));"),
+        "expected the union named as one operand, got: {slug}"
+    );
+    assert!(
+        !slug.contains(".and(z.lazy(() => MemberSlug$Schema))"),
+        "the brand member reached the intersection in: {slug}"
+    );
 }
 
 /// And flattening one is refused at expansion rather than emitted — the branch that used to be


### PR DESCRIPTION
Two residual gaps in the flattened-union member refusal, each settled by capture:

- An Option-reached member: serde WRITES the absent form (`{"own":"o"}`) but refuses to READ it back — the write and read sides describe different payload sets, so no branch set describes the type and refusal is the verdict, not multiplication. `zod_member_leaves` models the member's Option as a document level (value leaves under choice 1, the null leaf at choice 2), so the refusal names the same `2.2`-style trail the JSON merge panics with; the outer flatten-field Option — which does round-trip — stays byte-identical, pinned in deliberate contrast. A side effect aligned the two surfaces' branch naming for optional scalar members.
- A member naming a registered brand or enum: the marker now falls through to `registered_non_object_wire`, one registry read beside the constrained-brand guard's — enumerated shapes and string-wire registrations are proof of a non-object wire and refuse with the keyword the JSON merge uses; two narrowings forced by capture are recorded (one integer wire publishes two keywords today — filed; a bare `Stringified` kind can ride on an unregistered generic and proves nothing). Unregistered names keep the declaration-order fallback.