### PR TITLE
write every JSDoc block through one builder and make the README's Option examples declarations the crate accepts

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ pub struct UserWithCollections {
     pub tags: Vec<String>,
     pub scores: Vec<u32>,
     pub metadata: HashMap<String, String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub settings: Option<HashMap<String, String>>,
 }
 ```
@@ -804,7 +805,6 @@ const buildWrapper$Schema = <IdType extends ZodType>(
   children: z.array(idType),
   id: idType,
   name: z.string(),
-
 });
 
 type Wrapper$SchemaOf<IdType extends ZodType> = ReturnType<
@@ -1478,6 +1478,7 @@ This is a TypeScript-only knob -- the Zod schema and JSON Schema are unchanged (
 pub struct Profile {
     pub name: String,
     #[model_schema_prop(ts_optional)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub nickname: Option<String>,
 }
 ```
@@ -1592,6 +1593,7 @@ pub struct Document {
     pub author_id: ObjectId,
     pub tags: Vec<ObjectId>,
     pub metadata: HashMap<String, ObjectId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parent_id: Option<ObjectId>,
     pub related_docs: HashMap<String, Vec<ObjectId>>,
 }
@@ -1606,7 +1608,7 @@ export type Document = {
   author_id: ObjectId;
   tags: Array<ObjectId>;
   metadata: Partial<Record<string, ObjectId>>;
-  parent_id: ObjectId | undefined;
+  parent_id?: ObjectId;
   related_docs: Partial<Record<string, Array<ObjectId>>>;
 };
 
@@ -1681,6 +1683,7 @@ pub struct Event {
     pub created_at: DateTime<Utc>,
     #[model_schema_prop(as_number)]
     pub epoch_ms: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub updated_at: Option<DateTime<Utc>>,
 }
 ```
@@ -1695,7 +1698,7 @@ export type Event = {
   local_datetime: string;
   created_at: Date;
   epoch_ms: number;
-  updated_at: Date | undefined;
+  updated_at?: Date;
 };
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,36 +87,33 @@ use proc_macro::TokenStream;
  *     "roles"
  *   ]
  * }
- **/
-
-
+ */
 export type User = {
   /**
- * age
- * 
-**/
+   * age
+   * 
+   */
   age?: number;
   /**
- * firstName
- * 
-**/
+   * firstName
+   * 
+   */
   firstName: string;
   /**
- * id
- * 
-**/
+   * id
+   * 
+   */
   id: string;
   /**
- * lastName
- * 
-**/
+   * lastName
+   * 
+   */
   lastName: string;
   /**
- * roles
- * 
-**/
+   * roles
+   * 
+   */
   roles: Array<string>;
-
 };
 ```"#]
 ///
@@ -129,7 +126,6 @@ const User$RawSchema = z.strictObject({
   id: z.string(),
   lastName: z.string(),
   roles: z.array(z.string()),
-
 });
 
 export const User$Schema: ZodType<User> = User$RawSchema;
@@ -167,7 +163,7 @@ export const User$Schema: ZodType<User> = User$RawSchema;
  *     "pending"
  *   ]
  * }
- **/
+ */
 export type Status =
   | "active"
   | "inactive"
@@ -258,36 +254,38 @@ export const Status$Schema: ZodType<Status> = Status$RawSchema;
  *     }
  *   ]
  * }
- **/
-export type Event = {  /**
- * userCreated
- * 
-**/
+ */
+export type Event = {
+  /**
+   * userCreated
+   * 
+   */
   type: "userCreated";
   /**
- * timestamp
- * 
-**/
+   * timestamp
+   * 
+   */
   timestamp: string;
   /**
- * userId
- * 
-**/
+   * userId
+   * 
+   */
   userId: string;
-} | {  /**
- * userDeleted
- * 
-**/
+} | {
+  /**
+   * userDeleted
+   * 
+   */
   type: "userDeleted";
   /**
- * reason
- * 
-**/
+   * reason
+   * 
+   */
   reason?: string;
   /**
- * userId
- * 
-**/
+   * userId
+   * 
+   */
   userId: string;
 };
 ```"#]
@@ -431,41 +429,38 @@ pub struct Document {
  *     "title"
  *   ]
  * }
- **/
-
-
+ */
 export type Document = {
   /**
- * author_id
- * 
-**/
+   * author_id
+   * 
+   */
   author_id: ObjectId;
   /**
- * id
- * 
-**/
+   * id
+   * 
+   */
   id: ObjectId;
   /**
- * metadata
- * 
-**/
+   * metadata
+   * 
+   */
   metadata: Partial<Record<string, ObjectId>>;
   /**
- * parent_id
- * 
-**/
+   * parent_id
+   * 
+   */
   parent_id?: ObjectId;
   /**
- * tags
- * 
-**/
+   * tags
+   * 
+   */
   tags: Array<ObjectId>;
   /**
- * title
- * 
-**/
+   * title
+   * 
+   */
   title: string;
-
 };
 ```
 
@@ -479,7 +474,6 @@ const Document$RawSchema = z.strictObject({
   parent_id: z.union([z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) }), z.undefined()]).prefault(undefined),
   tags: z.array(z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) })),
   title: z.string(),
-
 });
 
 export const Document$Schema: ZodType<Document> = Document$RawSchema;

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -147,6 +147,10 @@ const TYPESCRIPT_PREAMBLE: &str = "const createSchemaCache = <Cache extends obje
 #[cfg(all(feature = "zod", not(feature = "typescript")))]
 const TYPESCRIPT_PREAMBLE: &str = "const createSchemaCache = () => new WeakMap();";
 
+/// The indent every member of an emitted object is written at, and so the indent its `JSDoc` block
+/// is written at.
+const MEMBER_INDENT: &str = "  ";
+
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 const WRITTEN_AS_ARRAY: &str = "a JSON array";
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
@@ -2452,8 +2456,10 @@ fn build_tuple_struct_ts_definition_method(
     ts_body: &str,
 ) -> proc_macro2::TokenStream {
     let reexport = ident_reexport_ts(rust_ident, item_name, ts_generics);
-    let type_str =
-        format!("/**\n{docs}\n **/\nexport type {item_name}{ts_generics} = {ts_body};{reexport}");
+    let type_str = format!(
+        "{}\nexport type {item_name}{ts_generics} = {ts_body};{reexport}",
+        jsdoc_block(docs, "")
+    );
     quote! {
         pub fn ts_definition() -> String {
             #type_str.to_owned()
@@ -3931,6 +3937,29 @@ fn item_jsdoc_body(lines: &[String]) -> String {
         .join("\n")
 }
 
+/// The complete `JSDoc` block a body is written as, at the indent of whatever it documents: the
+/// opener, the body's own lines carried to that indent, and the `*/` that closes it.
+///
+/// Every surface splices this whole. Spelling the delimiters beside each member instead is what let
+/// a block open at its member's indent and continue at column 0, and let one writer close with a
+/// `**/` that closes nothing — a block comment already ended by the `*/` inside it, trailed by a
+/// stray `/`. The body arrives already prefixed with ` * ` per line, so the indent is all that is
+/// added and the text a block carries is untouched.
+fn jsdoc_block(body: &str, indent: &str) -> String {
+    let mut block = format!("{indent}/**\n");
+    for line in body.lines() {
+        let _ = writeln!(block, "{indent}{line}");
+    }
+    let _ = write!(block, "{indent} */");
+    block
+}
+
+/// The `JSDoc` block a member is written under: [`jsdoc_block`] at the one indent every emitted
+/// member sits at.
+fn member_jsdoc_block(body: &str) -> String {
+    jsdoc_block(body, MEMBER_INDENT)
+}
+
 /// The one-line description a set of lines is published as, escaped for the `description: "…"` it
 /// is spliced into.
 ///
@@ -4615,7 +4644,7 @@ fn render_external_variant(
         let json = quote! {};
 
         return (
-            format!("/**\n{docs}\n**/\n  \"{key}\""),
+            format!("{}\n  \"{key}\"", member_jsdoc_block(docs)),
             format!("z.literal(\"{key}\")"),
             json,
         );
@@ -4679,7 +4708,10 @@ fn render_external_variant(
     };
 
     (
-        format!("{{  /**\n{docs}\n**/\n  \"{key}\": {content_ts};\n}}"),
+        format!(
+            "{{\n{}\n  \"{key}\": {content_ts};\n}}",
+            member_jsdoc_block(docs)
+        ),
         zod,
         json,
     )
@@ -6050,7 +6082,8 @@ fn tagged_variant_parts(
         optional_fields: Vec::new(),
         schema_code: format!("{{\n  {tag_name}: z.literal(\"{discriminator_value}\"),\n"),
         type_code: format!(
-            "{{  /**\n{discriminator_docs}\n**/\n  {tag_name}: \"{discriminator_value}\";\n"
+            "{{\n{}\n  {tag_name}: \"{discriminator_value}\";\n",
+            member_jsdoc_block(discriminator_docs)
         ),
     }
 }
@@ -6183,8 +6216,8 @@ fn write_named_variant_fields(
         // Add TypeScript type definition
         let _ = writeln!(
             variant_type_code,
-            "  /**\n{}\n**/\n  {}{}: {};",
-            fld.docs,
+            "{}\n  {}{}: {};",
+            member_jsdoc_block(&fld.docs),
             fld.name,
             fld.optional_key_marker(),
             fld.typescript_typename()
@@ -7660,8 +7693,8 @@ fn write_field_type_and_schema(
     // Always write TypeScript type
     let _ = writeln!(
         type_code,
-        "  /**\n{}\n**/\n  {}{}: {};",
-        fld.docs,
+        "{}\n  {}{}: {};",
+        member_jsdoc_block(&fld.docs),
         fld.name,
         fld.optional_key_marker(),
         fld.typescript_typename()
@@ -9062,34 +9095,31 @@ fn generate_ts_definition_method(
     let typescript_type_gen = if fields_empty {
         if has_flatten {
             quote::quote! {
-                format!("{}\n\nexport type {}{} = {};{}", docs, #item_name, #ts_generics, #intersection_only, #reexport)
+                format!("{}export type {}{} = {};{}", docs, #item_name, #ts_generics, #intersection_only, #reexport)
             }
         } else {
             quote::quote! {
-                format!(r#"/**\n{}\n**/\nexport type {}{} = Record<string, never>;{}"#, docs, #item_name, #ts_generics, #reexport)
+                format!("{}export type {}{} = Record<string, never>;{}", docs, #item_name, #ts_generics, #reexport)
             }
         }
     } else if has_flatten {
         quote::quote! {
-            format!("{}\n\nexport type {}{} = {{\n{}\n}}{};{}", docs, #item_name, #ts_generics, #type_code, #intersection_suffix, #reexport)
+            format!("{}export type {}{} = {{\n{}}}{};{}", docs, #item_name, #ts_generics, #type_code, #intersection_suffix, #reexport)
         }
     } else {
         quote::quote! {
-            format!("{}\n\nexport type {}{} = {{\n{}\n}};{}", docs, #item_name, #ts_generics, #type_code, #reexport)
+            format!("{}export type {}{} = {{\n{}}};{}", docs, #item_name, #ts_generics, #type_code, #reexport)
         }
     };
 
-    #[cfg(all(feature = "jsonschema", feature = "typescript"))]
-    let json_docs_gen = generate_json_docs_part();
+    #[cfg(feature = "jsonschema")]
+    let json_docs_gen = bind_item_jsdoc_local(docs, true);
 
     #[cfg(not(feature = "jsonschema"))]
-    let json_docs_gen = quote::quote! {
-        let docs = format!("/**\n{docs}\n **/\n");
-    };
+    let json_docs_gen = bind_item_jsdoc_local(docs, false);
 
     quote::quote! {
         pub fn ts_definition() -> String {
-            let docs = #docs;
             #json_docs_gen
             #typescript_type_gen
         }
@@ -9479,7 +9509,7 @@ fn generate_zod_schema_method(
     #[cfg(feature = "zod")]
     {
         let reexport = ident_reexport_zod(rust_ident, item_name, zod_binding_suffix(parameters));
-        let own = format!("z.strictObject({{\n{schema_code}\n}}){show_opts}");
+        let own = format!("z.strictObject({{\n{schema_code}}}){show_opts}");
         let (preamble, expression) = zod_merged_statements(item_name, &own, flatten_schemas);
         // Note: Example injection is handled by the delegating method on the type itself.
         let body = zod_published_binding(item_name, parameters, &preamble, &expression, &reexport);
@@ -9509,36 +9539,36 @@ fn generate_zod_schema_method(
     }
 }
 
-#[cfg(all(feature = "jsonschema", feature = "typescript"))]
-fn generate_json_docs_part() -> proc_macro2::TokenStream {
-    quote::quote! {
-        let prettified = serde_json::to_string_pretty(&Self::json_schema()).unwrap().lines().map(|l| format!(" * {l}")).collect::<Vec<_>>().join("\n");
-        let docs = format!("/**\n{docs}\n * JSON Schema:\n{prettified}\n **/\n");
+/// Binds the `docs` local an item's `ts_definition()` opens with: the item's `JSDoc` block, its
+/// body enriched with the item's JSON schema where the caller says this build can produce one, and
+/// a trailing newline, so what the block documents is the line straight beneath it.
+///
+/// The block cannot be built by [`jsdoc_block`] here — the JSON schema is only there once the
+/// expanded code runs — so this is where its shape is spelled for the runtime side, once, rather
+/// than once per item kind.
+#[cfg(feature = "typescript")]
+fn bind_item_jsdoc_local(docs: &str, with_json_schema: bool) -> proc_macro2::TokenStream {
+    if with_json_schema {
+        quote::quote! {
+            let prettified = serde_json::to_string_pretty(&Self::json_schema()).unwrap().lines().map(|l| format!(" * {l}")).collect::<Vec<_>>().join("\n");
+            let docs = format!("/**\n{}\n * JSON Schema:\n{}\n */\n", #docs, prettified);
+        }
+    } else {
+        quote::quote! {
+            let docs = format!("/**\n{}\n */\n", #docs);
+        }
     }
 }
 
-/// Binds the `docs` local that an enum's `ts_definition()` renders, enriched with the JSON
-/// schema when this build of tixschema can produce one.
+/// Binds the `docs` local an enum's `ts_definition()` renders, enriched with the JSON schema when
+/// this build of tixschema can produce one.
 ///
 /// The enrichment reads `Self::json_schema()`, so it may only be emitted when tixschema's own
 /// features put that method in the schema module — deciding here rather than emitting a `cfg`
 /// keeps the reader and the method in agreement regardless of the consumer's feature table.
 #[cfg(feature = "typescript")]
 fn generate_enum_json_docs_part(docs: &str) -> proc_macro2::TokenStream {
-    #[cfg(all(feature = "jsonschema", feature = "zod"))]
-    {
-        quote::quote! {
-            let prettified = serde_json::to_string_pretty(&Self::json_schema()).unwrap().lines().map(|l| format!(" * {l}")).collect::<Vec<_>>().join("\n");
-            let docs = format!("/**\n{}\n * JSON Schema:\n{}\n **/\n", #docs, prettified);
-        }
-    }
-
-    #[cfg(not(all(feature = "jsonschema", feature = "zod")))]
-    {
-        quote::quote! {
-            let docs = format!("/**\n{}\n**/\n", #docs);
-        }
-    }
+    bind_item_jsdoc_local(docs, cfg!(all(feature = "jsonschema", feature = "zod")))
 }
 
 #[cfg(feature = "jsonschema")]
@@ -9761,12 +9791,12 @@ fn generate_ts_alias_method(
     let target_ts = field_def.typescript_typename();
     let reexport = ident_reexport_ts(rust_ident, export_name, ts_generics);
 
-    let docs_block = docs.to_owned();
+    let docs_block = jsdoc_block(docs, "");
 
     quote! {
         pub fn ts_definition() -> String {
             format!(
-                "/**\n{}\n**/\nexport type {} = {};{}",
+                "{}\nexport type {} = {};{}",
                 #docs_block,
                 #alias_name_ts,
                 #target_ts,

--- a/tests/collection_tests/tests.rs
+++ b/tests/collection_tests/tests.rs
@@ -3405,19 +3405,19 @@ fn test_an_alias_of_a_nested_sequence_publishes_its_depth() {
 fn test_a_doc_comment_reaches_ts_from_a_collapsed_wrapper_field() {
     let ts = DocumentedSequenceFields::ts_definition();
     let documented_nested = format!(
-        " * Documented nested field.\n * \n**/\n  {}",
+        "   * Documented nested field.\n   * \n   */\n  {}",
         omitted_member("documented_nested", "Array<number>")
     );
     let documented_optional = format!(
-        " * Documented optional field.\n * \n**/\n  {}",
+        "   * Documented optional field.\n   * \n   */\n  {}",
         omitted_member("documented_optional", "string")
     );
     for spelling in [
         documented_nested.as_str(),
         documented_optional.as_str(),
-        " * Documented set field.\n * \n**/\n  documented_set: Array<string>;",
-        " * Documented vec field.\n * \n**/\n  documented_vec: Array<string>;",
-        " * undocumented_vec\n * \n**/\n  undocumented_vec: Array<string>;",
+        "   * Documented set field.\n   * \n   */\n  documented_set: Array<string>;",
+        "   * Documented vec field.\n   * \n   */\n  documented_vec: Array<string>;",
+        "   * undocumented_vec\n   * \n   */\n  undocumented_vec: Array<string>;",
     ] {
         assert!(ts.contains(spelling), "Got: {ts}");
     }

--- a/tests/flatten_tests/tests.rs
+++ b/tests/flatten_tests/tests.rs
@@ -1634,7 +1634,7 @@ fn test_the_optional_flatten_schema_admits_no_partial_base() {
 fn test_the_optional_flatten_schema_binds_the_objects_own_keys_once() {
     let zod = OptHolder::zod_schema();
     assert!(
-        zod.contains("const OptHolder$OwnSchema = z.strictObject({\n  own: z.string(),\n\n});"),
+        zod.contains("const OptHolder$OwnSchema = z.strictObject({\n  own: z.string(),\n});"),
         "expected the object's own keys bound once, got: {zod}"
     );
     assert_eq!(
@@ -1654,7 +1654,7 @@ fn test_a_non_optional_flatten_type_is_byte_identical() {
     let declared = &ts[ts.find("export type").unwrap()..];
     assert_eq!(
         declared,
-        "export type MultiFlatten = {\n  /**\n * id\n * \n**/\n  id: string;\n\n} & BasePart & ExtraPart;"
+        "export type MultiFlatten = {\n  /**\n   * id\n   * \n   */\n  id: string;\n} & BasePart & ExtraPart;"
     );
 }
 
@@ -1662,9 +1662,9 @@ fn test_a_non_optional_flatten_type_is_byte_identical() {
 #[cfg(feature = "zod")]
 fn test_a_non_optional_flatten_schema_is_byte_identical() {
     #[cfg(feature = "typescript")]
-    const EXPECTED: &str = "const MultiFlatten$RawSchema = z.strictObject({\n  id: z.string(),\n\n}).and(z.lazy(() => BasePart$Schema)).and(z.lazy(() => ExtraPart$Schema));\n\nexport const MultiFlatten$Schema: ZodType<MultiFlatten> = MultiFlatten$RawSchema;";
+    const EXPECTED: &str = "const MultiFlatten$RawSchema = z.strictObject({\n  id: z.string(),\n}).and(z.lazy(() => BasePart$Schema)).and(z.lazy(() => ExtraPart$Schema));\n\nexport const MultiFlatten$Schema: ZodType<MultiFlatten> = MultiFlatten$RawSchema;";
     #[cfg(not(feature = "typescript"))]
-    const EXPECTED: &str = "export const MultiFlatten$Schema = z.strictObject({\n  id: z.string(),\n\n}).and(z.lazy(() => BasePart$Schema)).and(z.lazy(() => ExtraPart$Schema));";
+    const EXPECTED: &str = "export const MultiFlatten$Schema = z.strictObject({\n  id: z.string(),\n}).and(z.lazy(() => BasePart$Schema)).and(z.lazy(() => ExtraPart$Schema));";
 
     assert_eq!(MultiFlatten::zod_schema(), EXPECTED);
 }
@@ -1684,9 +1684,9 @@ fn test_a_non_optional_flatten_schema_is_byte_identical() {
 #[cfg(feature = "zod")]
 fn test_the_untagged_flatten_schema_multiplies_the_object_over_the_unions_members() {
     #[cfg(feature = "typescript")]
-    const EXPECTED: &str = "const FlatOverUntagged$OwnSchema = z.strictObject({\n  own: z.string(),\n\n});\n\nconst FlatOverUntagged$RawSchema = z.union([\n  FlatOverUntagged$OwnSchema.and(z.lazy(() => FlatFirst$Schema)),\n  FlatOverUntagged$OwnSchema.and(z.lazy(() => FlatSecond$Schema)),\n]);\n\nexport const FlatOverUntagged$Schema: ZodType<FlatOverUntagged> = FlatOverUntagged$RawSchema;";
+    const EXPECTED: &str = "const FlatOverUntagged$OwnSchema = z.strictObject({\n  own: z.string(),\n});\n\nconst FlatOverUntagged$RawSchema = z.union([\n  FlatOverUntagged$OwnSchema.and(z.lazy(() => FlatFirst$Schema)),\n  FlatOverUntagged$OwnSchema.and(z.lazy(() => FlatSecond$Schema)),\n]);\n\nexport const FlatOverUntagged$Schema: ZodType<FlatOverUntagged> = FlatOverUntagged$RawSchema;";
     #[cfg(not(feature = "typescript"))]
-    const EXPECTED: &str = "const FlatOverUntagged$OwnSchema = z.strictObject({\n  own: z.string(),\n\n});\n\nexport const FlatOverUntagged$Schema = z.union([\n  FlatOverUntagged$OwnSchema.and(z.lazy(() => FlatFirst$Schema)),\n  FlatOverUntagged$OwnSchema.and(z.lazy(() => FlatSecond$Schema)),\n]);";
+    const EXPECTED: &str = "const FlatOverUntagged$OwnSchema = z.strictObject({\n  own: z.string(),\n});\n\nexport const FlatOverUntagged$Schema = z.union([\n  FlatOverUntagged$OwnSchema.and(z.lazy(() => FlatFirst$Schema)),\n  FlatOverUntagged$OwnSchema.and(z.lazy(() => FlatSecond$Schema)),\n]);";
 
     assert_eq!(FlatOverUntagged::zod_schema(), EXPECTED);
 }
@@ -1833,9 +1833,9 @@ fn test_a_union_declared_below_the_object_is_named_as_one_operand() {
 #[cfg(feature = "zod")]
 fn test_an_internally_tagged_flatten_schema_is_byte_identical() {
     #[cfg(feature = "typescript")]
-    const EXPECTED: &str = "const DataElementSampleValueEntry$RawSchema = z.strictObject({\n  dataElementId: z.string(),\n\n}).and(z.lazy(() => DataElementSampleValueVariant$Schema));\n\nexport const DataElementSampleValueEntry$Schema: ZodType<DataElementSampleValueEntry> = DataElementSampleValueEntry$RawSchema;";
+    const EXPECTED: &str = "const DataElementSampleValueEntry$RawSchema = z.strictObject({\n  dataElementId: z.string(),\n}).and(z.lazy(() => DataElementSampleValueVariant$Schema));\n\nexport const DataElementSampleValueEntry$Schema: ZodType<DataElementSampleValueEntry> = DataElementSampleValueEntry$RawSchema;";
     #[cfg(not(feature = "typescript"))]
-    const EXPECTED: &str = "export const DataElementSampleValueEntry$Schema = z.strictObject({\n  dataElementId: z.string(),\n\n}).and(z.lazy(() => DataElementSampleValueVariant$Schema));";
+    const EXPECTED: &str = "export const DataElementSampleValueEntry$Schema = z.strictObject({\n  dataElementId: z.string(),\n}).and(z.lazy(() => DataElementSampleValueVariant$Schema));";
 
     assert_eq!(DataElementSampleValueEntry::zod_schema(), EXPECTED);
 }

--- a/tests/item_description_tests/tests.rs
+++ b/tests/item_description_tests/tests.rs
@@ -204,7 +204,7 @@ fn without_ident_reexport(surface: &str, ident: &str, exported: &str) -> String 
 fn jsdoc_body_lines(ts: &str) -> Vec<String> {
     let (block, _) = ts
         .strip_prefix("/**\n")
-        .and_then(|rest| rest.split_once("**/"))
+        .and_then(|rest| rest.split_once(" */"))
         .unwrap();
     block
         .lines()

--- a/tests/item_jsdoc_example_tests/tests.rs
+++ b/tests/item_jsdoc_example_tests/tests.rs
@@ -399,11 +399,14 @@ fn an_example_only_item_and_member_name_themselves() {
         ts.starts_with("/**\n * ExampleOnlyStruct\n * \n"),
         "item did not name itself: {ts}"
     );
-    assert!(ts.contains("/**\n * label\n * \n"), "field unnamed: {ts}");
+    assert!(
+        ts.contains("  /**\n   * label\n   * \n"),
+        "field unnamed: {ts}"
+    );
 
     let variants = ExampleOnlyVariantHolder::ts_definition();
     assert!(
-        variants.contains("/**\n * Named\n * \n"),
+        variants.contains("  /**\n   * Named\n   * \n"),
         "variant unnamed: {variants}"
     );
 

--- a/tests/jsdoc_block_tests.rs
+++ b/tests/jsdoc_block_tests.rs
@@ -1,0 +1,3 @@
+#[cfg(test)]
+#[path = "jsdoc_block_tests/tests.rs"]
+mod tests;

--- a/tests/jsdoc_block_tests/tests.rs
+++ b/tests/jsdoc_block_tests/tests.rs
@@ -1,0 +1,160 @@
+//! One `JSDoc` block, one shape, wherever a surface writes one.
+//!
+//! A block opens at the indent of the member it documents, carries its body at that same indent,
+//! and closes with the delimiter JavaScript closes a block comment with. Nothing between the block
+//! and what it documents, and nothing between the last member and the brace that closes the object
+//! — the emitted text is what a caller writes to a `.ts` file, so a struct, a plain enum and a
+//! tagged enum have to agree on all of it rather than each spelling its own.
+
+#![cfg(feature = "typescript")]
+
+use serde::{Deserialize, Serialize};
+use tixschema::model_schema;
+
+/// The block a documented member is written under, and the one an undocumented member falls back
+/// to, both read off the same struct.
+#[model_schema()]
+#[derive(Serialize, Deserialize)]
+struct Member {
+    /// Documented member.
+    documented: String,
+    plain: String,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
+enum Plain {
+    Active,
+    Inactive,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize)]
+#[cfg_attr(feature = "serde", serde(tag = "type", rename_all = "camelCase"))]
+enum Tagged {
+    Created { at: String },
+    Deleted { at: String },
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize)]
+enum External {
+    Nothing,
+    Wrapped { at: String },
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize)]
+struct Empty;
+
+/// The one closer. `**/` closes nothing in JavaScript — it is a block comment already closed by the
+/// `*/` inside it, followed by a stray `/`.
+#[test]
+fn no_surface_closes_a_block_with_anything_but_the_javascript_closer() {
+    for emission in [
+        Member::ts_definition(),
+        Plain::ts_definition(),
+        Tagged::ts_definition(),
+        External::ts_definition(),
+        Empty::ts_definition(),
+    ] {
+        assert!(!emission.contains("**/"), "Got: {emission}");
+        assert!(emission.contains(" */"), "Got: {emission}");
+    }
+}
+
+/// A member's block sits at the member's own indent, continuation lines included, so the block and
+/// the member it documents read as one thing.
+#[test]
+fn a_members_block_is_written_at_the_members_indent() {
+    let ts = Member::ts_definition();
+
+    assert!(
+        ts.contains("  /**\n   * Documented member.\n   * \n   */\n  documented: string;\n"),
+        "Got: {ts}"
+    );
+    assert!(
+        ts.contains("  /**\n   * plain\n   * \n   */\n  plain: string;\n"),
+        "Got: {ts}"
+    );
+}
+
+/// The item's own block is at column 0, and what it documents is the line straight beneath it — on
+/// every item kind, rather than two blank lines on one and none on the others.
+#[test]
+fn every_item_kind_puts_its_export_on_the_line_below_its_block() {
+    for emission in [
+        Member::ts_definition(),
+        Plain::ts_definition(),
+        Tagged::ts_definition(),
+        External::ts_definition(),
+        Empty::ts_definition(),
+    ] {
+        assert!(emission.contains(" */\nexport type "), "Got: {emission}");
+    }
+}
+
+/// A tagged variant's first member is a member like any other, so its block opens on its own line
+/// rather than trailing the brace.
+#[test]
+#[cfg(feature = "serde")]
+fn a_tagged_variants_first_member_opens_its_block_on_its_own_line() {
+    let ts = Tagged::ts_definition();
+
+    assert!(
+        ts.contains("= {\n  /**\n   * created\n   * \n   */\n  type: \"created\";\n"),
+        "Got: {ts}"
+    );
+    assert!(
+        ts.contains("} | {\n  /**\n   * deleted\n   * \n   */\n  type: \"deleted\";\n"),
+        "Got: {ts}"
+    );
+}
+
+/// An externally tagged variant's key is a member too, whether the variant carries an object or is
+/// the bare key a unit writes.
+#[test]
+#[cfg(feature = "serde")]
+fn an_externally_tagged_variants_block_sits_at_its_keys_indent() {
+    let ts = External::ts_definition();
+
+    assert!(
+        ts.contains("  /**\n   * Nothing\n   * \n   */\n  \"Nothing\""),
+        "Got: {ts}"
+    );
+    assert!(
+        ts.contains("{\n  /**\n   * Wrapped\n   * \n   */\n  \"Wrapped\":"),
+        "Got: {ts}"
+    );
+}
+
+/// Nothing stands between the last member and the brace that closes the object, on either surface.
+#[test]
+fn no_surface_leaves_a_blank_line_before_the_brace_that_closes_an_object() {
+    let ts = Member::ts_definition();
+    assert!(ts.contains("  plain: string;\n};"), "Got: {ts}");
+
+    let tagged = Tagged::ts_definition();
+    assert!(!tagged.contains(";\n\n}"), "Got: {tagged}");
+}
+
+/// The same holding on the Zod surface, where the struct emitter and the tagged-enum emitter
+/// disagreed.
+#[test]
+#[cfg(feature = "zod")]
+fn the_zod_object_closes_straight_after_its_last_member() {
+    let zod = Member::zod_schema();
+    assert!(zod.contains("  plain: z.string(),\n});"), "Got: {zod}");
+    assert!(!zod.contains(",\n\n})"), "Got: {zod}");
+}
+
+/// Layout is all that this normalizes: what a block says is what the author wrote, and an
+/// undocumented member still falls back to its own exported name.
+#[test]
+fn the_body_a_block_carries_is_the_one_the_author_wrote() {
+    let ts = Member::ts_definition();
+
+    assert!(ts.contains("   * Documented member.\n"), "Got: {ts}");
+    assert!(ts.contains("   * plain\n"), "Got: {ts}");
+}

--- a/tests/readme_example_tests.rs
+++ b/tests/readme_example_tests.rs
@@ -1,0 +1,3 @@
+#[cfg(test)]
+#[path = "readme_example_tests/tests.rs"]
+mod tests;

--- a/tests/readme_example_tests/tests.rs
+++ b/tests/readme_example_tests/tests.rs
@@ -1,0 +1,218 @@
+//! The README's `Option` examples, expanded here as the README declares them.
+//!
+//! An `Option` field serde writes as `null` for a `None` is refused where it is declared, so an
+//! example carrying one is not a declaration a reader can paste — and the block beside it, showing
+//! the key that declaration would render, describes a build the declaration cannot be written in.
+//! Each example is therefore held to two things: the README still declares it exactly as it is
+//! declared here, and the emission the README shows beside it is what the generator answers with.
+//! Drift on either side fails here rather than in someone's editor.
+//!
+//! Each type is declared with its fields ordered alphabetically, as this crate's lints require of
+//! Rust source; the README orders its examples for reading. Only the order the members are written
+//! in differs, so every member is held as a whole line rather than as part of a block — what is
+//! pinned is the spelling of each, which is what an omitted key changes.
+
+#![cfg(all(feature = "serde", feature = "typescript"))]
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use tixschema::model_schema;
+
+fn readme() -> &'static str {
+    include_str!("../../README.md")
+}
+
+/// The README declares this, and the generator writes that.
+///
+/// A member is matched as a whole line on both sides, so a spelling that is merely a prefix of the
+/// emitted one cannot pass for it.
+fn assert_readme_declares_and_shows(declaration: &str, emission: &str, members: &[&str]) {
+    assert!(
+        readme().contains(declaration),
+        "the README no longer declares this verbatim:\n{declaration}"
+    );
+    for member in members {
+        assert!(
+            emission.lines().any(|line| line == *member),
+            "the generator no longer writes this member: {member}\nGot: {emission}"
+        );
+        assert!(
+            readme().lines().any(|line| line == *member),
+            "the README no longer shows this member verbatim: {member}"
+        );
+    }
+}
+
+/// The "Optional Fields" example: three keys the payload may omit, beside two it may not.
+#[test]
+fn test_the_optional_fields_example_is_declarable_and_shows_what_it_emits() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize)]
+    pub struct UserWithOptionals {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub avatar_url: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub email: Option<String>,
+        pub id: String,
+        pub name: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub phone: Option<String>,
+    }
+
+    assert_readme_declares_and_shows(
+        "    #[serde(default, skip_serializing_if = \"Option::is_none\")]\n    pub email: Option<String>,\n",
+        &UserWithOptionals::ts_definition(),
+        &[
+            "export type UserWithOptionals = {",
+            "  id: string;",
+            "  name: string;",
+            "  email?: string;",
+            "  phone?: string;",
+            "  avatar_url?: string;",
+            "};",
+        ],
+    );
+}
+
+/// The "Collections and Maps" example. It shows no emission of its own — the section is about what
+/// each container describes as — so what is held here is that it is a declaration at all.
+#[test]
+fn test_the_collections_example_is_declarable() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize)]
+    pub struct UserWithCollections {
+        pub id: String,
+        pub metadata: HashMap<String, String>,
+        pub scores: Vec<u32>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub settings: Option<HashMap<String, String>>,
+        pub tags: Vec<String>,
+    }
+
+    assert_readme_declares_and_shows(
+        "    #[serde(default, skip_serializing_if = \"Option::is_none\")]\n    pub settings: Option<HashMap<String, String>>,\n",
+        &UserWithCollections::ts_definition(),
+        &[],
+    );
+}
+
+/// The `ts_optional` example. The flag asks for the optional key on the author's word; the omission
+/// attribute the guard requires of the field asks for it off the wire. Both are on the field here,
+/// as the README declares it, and the key the section shows is the one that comes out.
+#[test]
+fn test_the_optional_key_flag_example_is_declarable_and_shows_what_it_emits() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize)]
+    pub struct Profile {
+        pub name: String,
+        #[model_schema_prop(ts_optional)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub nickname: Option<String>,
+    }
+
+    assert_readme_declares_and_shows(
+        "    #[model_schema_prop(ts_optional)]\n    #[serde(default, skip_serializing_if = \"Option::is_none\")]\n    pub nickname: Option<String>,\n",
+        &Profile::ts_definition(),
+        &[
+            "export type Profile = {",
+            "  name: string;",
+            "  nickname?: string;",
+            "};",
+        ],
+    );
+}
+
+/// The `ObjectId` example. The block it stands in a dummy `ObjectId` for the reason the crate
+/// rustdoc's does: the type is recognised by name, so nothing here needs `mongodb` pulled in.
+#[test]
+#[cfg(feature = "object_id")]
+fn test_the_object_id_example_is_declarable_and_shows_what_it_emits() {
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    pub struct ObjectId(pub String);
+
+    #[model_schema()]
+    #[derive(Serialize, Deserialize)]
+    pub struct Document {
+        pub author_id: ObjectId,
+        pub id: ObjectId,
+        pub metadata: HashMap<String, ObjectId>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub parent_id: Option<ObjectId>,
+        pub related_docs: HashMap<String, Vec<ObjectId>>,
+        pub tags: Vec<ObjectId>,
+        pub title: String,
+    }
+
+    assert_readme_declares_and_shows(
+        "    #[serde(default, skip_serializing_if = \"Option::is_none\")]\n    pub parent_id: Option<ObjectId>,\n",
+        &Document::ts_definition(),
+        &[
+            "export type Document = {",
+            "  id: ObjectId;",
+            "  title: string;",
+            "  author_id: ObjectId;",
+            "  tags: Array<ObjectId>;",
+            "  metadata: Partial<Record<string, ObjectId>>;",
+            "  parent_id?: ObjectId;",
+            "  related_docs: Partial<Record<string, Array<ObjectId>>>;",
+            "};",
+        ],
+    );
+
+    #[cfg(feature = "zod")]
+    assert_readme_declares_and_shows(
+        "pub struct Document {",
+        &Document::zod_schema(),
+        &[
+            "  parent_id: z.union([z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: \"Invalid ObjectId\" }) }), z.undefined()]).prefault(undefined),",
+        ],
+    );
+}
+
+/// The chrono example, whose `DateTime<Tz>` renders as a native `Date` and whose `as_number` field
+/// renders as the epoch-milliseconds number beside it.
+#[test]
+#[cfg(feature = "chrono")]
+fn test_the_chrono_example_is_declarable_and_shows_what_it_emits() {
+    use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
+
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct Event {
+        pub created_at: DateTime<Utc>,
+        pub date: NaiveDate,
+        #[model_schema_prop(as_number)]
+        pub epoch_ms: DateTime<Utc>,
+        pub local_datetime: NaiveDateTime,
+        pub name: String,
+        pub time: NaiveTime,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pub updated_at: Option<DateTime<Utc>>,
+    }
+
+    assert_readme_declares_and_shows(
+        "    #[serde(default, skip_serializing_if = \"Option::is_none\")]\n    pub updated_at: Option<DateTime<Utc>>,\n",
+        &Event::ts_definition(),
+        &[
+            "export type Event = {",
+            "  name: string;",
+            "  date: string;",
+            "  time: string;",
+            "  local_datetime: string;",
+            "  created_at: Date;",
+            "  epoch_ms: number;",
+            "  updated_at?: Date;",
+            "};",
+        ],
+    );
+
+    #[cfg(feature = "zod")]
+    assert_readme_declares_and_shows(
+        "pub struct Event {",
+        &Event::zod_schema(),
+        &[
+            "  created_at: z.coerce.date(),",
+            "  updated_at: z.union([z.coerce.date(), z.undefined()]).prefault(undefined),",
+        ],
+    );
+}


### PR DESCRIPTION
Two doc-truth closures:

- Every per-member JSDoc block is now spliced whole from one `jsdoc_block` builder (opener, body at the member's indent, `*/` closer, one blank-line rule) by all six writers; the runtime-assembled item block is spelled once. Content is byte-identical — only layout normalizes — and the eight crate-rustdoc blocks were re-spliced from a fresh run in the same change, which is the pins doing their job. The empty-struct arm's double-wrapped raw block fell out of the unification.
- The README's four Option examples carried no omission attribute — the exact declaration the Option-null guard refuses — so a reader pasting the crate's own docs got a refusal. Each now carries the required spelling with its shown emission updated from capture, and a new pin suite holds both directions per example: the README must declare the field verbatim and the generator must write every member the README shows.