### PR TITLE
take a default filling per declared parameter, required exactly where a JSON document must be built

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -340,7 +340,7 @@ The macro also generates into the type's schema module:
 Single-field tuple structs with `#[serde(transparent)]` are treated as branded/opaque types. If the Rust name has a `Json` suffix, it is stripped from the TypeScript name.
 
 ```rust
-#[model_schema()]
+#[model_schema(default_types(ID_TYPE = String))]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct UserId<ID_TYPE>(pub ID_TYPE);
@@ -388,6 +388,28 @@ infers every field as `unknown`.
 every generated module carries once above its per-type definitions. It holds the only assertion
 anywhere in the output: a cache's value type depends on its key type, which TypeScript can declare
 but cannot construct.
+
+### Declaring a Default Type per Parameter
+
+JSON Schema has no type parameters, so a generic item's document is built from one concrete
+filling, and `default_types(IdType = String, DateType = f64)` is where an author names it — one
+`Parameter = Type` pair per type parameter, in any order, beside every other item-level argument.
+
+`default_types_guard_errors` reads the declaration against the item's own parameters at
+`exec_model_schema`, the one seam every expanded shape is dispatched from, so a struct, a tuple
+struct, a branded newtype, an enum and an alias are all answered the same way and before any of
+them is split off. It refuses in both directions:
+
+- an entry naming nothing the item declares — refused in **every** feature configuration, spanned
+  on the entry, since a misspelled parameter fills nothing while the one it was meant for keeps no
+  default;
+- a type parameter with no entry — refused only under `#[cfg(feature = "jsonschema")]`, spanned on
+  the parameter, because nothing else reads the default;
+- `default_types` on an item with no type parameter, and an empty `default_types()`, both being a
+  declaration with nothing to declare.
+
+There is no fallback filling. A guessed one produces a document that silently rejects valid
+payloads, which is what the declaration exists to prevent.
 
 ### Adding Examples to Types
 

--- a/README.md
+++ b/README.md
@@ -783,8 +783,10 @@ A struct, a tuple struct, an enum, an alias and a branded newtype can each name 
 
 **Zod publishes a factory rather than a schema.** A Zod schema is a runtime value and TypeScript generics do not exist at runtime, so there is no one value a generic type could publish: the caller has to say what fills each parameter before anything can validate. A generic type therefore exports `X$SchemaFactory`, a function taking one required schema argument per parameter, and a field written with a parameter composes the argument bound for it.
 
+**With the `jsonschema` feature on, every type parameter needs a declared default type.** JSON Schema has no type parameters, so its document has to be built from one concrete filling, and `default_types` is where that filling is named — see [Declaring the default type](#declaring-the-default-type) below.
+
 ```rust
-#[model_schema()]
+#[model_schema(default_types(IdType = String))]
 pub struct Wrapper<IdType> {
     pub children: Vec<IdType>,
     pub id: IdType,
@@ -845,6 +847,32 @@ EcmDocument$SchemaFactory(z.string(), z.number()) === wireDocument;  // false --
 
 A generic type that also flattens keeps the deferred read of its base, so declaration order stays irrelevant: `.and(z.lazy(() => Envelope$Schema))` composes inside the factory unchanged.
 
+#### Declaring the default type
+
+JSON Schema has no type parameters. A generic type's document has to be built from one concrete filling, and nothing in the declaration says which — so `default_types` says it, one `Parameter = Type` pair per type parameter:
+
+```rust
+#[model_schema(default_types(IdType = String, DateType = f64))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EcmDocument<IdType, DateType> {
+    pub document_id: DocumentId<IdType>,
+    pub created_at: DateType,
+}
+```
+
+The pairs may be written in any order, and the argument sits beside every other item-level argument -- `name`, `pattern`, `minLength`, `maxLength`, `no_display` -- changing none of them. A lifetime and a const parameter name no type, so neither takes an entry.
+
+The declaration is read in both directions, and each refusal points at what earned it:
+
+| Written | Verdict |
+|---------|---------|
+| An entry naming something the item does not declare | Refused in **every** feature configuration, spanned on the entry. A misspelled parameter fills nothing, and the parameter it was meant for would be left with no default at all. |
+| A type parameter with no entry | Refused only where `jsonschema` is on, spanned on the parameter. Nothing else reads the default, so the same item compiles untouched without that feature. |
+| `default_types` on an item declaring no type parameter | Refused, there being nothing for a filling to fill. |
+
+There is deliberately no fallback. Guessing a filling produces a document that silently rejects valid payloads, which is the failure the declaration exists to prevent.
+
 #### The module preamble
 
 The factories share one helper, which every generated module carries once above its per-type definitions:
@@ -866,7 +894,7 @@ A cache maps an argument to the schema built from *that* argument, so its value 
 A generic alias and a generic branded newtype publish a plain `const`, so a parameter inside either has no argument to name and still renders as the opaque value -- `z.unknown()`, the same answer JSON Schema gives:
 
 ```rust
-#[model_schema()]
+#[model_schema(default_types(T = String))]
 pub type Wrapper<T> = Vec<T>;
 ```
 
@@ -883,7 +911,7 @@ Only the item's *own* parameters are read this way. A name the expansion cannot 
 One consequence is worth stating outright: an opaque value carries no checks, so no `model_schema_prop` bound may be spelled against a type parameter. A branded newtype cannot apply `pattern`, `minLength`, or `maxLength` to one of its own — see [Branded Newtype Validation Constraints](#branded-newtype-validation-constraints) — and a *field* typed with one is refused for the same reason, at every depth the parameter is reached through:
 
 ```rust
-#[model_schema()]
+#[model_schema(default_types(IdType = String))]
 pub struct Constrained<IdType> {
     #[model_schema_prop(minLength = 3)] // refused, and so is it on `Option<IdType>` or `Vec<IdType>`
     pub id: IdType,
@@ -901,7 +929,7 @@ use tixschema::model_schema;
 use serde::{Deserialize, Serialize};
 
 // Generic branded newtype (good for parameterized IDs)
-#[model_schema()]
+#[model_schema(default_types(ID_TYPE = String))]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct UserId<ID_TYPE>(pub ID_TYPE);
@@ -1019,7 +1047,7 @@ An opaque inner is `serde_json::Value` **or one of the brand's own type paramete
 
 ```rust
 // Rejected: the checks would have to measure a value no surface has a shape for.
-#[model_schema(minLength = 3)]
+#[model_schema(minLength = 3, default_types(T = String))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct GenericSlug<T>(pub T);
@@ -1164,7 +1192,7 @@ Branded newtypes support doc comments (for Zod `.meta({ description })`) and com
 /// ```rust example
 /// DocumentId("64de3d95ff45b119e5b53a7e".to_string())
 /// ```
-#[model_schema()]
+#[model_schema(default_types(ID_TYPE = String))]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct DocumentId<ID_TYPE>(pub ID_TYPE);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -513,6 +513,35 @@ export const Document$Schema: ZodType<Document> = Document$RawSchema;
 /// Moving the named type out of the function body — to the module the referencing type is written
 /// in, or any module in scope there — is what resolves it.
 ///
+/// ## Type Parameters and `default_types`
+///
+/// JSON Schema has no type parameters, so a generic item's document has to be built from one
+/// concrete filling. `default_types` is where that filling is named — one `Parameter = Type` pair
+/// per type parameter, in any order, beside every other item-level argument:
+///
+/// ```rust
+/// use tixschema::model_schema;
+/// use serde::{Deserialize, Serialize};
+///
+/// #[model_schema(default_types(IdType = String, DateType = f64))]
+/// #[derive(Serialize, Deserialize)]
+/// pub struct EcmDocument<IdType, DateType> {
+///     pub document_id: IdType,
+///     pub created_at: DateType,
+/// }
+/// ```
+///
+/// The declaration is read in both directions, and each refusal is spanned on what earned it. An
+/// entry naming something the item does not declare is refused in **every** feature configuration:
+/// a misspelled parameter fills nothing, and the parameter it was meant for would keep no default
+/// at all. A type parameter with no entry is refused only where the `jsonschema` feature is on,
+/// nothing else reading the default — without that feature the same item compiles untouched.
+/// `default_types` on an item that declares no type parameter is refused, there being nothing for a
+/// filling to fill; a lifetime and a const parameter name no type, so neither takes an entry.
+///
+/// There is no fallback filling. A guessed one produces a document that silently rejects valid
+/// payloads, which is the failure the declaration exists to prevent.
+///
 /// ## Branded Newtypes and `no_display`
 ///
 /// A `#[serde(transparent)]` single-field tuple struct becomes a branded type, and the macro gives
@@ -548,8 +577,8 @@ export const Document$Schema: ZodType<Document> = Document$RawSchema;
 /// real, but the two validating surfaces read it as the opaque value — one schema is written for
 /// every instantiation — and an opaque value takes no string checks: Zod 4's `z.unknown()` carries
 /// no `.min`/`.max`, and `.brand()` returns that same schema rather than a wrapper that could. So
-/// `#[model_schema(minLength = 3)] struct Slug<T>(pub T);` is refused at the inner field. Constrain
-/// a string-typed inner instead.
+/// `#[model_schema(minLength = 3, default_types(T = String))] struct Slug<T>(pub T);` is refused at
+/// the inner field. Constrain a string-typed inner instead.
 ///
 /// A named inner is judged by what that name publishes, since that is the schema the checks are
 /// appended to: `#[model_schema(minLength = 3)] struct Outer(pub Blob);` over

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -5,7 +5,7 @@ use core::fmt::Write as _;
 
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::parse::Parser as _;
+use syn::parse::{Parse, ParseStream, Parser as _};
 use syn::punctuated::Punctuated;
 use syn::{Field, Item, ItemType, Meta, Token, parse_macro_input};
 
@@ -114,7 +114,14 @@ use crate::rename_rule::resolve_rename_rule;
 ///
 /// An argument added to [`apply_arg`] belongs here too: `no_argument_the_parser_reads_is_rejected`
 /// walks this list back through the parser and fails on any name here it does not read.
-const KNOWN_ARGS: &[&str] = &["name", "pattern", "minLength", "maxLength", "no_display"];
+const KNOWN_ARGS: &[&str] = &[
+    "name",
+    "pattern",
+    "minLength",
+    "maxLength",
+    "no_display",
+    "default_types",
+];
 
 /// What every plain-enum flatten diagnostic says about its own reach, so an author who fixes the
 /// one declaration named there knows what was and was not checked around it.
@@ -468,11 +475,26 @@ enum TaggedContent {
     Unnameable(&'static str),
 }
 
+/// One `default_types(IdType = String)` entry as written: the parameter it names, and the type
+/// declared for that parameter.
+struct DefaultTypeEntry {
+    name: syn::Ident,
+    ty: syn::Type,
+}
+
 #[derive(Default, Clone)]
 struct ModelSchemaArgs {
     /// The parser's refusal of the attribute's arguments — one it does not read, or a value it
     /// cannot read — spanned on the tokens that earned it.
     arg_rejection: Option<syn::Error>,
+    /// The default type declared for each of the item's own type parameters, in the order they
+    /// were written: `default_types(IdType = String, DateType = f64)`. Read by JSON-schema
+    /// generation, which has no type parameters of its own and so has to build its document from
+    /// one concrete filling.
+    ///
+    /// The parameter is kept as the ident it was written as rather than its text, because a
+    /// refusal of an entry is spanned on it and only the ident carries that span.
+    default_types: Vec<(syn::Ident, syn::Type)>,
     max_length: Option<usize>,
     min_length: Option<usize>,
     name_override: Option<String>,
@@ -552,6 +574,15 @@ impl ModelSchemaArgs {
     }
 }
 
+impl Parse for DefaultTypeEntry {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let name = input.parse()?;
+        input.parse::<Token![=]>()?;
+        let ty = input.parse()?;
+        Ok(Self { name, ty })
+    }
+}
+
 /// Parses the arguments of a `model_schema` attribute.
 ///
 /// What the parser cannot read is recorded as [`ModelSchemaArgs::arg_rejection`] rather than
@@ -594,6 +625,8 @@ fn apply_arg(result: &mut ModelSchemaArgs, meta: &Meta) -> syn::Result<()> {
         result.max_length = Some(length_arg(meta, "maxLength")?);
     } else if path.is_ident("no_display") {
         result.no_display = flag_arg(meta, "no_display")?;
+    } else if path.is_ident("default_types") {
+        result.default_types = default_types_arg(meta)?;
     } else {
         return Err(unknown_arg_rejection(meta));
     }
@@ -663,6 +696,29 @@ fn length_arg(meta: &Meta, name: &str) -> syn::Result<usize> {
     } else {
         Err(arg_rejection(lit, name, &takes))
     }
+}
+
+/// The pairs a `default_types(…)` argument was written as, in that order.
+///
+/// A list with no pair in it is refused rather than read as an empty declaration: the argument
+/// exists to name a filling per parameter, so one that names none says nothing that leaving it off
+/// does not already say — and on an item that declares parameters it would read as a declaration
+/// while declaring nothing.
+fn default_types_arg(meta: &Meta) -> syn::Result<Vec<(syn::Ident, syn::Type)>> {
+    let takes = "a list of `Parameter = Type` pairs, written `default_types(IdType = String, \
+                 DateType = f64)`";
+    let Meta::List(list) = meta else {
+        return Err(arg_rejection(meta, "default_types", takes));
+    };
+    let entries =
+        list.parse_args_with(Punctuated::<DefaultTypeEntry, Token![,]>::parse_terminated)?;
+    if entries.is_empty() {
+        return Err(arg_rejection(list, "default_types", takes));
+    }
+    Ok(entries
+        .into_iter()
+        .map(|entry| (entry.name, entry.ty))
+        .collect())
 }
 
 /// Whether a flag argument is set: it stands alone, or takes the boolean literal that says which
@@ -743,6 +799,16 @@ pub fn exec_model_schema(args: TokenStream, input: TokenStream) -> TokenStream {
             &[attr_guard_error(rejection, &item_label(&item))],
         )
     {
+        return output;
+    }
+    // A `default_types` declaration is read against the item's own parameters, which the parser
+    // never sees, so both directions are answered here — ahead of every shape, and of the branded
+    // split inside the struct path.
+    if let Some(output) = guard_failure_output(
+        &item,
+        item_schema_ident(&item),
+        &default_types_guard_errors(&item, &parsed_args),
+    ) {
         return output;
     }
     if let Item::Struct(item_struct) = item {
@@ -1573,6 +1639,135 @@ const fn item_schema_ident(item: &Item) -> Option<&syn::Ident> {
     } else {
         None
     }
+}
+
+/// The parameters an item declares — the three shapes `model_schema` expands each bind their own;
+/// anything else binds none this expansion can read.
+const fn item_generics(item: &Item) -> Option<&syn::Generics> {
+    if let Item::Struct(item_struct) = item {
+        Some(&item_struct.generics)
+    } else if let Item::Enum(item_enum) = item {
+        Some(&item_enum.generics)
+    } else if let Item::Type(item_type) = item {
+        Some(&item_type.generics)
+    } else {
+        None
+    }
+}
+
+/// The `compile_error!` tokens a `default_types` declaration earns against the item it was written
+/// on, checked in both directions: an entry naming nothing the item declares, and — where a JSON
+/// document is generated — a parameter the declaration left out.
+///
+/// The comparison is the item's to make, not the parser's: the parser reads the attribute alone and
+/// never sees the declaration the entries are held against. It is made at the one seam every
+/// expanded shape is dispatched from, so a struct, an enum and an alias cannot come to answer
+/// differently, and a branded newtype is answered before the struct path splits it off.
+///
+/// Only the missing-entry direction is gated. An entry that names nothing declares a filling no
+/// reader will ever find a parameter for, in any build; a parameter with no entry is only short of
+/// something where something is generated from the default.
+fn default_types_guard_errors(
+    item: &Item,
+    args: &ModelSchemaArgs,
+) -> Vec<proc_macro2::TokenStream> {
+    let Some(generics) = item_generics(item) else {
+        return Vec::new();
+    };
+    let declared: Vec<&syn::Ident> = generics
+        .params
+        .iter()
+        .filter_map(|param| match param {
+            syn::GenericParam::Type(type_param) => Some(&type_param.ident),
+            syn::GenericParam::Const(_) | syn::GenericParam::Lifetime(_) => None,
+        })
+        .collect();
+
+    #[cfg(feature = "jsonschema")]
+    let mut rejections = entries_naming_no_parameter(args, &declared);
+    #[cfg(not(feature = "jsonschema"))]
+    let rejections = entries_naming_no_parameter(args, &declared);
+    #[cfg(feature = "jsonschema")]
+    rejections.extend(parameters_left_without_a_default(args, &declared));
+
+    rejections
+        .iter()
+        .map(|rejection| attr_guard_error(rejection, &item_label(item)))
+        .collect()
+}
+
+/// The refusal every `default_types` entry that names no type parameter of the item earns, spanned
+/// on the entry as written.
+fn entries_naming_no_parameter(
+    args: &ModelSchemaArgs,
+    declared: &[&syn::Ident],
+) -> Vec<syn::Error> {
+    args.default_types
+        .iter()
+        .filter(|(name, _)| !declared.contains(&name))
+        .map(|(name, _)| syn::Error::new_spanned(name, undeclared_entry_message(name, declared)))
+        .collect()
+}
+
+/// Why an entry naming nothing is refused, in the two spellings the item earns: one that declares
+/// parameters names them back, and one that declares none says so.
+fn undeclared_entry_message(name: &syn::Ident, declared: &[&syn::Ident]) -> String {
+    if declared.is_empty() {
+        return format!(
+            "`default_types` entry `{name}` names a type parameter, but this item declares none. A \
+             default type is the concrete filling a parameter is described from, so an item with \
+             no type parameter has nothing for one to fill."
+        );
+    }
+    let names = declared
+        .iter()
+        .map(|declared_name| format!("`{declared_name}`"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "`default_types` entry `{name}` names no type parameter of this item. An entry declares \
+         the filling for the parameter it names, so one that names none fills nothing while the \
+         parameter it was meant for is left with no default at all. Type parameters of this item: \
+         {names}."
+    )
+}
+
+/// The refusal every type parameter the declaration left out earns, spanned on the parameter.
+#[cfg(feature = "jsonschema")]
+fn parameters_left_without_a_default(
+    args: &ModelSchemaArgs,
+    declared: &[&syn::Ident],
+) -> Vec<syn::Error> {
+    declared
+        .iter()
+        .filter(|name| {
+            !args
+                .default_types
+                .iter()
+                .any(|(written, _)| written == **name)
+        })
+        .map(|name| syn::Error::new_spanned(name, missing_default_message(name, declared)))
+        .collect()
+}
+
+/// Why a parameter with no default is refused: what the default is for, what the feature has to do
+/// with it, and the declaration to write for this item's own parameters.
+#[cfg(feature = "jsonschema")]
+fn missing_default_message(name: &syn::Ident, declared: &[&syn::Ident]) -> String {
+    let sample = declared
+        .iter()
+        .map(|parameter| format!("{parameter} = String"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "`#[model_schema]` requires a default type for every type parameter, and `{name}` has \
+         none. The default type is what the JSON-schema document is generated from: JSON Schema \
+         has no type parameters, so without a declared default the macro would have to guess — and \
+         a wrong guess produces a document that silently rejects valid payloads. This is required \
+         because the `jsonschema` feature is enabled. Declare one for every parameter of this item, \
+         each with the type its document should be generated from: \
+         `#[model_schema(default_types({sample}))]`."
+    )
 }
 
 /// The `compile_error!` tokens for every `cfg_attr`-wrapped serde attribute an enum carries: on the

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -32,7 +32,6 @@ use super::tuple_struct_zod_body;
 #[cfg(feature = "jsonschema")]
 use super::tuple_struct_json_body;
 
-#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 use syn::spanned::Spanned as _;
 
 /// The variants of [`rendered_discriminated_union`]'s enum, in the order they are declared.
@@ -3345,12 +3344,13 @@ fn an_exported_name_can_carry_no_double_quote() {
 /// name is one it actually reads — the list and the arms cannot drift apart while both hold.
 #[test]
 fn no_argument_the_parser_reads_is_rejected() {
-    let probes: [proc_macro2::TokenStream; 5] = [
+    let probes: [proc_macro2::TokenStream; 6] = [
         quote::quote! { name = "Renamed" },
         quote::quote! { pattern = "^[a-z]+$" },
         quote::quote! { minLength = 1 },
         quote::quote! { maxLength = 50 },
         quote::quote! { no_display },
+        quote::quote! { default_types(IdType = String) },
     ];
     assert_eq!(probes.len(), super::KNOWN_ARGS.len());
 
@@ -3435,6 +3435,226 @@ fn every_expanded_shape_names_itself_in_a_guard_message() {
         (syn::parse_quote! { fn carrier() {} }, "item"),
     ] {
         assert_eq!(super::item_label(&item), label);
+    }
+}
+
+/// `default_types(IdType = String, DateType = f64)` reads as the pairs it was written as, in the
+/// order they were written, each type kept whole — the order is what a reader of the declaration
+/// lines up against the parameter list.
+#[test]
+fn default_types_reads_its_pairs_in_declaration_order() {
+    let args = super::parse_model_schema_args(quote::quote! {
+        default_types(IdType = String, DateType = f64, Nested = Vec<Option<u8>>)
+    });
+    assert_eq!(args.arg_rejection.as_ref().map(ToString::to_string), None);
+    let read: Vec<(String, String)> = args
+        .default_types
+        .iter()
+        .map(|(name, ty)| (name.to_string(), quote::quote!(#ty).to_string()))
+        .collect();
+    assert_eq!(
+        read,
+        vec![
+            ("IdType".to_owned(), "String".to_owned()),
+            ("DateType".to_owned(), "f64".to_owned()),
+            ("Nested".to_owned(), "Vec < Option < u8 > >".to_owned()),
+        ]
+    );
+}
+
+/// Every shape the argument is not: a value where the list belongs, a bare flag, an entry with no
+/// type beside it, a name no parameter can be spelled as, a trailing hole, and a list that
+/// declares nothing at all.
+#[test]
+fn a_default_types_shape_the_parser_cannot_read_is_refused() {
+    let probes: [proc_macro2::TokenStream; 6] = [
+        quote::quote! { default_types = "IdType" },
+        quote::quote! { default_types },
+        quote::quote! { default_types() },
+        quote::quote! { default_types(IdType) },
+        quote::quote! { default_types("IdType" = String) },
+        quote::quote! { default_types(IdType = String, , DateType = f64) },
+    ];
+    for probe in probes {
+        let rendered = probe.to_string();
+        assert!(args_rejection(probe).is_some(), "for {rendered}");
+    }
+}
+
+/// The argument shares the list with the string constraints and the name override, and reading it
+/// costs none of them. This is the only place the coexistence can be asked: a type-level string
+/// constraint is a brand's alone, and a brand over a type parameter is already refused at its
+/// inner field, so no one item reaches an emitter carrying both.
+#[test]
+fn default_types_coexists_with_every_other_argument() {
+    let args = super::parse_model_schema_args(quote::quote! {
+        name = "Slug", pattern = "^[a-z]+$", minLength = 1, maxLength = 8, no_display,
+        default_types(IdType = String)
+    });
+    assert_eq!(args.arg_rejection.as_ref().map(ToString::to_string), None);
+    assert_eq!(args.name_override.as_deref(), Some("Slug"));
+    assert_eq!(args.pattern.as_deref(), Some("^[a-z]+$"));
+    assert_eq!(args.min_length, Some(1));
+    assert_eq!(args.max_length, Some(8));
+    assert!(args.no_display);
+    assert_eq!(args.default_types.len(), 1);
+}
+
+/// The `compile_error!` tokens `default_types` earns when `args` is written on `source`. Both are
+/// parsed from text so their tokens carry file locations and each refusal's span can be read back
+/// as the source it points at.
+fn default_types_refusals(source: &str, args: &str) -> Vec<proc_macro2::TokenStream> {
+    let item: syn::Item = syn::parse_str(source).unwrap();
+    let parsed = super::parse_model_schema_args(syn::parse_str(args).unwrap());
+    assert_eq!(
+        parsed.arg_rejection.as_ref().map(ToString::to_string),
+        None,
+        "for {args}"
+    );
+    super::default_types_guard_errors(&item, &parsed)
+}
+
+/// The refusals of `args` on `source`, rendered.
+fn default_types_messages(source: &str, args: &str) -> Vec<String> {
+    default_types_refusals(source, args)
+        .iter()
+        .map(ToString::to_string)
+        .collect()
+}
+
+/// An entry naming nothing the item declares fills nothing, so it is refused in every build: no
+/// surface reads the default it carries, and the parameter it was meant for is left without one.
+#[test]
+fn an_entry_naming_no_declared_parameter_is_refused_in_every_build() {
+    let messages = default_types_messages(
+        "pub struct Renamed<IdType, DateType> { pub id: IdType, pub at: DateType }",
+        "default_types(IdType = String, DateType = f64, WrongName = String)",
+    );
+    assert_eq!(messages.len(), 1, "got: {messages:?}");
+    for needle in [
+        "compile_error",
+        "WrongName",
+        "IdType",
+        "DateType",
+        "type `Renamed`",
+    ] {
+        assert!(
+            messages[0].contains(needle),
+            "{needle} missing: {}",
+            messages[0]
+        );
+    }
+}
+
+/// An item with no type parameter has nothing for a default to fill, whatever the entry names and
+/// whichever shape carries the attribute — a lifetime and a const name no type either.
+#[test]
+fn default_types_on_an_item_declaring_no_type_parameter_is_refused() {
+    for source in [
+        "pub struct Plain { pub id: String }",
+        "pub enum Plain { One }",
+        "pub type Plain = String;",
+        "pub struct Borrowed<'label> { pub id: &'label str }",
+        "pub struct Fixed<const WIDTH: usize> { pub id: [u8; WIDTH] }",
+    ] {
+        let messages = default_types_messages(source, "default_types(IdType = String)");
+        assert_eq!(messages.len(), 1, "for {source}: {messages:?}");
+        assert!(
+            messages[0].contains("IdType"),
+            "for {source}: {}",
+            messages[0]
+        );
+    }
+}
+
+/// A declaration that answers for every parameter earns nothing, in every shape the attribute
+/// expands and beside the lifetimes and consts that name no type.
+#[test]
+fn an_item_declaring_a_default_for_every_parameter_earns_no_refusal() {
+    for (source, args) in [
+        (
+            "pub struct Both<IdType, DateType> { pub id: IdType, pub at: DateType }",
+            "default_types(IdType = String, DateType = f64)",
+        ),
+        (
+            "pub enum Tagged<IdType> { Named { id: IdType } }",
+            "default_types(IdType = String)",
+        ),
+        (
+            "pub type Boxed<ValueType> = Vec<ValueType>;",
+            "default_types(ValueType = String)",
+        ),
+        (
+            "pub struct Mixed<'label, IdType, const WIDTH: usize> { pub id: IdType }",
+            "default_types(IdType = String)",
+        ),
+        ("pub struct Plain { pub id: String }", ""),
+    ] {
+        let messages = default_types_messages(source, args);
+        assert!(messages.is_empty(), "for {source}: {messages:?}");
+    }
+}
+
+/// The refusal points at what earned it: the entry, for a name the item does not declare, and the
+/// parameter itself, for one left with no default.
+#[test]
+fn a_default_types_refusal_is_spanned_on_what_earned_it() {
+    let entry = default_types_refusals(
+        "pub struct Renamed<IdType> { pub id: IdType }",
+        "default_types(IdType = String, WrongName = String)",
+    );
+    assert_eq!(entry.len(), 1, "got: {}", entry.len());
+    assert_eq!(entry[0].span().source_text().as_deref(), Some("WrongName"));
+
+    #[cfg(feature = "jsonschema")]
+    {
+        let parameter = default_types_refusals(
+            "pub struct EcmDocument<IdType, DateType> { pub id: IdType, pub at: DateType }",
+            "default_types(IdType = String)",
+        );
+        assert_eq!(parameter.len(), 1, "got: {}", parameter.len());
+        assert_eq!(
+            parameter[0].span().source_text().as_deref(),
+            Some("DateType")
+        );
+    }
+}
+
+/// The JSON document is built from the declared default, so a parameter left without one is
+/// refused wherever that document is written — and the refusal says what the default is for, that
+/// the feature is what requires it, and the attribute to write for this item's own parameters.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_parameter_with_no_default_is_refused_where_the_json_document_is_built() {
+    let messages = default_types_messages(
+        "pub struct EcmDocument<IdType, DateType> { pub id: IdType, pub at: DateType }",
+        "",
+    );
+    assert_eq!(messages.len(), 2, "got: {messages:?}");
+    let joined = messages.join("\n");
+    for needle in [
+        "IdType",
+        "DateType",
+        "silently rejects valid payloads",
+        "`jsonschema` feature",
+        "default_types(IdType = String, DateType = String)",
+        "type `EcmDocument`",
+    ] {
+        assert!(joined.contains(needle), "{needle} missing: {joined}");
+    }
+}
+
+/// Without the feature that reads it, nothing is generated from a default type, so an item that
+/// declares none is left alone — the same item that is refused above.
+#[cfg(not(feature = "jsonschema"))]
+#[test]
+fn a_parameter_with_no_default_is_accepted_where_no_json_document_is_built() {
+    for args in ["", "default_types(IdType = String)"] {
+        let messages = default_types_messages(
+            "pub struct EcmDocument<IdType, DateType> { pub id: IdType, pub at: DateType }",
+            args,
+        );
+        assert!(messages.is_empty(), "for {args:?}: {messages:?}");
     }
 }
 

--- a/tests/branded_newtype_tests/tests.rs
+++ b/tests/branded_newtype_tests/tests.rs
@@ -24,12 +24,12 @@ mod zod_ts_tests {
     /// ```rust example
     /// DocumentId("64de3d95ff45b119e5b53a7e".to_string())
     /// ```
-    #[model_schema()]
+    #[model_schema(default_types(IdType = String))]
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     #[serde(transparent)]
     pub struct DocumentId<IdType>(pub IdType);
 
-    #[model_schema()]
+    #[model_schema(default_types(IdType = String))]
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     #[serde(transparent)]
     pub struct RoleId<IdType>(pub IdType);
@@ -584,7 +584,7 @@ mod branded_in_struct_all_features_tests {
     #[serde(transparent)]
     pub struct TaskId(pub String);
 
-    #[model_schema()]
+    #[model_schema(default_types(T = String))]
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     #[serde(transparent)]
     pub struct TaskTypeId<T>(pub T);
@@ -669,7 +669,7 @@ mod branded_in_struct_no_jsonschema_tests {
     #[serde(transparent)]
     pub struct TaskIdNJ(pub String);
 
-    #[model_schema()]
+    #[model_schema(default_types(T = String))]
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     #[serde(transparent)]
     pub struct TaskTypeIdNJ<T>(pub T);
@@ -720,7 +720,7 @@ mod branded_in_struct_jsonschema_only_tests {
     #[serde(transparent)]
     pub struct TaskIdJO(pub String);
 
-    #[model_schema()]
+    #[model_schema(default_types(T = String))]
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     #[serde(transparent)]
     pub struct TaskTypeIdJO<T>(pub T);
@@ -773,7 +773,7 @@ mod branded_in_struct_typescript_only_tests {
     #[serde(transparent)]
     pub struct TaskIdTO(pub String);
 
-    #[model_schema()]
+    #[model_schema(default_types(T = String))]
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     #[serde(transparent)]
     pub struct TaskTypeIdTO<T>(pub T);
@@ -847,7 +847,7 @@ mod branded_constrained_json_schema_tests {
 mod branded_display_tests {
     use super::*;
 
-    #[model_schema()]
+    #[model_schema(default_types(T = String))]
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     #[serde(transparent)]
     pub struct DisplayId<T>(pub T);
@@ -888,7 +888,7 @@ mod branded_no_display_tests {
     #[serde(transparent)]
     pub struct Tags(pub Vec<String>);
 
-    #[model_schema(no_display)]
+    #[model_schema(no_display, default_types(T = String))]
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     #[serde(transparent)]
     pub struct TagList<T>(pub Vec<T>);
@@ -1256,23 +1256,23 @@ mod branded_generic_inner_tests {
     use super::*;
     use std::collections::HashMap;
 
-    #[model_schema()]
+    #[model_schema(default_types(T = String))]
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     #[serde(transparent)]
     pub struct BareTag<T>(pub T);
 
-    #[model_schema(no_display)]
+    #[model_schema(no_display, default_types(T = u32))]
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     #[serde(transparent)]
     pub struct WeightIndex<T>(pub HashMap<String, T>);
 
-    #[model_schema()]
+    #[model_schema(default_types(T = String))]
     pub type BareSeq<T> = T;
 
-    #[model_schema()]
+    #[model_schema(default_types(T = String))]
     pub type TagSeq<T> = Vec<T>;
 
-    #[model_schema()]
+    #[model_schema(default_types(T = u32))]
     pub type WeightSeq<T> = HashMap<String, T>;
 
     #[test]
@@ -1489,7 +1489,7 @@ mod branded_example_arity_tests {
     /// ```rust example
     /// PairId(("a".to_string(), "b".to_string()))
     /// ```
-    #[model_schema(no_display)]
+    #[model_schema(no_display, default_types(A = String, B = String))]
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     #[serde(transparent)]
     pub struct PairId<A, B>(pub (A, B));
@@ -1499,7 +1499,7 @@ mod branded_example_arity_tests {
     /// ```rust example
     /// SoloId("a".to_string())
     /// ```
-    #[model_schema()]
+    #[model_schema(default_types(T = String))]
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     #[serde(transparent)]
     pub struct SoloId<T>(pub T);
@@ -2121,7 +2121,7 @@ mod constrained_no_display_tests {
 mod no_zod_tests {
     use super::*;
 
-    #[model_schema()]
+    #[model_schema(default_types(IdType = String))]
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     #[serde(transparent)]
     pub struct RoleIdNoZod<IdType>(pub IdType);
@@ -2170,7 +2170,7 @@ mod no_zod_tests {
 mod serde_tests {
     use super::*;
 
-    #[model_schema()]
+    #[model_schema(default_types(IdType = String))]
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     #[serde(transparent)]
     pub struct GenericId<IdType>(pub IdType);

--- a/tests/generic_types_tests/tests.rs
+++ b/tests/generic_types_tests/tests.rs
@@ -892,11 +892,6 @@ pub struct Undefaulted<IdType> {
     pub id: IdType,
 }
 
-#[cfg(not(feature = "jsonschema"))]
-#[test]
-fn a_parameter_with_no_default_still_expands_where_no_json_document_is_built() {
-    assert_eq!(Undefaulted { id: 1_u32 }.id, 1);
-}
 
 /// The item the reference-site fixtures below point at. A generic type publishes a factory rather
 /// than a schema, so a field naming it has nothing to name — it has to call that factory with what
@@ -960,6 +955,12 @@ pub struct MixedArguments {
 pub struct Referrer {
     pub boxed: Boxed<u32>,
     pub tagged: Tagged<String>,
+}
+
+#[cfg(not(feature = "jsonschema"))]
+#[test]
+fn a_parameter_with_no_default_still_expands_where_no_json_document_is_built() {
+    assert_eq!(Undefaulted { id: 1_u32 }.id, 1);
 }
 
 /// The pair the attribute used to produce on any generic item: `E0107` on the emitted `impl`,

--- a/tests/generic_types_tests/tests.rs
+++ b/tests/generic_types_tests/tests.rs
@@ -11,6 +11,11 @@
 //! declaration for an unused parameter before the attribute is reached. What it can bind is a
 //! const, which `PlainConst` carries, and that is the plain-enum shape of the same question: the
 //! `impl` has to repeat the const while the declaration names nothing.
+//!
+//! Every fixture binding a type parameter declares a default type for it, which is what a build
+//! generating a JSON document requires. Nothing here reads that declaration yet, so the surfaces
+//! pinned below are the ones the undeclared fixtures pinned — which is the whole of the evidence
+//! that declaring a default changes no emission.
 
 #[cfg(feature = "typescript")]
 mod typescript {
@@ -632,7 +637,7 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 use tixschema::model_schema;
 
-#[model_schema()]
+#[model_schema(default_types(IdType = String))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Wrapper<IdType> {
     pub children: Vec<IdType>,
@@ -640,7 +645,7 @@ pub struct Wrapper<IdType> {
     pub name: String,
 }
 
-#[model_schema()]
+#[model_schema(default_types(KeyType = String, ValueType = u32))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Pair<KeyType, ValueType> {
     pub by_key: HashMap<String, ValueType>,
@@ -650,7 +655,7 @@ pub struct Pair<KeyType, ValueType> {
     pub tuple: (KeyType, ValueType),
 }
 
-#[model_schema()]
+#[model_schema(default_types(IdType = String))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "kind", content = "payload")]
 pub enum Adjacent<IdType> {
@@ -659,7 +664,7 @@ pub enum Adjacent<IdType> {
     Single(IdType),
 }
 
-#[model_schema()]
+#[model_schema(default_types(IdType = String))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "kind")]
 pub enum Internal<IdType> {
@@ -667,7 +672,7 @@ pub enum Internal<IdType> {
     Nothing,
 }
 
-#[model_schema()]
+#[model_schema(default_types(IdType = String))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum External<IdType> {
     Named { id: IdType },
@@ -675,7 +680,7 @@ pub enum External<IdType> {
     Single(IdType),
 }
 
-#[model_schema()]
+#[model_schema(default_types(IdType = String))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Untagged<IdType> {
@@ -691,13 +696,13 @@ pub enum PlainConst<const WIDTH: usize> {
     Wide,
 }
 
-#[model_schema(name = "RenamedHolder")]
+#[model_schema(name = "RenamedHolder", default_types(IdType = String))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Holder<IdType> {
     pub id: IdType,
 }
 
-#[model_schema()]
+#[model_schema(default_types(IdType = String))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Positional<IdType>(pub IdType, pub String);
 
@@ -710,7 +715,7 @@ pub struct Positional<IdType>(pub IdType, pub String);
     feature = "zod",
     feature = "jsonschema"
 ))]
-#[model_schema()]
+#[model_schema(default_types(KeyType = String, ValueType = u32))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct KeyedByParameter<KeyType: Eq + Hash, ValueType> {
     pub both_parameters: HashMap<KeyType, ValueType>,
@@ -729,7 +734,13 @@ pub struct LifetimeStruct<'label> {
 /// Enough parameters that every level of the lookup is a level with two neighbours: the first
 /// argument keys the outermost map, the last keys the one the schema is stored in, and the three
 /// between are only reached through the two.
-#[model_schema()]
+#[model_schema(default_types(
+    AType = u32,
+    BType = String,
+    CType = u32,
+    DType = String,
+    EType = u32
+))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Quintet<AType, BType, CType, DType, EType> {
     pub alpha: AType,
@@ -747,22 +758,39 @@ pub struct Envelope {
 
 /// A generic alias, and a generic branded newtype: the two surfaces that publish a `const` rather
 /// than a factory, and so the two a parameter inside still reaches as the opaque value.
-#[model_schema(name = "Boxed")]
+#[model_schema(name = "Boxed", default_types(ValueType = String))]
 pub type Boxed<ValueType> = Vec<ValueType>;
 
-#[model_schema()]
+#[model_schema(default_types(ValueType = String))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct Tagged<ValueType>(pub ValueType);
 
 /// A generic type that also flattens, which is the one shape where the parameters and the deferred
 /// read of another type's binding have to hold at once.
-#[model_schema()]
+#[model_schema(default_types(IdType = String))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Carried<IdType> {
     #[serde(flatten)]
     pub envelope: Envelope,
     pub id: IdType,
+}
+
+/// A parameter with no declared default type, which only a build generating a JSON document
+/// refuses: nothing else reads the default, so there is nothing for the absence to break. The
+/// fixture compiling under the feature sets that admit it is the whole of the assertion — under
+/// the one that does not, it is not declared at all.
+#[cfg(not(feature = "jsonschema"))]
+#[model_schema()]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Undefaulted<IdType> {
+    pub id: IdType,
+}
+
+#[cfg(not(feature = "jsonschema"))]
+#[test]
+fn a_parameter_with_no_default_still_expands_where_no_json_document_is_built() {
+    assert_eq!(Undefaulted { id: 1_u32 }.id, 1);
 }
 
 /// The pair the attribute used to produce on any generic item: `E0107` on the emitted `impl`,

--- a/tests/generic_types_tests/tests.rs
+++ b/tests/generic_types_tests/tests.rs
@@ -892,7 +892,6 @@ pub struct Undefaulted<IdType> {
     pub id: IdType,
 }
 
-
 /// The item the reference-site fixtures below point at. A generic type publishes a factory rather
 /// than a schema, so a field naming it has nothing to name — it has to call that factory with what
 /// fills each parameter.

--- a/tests/semantic_types_tests/tests.rs
+++ b/tests/semantic_types_tests/tests.rs
@@ -49,7 +49,7 @@ pub type OrderId = String;
 
 /// Generic type alias with two type parameters.
 #[cfg(all(test, feature = "typescript"))]
-#[model_schema(name = "Pair")]
+#[model_schema(name = "Pair", default_types(T = String, U = u32))]
 pub type Pair<T, U> = (T, U);
 
 /// Numeric type alias (i64).
@@ -73,7 +73,7 @@ pub type Tags = Vec<String>;
 
 /// Generic type alias with single type parameter.
 #[cfg(all(test, feature = "typescript"))]
-#[model_schema(name = "Wrapper")]
+#[model_schema(name = "Wrapper", default_types(T = String))]
 pub type Wrapper<T> = Option<T>;
 
 #[cfg(all(test, feature = "typescript", feature = "serde"))]


### PR DESCRIPTION
`#[model_schema(default_types(IdType = String, …))]` parses one filling per declared parameter, in declaration order. The two-direction guard sits at the dispatch seam (one check covers struct, tuple struct, brand, enum, and alias — the alias publishing a JSON document too): under `jsonschema` a parameter with no entry is refused with the exact attribute to write; an entry naming no declared parameter is refused in every build; `default_types` on a non-generic item is refused; every refusal spanned on the entry or parameter that earned it (source-text pinned). Without `jsonschema` an undefaulted parameter still expands — nothing else reads the filling yet.

Three recorded deviations from the task's draft: the guard lives at `exec_model_schema` (it needs the item's generics; the parser never sees them, so no parse-slot for the refusal), and entries key by `syn::Ident` for the spans. Thirty-two existing generic fixtures gained declarations with zero assertion changes — the evidence the attribute alters no emission today. The merge added the same declarations to the reference-site fixtures that landed meanwhile.