### PR TITLE
read the omission a field declares in every build, generalize it past Option, and refuse the spelling serde cannot read back

### DIFF
--- a/src/features.rs
+++ b/src/features.rs
@@ -3,7 +3,9 @@
 //! This module provides compile-time feature detection and utilities for handling
 //! different feature combinations in the macro expansion process.
 
-#[cfg(feature = "serde")]
+// Not gated on the `serde` feature: the attributes that decide whether a key reaches the wire are
+// written on the item under every toggle, and the surfaces describe that wire in every build. What
+// the feature gates is everything else the module reads — renaming, tagging, and the guards.
 pub mod serde;
 
 #[cfg(feature = "zod")]

--- a/src/features/serde.rs
+++ b/src/features/serde.rs
@@ -1,20 +1,48 @@
 //! Serde integration feature module.
 //!
-//! This module handles serde attribute parsing and field name transformation
-//! when the "serde" feature is enabled.
+//! This module handles serde attribute parsing and field name transformation.
+//!
+//! Most of it is gated on the "serde" feature: renaming, tagging, and the guards are all things
+//! the feature buys. The omission walk at the top is not. Whether a key reaches the serialized
+//! object is a fact about the wire, the attribute stating it is on the field under every toggle,
+//! and every build emits surfaces that claim to describe that wire — so a build that could not
+//! read the attribute would describe a different wire than the one serde writes.
 
-#[cfg(test)]
+#[cfg(all(test, feature = "serde"))]
 use crate::rename_rule::resolve_rename_rule;
+#[cfg(feature = "serde")]
 use proc_macro2::{Delimiter, TokenTree};
 use syn::meta::ParseNestedMeta;
-use syn::{Attribute, Error, LitStr, Meta, Token};
+use syn::{Attribute, Token};
+#[cfg(feature = "serde")]
+use syn::{Error, LitStr, Meta};
 
 /// Message of the rejection raised for a serde attribute hidden behind `cfg_attr`.
+#[cfg(feature = "serde")]
 const CFG_ATTR_SERDE_REJECTION: &str = "cfg_attr-wrapped serde attribute is invisible to \
      model_schema and will be silently ignored by the generator; write #[serde(...)] \
      unconditionally (serde attrs are inert without the serde derive)";
 
+/// What a field's serde attributes say about the key it writes.
+///
+/// Read in every build, unlike the rest of this module. The three questions are asked together
+/// because one walk answers all of them and because the guard that polices the combination needs
+/// them side by side: an attribute that drops the key while serde still insists on reading the
+/// field is only coherent when something writes the value the missing key does not carry.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SerdeKeyOmission {
+    /// A `default` in either spelling (`default` or `default = "path"`) — the field supplies a
+    /// value for itself when the key is missing.
+    pub defaulted: bool,
+    /// A `skip`, `skip_serializing` or `skip_serializing_if` leaves the key out of the output.
+    pub omits_key: bool,
+    /// A `skip` also stops serde reading the field, which is its own answer to a missing key and
+    /// so needs no `default` written beside it. The other two omission spellings still read.
+    pub skips_deserializing: bool,
+}
+
 /// Metadata for serde attributes applied to a struct or enum.
+#[cfg(feature = "serde")]
 #[derive(Clone, Debug, Default)]
 pub struct SerdeTypeMeta {
     /// The rejection raised when the walk met a `cfg_attr`-wrapped serde attribute.
@@ -26,16 +54,79 @@ pub struct SerdeTypeMeta {
 }
 
 /// Metadata for serde attributes applied to a field.
+///
+/// Whether the field's key is omitted is not here: [`parse_serde_key_omission`] answers that in
+/// every build, and one answer read from one place is what keeps the surfaces from disagreeing
+/// across the feature toggle.
+#[cfg(feature = "serde")]
 #[derive(Clone, Debug, Default)]
 pub struct SerdeFieldMeta {
     /// The rejection raised when the walk met a `cfg_attr`-wrapped serde attribute.
     pub cfg_attr_rejection: Option<Error>,
-    pub flatten: bool, // Whether the field is `#[serde(flatten)]`
-    /// Whether a `None` is left out of the serialized output entirely. `skip_deserializing`
-    /// does not qualify: it still writes `null` on the way out.
-    pub omits_none: bool,
+    pub flatten: bool,          // Whether the field is `#[serde(flatten)]`
     pub rename: Option<String>, // e.g., "new_name"
     pub skip: bool,             // Whether to skip the field
+}
+
+/// Walks the serde attributes for exactly the keys [`SerdeKeyOmission`] names, ignoring every
+/// other one.
+///
+/// Attributes wrapped in a `cfg_attr` are not reached, the same way nothing else in this module
+/// reaches them — a predicate a proc macro cannot evaluate is not one this walk may guess at.
+pub fn parse_serde_key_omission(attrs: &[Attribute]) -> SerdeKeyOmission {
+    let mut omission = SerdeKeyOmission::default();
+
+    for attr in attrs {
+        if !attr.path().is_ident("serde") {
+            continue;
+        }
+        attr.parse_nested_meta(|nested| {
+            if nested.path.is_ident("skip") {
+                omission.omits_key = true;
+                omission.skips_deserializing = true;
+            } else if nested.path.is_ident("skip_serializing")
+                || nested.path.is_ident("skip_serializing_if")
+            {
+                omission.omits_key = true;
+            } else if nested.path.is_ident("skip_deserializing") {
+                omission.skips_deserializing = true;
+            } else if nested.path.is_ident("default") {
+                omission.defaulted = true;
+            } else {
+                // Every other serde key is someone else's business.
+            }
+            consume_unread_value(&nested)?;
+            Ok(())
+        })
+        .unwrap_or_else(|e| {
+            log::trace!("Failed to parse serde key-omission attribute: {e}");
+        });
+    }
+
+    omission
+}
+
+/// Consumes the value of a `key = value` the walk had no use for.
+///
+/// An unread value ends the walk on the comma that follows it, taking every attribute written
+/// after it along — so which attributes a field is read by would otherwise depend on the order
+/// someone happened to write them in.
+fn consume_unread_value(nested: &ParseNestedMeta<'_>) -> syn::Result<()> {
+    if nested.input.peek(Token![=]) {
+        nested.value()?.parse::<syn::Expr>()?;
+    }
+    Ok(())
+}
+
+/// Whether the field writes a value for itself when its key is missing, in either spelling
+/// (`default` and `default = "path"`).
+///
+/// Asked of the attributes rather than carried on [`SerdeFieldMeta`]: nothing the generated
+/// surfaces describe turns on it — it is read where a serde hook is written, to decide whether
+/// that hook has a missing key to answer for, and where a guard asks whether a dropped key can be
+/// read back.
+pub fn has_serde_default(attrs: &[Attribute]) -> bool {
+    parse_serde_key_omission(attrs).defaulted
 }
 
 /// The rejection for a `cfg_attr` carrying a `serde(...)` attribute, or `None` for every other
@@ -47,6 +138,7 @@ pub struct SerdeFieldMeta {
 /// so those arrive already expanded or already stripped and never reach this check.) Reading the
 /// payload would mean applying it in builds where the consumer's cfg predicate is false, and that
 /// predicate cannot be evaluated from a proc macro, so the attribute is rejected, not guessed at.
+#[cfg(feature = "serde")]
 fn cfg_attr_serde_rejection(attr: &Attribute) -> Option<Error> {
     let Meta::List(list) = &attr.meta else {
         return None;
@@ -67,6 +159,7 @@ fn cfg_attr_serde_rejection(attr: &Attribute) -> Option<Error> {
 }
 
 /// Parses serde attributes from a struct or enum.
+#[cfg(feature = "serde")]
 pub fn parse_serde_type_attributes(attrs: &[Attribute]) -> SerdeTypeMeta {
     let mut meta = SerdeTypeMeta::default();
 
@@ -113,6 +206,7 @@ pub fn parse_serde_type_attributes(attrs: &[Attribute]) -> SerdeTypeMeta {
 }
 
 /// Parses serde attributes from a field.
+#[cfg(feature = "serde")]
 pub fn parse_serde_field_attributes(attrs: &[Attribute]) -> SerdeFieldMeta {
     let mut meta = SerdeFieldMeta::default();
 
@@ -127,17 +221,12 @@ pub fn parse_serde_field_attributes(attrs: &[Attribute]) -> SerdeFieldMeta {
                     let lit: LitStr = value.parse()?;
                     meta.rename = Some(lit.value());
                 }
-                // Handle `skip` or `skip_serializing_if`
+                // Handle the whole `skip` lump
                 else if nested.path.is_ident("skip")
                     || nested.path.is_ident("skip_serializing")
                     || nested.path.is_ident("skip_serializing_if")
+                    || nested.path.is_ident("skip_deserializing")
                 {
-                    meta.skip = true;
-                    meta.omits_none = true;
-                }
-                // `skip_deserializing` belongs to the `skip` lump but never suppresses a
-                // serialized `null`, so it must not set `omits_none`.
-                else if nested.path.is_ident("skip_deserializing") {
                     meta.skip = true;
                 }
                 // Handle `flatten`
@@ -160,50 +249,14 @@ pub fn parse_serde_field_attributes(attrs: &[Attribute]) -> SerdeFieldMeta {
     meta
 }
 
-/// Consumes the value of a `key = value` the walk had no use for.
-///
-/// An unread value ends the walk on the comma that follows it, taking every attribute written
-/// after it along — so which attributes a field is read by would otherwise depend on the order
-/// someone happened to write them in.
-fn consume_unread_value(nested: &ParseNestedMeta<'_>) -> syn::Result<()> {
-    if nested.input.peek(Token![=]) {
-        nested.value()?.parse::<syn::Expr>()?;
-    }
-    Ok(())
-}
-
-/// Whether the field writes a value for itself when its key is missing, in either spelling
-/// (`default` and `default = "path"`).
-///
-/// Asked of the attributes rather than carried on [`SerdeFieldMeta`]: nothing the generated
-/// surfaces describe turns on it — it is read where a serde hook is written, to decide whether
-/// that hook has a missing key to answer for.
-pub fn has_serde_default(attrs: &[Attribute]) -> bool {
-    let mut defaulted = false;
-    for attr in attrs {
-        if !attr.path().is_ident("serde") {
-            continue;
-        }
-        attr.parse_nested_meta(|nested| {
-            defaulted |= nested.path.is_ident("default");
-            consume_unread_value(&nested)?;
-            Ok(())
-        })
-        .unwrap_or_else(|e| {
-            log::trace!("Failed to parse serde field attribute: {e}");
-        });
-    }
-    defaulted
-}
-
 /// Applies serde `rename_all` transformation to a field name.
-#[cfg(test)]
+#[cfg(all(test, feature = "serde"))]
 pub fn apply_rename_all(field_name: &str, rename_all: Option<&str>) -> String {
     resolve_rename_rule(rename_all).apply_to_field(field_name)
 }
 
 /// Get the final field name after applying serde transformations.
-#[cfg(test)]
+#[cfg(all(test, feature = "serde"))]
 pub fn get_final_field_name(
     original_name: &str,
     field_meta: &SerdeFieldMeta,
@@ -219,4 +272,8 @@ pub fn get_final_field_name(
 }
 
 #[cfg(test)]
+mod key_omission_tests;
+
+#[cfg(test)]
+#[cfg(feature = "serde")]
 mod tests;

--- a/src/features/serde/key_omission_tests.rs
+++ b/src/features/serde/key_omission_tests.rs
@@ -1,0 +1,112 @@
+//! The omission walk is compiled in every build, so its tests are too — nothing here may reach
+//! anything the `serde` feature gates.
+
+use super::{SerdeKeyOmission, has_serde_default, parse_serde_key_omission};
+
+fn field_attrs(item: &syn::ItemStruct) -> &[syn::Attribute] {
+    &item.fields.iter().next().unwrap().attrs
+}
+
+fn omission(item: &syn::ItemStruct) -> SerdeKeyOmission {
+    parse_serde_key_omission(field_attrs(item))
+}
+
+/// The three spellings that leave the key out of the output, and what each one costs the read
+/// side: only a bare `skip` also stops serde looking for the key.
+#[test]
+fn test_key_omission_set_by_serialization_skips() {
+    let skip: syn::ItemStruct = syn::parse_quote! {
+        struct S {
+            #[serde(skip)]
+            note: Option<String>,
+        }
+    };
+    let skip_serializing: syn::ItemStruct = syn::parse_quote! {
+        struct S {
+            #[serde(skip_serializing)]
+            note: Option<String>,
+        }
+    };
+    let skip_serializing_if: syn::ItemStruct = syn::parse_quote! {
+        struct S {
+            #[serde(skip_serializing_if = "Option::is_none")]
+            note: Option<String>,
+        }
+    };
+    assert!(omission(&skip).omits_key);
+    assert!(omission(&skip).skips_deserializing);
+    assert!(omission(&skip_serializing).omits_key);
+    assert!(!omission(&skip_serializing).skips_deserializing);
+    assert!(omission(&skip_serializing_if).omits_key);
+    assert!(!omission(&skip_serializing_if).skips_deserializing);
+}
+
+#[test]
+fn test_key_omission_default_is_false() {
+    let omission = SerdeKeyOmission::default();
+    assert!(!omission.omits_key);
+    assert!(!omission.skips_deserializing);
+    assert!(!omission.defaulted);
+}
+
+/// A field's default is read in either spelling, since either one answers for a missing key.
+#[test]
+fn test_has_serde_default_reads_either_spelling() {
+    let bare: syn::ItemStruct = syn::parse_quote! {
+        struct S {
+            #[serde(default)]
+            note: Option<String>,
+        }
+    };
+    let named: syn::ItemStruct = syn::parse_quote! {
+        struct S {
+            #[serde(default = "make_note")]
+            note: Option<String>,
+        }
+    };
+    let neither: syn::ItemStruct = syn::parse_quote! {
+        struct S {
+            #[serde(skip_serializing_if = "Option::is_none")]
+            note: Option<String>,
+        }
+    };
+    assert!(has_serde_default(field_attrs(&bare)));
+    assert!(has_serde_default(field_attrs(&named)));
+    assert!(!has_serde_default(field_attrs(&neither)));
+}
+
+/// `skip_deserializing` stops serde reading the field but never suppresses the key on the way
+/// out, so it is the one member of the `skip` lump that omits nothing.
+#[test]
+fn test_key_omission_not_set_by_skip_deserializing() {
+    let item: syn::ItemStruct = syn::parse_quote! {
+        struct S {
+            #[serde(skip_deserializing)]
+            note: Option<String>,
+        }
+    };
+    assert!(!omission(&item).omits_key);
+    assert!(omission(&item).skips_deserializing);
+}
+
+/// The walk reads every attribute in the list, wherever it sits. A `key = value` this parser has
+/// no use for still has to be consumed: an unread value ends the walk on the comma after it, and
+/// everything written past that point would go unseen — which is a key read or not read according
+/// to the order someone happened to write the attributes in.
+#[test]
+fn test_omission_keys_after_an_unread_value_are_still_read() {
+    let item: syn::ItemStruct = syn::parse_quote! {
+        struct S {
+            #[serde(skip_serializing_if = "Option::is_none", default)]
+            note: Option<String>,
+        }
+    };
+    assert!(
+        omission(&item).omits_key,
+        "skip_serializing_if is the attribute read first"
+    );
+    assert!(
+        omission(&item).defaulted,
+        "default is written after an unread value"
+    );
+}

--- a/src/features/serde/tests.rs
+++ b/src/features/serde/tests.rs
@@ -40,7 +40,6 @@ fn test_final_field_name() {
         cfg_attr_rejection: None,
         rename: Some("customName".to_owned()),
         skip: false,
-        omits_none: false,
         flatten: false,
     };
     assert_eq!(
@@ -53,7 +52,6 @@ fn test_final_field_name() {
         cfg_attr_rejection: None,
         rename: None,
         skip: false,
-        omits_none: false,
         flatten: false,
     };
     assert_eq!(
@@ -106,47 +104,14 @@ fn field_attrs(item: &syn::ItemStruct) -> &[syn::Attribute] {
 }
 
 #[test]
-fn test_omits_none_set_by_serialization_skips() {
-    let skip: syn::ItemStruct = syn::parse_quote! {
-        struct S {
-            #[serde(skip)]
-            note: Option<String>,
-        }
-    };
-    let skip_serializing: syn::ItemStruct = syn::parse_quote! {
-        struct S {
-            #[serde(skip_serializing)]
-            note: Option<String>,
-        }
-    };
-    let skip_serializing_if: syn::ItemStruct = syn::parse_quote! {
-        struct S {
-            #[serde(skip_serializing_if = "Option::is_none")]
-            note: Option<String>,
-        }
-    };
-    assert!(field_meta(&skip).omits_none);
-    assert!(field_meta(&skip_serializing).omits_none);
-    assert!(field_meta(&skip_serializing_if).omits_none);
-}
-
-#[test]
-fn test_omits_none_not_set_by_skip_deserializing() {
+fn test_skip_deserializing_belongs_to_the_skip_lump() {
     let item: syn::ItemStruct = syn::parse_quote! {
         struct S {
             #[serde(skip_deserializing)]
             note: Option<String>,
         }
     };
-    let meta = field_meta(&item);
-    assert!(!meta.omits_none);
-    assert!(meta.skip);
-}
-
-#[test]
-fn test_omits_none_default_is_false() {
-    let meta = SerdeFieldMeta::default();
-    assert!(!meta.omits_none);
+    assert!(field_meta(&item).skip);
 }
 
 #[test]
@@ -235,32 +200,6 @@ fn test_untagged_default_is_false() {
     assert!(!meta.untagged);
 }
 
-/// A field's default is read in either spelling, since either one answers for a missing key.
-#[test]
-fn test_has_serde_default_reads_either_spelling() {
-    let bare: syn::ItemStruct = syn::parse_quote! {
-        struct S {
-            #[serde(default)]
-            note: Option<String>,
-        }
-    };
-    let named: syn::ItemStruct = syn::parse_quote! {
-        struct S {
-            #[serde(default = "make_note")]
-            note: Option<String>,
-        }
-    };
-    let neither: syn::ItemStruct = syn::parse_quote! {
-        struct S {
-            #[serde(skip_serializing_if = "Option::is_none")]
-            note: Option<String>,
-        }
-    };
-    assert!(has_serde_default(field_attrs(&bare)));
-    assert!(has_serde_default(field_attrs(&named)));
-    assert!(!has_serde_default(field_attrs(&neither)));
-}
-
 /// The walk reads every attribute in the list, wherever it sits. A `key = value` this parser has
 /// no use for still has to be consumed: an unread value ends the walk on the comma after it, and
 /// everything written past that point would go unseen — which is a field diagnosed by the
@@ -274,14 +213,6 @@ fn test_attributes_after_an_unread_value_are_still_read() {
         }
     };
     let meta = field_meta(&item);
-    assert!(
-        meta.omits_none,
-        "skip_serializing_if is the attribute read first"
-    );
-    assert!(
-        has_serde_default(field_attrs(&item)),
-        "default is written after an unread value"
-    );
     assert!(meta.flatten, "flatten is written after an unread value");
     assert_eq!(
         meta.rename.as_deref(),

--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -156,9 +156,9 @@ pub enum FieldDefType {
 ///   (`[null]` against `null`) that a single flag could not tell apart. `is_optional` asks it for
 ///   the outermost level, the only one whose `None` is not written inside an array and so the only
 ///   one whose flavor depends on where the field sits: a dropped or `| undefined`-valued key /
-///   `z.union([type, z.undefined()])` in struct-field position — `omits_none` deciding which of the
-///   two the key gets — and `| null` / `z.nullable(type)` in a tuple element or map value, neither
-///   of which can be dropped the way an object key can.
+///   `z.union([type, z.undefined()])` in struct-field position — `omits_value` deciding which of
+///   the two the key gets — and `| null` / `z.nullable(type)` in a tuple element or map value,
+///   neither of which can be dropped the way an object key can.
 /// - name: Safe field name (uses serde rename if feature enabled)
 /// - docs: Doc comments from Rust - included in generated TS as `JSDoc`
 /// - `field_type`: The core type classification (see `FieldDefType`)
@@ -176,13 +176,16 @@ pub enum FieldDefType {
 /// - `model_schema_prop_meta`: Optional metadata from #[`model_schema_prop`] attribute
 ///   - Used for overrides like literals, minLength, etc.
 ///   - See Phase 5 in `notes/20250707_field_features.md` for minLength details
-/// - `omits_none`: whether the serde attributes on a *named* field leave a `None` out of the
-///   serialized output entirely rather than writing it. Set only where the attribute was read —
-///   an unnamed field has no key to drop, and without the `serde` feature no attribute is read at
-///   all — so a field carrying it is one whose key serde may never write. Together with
-///   `is_optional` it is what the object surfaces ask before choosing between the two spellings of
-///   an optional member: the key-optional `field?: T` for a key that may be absent, `field: T |
-///   undefined` for one that is always written.
+/// - `omits_value`: whether the serde attributes on a *named* field leave its value out of the
+///   serialized output entirely rather than writing it — a `None` under a
+///   `skip_serializing_if = "Option::is_none"`, an empty `Vec` under a `Vec::is_empty`, every
+///   value at all under a bare `skip`. Only a named field has a key to drop: a positional one is
+///   written by its place in a tuple, where nothing can be omitted. A field carrying it is one
+///   whose key serde may never write, which is what the object surfaces ask before choosing
+///   between the two spellings of an optional member — the key-optional `field?: T` for a key
+///   that may be absent, `field: T | undefined` for one that is always written — and what takes
+///   the field out of the JSON surface's `required`. Read in every build: the attribute stating
+///   it is on the field whatever the features say, and one declaration describes one wire.
 /// - `type_span`: where the type this field carries was written — the name segment of a path, the
 ///   whole type otherwise, and the innermost name under a wrapper, so `Vec<Inner>` points at
 ///   `Inner`. The JSON schema is the one surface that emits a Rust path built from a type name, so
@@ -205,7 +208,7 @@ pub struct FieldDef {
     pub model_schema_prop_meta: Option<ModelSchemaPropMeta>,
     pub name: String,
     pub nullable_levels: Vec<u8>,
-    pub omits_none: bool,
+    pub omits_value: bool,
     #[cfg(feature = "jsonschema")]
     pub type_span: Span,
 }
@@ -253,7 +256,7 @@ impl FieldDef {
         arrayed
             .model_schema_prop_meta
             .clone_from(&self.model_schema_prop_meta);
-        arrayed.omits_none = self.omits_none;
+        arrayed.omits_value = self.omits_value;
         arrayed
     }
 
@@ -531,18 +534,33 @@ impl FieldDef {
         self.is_nullable_at(self.array_depth)
     }
 
+    /// Whether every payload serde writes carries a key for this field — what the JSON surface's
+    /// `required` names, and the one question there that a field's `Option`-ness alone cannot
+    /// answer.
+    ///
+    /// An `Option` in struct-field position may write no key. A serde attribute that omits the
+    /// value means the same thing for a field of any type. Either one is enough to take the field
+    /// out of `required`, because `required` is a claim about every payload and one payload
+    /// without the key is enough to falsify it.
+    #[cfg(feature = "jsonschema")]
+    pub fn key_is_required(&self) -> bool {
+        !self.is_optional() && !self.omits_value
+    }
+
     /// Whether the object key this field writes may be absent, which is the question the two
     /// spellings of an optional member answer differently — `field?: T` admits the payload with no
     /// such key, `field: T | undefined` demands the key and lets its value be `undefined`.
     ///
     /// Two things say it, and either alone is enough. `ts_optional` says it for the TypeScript
-    /// surface on the author's word. A serde attribute that omits a `None` says it off the wire:
-    /// the payload serde writes for that field simply has no key, which is the same fact the JSON
-    /// surface spends when it leaves the field out of `required`.
+    /// surface on the author's word, which only an `Option` field may give. A serde attribute that
+    /// omits the value says it off the wire, whatever the field is written as: the payload serde
+    /// writes simply has no key there. That second one asks nothing about `Option`-ness on purpose
+    /// — a `Vec` behind a `Vec::is_empty` predicate has no `None` anywhere in it and its key still
+    /// goes missing, so a rule keyed on `Option` would describe a payload serde does not write.
     fn key_may_be_absent(&self) -> bool {
-        self.is_optional()
-            && (self.omits_none
-                || self
+        self.omits_value
+            || (self.is_optional()
+                && self
                     .model_schema_prop_meta
                     .as_ref()
                     .is_some_and(|m| m.ts_optional))
@@ -1048,6 +1066,11 @@ impl FieldDef {
     ///   position wraps `z.union([type, z.undefined()])`; tuple-element and map-value positions wrap
     ///   `z.nullable(type)` (neither can be omitted like an object key, so a `None` there
     ///   serializes as `null`)
+    /// - Otherwise, if the key may still go missing — a serde attribute dropping the value of a
+    ///   field that is no `Option` — appends `.optional()`. The value under the key is unchanged,
+    ///   so the type is left as it stands and only its presence is relaxed. Recorded against zod
+    ///   4.4.3: inside a `z.strictObject`, that member admits the payload with the key absent and
+    ///   the payload carrying it, still rejects `null`, and still rejects an unrecognized key.
     ///
     /// Requires Zod v4 in frontend - generates v4-compatible syntax.
     /// See `notes/20250706_features.md` for Zod feature details.
@@ -1055,6 +1078,8 @@ impl FieldDef {
         let pre_result = self.zod_base();
         if self.is_optional() {
             format!("z.union([{pre_result}, z.undefined()]).prefault(undefined)")
+        } else if self.key_may_be_absent() {
+            format!("{pre_result}.optional()")
         } else {
             pre_result
         }
@@ -1203,7 +1228,7 @@ fn get_field_def_from_type_path(
             docs: field_docs.to_owned(),
             model_schema_prop_meta: None,
             nullable_levels: Vec::new(),
-            omits_none: false,
+            omits_value: false,
             #[cfg(feature = "jsonschema")]
             type_span: type_path.span(),
         };
@@ -1218,7 +1243,7 @@ fn get_field_def_from_type_path(
             docs: field_docs.to_owned(),
             model_schema_prop_meta: None,
             nullable_levels: Vec::new(),
-            omits_none: false,
+            omits_value: false,
             // The name segment, not the whole path: it is what a generated module is named after,
             // so a reference the module cannot resolve is blamed on the name it was built from.
             #[cfg(feature = "jsonschema")]
@@ -1236,7 +1261,7 @@ fn get_field_def_from_type_path(
             docs: field_docs.to_owned(),
             model_schema_prop_meta: None,
             nullable_levels: Vec::new(),
-            omits_none: false,
+            omits_value: false,
             #[cfg(feature = "jsonschema")]
             type_span: segment.ident.span(),
         },
@@ -1286,7 +1311,7 @@ fn get_field_def_from_generic_type(
             docs: field_docs.to_owned(),
             model_schema_prop_meta: None,
             nullable_levels: Vec::new(),
-            omits_none: false,
+            omits_value: false,
             #[cfg(feature = "jsonschema")]
             type_span: type_ident.span(),
         }
@@ -1334,7 +1359,7 @@ fn get_field_def_from_generic_type(
             docs: field_docs.to_owned(),
             model_schema_prop_meta: None,
             nullable_levels: Vec::new(),
-            omits_none: false,
+            omits_value: false,
             #[cfg(feature = "jsonschema")]
             type_span: type_ident.span(),
         }
@@ -1348,7 +1373,7 @@ fn get_field_def_from_generic_type(
             docs: field_docs.to_owned(),
             model_schema_prop_meta: None,
             nullable_levels: Vec::new(),
-            omits_none: false,
+            omits_value: false,
             #[cfg(feature = "jsonschema")]
             type_span: type_ident.span(),
         }
@@ -1362,7 +1387,7 @@ fn get_field_def_from_generic_type(
             docs: field_docs.to_owned(),
             model_schema_prop_meta: None,
             nullable_levels: Vec::new(),
-            omits_none: false,
+            omits_value: false,
             #[cfg(feature = "jsonschema")]
             type_span: type_ident.span(),
         }
@@ -1426,7 +1451,7 @@ pub fn get_field_def(name: &str, ty: &Type, field_docs: &str) -> FieldDef {
             docs: field_docs.to_owned(),
             model_schema_prop_meta: None,
             nullable_levels: Vec::new(),
-            omits_none: false,
+            omits_value: false,
             #[cfg(feature = "jsonschema")]
             type_span: ty.span(),
         }
@@ -1440,7 +1465,7 @@ pub fn get_field_def(name: &str, ty: &Type, field_docs: &str) -> FieldDef {
             docs: field_docs.to_owned(),
             model_schema_prop_meta: None,
             nullable_levels: Vec::new(),
-            omits_none: false,
+            omits_value: false,
             #[cfg(feature = "jsonschema")]
             type_span: ty.span(),
         }

--- a/src/field_type/tests.rs
+++ b/src/field_type/tests.rs
@@ -19,7 +19,7 @@ fn field(field_type: FieldDefType) -> FieldDef {
         model_schema_prop_meta: None,
         nullable_levels: Vec::new(),
         name: "items".to_owned(),
-        omits_none: false,
+        omits_value: false,
         #[cfg(feature = "jsonschema")]
         type_span: proc_macro2::Span::call_site(),
     }

--- a/src/generation/tests.rs
+++ b/src/generation/tests.rs
@@ -21,7 +21,7 @@ fn test_typescript_field_formatting() {
         array_lengths: Vec::new(),
         model_schema_prop_meta: None,
         nullable_levels: Vec::new(),
-        omits_none: false,
+        omits_value: false,
         #[cfg(feature = "jsonschema")]
         type_span: proc_macro2::Span::call_site(),
     };

--- a/src/generation/typescript/tests.rs
+++ b/src/generation/typescript/tests.rs
@@ -20,7 +20,7 @@ fn test_generate_struct_type_with_fields() {
             array_lengths: Vec::new(),
             model_schema_prop_meta: None,
             nullable_levels: Vec::new(),
-            omits_none: false,
+            omits_value: false,
             #[cfg(feature = "jsonschema")]
             type_span: proc_macro2::Span::call_site(),
         },
@@ -32,7 +32,7 @@ fn test_generate_struct_type_with_fields() {
             array_lengths: Vec::new(),
             model_schema_prop_meta: None,
             nullable_levels: vec![0],
-            omits_none: false,
+            omits_value: false,
             #[cfg(feature = "jsonschema")]
             type_span: proc_macro2::Span::call_site(),
         },

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -50,7 +50,8 @@ use crate::utils::{
 use crate::utils::{TrivialPattern, trivial_pattern};
 
 #[cfg(feature = "serde")]
-use crate::features::serde::{SerdeFieldMeta, SerdeTypeMeta, has_serde_default};
+use crate::features::serde::{SerdeFieldMeta, SerdeTypeMeta};
+use crate::features::serde::{has_serde_default, parse_serde_key_omission};
 
 #[cfg(feature = "serde")]
 use crate::field_type::{parse_serde_field_attributes, parse_serde_type_attributes};
@@ -476,6 +477,20 @@ struct MergedOperand {
     members: Vec<ZodUnionMember>,
     optional: bool,
     spelling: String,
+}
+
+/// What the item around a field says about it: everything [`process_field`] needs that is not the
+/// field itself, bundled so the walk hands one context down instead of six loose parameters.
+struct FieldContext<'ctx> {
+    /// Whether the container carries `#[serde(default)]`, which supplies a value for every field
+    /// under it whose key the payload leaves out.
+    container_defaulted: bool,
+    rename_all: Option<&'ctx str>,
+    schema_module_name: Option<&'ctx str>,
+    type_name: &'ctx str,
+    type_parameters: &'ctx [String],
+    /// The variant this field belongs to, or `None` for a struct's own field.
+    variant_ident: Option<&'ctx str>,
 }
 
 /// Mutable output buffers shared by the discriminated-enum variant writers. Bundled so each writer
@@ -2017,6 +2032,7 @@ fn collect_struct_fields(
     module_name_opt: Option<&str>,
     type_name: &str,
     generics: &syn::Generics,
+    container_defaulted: bool,
 ) -> StructFieldData {
     let type_parameters = type_parameters_in_scope(generics);
     let mut field_defs = Vec::new();
@@ -2047,12 +2063,15 @@ fn collect_struct_fields(
         }
 
         let (f_def, validation_fn, validate_body, field_guard_errors) = process_field(
-            rename_all,
+            &FieldContext {
+                container_defaulted,
+                rename_all,
+                schema_module_name: module_name_opt,
+                type_name,
+                type_parameters: &type_parameters,
+                variant_ident: None,
+            },
             field,
-            module_name_opt,
-            None,
-            type_name,
-            &type_parameters,
             &mut deferred_attrs,
         );
 
@@ -2209,6 +2228,10 @@ fn process_struct(mut item_struct: syn::ItemStruct, args: &ModelSchemaArgs) -> T
     #[cfg(not(feature = "serde"))]
     let rename_all: Option<String> = None;
 
+    // A `default` on the container answers a missing key for every field under it, which is one of
+    // the things that makes a dropped key readable.
+    let container_defaulted = has_serde_default(&item_struct.attrs);
+
     // A tuple struct's slots have no keys, so the named-field emitters below would render every
     // one of them under the empty ident it carries.
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
@@ -2242,6 +2265,7 @@ fn process_struct(mut item_struct: syn::ItemStruct, args: &ModelSchemaArgs) -> T
         module_name_opt,
         &rust_ident,
         &item_struct.generics,
+        container_defaulted,
     );
     #[cfg(not(any(feature = "typescript", feature = "zod", feature = "jsonschema")))]
     let _: &_ = &&collected;
@@ -2338,6 +2362,7 @@ fn collect_tuple_slots(
     module_name: &str,
     type_name: &str,
     generics: &syn::Generics,
+    container_defaulted: bool,
 ) -> (Vec<FieldDef>, Vec<proc_macro2::TokenStream>) {
     let type_parameters = type_parameters_in_scope(generics);
     let mut slots: Vec<FieldDef> = Vec::new();
@@ -2345,12 +2370,15 @@ fn collect_tuple_slots(
     let mut deferred_attrs: Vec<Vec<syn::Attribute>> = Vec::new();
     for field in fields.iter_mut() {
         let (slot, _, _, slot_guard_errors) = process_field(
-            rename_all,
+            &FieldContext {
+                container_defaulted,
+                rename_all,
+                schema_module_name: Some(module_name),
+                type_name,
+                type_parameters: &type_parameters,
+                variant_ident: None,
+            },
             field,
-            Some(module_name),
-            None,
-            type_name,
-            &type_parameters,
             &mut deferred_attrs,
         );
         guard_errors.extend(slot_guard_errors);
@@ -2502,6 +2530,7 @@ fn process_tuple_struct(
         &module_name,
         &name.to_string(),
         &item_struct.generics,
+        has_serde_default(&item_struct.attrs),
     );
 
     // A violated slot guard makes the whole contract unsound, so the schema surface is dropped and
@@ -4192,6 +4221,9 @@ fn collect_discriminated_variants(
         let final_name =
             get_final_variant_name(&variant_ident, field_rename.as_deref(), rename_all);
         let variant_kind = classify_variant(item);
+        // A struct variant is where serde accepts a container-level `default`, so it is the
+        // container its own fields' omissions are read against.
+        let variant_defaulted = has_serde_default(&item.attrs);
 
         let mut field_defs: Vec<FieldDef> = Vec::new();
         let mut bound: Vec<(proc_macro2::Ident, proc_macro2::Ident)> = Vec::new();
@@ -4199,12 +4231,15 @@ fn collect_discriminated_variants(
         let total_fields = item.fields.len();
         for field in &mut item.fields {
             let (f_def, validation_fn, validate_body, field_guard_errors) = process_field(
-                rename_all,
+                &FieldContext {
+                    container_defaulted: variant_defaulted,
+                    rename_all,
+                    schema_module_name: enum_module_name_opt,
+                    type_name: &enum_type_name,
+                    type_parameters: &type_parameters,
+                    variant_ident: Some(&variant_ident),
+                },
                 field,
-                enum_module_name_opt,
-                Some(&variant_ident),
-                &enum_type_name,
-                &type_parameters,
                 &mut deferred_attrs,
             );
             if let Some(vfn) = validation_fn {
@@ -5383,12 +5418,12 @@ fn untagged_named_json_value(field_defs: &[FieldDef]) -> proc_macro2::TokenStrea
     let property_inserts = field_defs.iter().map(|fld| {
         let name_str = fld.name.clone();
         let value = field_json_schema_value(fld);
-        let required_insert = if fld.is_optional() {
-            quote! {}
-        } else {
+        let required_insert = if fld.key_is_required() {
             quote! {
                 required.push(serde_json::Value::String(#name_str.to_string()));
             }
+        } else {
+            quote! {}
         };
         quote! {
             properties.insert(#name_str.to_string(), #value);
@@ -5560,6 +5595,9 @@ fn member_rejection_value(
 /// The guard verdicts one untagged member earns, serde's and this crate's own combined — the
 /// checks [`process_field`] runs through its own channels, asked here by the walk that builds its
 /// field defs directly.
+///
+/// `container_defaulted` is the variant's own `#[serde(default)]`: a struct variant is where serde
+/// accepts one, and it is the container this member's omission is read against.
 #[cfg(feature = "serde")]
 fn untagged_member_guard_errors(
     field: &Field,
@@ -5567,6 +5605,7 @@ fn untagged_member_guard_errors(
     field_name: &str,
     prop_meta: &ModelSchemaPropMeta,
     serde_field_meta: &SerdeFieldMeta,
+    container_defaulted: bool,
     positional_constraint_error: Option<proc_macro2::TokenStream>,
 ) -> Vec<proc_macro2::TokenStream> {
     let serde_guard_errors = field_guard_errors(
@@ -5574,6 +5613,7 @@ fn untagged_member_guard_errors(
         field_name,
         field_def.is_optional(),
         serde_field_meta,
+        container_defaulted,
         positional_constraint_error,
     );
     collect_field_guard_errors(field, field_def, field_name, prop_meta, serde_guard_errors)
@@ -5627,17 +5667,14 @@ fn collect_untagged_members(
     for variant in &mut item_enum.variants {
         let kind = classify_variant(variant);
         let variant_name = variant.ident.to_string();
+        let variant_defaulted = has_serde_default(&variant.attrs);
 
         let mut field_defs: Vec<FieldDef> = Vec::new();
         let mut bound: Vec<(proc_macro2::Ident, proc_macro2::Ident)> = Vec::new();
         let mut checks: Vec<proc_macro2::TokenStream> = Vec::new();
         let total_fields = variant.fields.len();
         for field in &mut variant.fields {
-            let field_name = field
-                .ident
-                .as_ref()
-                .map(ToString::to_string)
-                .unwrap_or_default();
+            let field_name = field_ident_string(field);
             let prop_meta = parse_model_schema_prop_attributes(&field.attrs);
             let serde_field_meta = parse_serde_field_attributes(&field.attrs);
 
@@ -5661,13 +5698,14 @@ fn collect_untagged_members(
             }
 
             let mut field_def = get_field_def(&field_name, &field.ty, "");
-            apply_serde_key_omission(&mut field_def, field, &serde_field_meta);
+            apply_serde_key_omission(&mut field_def, field);
             guard_errors.extend(untagged_member_guard_errors(
                 field,
                 &field_def,
                 &field_name,
                 &prop_meta,
                 &serde_field_meta,
+                variant_defaulted,
                 positional_constraint_error,
             ));
 
@@ -7603,12 +7641,12 @@ fn build_field_schema(fld: &FieldDef) -> proc_macro2::TokenStream {
     let field_name_str = fld.name.clone();
     let schema_code = build_field_type_schema(fld, &field_name_str);
 
-    let required_code = if fld.is_optional() {
-        quote! {}
-    } else {
+    let required_code = if fld.key_is_required() {
         quote! {
             required.push(serde_json::Value::String(#field_name_str.to_string()));
         }
+    } else {
+        quote! {}
     };
 
     quote! {
@@ -8281,15 +8319,28 @@ fn validate_ts_optional_flag(field_optional: bool, flag_set: bool) -> Result<(),
     Ok(())
 }
 
-/// Hands the field def the one serde fact the object surfaces spend: whether a `None` leaves the
-/// key out of the serialized object rather than writing it.
+/// The field's ident as a string, empty for a positional slot that has none.
+fn field_ident_string(field: &Field) -> String {
+    field
+        .ident
+        .as_ref()
+        .map(ToString::to_string)
+        .unwrap_or_default()
+}
+
+/// Hands the field def the one serde fact the object surfaces spend: whether the field's value
+/// leaves the key out of the serialized object rather than writing it.
 ///
 /// Only a named field has a key to leave out. A positional one is written by its place in a tuple,
 /// where nothing can be dropped and a `None` reaches the wire as a `null`, so the omission the
 /// attribute names never happens there and the slot spellings stand as written.
-#[cfg(feature = "serde")]
-const fn apply_serde_key_omission(field_def: &mut FieldDef, field: &Field, meta: &SerdeFieldMeta) {
-    field_def.omits_none = field.ident.is_some() && meta.omits_none;
+///
+/// Not gated on the `serde` feature. The attribute is on the field in every build and the surfaces
+/// claim to describe the payload serde writes in every build, so a toggle that changed the answer
+/// would make one declaration describe two different wires.
+fn apply_serde_key_omission(field_def: &mut FieldDef, field: &Field) {
+    field_def.omits_value =
+        field.ident.is_some() && parse_serde_key_omission(&field.attrs).omits_key;
 }
 
 /// Rejects a named `Option` field whose serde attributes let a `None` reach the wire as `null`.
@@ -8305,15 +8356,11 @@ const fn apply_serde_key_omission(field_def: &mut FieldDef, field: &Field, meta:
 /// array around it is always written, so the key is always present and the `None` is an item, which
 /// the field's own schema describes as nullable.
 #[cfg(feature = "serde")]
-fn check_optional_field_serialization(
-    field: &Field,
-    is_optional: bool,
-    meta: &SerdeFieldMeta,
-) -> Result<(), syn::Error> {
+fn check_optional_field_serialization(field: &Field, is_optional: bool) -> Result<(), syn::Error> {
     let Some(ident) = field.ident.as_ref() else {
         return Ok(());
     };
-    if !is_optional || meta.omits_none {
+    if !is_optional || parse_serde_key_omission(&field.attrs).omits_key {
         return Ok(());
     }
     Err(syn::Error::new_spanned(
@@ -8323,6 +8370,51 @@ fn check_optional_field_serialization(
              while the generated schema only accepts the key being absent. Add \
              #[serde(skip_serializing_if = \"Option::is_none\")] (plus `default` if the type \
              derives Deserialize), or `skip` / `skip_serializing`."
+        ),
+    ))
+}
+
+/// Rejects a named field whose serde attributes drop its key on the way out while serde still
+/// insists on finding that key on the way in.
+///
+/// `skip_serializing` and `skip_serializing_if` suppress the key but leave deserialization alone,
+/// so the field is still looked for by name — and a field with no `default` behind it has nothing
+/// to be when the key is missing. Recorded from serde itself: a `Vec` field carrying
+/// `skip_serializing_if = "Vec::is_empty"` and nothing else serializes to `{"id":"1"}` and then
+/// fails to deserialize that very payload, reporting the field as missing. The generated surfaces
+/// are now written to admit the absent key, so leaving this spelling alone would publish a
+/// contract whose own author cannot read what it describes.
+///
+/// Three spellings are exempt, each because serde already answers the missing key:
+/// - a bare `skip`, which stops deserializing too and so supplies `Default` itself;
+/// - an `Option` field, which serde reads back as `None` from a missing key with no `default`
+///   written (the `Option`-null guard above is what polices those);
+/// - a `default` on the field or on the container, either of which writes the value.
+#[cfg(feature = "serde")]
+fn check_omitted_key_is_readable(
+    field: &Field,
+    is_optional: bool,
+    container_defaulted: bool,
+) -> Result<(), syn::Error> {
+    let Some(ident) = field.ident.as_ref() else {
+        return Ok(());
+    };
+    let omission = parse_serde_key_omission(&field.attrs);
+    if is_optional
+        || container_defaulted
+        || omission.defaulted
+        || omission.skips_deserializing
+        || !omission.omits_key
+    {
+        return Ok(());
+    }
+    Err(syn::Error::new_spanned(
+        field,
+        format!(
+            "model_schema: field `{ident}` is left out of the serialized object by its serde \
+             attribute, but serde still requires the key when deserializing, so the payload it \
+             writes cannot be read back. Add #[serde(default)] to the field (or to the type), or \
+             use `skip` if the field should never be read from the payload."
         ),
     ))
 }
@@ -8338,13 +8430,17 @@ fn field_guard_errors(
     raw_field_ident: &str,
     is_optional: bool,
     serde_field_meta: &SerdeFieldMeta,
+    container_defaulted: bool,
     positional_constraint_error: Option<proc_macro2::TokenStream>,
 ) -> Vec<proc_macro2::TokenStream> {
     positional_constraint_error
         .into_iter()
         .chain(serde_field_meta.cfg_attr_rejection.as_ref().map_or_else(
             || {
-                check_optional_field_serialization(field, is_optional, serde_field_meta)
+                check_optional_field_serialization(field, is_optional)
+                    .and_then(|()| {
+                        check_omitted_key_is_readable(field, is_optional, container_defaulted)
+                    })
                     .err()
                     .map(|err| err.to_compile_error())
             },
@@ -8614,12 +8710,8 @@ fn check_os_string_field(
 /// and inert to every derive, so a copy left on the emitted item is one rustc reports as an
 /// attribute that does not exist.
 fn process_field(
-    rename_all: Option<&str>,
+    ctx: &FieldContext<'_>,
     field: &mut Field,
-    schema_module_name: Option<&str>,
-    variant_ident: Option<&str>,
-    type_name: &str,
-    type_parameters: &[String],
     deferred_attrs: &mut Vec<Vec<syn::Attribute>>,
 ) -> (
     FieldDef,
@@ -8641,11 +8733,7 @@ fn process_field(
     let field_rename: Option<String> = None;
 
     // Get raw field ident (before renaming) for validation function name
-    let raw_field_ident = field
-        .ident
-        .as_ref()
-        .map(ToString::to_string)
-        .unwrap_or_default();
+    let raw_field_ident = field_ident_string(field);
 
     // Parse model_schema_prop attributes before filtering them out
     let model_schema_prop_meta = parse_model_schema_prop_attributes(&field.attrs);
@@ -8656,9 +8744,9 @@ fn process_field(
     #[cfg(feature = "serde")]
     let (validation_fn, validate_body, positional_constraint_error) = generate_field_validation(
         field,
-        schema_module_name,
+        ctx.schema_module_name,
         &raw_field_ident,
-        variant_ident,
+        ctx.variant_ident,
         &model_schema_prop_meta,
         &mut injected_attrs,
     );
@@ -8669,14 +8757,15 @@ fn process_field(
         Option<proc_macro2::TokenStream>,
     ) = (None, None);
     #[cfg(not(feature = "serde"))]
-    let _: &_ = &(schema_module_name, variant_ident);
+    let _: &_ = &(ctx.schema_module_name, ctx.variant_ident);
 
     field.attrs = new_attrs;
     deferred_attrs.push(injected_attrs);
 
     let field_type: &syn::Type = &field.ty;
 
-    let final_name = get_final_field_name(&raw_field_ident, field_rename.as_deref(), rename_all);
+    let final_name =
+        get_final_field_name(&raw_field_ident, field_rename.as_deref(), ctx.rename_all);
     let field_docs = build_jsdoc_body(get_field_docs(field).as_deref(), &final_name);
 
     // Create the field definition and apply any model_schema_prop overrides
@@ -8685,10 +8774,9 @@ fn process_field(
     // Resolve `Self` references to the concrete type name so recursive fields
     // (e.g. `Vec<Self>`) are treated exactly like `Vec<EnclosingType>`. Resolved before the guards
     // read the field so each one asks its question of the type the surfaces will render.
-    field_def.resolve_self_references(type_name);
+    field_def.resolve_self_references(ctx.type_name);
 
-    #[cfg(feature = "serde")]
-    apply_serde_key_omission(&mut field_def, field, &serde_field_meta);
+    apply_serde_key_omission(&mut field_def, field);
 
     #[cfg(feature = "serde")]
     let serde_guard_errors = field_guard_errors(
@@ -8696,10 +8784,14 @@ fn process_field(
         &raw_field_ident,
         field_def.is_optional(),
         &serde_field_meta,
+        ctx.container_defaulted,
         positional_constraint_error,
     );
     #[cfg(not(feature = "serde"))]
-    let serde_guard_errors: Vec<proc_macro2::TokenStream> = Vec::new();
+    let serde_guard_errors: Vec<proc_macro2::TokenStream> = {
+        let _: bool = ctx.container_defaulted;
+        Vec::new()
+    };
 
     let guard_errors = collect_field_guard_errors(
         field,
@@ -8713,7 +8805,7 @@ fn process_field(
 
     // Last, so every guard above asked its question of the type the author wrote, and so an
     // `as = Type` override is read for a parameter too.
-    field_def.erase_type_parameters(type_parameters);
+    field_def.erase_type_parameters(ctx.type_parameters);
 
     (field_def, validation_fn, validate_body, guard_errors)
 }

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -2266,25 +2266,16 @@ fn struct_cfg_attr_guard_output(
         &[cfg_attr_guard_error(rejection?, &format!("type `{ident}`"))],
     )
 }
-/// The struct's own `rename_all`, or the `cfg_attr` refusal that pre-empts reading anything —
-/// serde's attributes are the one place a rename can be written, so without that feature there is
-/// nothing to read and nothing to refuse.
+/// The struct's own `rename_all`, or the `cfg_attr` refusal that pre-empts reading anything.
+#[cfg(feature = "serde")]
 fn struct_rename_all(item_struct: &syn::ItemStruct) -> Result<Option<String>, TokenStream> {
-    #[cfg(feature = "serde")]
+    let serde_type_meta = parse_serde_type_attributes(&item_struct.attrs);
+    if let Some(output) =
+        struct_cfg_attr_guard_output(item_struct, serde_type_meta.cfg_attr_rejection.as_ref())
     {
-        let serde_type_meta = parse_serde_type_attributes(&item_struct.attrs);
-        if let Some(output) =
-            struct_cfg_attr_guard_output(item_struct, serde_type_meta.cfg_attr_rejection.as_ref())
-        {
-            return Err(output);
-        }
-        Ok(serde_type_meta.rename_all)
+        return Err(output);
     }
-    #[cfg(not(feature = "serde"))]
-    {
-        let _: &_ = &item_struct;
-        Ok(None)
-    }
+    Ok(serde_type_meta.rename_all)
 }
 
 fn process_struct(mut item_struct: syn::ItemStruct, args: &ModelSchemaArgs) -> TokenStream {
@@ -2300,10 +2291,13 @@ fn process_struct(mut item_struct: syn::ItemStruct, args: &ModelSchemaArgs) -> T
     let name = item_struct.ident.clone();
     let rust_ident = name.to_string();
 
+    #[cfg(feature = "serde")]
     let rename_all = match struct_rename_all(&item_struct) {
         Ok(rename_all) => rename_all,
         Err(output) => return output,
     };
+    #[cfg(not(feature = "serde"))]
+    let rename_all: Option<String> = None;
 
     // A `default` on the container answers a missing key for every field under it, which is one of
     // the things that makes a dropped key readable.

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -7,11 +7,11 @@ use super::{
 #[cfg(feature = "serde")]
 use super::{
     ConstraintLeaf, MemberAccess, ModelSchemaPropMeta, build_field_validation,
-    cfg_attr_guard_error, check_optional_field_serialization, collect_untagged_members,
-    constrained_shape, enum_cfg_attr_guard_errors, generate_field_validation,
-    generate_numeric_validation_code, generate_string_validation_code, helper_name_stem,
-    internally_tagged_guard_errors, needs_injected_default, parse_serde_field_attributes,
-    parse_serde_type_attributes,
+    cfg_attr_guard_error, check_omitted_key_is_readable, check_optional_field_serialization,
+    collect_untagged_members, constrained_shape, enum_cfg_attr_guard_errors,
+    generate_field_validation, generate_numeric_validation_code, generate_string_validation_code,
+    has_serde_default, helper_name_stem, internally_tagged_guard_errors, needs_injected_default,
+    parse_serde_field_attributes, parse_serde_type_attributes,
 };
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
@@ -131,8 +131,25 @@ fn guard_result(item: &syn::ItemStruct) -> Result<(), syn::Error> {
         .map(ToString::to_string)
         .unwrap_or_default();
     let field_def = get_field_def(&field_name, &field.ty, "");
-    let meta = parse_serde_field_attributes(&field.attrs);
-    check_optional_field_serialization(field, field_def.is_optional(), &meta)
+    check_optional_field_serialization(field, field_def.is_optional())
+}
+
+/// Runs the omitted-key readability guard over the sole field of `item`, with the container's own
+/// `default` read off the item the way the generator reads it.
+#[cfg(feature = "serde")]
+fn omitted_key_guard_result(item: &syn::ItemStruct) -> Result<(), syn::Error> {
+    let field = item.fields.iter().next().unwrap();
+    let field_name = field
+        .ident
+        .as_ref()
+        .map(ToString::to_string)
+        .unwrap_or_default();
+    let field_def = get_field_def(&field_name, &field.ty, "");
+    check_omitted_key_is_readable(
+        field,
+        field_def.is_optional(),
+        has_serde_default(&item.attrs),
+    )
 }
 
 #[cfg(feature = "serde")]
@@ -146,6 +163,65 @@ fn bare_option_field_is_rejected() {
     let message = guard_result(&item).unwrap_err().to_string();
     assert!(message.contains("note"));
     assert!(message.contains("skip_serializing_if = \"Option::is_none\""));
+}
+
+/// Read off serde itself: a `Vec` behind a `skip_serializing_if` and nothing else serializes to
+/// `{"id":"1"}` and then fails to deserialize that payload, reporting the field as missing. The
+/// surfaces now admit the absent key, so the spelling that writes a payload it cannot read back is
+/// refused rather than described.
+#[cfg(feature = "serde")]
+#[test]
+fn a_non_option_omitted_key_with_no_default_is_rejected() {
+    for spelling in [
+        "skip_serializing_if = \"Vec::is_empty\"",
+        "skip_serializing",
+    ] {
+        let item: syn::ItemStruct = syn::parse_str(&format!(
+            "struct Report {{ #[serde({spelling})] roles: Vec<String> }}"
+        ))
+        .unwrap();
+        let message = omitted_key_guard_result(&item).unwrap_err().to_string();
+        assert!(message.contains("roles"), "{spelling}: {message}");
+        assert!(message.contains("default"), "{spelling}: {message}");
+    }
+}
+
+/// Every spelling serde can already read a missing key back from. Each is left alone, because the
+/// guard's subject is a payload with no reader — not an omitted key as such.
+#[cfg(feature = "serde")]
+#[test]
+fn an_omitted_key_serde_can_read_back_is_left_alone() {
+    for item_source in [
+        // `default` on the field writes the value the missing key does not carry.
+        "struct Report { #[serde(default, skip_serializing_if = \"Vec::is_empty\")] roles: Vec<String> }",
+        "struct Report { #[serde(default = \"mk\", skip_serializing_if = \"Vec::is_empty\")] roles: Vec<String> }",
+        // A bare `skip` stops serde reading the field at all, so it supplies `Default` itself.
+        "struct Report { #[serde(skip)] roles: Vec<String> }",
+        // serde reads a missing `Option` field back as `None` with no `default` written.
+        "struct Report { #[serde(skip_serializing_if = \"Option::is_none\")] note: Option<String> }",
+        // A `default` on the container answers for every field under it.
+        "#[serde(default)] struct Report { #[serde(skip_serializing_if = \"Vec::is_empty\")] roles: Vec<String> }",
+        // No omission at all.
+        "struct Report { roles: Vec<String> }",
+    ] {
+        let item: syn::ItemStruct = syn::parse_str(item_source).unwrap();
+        let refusal = omitted_key_guard_result(&item)
+            .err()
+            .map(|err| err.to_string());
+        assert_eq!(refusal, None, "for: {item_source}");
+    }
+}
+
+/// A positional slot has no key to drop — it is written by its place in the tuple — so the guard
+/// has no subject there whatever the attribute says.
+#[cfg(feature = "serde")]
+#[test]
+fn a_positional_slot_is_not_subject_to_the_omitted_key_guard() {
+    let item: syn::ItemStruct = syn::parse_str(
+        "struct Report(#[serde(skip_serializing_if = \"Vec::is_empty\")] Vec<String>);",
+    )
+    .unwrap();
+    omitted_key_guard_result(&item).unwrap();
 }
 
 /// The single-field `Report` written with `notes` at the given spelling.
@@ -1575,6 +1651,7 @@ fn a_refused_pattern_leaves_no_hook_naming_the_dropped_module() {
         Some("probe_caret_schema"),
         "ProbeCaret",
         &syn::Generics::default(),
+        false,
     )
     .4;
     assert_eq!(errors.len(), 1, "got: {errors:?}");
@@ -1662,6 +1739,7 @@ fn a_field_that_clears_the_guards_carries_the_hook_it_earned() {
         Some("report_schema"),
         "Report",
         &syn::Generics::default(),
+        false,
     )
     .4;
     assert!(errors.is_empty(), "got: {errors:?}");
@@ -4856,7 +4934,7 @@ fn wrapped_u32_value(wrapper: &str) -> super::FieldDef {
         model_schema_prop_meta: None,
         nullable_levels: Vec::new(),
         name: "items".to_owned(),
-        omits_none: false,
+        omits_value: false,
         type_span: proc_macro2::Span::call_site(),
     }
 }

--- a/tests/advanced_tests/tests.rs
+++ b/tests/advanced_tests/tests.rs
@@ -276,16 +276,12 @@ fn assert_ts_contains_fields(ts_definition: &str, assertions: &[(&str, &str)]) {
 }
 
 /// Holds the members whose key serde drops for a `None` to the spelling that admits the payload
-/// without the key. Only a build that reads the attribute knows the key can go, so without the
-/// `serde` feature the key stays written and carries an `undefined` value instead.
+/// without the key. One spelling under every toggle: the attribute that drops the key is on the
+/// field whether or not the `serde` feature is on.
 #[cfg(all(feature = "typescript", feature = "zod"))]
 fn assert_ts_contains_omitted_fields(ts_definition: &str, assertions: &[(&str, &str)]) {
     for (field, expected_type) in assertions {
-        let expected = if cfg!(feature = "serde") {
-            format!("{field}?: {expected_type};")
-        } else {
-            format!("{field}: {expected_type} | undefined;")
-        };
+        let expected = format!("{field}?: {expected_type};");
         assert!(
             ts_definition.contains(&expected),
             "missing {expected}, got: {ts_definition}"
@@ -577,13 +573,11 @@ fn test_documented_struct() {
     assert!(ts_definition.contains("email: string;"));
     assert!(ts_definition.contains("is_active: boolean;"));
     // HashMap becomes Partial<Record<...>>
-    // The key serde drops for a `None`, spelled as the build that reads the attribute renders it.
-    let metadata = if cfg!(feature = "serde") {
-        "metadata?: Partial<Record<string, string>>;"
-    } else {
-        "metadata: Partial<Record<string, string>> | undefined;"
-    };
-    assert!(ts_definition.contains(metadata), "Got: {ts_definition}");
+    // The key serde drops for a `None`, which every build reads off the attribute on the field.
+    assert!(
+        ts_definition.contains("metadata?: Partial<Record<string, string>>;"),
+        "Got: {ts_definition}"
+    );
 }
 
 // Test validation of generated JSON schemas

--- a/tests/basic_tests/tests.rs
+++ b/tests/basic_tests/tests.rs
@@ -181,15 +181,11 @@ fn test_optional_fields_json_schema() {
 /// The member spelling an `Option` field written with a `skip_serializing_if` renders as.
 ///
 /// serde drops the key for a `None`, so the payload has no such key and the member is written with
-/// an optional one. Only a build that reads the attribute knows that: without the `serde` feature
-/// none is read, and the key stays written with an `undefined` value.
+/// an optional one. The attribute is on the field under every toggle, so this is one spelling and
+/// not two.
 #[cfg(feature = "typescript")]
 fn omitted_member(name: &str, ts_type: &str) -> String {
-    if cfg!(feature = "serde") {
-        format!("{name}?: {ts_type};")
-    } else {
-        format!("{name}: {ts_type} | undefined;")
-    }
+    format!("{name}?: {ts_type};")
 }
 
 #[test]

--- a/tests/chrono_tests/tests.rs
+++ b/tests/chrono_tests/tests.rs
@@ -314,13 +314,8 @@ fn test_datetime_local_typescript() {
 #[cfg(feature = "typescript")]
 fn test_optional_datetime_typescript() {
     let ts = OptionalTimestamp::ts_definition();
-    // The omission attribute is serde's, so only a serde build reads it and writes the key
-    // optional; without serde the value stays the undefined-flavored member.
-    let expected = if cfg!(feature = "serde") {
-        "updated_at?: Date;"
-    } else {
-        "updated_at: Date | undefined;"
-    };
+    // serde drops the key for a `None`, which every build reads off the attribute on the field.
+    let expected = "updated_at?: Date;";
     assert!(
         ts.contains(expected),
         "Option<DateTime<Utc>> should map to {expected}. Got: {ts}"

--- a/tests/collection_tests/tests.rs
+++ b/tests/collection_tests/tests.rs
@@ -646,15 +646,11 @@ struct DocumentedSequenceFields {
 /// The member spelling an `Option` field written with a `skip_serializing_if` renders as.
 ///
 /// serde drops the key for a `None`, so the payload has no such key and the member is written with
-/// an optional one. Only a build that reads the attribute knows that: without the `serde` feature
-/// none is read, and the key stays written with an `undefined` value.
+/// an optional one. The attribute is on the field under every toggle, so this is one spelling and
+/// not two.
 #[cfg(feature = "typescript")]
 fn omitted_member(name: &str, ts_type: &str) -> String {
-    if cfg!(feature = "serde") {
-        format!("{name}?: {ts_type};")
-    } else {
-        format!("{name}: {ts_type} | undefined;")
-    }
+    format!("{name}?: {ts_type};")
 }
 
 fn one<T, C>(item: T) -> C

--- a/tests/fixed_array_tests/tests.rs
+++ b/tests/fixed_array_tests/tests.rs
@@ -35,15 +35,11 @@ struct FixedArraySlots {
 /// The member spelling an `Option` field written with a `skip_serializing_if` renders as.
 ///
 /// serde drops the key for a `None`, so the payload has no such key and the member is written with
-/// an optional one. Only a build that reads the attribute knows that: without the `serde` feature
-/// none is read, and the key stays written with an `undefined` value.
+/// an optional one. The attribute is on the field under every toggle, so this is one spelling and
+/// not two.
 #[cfg(feature = "typescript")]
 fn omitted_member(name: &str, ts_type: &str) -> String {
-    if cfg!(feature = "serde") {
-        format!("{name}?: {ts_type};")
-    } else {
-        format!("{name}: {ts_type} | undefined;")
-    }
+    format!("{name}?: {ts_type};")
 }
 
 fn fixed_array_fields() -> FixedArrayFields {

--- a/tests/generic_types_tests/tests.rs
+++ b/tests/generic_types_tests/tests.rs
@@ -45,14 +45,9 @@ mod typescript {
             ts.contains("  by_key: Partial<Record<string, ValueType>>;"),
             "Got: {ts}"
         );
-        // The omission attribute is serde's, so only a serde build reads it and writes the key
-        // optional; without serde the value stays the undefined-flavored member.
-        let maybe = if cfg!(feature = "serde") {
-            "  maybe?: ValueType;"
-        } else {
-            "  maybe: ValueType | undefined;"
-        };
-        assert!(ts.contains(maybe), "Got: {ts}");
+        // serde drops the key for a `None`, which every build reads off the attribute on the
+        // field.
+        assert!(ts.contains("  maybe?: ValueType;"), "Got: {ts}");
         assert!(ts.contains("  tuple: [KeyType, ValueType];"), "Got: {ts}");
     }
 

--- a/tests/model_schema_prop_tests/tests.rs
+++ b/tests/model_schema_prop_tests/tests.rs
@@ -211,15 +211,11 @@ enum TsOptionalVariant {
 /// The member spelling an `Option` field written with a `skip_serializing_if` renders as.
 ///
 /// serde drops the key for a `None`, so the payload has no such key and the member is written with
-/// an optional one. Only a build that reads the attribute knows that: without the `serde` feature
-/// none is read, and the key stays written with an `undefined` value.
+/// an optional one. The attribute is on the field under every toggle, so this is one spelling and
+/// not two.
 #[cfg(feature = "typescript")]
 fn omitted_member(name: &str, ts_type: &str) -> String {
-    if cfg!(feature = "serde") {
-        format!("{name}?: {ts_type};")
-    } else {
-        format!("{name}: {ts_type} | undefined;")
-    }
+    format!("{name}?: {ts_type};")
 }
 
 #[cfg(all(

--- a/tests/mongodb_real_tests/tests.rs
+++ b/tests/mongodb_real_tests/tests.rs
@@ -85,11 +85,7 @@ fn test_real_objectid_basic_types() {
     // TypeScript should use ObjectId type
     assert!(ts_definition.contains("id: ObjectId;"));
     assert!(ts_definition.contains("name: string;"));
-    assert!(ts_definition.contains(if cfg!(feature = "serde") {
-        "email?: string;"
-    } else {
-        "email: string | undefined;"
-    }));
+    assert!(ts_definition.contains("email?: string;"));
 
     // Zod schema should use the MongoDB ObjectId structure with regex validation - now in separate method
     let zod_schema = RealUser::zod_schema();
@@ -181,11 +177,7 @@ fn test_real_objectid_complex_structures() {
     assert!(ts_definition.contains("author_id: ObjectId;"));
     assert!(ts_definition.contains("references: Array<ObjectId>;"));
     assert!(ts_definition.contains("metadata: Partial<Record<string, ObjectId>>;"));
-    assert!(ts_definition.contains(if cfg!(feature = "serde") {
-        "parent_id?: ObjectId;"
-    } else {
-        "parent_id: ObjectId | undefined;"
-    }));
+    assert!(ts_definition.contains("parent_id?: ObjectId;"));
     assert!(ts_definition.contains("nested_refs: Partial<Record<string, Array<ObjectId>>>;"));
 
     // Zod schema should handle all ObjectId variations with regex validation - now in separate method

--- a/tests/mongodb_tests/tests.rs
+++ b/tests/mongodb_tests/tests.rs
@@ -238,11 +238,7 @@ fn test_basic_object_id_types() {
     // TypeScript should use ObjectId type
     assert!(ts_definition.contains("id: ObjectId;"));
     assert!(ts_definition.contains("name: string;"));
-    assert!(ts_definition.contains(if cfg!(feature = "serde") {
-        "email?: string;"
-    } else {
-        "email: string | undefined;"
-    }));
+    assert!(ts_definition.contains("email?: string;"));
 
     // Zod schema should use the MongoDB ObjectId structure with regex validation - now in separate method
     let zod_schema = User::zod_schema();
@@ -263,11 +259,7 @@ fn test_complex_nested_object_id_structures() {
     assert!(ts_definition.contains("author_id: ObjectId;"));
     assert!(ts_definition.contains("references: Array<ObjectId>;"));
     assert!(ts_definition.contains("metadata: Partial<Record<string, ObjectId>>;"));
-    assert!(ts_definition.contains(if cfg!(feature = "serde") {
-        "parent_id?: ObjectId;"
-    } else {
-        "parent_id: ObjectId | undefined;"
-    }));
+    assert!(ts_definition.contains("parent_id?: ObjectId;"));
     assert!(ts_definition.contains("nested_refs: Partial<Record<string, Array<ObjectId>>>;"));
 
     // Zod schema should handle all ObjectId variations with regex validation - now in separate method
@@ -485,11 +477,7 @@ fn test_optional_object_id() {
     let ts_definition = UserWithOptionalId::ts_definition();
 
     // TypeScript should use ObjectId type
-    assert!(ts_definition.contains(if cfg!(feature = "serde") {
-        "id?: ObjectId;"
-    } else {
-        "id: ObjectId | undefined;"
-    }));
+    assert!(ts_definition.contains("id?: ObjectId;"));
     assert!(ts_definition.contains("name: string;"));
     assert!(ts_definition.contains("email: string;"));
 

--- a/tests/omitted_key_tests.rs
+++ b/tests/omitted_key_tests.rs
@@ -1,11 +1,12 @@
-//! An `Option` field whose `None` serde leaves out of the output has an optional *key*, and every
-//! surface has to say so.
+//! A field whose key serde leaves out of the output has an optional *key*, and every surface has
+//! to say so.
 //!
-//! Reading the omission takes the `serde` feature, and there is nothing to describe without a
-//! generation feature, so the module is gated on both.
+//! There is nothing to describe without a generation feature, so the module is gated on those. The
+//! omission is read off attribute text that sits on the item whether or not the `serde` feature is
+//! on, so nothing here is gated on that one: one declaration describes one wire under every toggle,
+//! and these tests are where that is held.
 
 #[cfg(test)]
-#[cfg(feature = "serde")]
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[path = "omitted_key_tests/tests.rs"]
 mod tests;

--- a/tests/omitted_key_tests/tests.rs
+++ b/tests/omitted_key_tests/tests.rs
@@ -1,9 +1,10 @@
-//! The wire is the arbiter. serde writes two payloads for a field carrying
-//! `skip_serializing_if = "Option::is_none"` — one with the key, one without it — and each surface
-//! is held to admitting exactly those two.
+//! The wire is the arbiter. serde writes two payloads for a field carrying a `skip_serializing_if`
+//! — one with the key, one without it — and each surface is held to admitting exactly those two.
 //!
 //! The payloads are asserted first, in this file, so the surface expectations below are read off
-//! them rather than off each other.
+//! them rather than off each other. What serde writes does not turn on the crate's `serde` feature,
+//! and neither do the expectations: the attribute is on the declaration in every build, so every
+//! build owes the same answer.
 
 use serde::{Deserialize, Serialize};
 use tixschema::model_schema;
@@ -19,6 +20,17 @@ struct OmittedKeyFields {
     roles: Vec<String>,
 }
 
+/// The same omission asked of a field that is not an `Option`. A predicate drops the key for a
+/// value that is perfectly present in Rust, so the type under the key is unchanged — only whether
+/// the key is written at all.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct PredicateOmittedKey {
+    id: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    roles: Vec<String>,
+}
+
 fn with_age() -> OmittedKeyFields {
     OmittedKeyFields {
         age: Some(30),
@@ -30,6 +42,20 @@ fn with_age() -> OmittedKeyFields {
 fn without_age() -> OmittedKeyFields {
     OmittedKeyFields {
         age: None,
+        id: "1".to_owned(),
+        roles: vec![],
+    }
+}
+
+fn with_roles() -> PredicateOmittedKey {
+    PredicateOmittedKey {
+        id: "1".to_owned(),
+        roles: vec!["admin".to_owned()],
+    }
+}
+
+fn without_roles() -> PredicateOmittedKey {
+    PredicateOmittedKey {
         id: "1".to_owned(),
         roles: vec![],
     }
@@ -53,6 +79,29 @@ fn the_omitted_key_is_absent_from_the_payload_serde_writes() {
     );
 }
 
+/// The predicate drops the key for an empty `Vec` and writes it for a full one, and `default` is
+/// what reads the dropped key back — the pair the surfaces below have to admit.
+#[test]
+fn the_predicate_omitted_key_is_absent_from_the_payload_serde_writes() {
+    assert_eq!(
+        serde_json::to_string(&with_roles()).unwrap(),
+        r#"{"id":"1","roles":["admin"]}"#
+    );
+    assert_eq!(
+        serde_json::to_string(&without_roles()).unwrap(),
+        r#"{"id":"1"}"#
+    );
+
+    assert_eq!(
+        serde_json::from_str::<PredicateOmittedKey>(r#"{"id":"1"}"#).unwrap(),
+        without_roles()
+    );
+    assert_eq!(
+        serde_json::from_str::<PredicateOmittedKey>(r#"{"id":"1","roles":[]}"#).unwrap(),
+        without_roles()
+    );
+}
+
 /// `age: number | undefined` would demand the key the absent-key payload does not carry, so the
 /// member is written with an optional key instead. The members serde always writes keep theirs.
 #[test]
@@ -64,6 +113,18 @@ fn typescript_writes_the_omitted_key_as_optional() {
     assert!(!ts.contains("age: number"), "Got: {ts}");
     assert!(ts.contains("id: string;"), "Got: {ts}");
     assert!(ts.contains("roles: Array<string>;"), "Got: {ts}");
+}
+
+/// The key is optional; the value under it never is. A `Vec` serde declined to write is still a
+/// `Vec` when it is written, so the type keeps its own spelling and only the key gains the `?`.
+#[test]
+#[cfg(feature = "typescript")]
+fn typescript_writes_the_predicate_omitted_key_as_optional() {
+    let ts = PredicateOmittedKey::ts_definition();
+
+    assert!(ts.contains("roles?: Array<string>;"), "Got: {ts}");
+    assert!(!ts.contains("roles: Array<string>"), "Got: {ts}");
+    assert!(ts.contains("id: string;"), "Got: {ts}");
 }
 
 /// The Zod spelling already admits the payload without the key — a `z.strictObject` rejects an
@@ -82,6 +143,22 @@ fn zod_keeps_the_undefined_union_that_already_admits_the_absent_key() {
     assert!(zod.contains("roles: z.array(z.string()),"), "Got: {zod}");
 }
 
+/// A plain `z.array(...)` member rejects the payload serde writes for an empty `Vec` — recorded
+/// against zod 4.4.3 under node v26.2.0, `safeParse({ id: "1" })` failing with `invalid_type` at
+/// `roles`. `.optional()` is what admits the absent key while still rejecting `null` and still
+/// rejecting an unrecognized key under the surrounding `z.strictObject`.
+#[test]
+#[cfg(feature = "zod")]
+fn zod_marks_the_predicate_omitted_key_optional() {
+    let zod = PredicateOmittedKey::zod_schema();
+
+    assert!(
+        zod.contains("roles: z.array(z.string()).optional(),"),
+        "Got: {zod}"
+    );
+    assert!(zod.contains("id: z.string(),"), "Got: {zod}");
+}
+
 /// The JSON surface says it by leaving the field out of `required` while still describing it.
 #[test]
 #[cfg(feature = "jsonschema")]
@@ -92,6 +169,24 @@ fn the_json_schema_describes_the_omitted_key_without_requiring_it() {
     assert_eq!(
         schema["required"],
         serde_json::json!(["id", "roles"]),
+        "Got: {schema}"
+    );
+}
+
+/// Same for the predicate-dropped key: described, not required.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn the_json_schema_describes_the_predicate_omitted_key_without_requiring_it() {
+    let schema = PredicateOmittedKey::json_schema();
+
+    assert_eq!(
+        schema["properties"]["roles"]["type"],
+        serde_json::json!("array"),
+        "Got: {schema}"
+    );
+    assert_eq!(
+        schema["required"],
+        serde_json::json!(["id"]),
         "Got: {schema}"
     );
 }

--- a/tests/optional_nesting_tests/tests.rs
+++ b/tests/optional_nesting_tests/tests.rs
@@ -53,15 +53,11 @@ struct NullNestingSlots {
 /// The member spelling an `Option` field written with a `skip_serializing_if` renders as.
 ///
 /// serde drops the key for a `None`, so the payload has no such key and the member is written with
-/// an optional one. Only a build that reads the attribute knows that: without the `serde` feature
-/// none is read, and the key stays written with an `undefined` value.
+/// an optional one. The attribute is on the field under every toggle, so this is one spelling and
+/// not two.
 #[cfg(feature = "typescript")]
 fn omitted_member(name: &str, ts_type: &str) -> String {
-    if cfg!(feature = "serde") {
-        format!("{name}?: {ts_type};")
-    } else {
-        format!("{name}: {ts_type} | undefined;")
-    }
+    format!("{name}?: {ts_type};")
 }
 
 fn element_null_fields() -> ElementNullFields {

--- a/tests/primitive_types_tests/tests.rs
+++ b/tests/primitive_types_tests/tests.rs
@@ -185,15 +185,11 @@ fn assert_ts_fields_contain(ts_definition: &str, fields: &[&str], expected_suffi
 /// The member spelling an `Option` field written with a `skip_serializing_if` renders as.
 ///
 /// serde drops the key for a `None`, so the payload has no such key and the member is written with
-/// an optional one. Only a build that reads the attribute knows that: without the `serde` feature
-/// none is read, and the key stays written with an `undefined` value.
+/// an optional one. The attribute is on the field under every toggle, so this is one spelling and
+/// not two.
 #[cfg(all(feature = "typescript", feature = "zod"))]
 fn omitted_member(name: &str, ts_type: &str) -> String {
-    if cfg!(feature = "serde") {
-        format!("{name}?: {ts_type};")
-    } else {
-        format!("{name}: {ts_type} | undefined;")
-    }
+    format!("{name}?: {ts_type};")
 }
 
 #[cfg(all(feature = "typescript", feature = "zod"))]

--- a/tests/recursive_type_tests/tests.rs
+++ b/tests/recursive_type_tests/tests.rs
@@ -313,13 +313,9 @@ mod describes {
         );
 
         let boxed_self = produced("boxed_self_ts");
-        // serde drops the key for a `None`, so the member carries an optional one where the
-        // attribute is read at all.
-        let next = if cfg!(feature = "serde") {
-            "next?: ChainNode;"
-        } else {
-            "next: ChainNode | undefined;"
-        };
+        // serde drops the key for a `None`, which every build reads off the attribute on the
+        // field.
+        let next = "next?: ChainNode;";
         assert!(
             boxed_self.contains(next),
             "an optional box of self is the type's own name: {boxed_self}"


### PR DESCRIPTION
Three closures of the omitted-key contract:

- A non-Option `skip_serializing_if` field (`Vec::is_empty`) was absent from the payload yet required on all three surfaces, with zod rejecting serde's own output. The stamp generalizes to `omits_value` and `key_may_be_absent` stops asking about Option-ness; TypeScript writes the `?` with the bare type, Zod appends `.optional()` (the minimal spelling — the six-payload matrix against zod 4.4.3 proved the candidates identical), and `required` reads one `key_is_required` predicate.
- The captured coherence matrix showed the no-default spelling cannot round-trip (`missing field`), so it is refused through the existing serde-coherence channel — with the exemptions the matrix proved coherent (bare skip, Option fields, field- and container-level defaults, the last threaded through every collector).
- The omission walk now compiles in every build (`SerdeKeyOmission` + its parser moved out of the feature gate; `omits_key` removed from the serde-only meta rather than duplicated), so one declaration emits one TypeScript surface across toggles and every `cfg!(serde)` expectation fork collapsed back to a single spelling.

Merge notes: the untagged member helper absorbed both landings (context struct, written-def guard, 2-arg omission), and two length-lint extractions came out of the union (`struct_rename_all`, the variant context constructor).