### PR TITLE
call the factory a referenced generic type published, reading what it published rather than guessing from the arguments

### DIFF
--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -912,20 +912,22 @@ impl FieldDef {
                     // The element carries this field's own array levels, so it applies the wrap.
                     return self.collection_element_field(element).zod_array_base();
                 } else if let Some(info) = lookup_alias_info(name) {
-                    // Always reference the $Schema, regardless of generic params.
-                    // For branded wrappers like DocumentTypeId<String>, the Zod
-                    // schema is defined on the wrapper itself.
-                    format!("{}$Schema", info.export_name)
+                    // What the named type published is what this can name. A generic struct or
+                    // enum published a factory, so the arguments written here are the call's; an
+                    // alias and a branded newtype published the one `const` they have whatever
+                    // they were declared with, and that `const` is the whole of what a reference
+                    // to either can say.
+                    if info.publishes_zod_factory {
+                        zod_factory_call(&info.export_name, lst)
+                    } else {
+                        format!("{}$Schema", info.export_name)
+                    }
                 } else if lst.is_empty() {
                     format!("{name}$Schema")
                 } else {
-                    format!(
-                        "{name}<{}>",
-                        lst.iter()
-                            .map(Self::typescript_typename)
-                            .collect::<Vec<_>>()
-                            .join(", ")
-                    )
+                    // A name the registry does not hold yet, written with arguments, is a generic
+                    // type expanded after this one: only a factory can take them.
+                    zod_factory_call(name, lst)
                 }
             }
             FieldDefType::Map(k, v) => {
@@ -1115,6 +1117,23 @@ impl FieldDef {
         };
         lookup_alias_info(name).map_or_else(Vec::new, |info| info.zod_union_members)
     }
+}
+
+/// A reference to a type that publishes a factory, as the call it has to be.
+///
+/// Each argument is rendered by the renderer that renders the reference itself, so an argument that
+/// is a forwarded parameter, a primitive, a date, or another generic reference all reach the call
+/// the same way — and one that is itself generic composes at whatever depth it was written at.
+#[cfg(feature = "zod")]
+fn zod_factory_call(name: &str, arguments: &[FieldDef]) -> String {
+    format!(
+        "{name}$SchemaFactory({})",
+        arguments
+            .iter()
+            .map(FieldDef::zod_type)
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
 }
 
 /// The one list of std wrappers the crate renders as arrays, shared by every surface.

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -33,7 +33,9 @@ use crate::utils::type_parameters_in_scope;
 use core::iter::once;
 
 #[cfg(feature = "zod")]
-use crate::utils::{escape_js_regex_literal, extract_example_from_docs, zod_factory_argument};
+use crate::utils::{
+    escape_js_regex_literal, extract_example_from_docs, record_zod_factory, zod_factory_argument,
+};
 
 #[cfg(all(feature = "zod", feature = "object_id"))]
 use crate::features::object_id::get_object_id_zod_schema_with;
@@ -1005,7 +1007,11 @@ fn build_struct_delegate_items(
     #[cfg(feature = "zod")]
     let has_example = schema_example_method.is_some();
     #[cfg(feature = "zod")]
-    let reexport = ident_reexport_zod(rust_ident, item_name, zod_binding_suffix(parameters));
+    let reexport = ident_reexport_zod(
+        rust_ident,
+        item_name,
+        zod_binding_suffix(rust_ident, parameters),
+    );
     #[cfg(not(feature = "zod"))]
     let _: &_ = &(item_name, rust_ident, parameters);
     #[cfg(not(feature = "zod"))]
@@ -2471,7 +2477,11 @@ fn build_tuple_struct_zod_schema_method(
     parameters: &[String],
     zod_body: &str,
 ) -> proc_macro2::TokenStream {
-    let reexport = ident_reexport_zod(rust_ident, item_name, zod_binding_suffix(parameters));
+    let reexport = ident_reexport_zod(
+        rust_ident,
+        item_name,
+        zod_binding_suffix(rust_ident, parameters),
+    );
     let schema_str = zod_published_binding(item_name, parameters, "", zod_body, &reexport);
     quote! {
         pub fn zod_schema() -> String {
@@ -9127,8 +9137,13 @@ pub fn typescript_preamble_tokens(input: proc_macro2::TokenStream) -> proc_macro
 /// The suffix the binding an item publishes is named with. A generic type publishes a factory —
 /// one schema per filling, built on demand — where a type that declares no parameter publishes the
 /// one schema it has.
+///
+/// Recorded on the item's registry entry as it is decided, because a reference to the item is
+/// written from it too and cannot read it off its own spelling — see [`record_zod_factory`]. This
+/// is the one place the decision is taken, so the binding and every reference to it move together.
 #[cfg(feature = "zod")]
-const fn zod_binding_suffix(parameters: &[String]) -> &'static str {
+fn zod_binding_suffix(rust_ident: &str, parameters: &[String]) -> &'static str {
+    record_zod_factory(rust_ident, !parameters.is_empty());
     if parameters.is_empty() {
         "$Schema"
     } else {
@@ -9478,7 +9493,11 @@ fn generate_zod_schema_method(
 ) -> proc_macro2::TokenStream {
     #[cfg(feature = "zod")]
     {
-        let reexport = ident_reexport_zod(rust_ident, item_name, zod_binding_suffix(parameters));
+        let reexport = ident_reexport_zod(
+            rust_ident,
+            item_name,
+            zod_binding_suffix(rust_ident, parameters),
+        );
         let own = format!("z.strictObject({{\n{schema_code}\n}}){show_opts}");
         let (preamble, expression) = zod_merged_statements(item_name, &own, flatten_schemas);
         // Note: Example injection is handled by the delegating method on the type itself.
@@ -9701,7 +9720,11 @@ fn generate_discriminated_enum_zod_schema_method(
 ) -> proc_macro2::TokenStream {
     #[cfg(feature = "zod")]
     {
-        let reexport = ident_reexport_zod(rust_ident, item_name, zod_binding_suffix(parameters));
+        let reexport = ident_reexport_zod(
+            rust_ident,
+            item_name,
+            zod_binding_suffix(rust_ident, parameters),
+        );
         let schema_str = zod_published_binding(item_name, parameters, "", schema_code, &reexport);
         quote::quote! {
             pub fn zod_schema() -> String {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -172,6 +172,11 @@ pub struct AliasInfo {
     pub kind: AliasKind,
     #[cfg(feature = "jsonschema")]
     pub module_name: String,
+    /// Whether the Zod binding published under this name is a factory rather than a `const`, which
+    /// is what a reference to the name has to know to write itself. Filled by
+    /// [`record_zod_factory`] as the item decides which of the two it publishes.
+    #[cfg(feature = "zod")]
+    pub publishes_zod_factory: bool,
     /// What the value surface written under this name is, in the vocabulary a constrained brand's
     /// refusal names shapes by — and `None` both when that surface is one string checks land on and
     /// when nothing has been recorded at all. Filled by [`record_value_shape`] as each item
@@ -545,6 +550,8 @@ pub fn register_alias_info(
                 kind,
                 #[cfg(feature = "jsonschema")]
                 module_name: module_name.to_owned(),
+                #[cfg(feature = "zod")]
+                publishes_zod_factory: false,
                 value_shape: None,
                 #[cfg(feature = "zod")]
                 zod_union_members: Vec::new(),
@@ -601,6 +608,26 @@ pub fn record_zod_union_members(rust_ident: &str, members: &[ZodUnionMember]) {
     ALIAS_INFO.with(|map| {
         if let Some(info) = map.borrow_mut().get_mut(rust_ident) {
             info.zod_union_members = members.to_vec();
+        }
+    });
+}
+
+/// Records which of the two Zod bindings a name publishes, on the entry that name has already
+/// registered.
+///
+/// A reference cannot read it off the spelling it was written in. `Held<String>` says a type named
+/// `Held` takes one argument and nothing about what `Held` published for it: a generic struct or
+/// enum publishes a factory that has to be called, while an alias and a branded newtype publish the
+/// one `const` they have whatever they were declared with. So each item answers for itself as it
+/// decides, and a reference reads the answer back rather than guessing from its own arguments.
+///
+/// A name not registered before the reference reading it leaves no answer at all, which is the same
+/// regime the export name already runs under — see [`ident_schema_module_name`].
+#[cfg(feature = "zod")]
+pub fn record_zod_factory(rust_ident: &str, publishes: bool) {
+    ALIAS_INFO.with(|map| {
+        if let Some(info) = map.borrow_mut().get_mut(rust_ident) {
+            info.publishes_zod_factory = publishes;
         }
     });
 }

--- a/tests/generic_types_tests/tests.rs
+++ b/tests/generic_types_tests/tests.rs
@@ -15,8 +15,8 @@
 #[cfg(feature = "typescript")]
 mod typescript {
     use super::{
-        Adjacent, External, Holder, Internal, LifetimeStruct, Pair, PlainConst, Positional,
-        Untagged, Wrapper,
+        Adjacent, External, FolderTree, Holder, Internal, LifetimeStruct, Pair, PlainConst,
+        Positional, Untagged, WireFolder, Wrapper,
     };
 
     /// The declaration binds what the fields under it are written with, so a field typed with a
@@ -123,6 +123,32 @@ mod typescript {
         assert!(ts.contains("  label: string;"), "Got: {ts}");
     }
 
+    /// A reference is a type name on this surface whatever it carries, because a TypeScript
+    /// generic is written and not called. Only the validating surface has a factory to reach.
+    #[test]
+    fn a_reference_carrying_arguments_is_still_written_as_a_type_name() {
+        let concrete = WireFolder::ts_definition();
+        assert!(
+            concrete.contains("  doc: EcmDocument<string, number>;"),
+            "Got: {concrete}"
+        );
+        assert!(concrete.contains("  plain: Envelope;"), "Got: {concrete}");
+
+        let forwarded = FolderTree::<String>::ts_definition();
+        for member in [
+            "  labels: Array<string>;",
+            "  many: Array<EcmDocument<IdType, number>>;",
+            "  nested: Outer<Inner<string>>;",
+            "  root: EcmDocument<IdType, number>;",
+        ] {
+            assert!(
+                forwarded.contains(member),
+                "Missing {member:?}: {forwarded}"
+            );
+        }
+        assert!(!forwarded.contains("$SchemaFactory"), "Got: {forwarded}");
+    }
+
     /// The line an item publishes under its own Rust ident is written after the declaration it
     /// refers to, and repeats the parameter list on both sides — a generic type named bare on
     /// either would be a TypeScript error of its own.
@@ -140,9 +166,11 @@ mod typescript {
 
 #[cfg(feature = "zod")]
 mod zod {
+    #[cfg(all(feature = "chrono", feature = "object_id"))]
+    use super::MixedArguments;
     use super::{
-        Adjacent, Carried, Envelope, External, Holder, Internal, LifetimeStruct, Pair, PlainConst,
-        Positional, Quintet, Tagged, Untagged, Wrapper,
+        Adjacent, Carried, Envelope, External, FolderTree, Holder, Internal, LifetimeStruct, Pair,
+        PlainConst, Positional, Quintet, Referrer, Tagged, Untagged, WireFolder, Wrapper,
     };
 
     /// Whether the output publishes `name` as a plain exported `const` — the binding a type that
@@ -450,6 +478,83 @@ mod zod {
         assert!(!brand.contains("$SchemaFactory"), "Got: {brand}");
     }
 
+    /// A field naming a generic type has no schema to name — the type publishes a factory — so it
+    /// calls that factory with what fills each parameter, and the plain sibling beside it still
+    /// names the one schema its own type publishes.
+    #[test]
+    fn a_reference_carrying_arguments_calls_the_factory() {
+        let zod = WireFolder::zod_schema();
+        assert!(
+            zod.contains("doc: EcmDocument$SchemaFactory(z.string(), z.number()),"),
+            "Got: {zod}"
+        );
+        assert!(zod.contains("plain: Envelope$Schema,"), "Got: {zod}");
+    }
+
+    /// A forwarded parameter and a concrete type reach the call the same way: the parameter is the
+    /// argument the enclosing factory binds, so there is no forwarding rule of its own.
+    #[test]
+    fn a_forwarded_parameter_is_an_argument_like_any_other() {
+        let zod = FolderTree::<String>::zod_schema();
+        assert!(
+            zod.contains("root: EcmDocument$SchemaFactory(idType, z.number()),"),
+            "Got: {zod}"
+        );
+    }
+
+    /// An argument is rendered by the renderer that renders the reference, so an argument that is
+    /// itself a reference composes at whatever depth it is written at.
+    #[test]
+    fn an_argument_that_is_itself_generic_nests() {
+        let zod = FolderTree::<String>::zod_schema();
+        assert!(
+            zod.contains("nested: Outer$SchemaFactory(Inner$SchemaFactory(z.string())),"),
+            "Got: {zod}"
+        );
+    }
+
+    /// A set is a name carrying one argument, which is the shape a reference to a generic type is
+    /// written in too — so the collection reading has to keep coming first, and the array it
+    /// writes has to keep carrying whatever its element renders as.
+    #[test]
+    fn a_set_is_still_read_as_the_collection_it_is() {
+        let zod = FolderTree::<String>::zod_schema();
+        assert!(zod.contains("labels: z.array(z.string()),"), "Got: {zod}");
+        assert!(
+            zod.contains("many: z.array(EcmDocument$SchemaFactory(idType, z.number())),"),
+            "Got: {zod}"
+        );
+        assert!(!zod.contains("HashSet$SchemaFactory"), "Got: {zod}");
+    }
+
+    /// Every argument reaches the call through whatever already answers for its type, so a date,
+    /// a database identifier and a number are each written exactly as they are written anywhere
+    /// else and none of the three is reached by a rule of its own.
+    #[cfg(all(feature = "chrono", feature = "object_id"))]
+    #[test]
+    fn an_argument_renders_through_the_renderer_that_already_answers_for_it() {
+        let zod = MixedArguments::zod_schema();
+        for call in [
+            "keyed: Inner$SchemaFactory(z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { \
+             message: \"Invalid ObjectId\" }) })),",
+            "sized: Inner$SchemaFactory(z.number().int()),",
+            "stamped: Inner$SchemaFactory(z.coerce.date()),",
+        ] {
+            assert!(zod.contains(call), "Missing {call:?} in: {zod}");
+        }
+    }
+
+    /// A reference names what the type it names publishes. An alias and a branded newtype publish
+    /// a `const` whatever they were written with, so a field supplying either an argument still
+    /// names that `const` rather than calling a factory neither declares.
+    #[test]
+    fn a_reference_to_a_type_publishing_a_const_still_names_it() {
+        let zod = Referrer::zod_schema();
+        assert!(zod.contains("boxed: Boxed$Schema,"), "Got: {zod}");
+        assert!(zod.contains("tagged: Tagged$Schema,"), "Got: {zod}");
+        assert!(!zod.contains("$SchemaFactory("), "Got: {zod}");
+    }
+
     /// The one helper every factory builds its cache with, and the only assertion in the output.
     #[cfg(feature = "typescript")]
     #[test]
@@ -522,8 +627,12 @@ mod jsonschema {
 }
 
 use alloc::borrow::Cow;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
+#[cfg(feature = "chrono")]
+use chrono::{DateTime, Utc};
+#[cfg(feature = "object_id")]
+use mongodb::bson::oid::ObjectId;
 use serde::{Deserialize, Serialize};
 use tixschema::model_schema;
 
@@ -642,6 +751,70 @@ pub struct Carried<IdType> {
     pub id: IdType,
 }
 
+/// The item the reference-site fixtures below point at. A generic type publishes a factory rather
+/// than a schema, so a field naming it has nothing to name — it has to call that factory with what
+/// fills each parameter.
+#[model_schema()]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EcmDocument<IdType, DateType> {
+    pub created_at: DateType,
+    pub document_id: IdType,
+}
+
+/// The inner half of a reference whose own argument is generic.
+#[model_schema()]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Inner<ValueType> {
+    pub value: ValueType,
+}
+
+#[model_schema()]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Outer<ValueType> {
+    pub held: ValueType,
+}
+
+/// A referrer that declares no parameter of its own: every argument it supplies is a concrete
+/// type, and the plain sibling beside them still names the one schema that one publishes.
+#[model_schema()]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WireFolder {
+    pub doc: EcmDocument<String, f64>,
+    pub plain: Envelope,
+}
+
+/// A referrer that forwards its own parameter into a reference beside a concrete argument, holds a
+/// reference whose argument is itself generic, and names a set — the shape a sibling carrying one
+/// argument could be mistaken for.
+#[model_schema()]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FolderTree<IdType> {
+    pub labels: HashSet<String>,
+    pub many: Vec<EcmDocument<IdType, f64>>,
+    pub nested: Outer<Inner<String>>,
+    pub root: EcmDocument<IdType, f64>,
+}
+
+/// A date, a database identifier and a number in argument position. Each is rendered by whatever
+/// already answers for it everywhere else, so none of the three is reached by a rule of its own.
+#[cfg(all(feature = "chrono", feature = "object_id"))]
+#[model_schema()]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MixedArguments {
+    pub keyed: Inner<ObjectId>,
+    pub sized: Inner<u32>,
+    pub stamped: Inner<DateTime<Utc>>,
+}
+
+/// The two surfaces that publish a `const` whatever they were written with, named from a field
+/// that supplies each of them an argument.
+#[model_schema()]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Referrer {
+    pub boxed: Boxed<u32>,
+    pub tagged: Tagged<String>,
+}
+
 /// The pair the attribute used to produce on any generic item: `E0107` on the emitted `impl`,
 /// which dropped the parameters the declaration binds, and `E0433` on a module named after a
 /// parameter, which names no type and so publishes none. Both are compile errors, so the suite
@@ -701,6 +874,66 @@ fn a_generic_item_expands_to_rust_that_compiles() {
     assert_eq!(quintet.charlie, 3);
     assert_eq!(quintet.delta, "d");
     assert_eq!(quintet.echo, 5);
+}
+
+/// The reference-site shapes, each named by a value: a concrete filling, a forwarded parameter, an
+/// argument that is itself generic, and an argument supplied to a type that publishes a `const`.
+#[test]
+fn a_reference_carrying_arguments_expands_to_rust_that_compiles() {
+    let document = |id: &str| EcmDocument {
+        created_at: 1.0_f64,
+        document_id: id.to_owned(),
+    };
+
+    let folder = WireFolder {
+        doc: document("d"),
+        plain: Envelope {
+            trace: "t".to_owned(),
+        },
+    };
+    assert!(folder.doc.created_at > 0.0_f64);
+    assert_eq!(folder.doc.document_id, "d");
+    assert_eq!(folder.plain.trace, "t");
+
+    let tree = FolderTree {
+        labels: HashSet::from(["l".to_owned()]),
+        many: vec![document("m")],
+        nested: Outer {
+            held: Inner {
+                value: "v".to_owned(),
+            },
+        },
+        root: document("r"),
+    };
+    assert_eq!(tree.labels.len(), 1);
+    assert_eq!(tree.many[0].document_id, "m");
+    assert_eq!(tree.nested.held.value, "v");
+    assert_eq!(tree.root.document_id, "r");
+
+    let referrer = Referrer {
+        boxed: vec![1_u32],
+        tagged: Tagged("t".to_owned()),
+    };
+    assert_eq!(referrer.boxed.len(), 1);
+    assert_eq!(referrer.tagged.0, "t");
+}
+
+/// The two argument kinds no build reaches without their own feature, named the same way.
+#[cfg(all(feature = "chrono", feature = "object_id"))]
+#[test]
+fn a_dated_and_an_identified_argument_expand_to_rust_that_compiles() {
+    let mixed = MixedArguments {
+        keyed: Inner {
+            value: ObjectId::new(),
+        },
+        sized: Inner { value: 1_u32 },
+        stamped: Inner {
+            value: DateTime::<Utc>::from_timestamp(0, 0).unwrap(),
+        },
+    };
+    assert_eq!(mixed.sized.value, 1);
+    assert_eq!(mixed.stamped.value.timestamp(), 0);
+    assert!(!mixed.keyed.value.to_hex().is_empty());
 }
 
 /// The enum half of the same question, in every shape the tagging attributes reach — plus the one

--- a/tests/generic_types_tests/tests.rs
+++ b/tests/generic_types_tests/tests.rs
@@ -732,7 +732,7 @@ use std::collections::{HashMap, HashSet};
 
 #[cfg(all(feature = "chrono", feature = "object_id"))]
 use chrono::{DateTime, Utc};
-#[cfg(feature = "object_id")]
+#[cfg(all(feature = "chrono", feature = "object_id"))]
 use mongodb::bson::oid::ObjectId;
 use serde::{Deserialize, Serialize};
 use tixschema::model_schema;

--- a/tests/generic_types_tests/tests.rs
+++ b/tests/generic_types_tests/tests.rs
@@ -730,7 +730,7 @@ use alloc::borrow::Cow;
 use core::hash::Hash;
 use std::collections::{HashMap, HashSet};
 
-#[cfg(feature = "chrono")]
+#[cfg(all(feature = "chrono", feature = "object_id"))]
 use chrono::{DateTime, Utc};
 #[cfg(feature = "object_id")]
 use mongodb::bson::oid::ObjectId;


### PR DESCRIPTION
A field naming a generic type now emits the factory call its arguments fill — `doc: EcmDocument$SchemaFactory(z.string(), z.number())`, forwarded parameters as the enclosing factory's own arguments, nested generics as nested calls, chrono/ObjectId/primitive fillings through their own spellings — while a reference to a type that published a `const` keeps naming it.

One recorded deviation from the task as written: capture showed the targeted fallback branch is not what fires — the registry catches every earlier-declared name — and it also serves generic aliases and brands, which still publish consts. So the reference site reads `publishes_zod_factory`, recorded by `record_zod_factory` inside the one place the $Schema/$SchemaFactory decision is taken; when brands become factories in their own task, reference sites follow with no second change. Emissions were run, not read: zod 4.4.3 parse/reject at four positions with memoization observed across fillings, and `tsc --strict` inference through the factory verified. Sequence wrappers stay arrays; TypeScript is untouched and now pinned so.