### PR TITLE
record each registration's wire leaves once, and read the JSON keyword from one scalar mapping

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -101,6 +101,9 @@ use crate::utils::ident_reexport_zod;
 #[cfg(feature = "zod")]
 use crate::utils::{ZodUnionMember, record_zod_union_members};
 
+#[cfg(all(feature = "serde", feature = "zod"))]
+use crate::utils::{WireLeaf, record_wire_leaves};
+
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 use crate::utils::register_alias_info;
 
@@ -124,16 +127,6 @@ const KNOWN_ARGS: &[&str] = &["name", "pattern", "minLength", "maxLength", "no_d
 ))]
 const FLATTENED_PLAIN_ENUM_SCOPE: &str = "Only a type the registry has already classified reaches this guard; one it has not keeps its \
      TypeScript and Zod intersection, and is refused by the JSON surface when the merge runs.";
-
-/// The two shapes [`crate::utils::record_value_shape`] records that a second reader matches on
-/// rather than merely prints: each names one JSON type keyword and only one, so the flatten guard
-/// can repeat the JSON-schema merge's words off the recorded shape alone. Written once so a rename
-/// moves both the recording and the reading.
-#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-const VALUE_SHAPE_BOOLEAN: &str = "boolean";
-
-#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-const VALUE_SHAPE_ENUMERATED: &str = "enumerated";
 
 /// The two shapes a map key can write that `serde_json` will not use as an object key, as
 /// [`MapKeyRejection::Unwritable`] names them.
@@ -511,6 +504,33 @@ struct MergedOperand {
     spelling: String,
 }
 
+/// Both answers the registry holds about what a `#[model_schema()]` item publishes, built together
+/// from one reading of the declaration so the two cannot come apart.
+///
+/// The shape is the constrained-brand guard's question — what a string check would be appended to.
+/// The wire is the flatten merge's — whether an object can be joined to what serde writes. One word
+/// cannot hold both: an `integer` and a `number` are one shape and two documents, an array and a map
+/// are one shape and opposite answers, and a nullable surface carries its leaves a level below the
+/// name rather than at it.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+struct Surface {
+    shape: Option<&'static str>,
+    #[cfg(all(feature = "serde", feature = "zod"))]
+    wire: RecordedWire,
+}
+
+/// What a [`Surface`] carries for the merge: the leaves a written type published, or the one
+/// keyword a surface read off no written type names.
+///
+/// The two are one recording — [`Surface::record`] writes either as leaves — and are held apart
+/// only so a surface named outright can be built without one, which is what lets the four fixed
+/// surfaces be `const`.
+#[cfg(all(feature = "serde", feature = "zod"))]
+enum RecordedWire {
+    Leaves(Vec<WireLeaf>),
+    Named(Option<&'static str>),
+}
+
 /// Mutable output buffers shared by the discriminated-enum variant writers. Bundled so each writer
 /// takes a single always-mutated `&mut`, keeping its conditionally-written fields (Zod schema, JSON
 /// fields) from tripping `needless_pass_by_ref_mut` under feature subsets.
@@ -549,6 +569,67 @@ impl MapMemberItem {
 impl ModelSchemaArgs {
     const fn has_string_constraints(&self) -> bool {
         self.pattern.is_some() || self.min_length.is_some() || self.max_length.is_some()
+    }
+}
+
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+impl Surface {
+    /// The fixed-arity JSON array a tuple struct of every arity but one writes, which takes no
+    /// string check and which no object can be merged with.
+    const fn array() -> Self {
+        Self::named(Some("container"), Some("array"))
+    }
+
+    /// The bare string a plain unit enum writes its member name as.
+    const fn enumerated() -> Self {
+        Self::named(Some("enumerated"), Some("string"))
+    }
+
+    /// A surface neither answer is read off a written type for.
+    const fn named(shape: Option<&'static str>, wire: Option<&'static str>) -> Self {
+        #[cfg(not(all(feature = "serde", feature = "zod")))]
+        let _: Option<&'static str> = wire;
+        Self {
+            shape,
+            #[cfg(all(feature = "serde", feature = "zod"))]
+            wire: RecordedWire::Named(wire),
+        }
+    }
+
+    /// The object a struct of named fields writes, which a merge joins its own keys to.
+    const fn object() -> Self {
+        Self::named(Some("object"), None)
+    }
+
+    /// Puts both answers on the entry the name has just registered — taken by value, because a
+    /// surface is built for one registration and spent on it.
+    fn record(self, rust_ident: &str) {
+        record_value_shape(rust_ident, self.shape);
+        #[cfg(all(feature = "serde", feature = "zod"))]
+        match self.wire {
+            RecordedWire::Leaves(leaves) => record_wire_leaves(rust_ident, &leaves),
+            RecordedWire::Named(non_object) => record_wire_leaves(
+                rust_ident,
+                &[WireLeaf {
+                    branch: Vec::new(),
+                    non_object,
+                }],
+            ),
+        }
+    }
+
+    /// The union an enum writes, whose own members the merge multiplies over where it holds them.
+    const fn union() -> Self {
+        Self::named(Some("union"), None)
+    }
+
+    /// The surface a written type publishes, both answers read off the one def.
+    fn written(written: &FieldDef) -> Self {
+        Self {
+            shape: published_value_shape(written),
+            #[cfg(all(feature = "serde", feature = "zod"))]
+            wire: RecordedWire::Leaves(published_wire_leaves(written)),
+        }
     }
 }
 
@@ -860,7 +941,7 @@ fn process_type_alias(item_type: ItemType, args: &ModelSchemaArgs) -> TokenStrea
     let kind = alias_target_kind(&alias_field_def);
     register_alias_info(&rust_ident_str, &export_name, &module_name, kind);
     // An alias's schema *is* its target's, so it publishes whatever the target publishes.
-    record_value_shape(&rust_ident_str, published_value_shape(&alias_field_def));
+    Surface::written(&alias_field_def).record(&rust_ident_str);
     // An alias *is* the type it names, so a merge that flattens it multiplies over exactly the
     // members the target's own name would have given it.
     #[cfg(feature = "zod")]
@@ -1733,7 +1814,7 @@ fn non_string_inner_shape(inner: &FieldDef) -> Option<&'static str> {
     match &inner.field_type {
         FieldDefType::SiblingType(inner_name, _) => registered_value_shape(inner_name),
         FieldDefType::Map(..) | FieldDefType::Tuple(..) => Some("container"),
-        FieldDefType::Boolean => Some(VALUE_SHAPE_BOOLEAN),
+        FieldDefType::Boolean => Some("boolean"),
         FieldDefType::U8
         | FieldDefType::U16
         | FieldDefType::U32
@@ -1774,33 +1855,65 @@ fn registered_value_shape(rust_ident: &str) -> Option<&'static str> {
 /// The JSON type keyword a registered name's wire describes as, when the registry proves that wire
 /// is no object, and `None` for every name it cannot prove one way or the other.
 ///
-/// The same entry the constrained-brand guard reads, asked the merge's question instead of the
-/// brand's, in one lookup: `value_shape` is what the named item published as a value, and `kind` is
-/// what serde writes it as. The shape answers wherever it names something no object can be — a
-/// `boolean`, and the `string` an `enumerated` unit enum writes its member name as. Where the shape
-/// is `None`, which the brand's vocabulary uses for exactly the surfaces a string check lands on,
-/// the kind is what separates a proven bare string from a name nothing has classified.
+/// Read off the wire the named item recorded rather than off the word the constrained-brand guard
+/// reads: that word answers what a string check can be appended to, which is a coarser question
+/// than this one and cannot be sharpened without changing what the brand's refusals say. An
+/// `integer` and a `number` are one shape and two documents; an array and a map are one shape and
+/// opposite answers, serde flattening the map and writing the array as an array no object can be
+/// merged with. The wire holds each apart because it is recorded as the keyword itself.
 ///
-/// `numeric` is deliberately not an answer. The one recorded word covers two published documents —
-/// a one-slot tuple struct over a `u32` publishes `{"type": "integer"}` and a
-/// `#[serde(transparent)]` brand over the same `u32` publishes `{"type": "number"}` — so naming
-/// either keyword would put this refusal into disagreement with the merge whose words it repeats,
-/// which is the disagreement it exists to remove. A `container`, which bundles the array with the
-/// map, and a `nullable`, whose absence sits a level below the name rather than at it, are
-/// unprovable here for the same reason. `Stringified` is likewise not read on its own: the map-key
-/// dispatch answers it for a generic spelling it has not resolved, so a brand over an unregistered
-/// `Foreign<T>` carries it with nothing recorded behind it.
-///
-/// A name the registry has no entry for keeps the emission it has always had — the fallback the
-/// merge already documents for a source declared below the object that flattens it.
+/// A choice is not answered here at all — it has no one position to be answered at, its leaves
+/// sitting below the name rather than at it — and is spliced by [`named_wire_leaves`] instead. A
+/// map, an object and a name nothing has classified answer alike, which is the fallback the merge
+/// already documents for a source declared below the object that flattens it.
 #[cfg(all(feature = "serde", feature = "zod"))]
 fn registered_non_object_wire(rust_ident: &str) -> Option<&'static str> {
-    let info = lookup_alias_info(rust_ident)?;
-    match info.value_shape {
-        Some(VALUE_SHAPE_BOOLEAN) => Some("boolean"),
-        Some(VALUE_SHAPE_ENUMERATED) => Some("string"),
-        Some(_) => None,
-        None => matches!(info.kind, AliasKind::StringWire).then_some("string"),
+    match lookup_alias_info(rust_ident)?.wire.as_slice() {
+        [only] => only.non_object,
+        _ => None,
+    }
+}
+
+/// The JSON type keyword a value one keyword describes writes, and `None` for every type that
+/// writes a document no single keyword names — a composite, a name, an `ObjectId`'s `$oid` object,
+/// an opaque value.
+///
+/// The one mapping every surface asking that question reads, because the answer has to be the same
+/// wherever it is asked. Read off the type, never off the TypeScript name it renders under: that
+/// name collapses every width of integer and every float alike onto `number`, so a keyword taken
+/// from it cannot say which of the two a value publishes — and the same `u32` then describes as an
+/// `integer` written as a field and as a `number` written under a brand, one wire named twice.
+///
+/// Named exhaustively rather than caught by a wildcard: a new variant must be classified here, not
+/// silently collapsed into whichever arm sits last.
+#[cfg(any(feature = "jsonschema", all(feature = "serde", feature = "zod")))]
+const fn scalar_json_type_keyword(field_type: &FieldDefType) -> Option<&'static str> {
+    match *field_type {
+        FieldDefType::Boolean => Some("boolean"),
+        FieldDefType::F32 | FieldDefType::F64 => Some("number"),
+        FieldDefType::I8
+        | FieldDefType::I16
+        | FieldDefType::I32
+        | FieldDefType::I64
+        | FieldDefType::Isize
+        | FieldDefType::U8
+        | FieldDefType::U16
+        | FieldDefType::U32
+        | FieldDefType::U64
+        | FieldDefType::Usize => Some("integer"),
+        FieldDefType::String | FieldDefType::StringLiteral(_) => Some("string"),
+        #[cfg(feature = "chrono")]
+        FieldDefType::DateTime
+        | FieldDefType::NaiveDate
+        | FieldDefType::NaiveDateTime
+        | FieldDefType::NaiveTime => Some("string"),
+        #[cfg(feature = "object_id")]
+        FieldDefType::ObjectId => None,
+        FieldDefType::Map(..)
+        | FieldDefType::SiblingType(..)
+        | FieldDefType::Tuple(..)
+        | FieldDefType::TypeParam(_)
+        | FieldDefType::Unknown => None,
     }
 }
 
@@ -1877,13 +1990,6 @@ fn branded_pattern_error(name: &Ident, args: &ModelSchemaArgs) -> Option<proc_ma
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn branded_inner_value_surface(generics: &syn::Generics, inner_field: &Field) -> FieldDef {
     value_surface_field_def(generics, &get_field_def("_inner", &inner_field.ty, ""))
-}
-
-/// What a brand publishes as a value: `.brand()` returns the inner schema itself rather than a
-/// wrapper around it, so the brand carries exactly what its inner carries.
-#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-fn branded_value_shape(generics: &syn::Generics, inner_field: &Field) -> Option<&'static str> {
-    non_string_inner_shape(&branded_inner_value_surface(generics, inner_field))
 }
 
 /// What the registry records for a brand.
@@ -2178,13 +2284,13 @@ fn is_branded_newtype(item_struct: &syn::ItemStruct) -> bool {
 /// The module is named from the Rust ident, not from the export name, so that a type naming the
 /// struct before it has expanded assumes the module the struct goes on to publish.
 ///
-/// `value_shape` is what the struct publishes as a value, for a brand written over its name to
-/// read back — see [`crate::utils::record_value_shape`].
+/// `surface` is what the struct publishes as a value and what it puts on the wire, for a brand
+/// written over its name and for a merge flattening it to read back — see [`Surface`].
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn struct_module_idents(
     name: &syn::Ident,
     name_override: Option<&str>,
-    value_shape: Option<&'static str>,
+    surface: Surface,
 ) -> (String, String, Ident) {
     let item_name = compute_item_export_name(&name.to_string(), name_override);
     let module_name = ident_schema_module_name(&name.to_string());
@@ -2195,7 +2301,7 @@ fn struct_module_idents(
         &module_name,
         AliasKind::NoEnumMembers,
     );
-    record_value_shape(&name.to_string(), value_shape);
+    surface.record(&name.to_string());
     (item_name, module_name, module_ident)
 }
 
@@ -2208,12 +2314,12 @@ fn enum_module_idents(
     name: &syn::Ident,
     item_name: &str,
     kind: AliasKind,
-    value_shape: Option<&'static str>,
+    surface: Surface,
 ) -> (String, Ident) {
     let module_name = ident_schema_module_name(&name.to_string());
     let module_ident = Ident::new(&module_name, name.span());
     register_alias_info(&name.to_string(), item_name, &module_name, kind);
-    record_value_shape(&name.to_string(), value_shape);
+    surface.record(&name.to_string());
     (module_name, module_ident)
 }
 
@@ -2286,7 +2392,7 @@ fn process_struct(mut item_struct: syn::ItemStruct, args: &ModelSchemaArgs) -> T
     // Compute schema-module identifiers and register the struct in the alias registry.
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
     let (item_name, module_name, module_ident) =
-        struct_module_idents(&name, args.name_override.as_deref(), Some("object"));
+        struct_module_idents(&name, args.name_override.as_deref(), Surface::object());
 
     // Extract docs early for example extraction
     #[cfg(any(feature = "typescript", feature = "zod"))]
@@ -2523,15 +2629,15 @@ fn build_tuple_struct_zod_schema_method(
     }
 }
 
-/// What a tuple struct publishes as a value: serde writes one slot as that slot's value alone, so
-/// the schema *is* the slot's schema and carries exactly what it carries; every other arity is the
-/// fixed array `z.tuple` writes, which takes no string check.
+/// What a tuple struct publishes: serde writes one slot as that slot's value alone, so the schema
+/// *is* the slot's schema and carries exactly what it carries; every other arity is the fixed array
+/// `z.tuple` writes, which takes no string check and which no object can be merged with.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-fn tuple_struct_value_shape(fields: &syn::Fields) -> Option<&'static str> {
+fn tuple_struct_surface(fields: &syn::Fields) -> Surface {
     let mut slots = fields.iter();
     match (slots.next(), slots.next()) {
-        (Some(slot), None) => published_value_shape(&get_field_def("_slot", &slot.ty, "")),
-        _ => Some("container"),
+        (Some(slot), None) => Surface::written(&get_field_def("_slot", &slot.ty, "")),
+        _ => Surface::array(),
     }
 }
 
@@ -2552,7 +2658,7 @@ fn process_tuple_struct(
     let (item_name, module_name, module_ident) = struct_module_idents(
         &name,
         args.name_override.as_deref(),
-        tuple_struct_value_shape(&item_struct.fields),
+        tuple_struct_surface(&item_struct.fields),
     );
 
     let (slots, guard_errors) = collect_tuple_slots(
@@ -3003,8 +3109,10 @@ fn branded_ts_type_and_generics(
 ///
 /// An `ObjectId`, a composite and a named type are then read off that same `FieldDef`, because none
 /// of them writes a value one `"type"` keyword describes; a chrono type writes a string one keyword
-/// names but not the only one it carries. Every remaining inner maps from the resolved TypeScript
-/// type name.
+/// names but not the only one it carries. Every remaining inner takes its keyword from
+/// [`scalar_json_type_keyword`], the one mapping the field path reads it from — not from the
+/// resolved TypeScript type name, which spells an `integer` and a `number` alike and so published a
+/// `number` for a value every other spelling of publishes an `integer` for.
 ///
 /// The composite question is asked before the other two, so an inner written under array levels
 /// answers for the array around whatever it holds — which is what `#[serde(transparent)]` puts on
@@ -3028,11 +3136,13 @@ fn branded_json_inner(inner: &FieldDef) -> BrandedJsonInner {
     if matches!(inner.field_type, FieldDefType::SiblingType(..)) {
         return BrandedJsonInner::Slot(Box::new(inner.clone()));
     }
-    BrandedJsonInner::Scalar(match inner.typescript_typename().as_str() {
-        "number" => "number".to_owned(),
-        "boolean" => "boolean".to_owned(),
-        _ => "string".to_owned(),
-    })
+    // Every shape the shared mapping leaves unanswered has been returned above, so the fallback
+    // stands for the one thing left over: a spelling that writes a bare string.
+    BrandedJsonInner::Scalar(
+        scalar_json_type_keyword(&inner.field_type)
+            .unwrap_or("string")
+            .to_owned(),
+    )
 }
 
 /// The Zod string checks a branded newtype's `minLength`, `maxLength`, and `pattern` render to,
@@ -3639,10 +3749,11 @@ fn register_branded_newtype(
     );
     // A brand is written straight onto its inner's schema — `.brand()` hands back that same
     // instance — so it publishes whatever its inner publishes.
-    record_value_shape(
-        rust_ident,
-        branded_value_shape(&item_struct.generics, inner_field),
-    );
+    Surface::written(&branded_inner_value_surface(
+        &item_struct.generics,
+        inner_field,
+    ))
+    .record(rust_ident);
 }
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
@@ -4099,7 +4210,7 @@ fn process_plain_enum(
         name,
         item_name,
         AliasKind::EnumMembers,
-        Some(VALUE_SHAPE_ENUMERATED),
+        Surface::enumerated(),
     );
     #[cfg(any(feature = "typescript", feature = "zod"))]
     let rust_ident = name.to_string();
@@ -4389,7 +4500,7 @@ fn process_discriminated_enum(
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
     // Every other enum shape is written as a union of what its variants render as.
     let (module_name, module_ident) =
-        enum_module_idents(name, item_name, AliasKind::NoEnumMembers, Some("union"));
+        enum_module_idents(name, item_name, AliasKind::NoEnumMembers, Surface::union());
 
     // Extract docs early for example extraction
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
@@ -4805,7 +4916,7 @@ fn process_externally_tagged_enum(
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
     // Every other enum shape is written as a union of what its variants render as.
     let (module_name, module_ident) =
-        enum_module_idents(name, item_name, AliasKind::NoEnumMembers, Some("union"));
+        enum_module_idents(name, item_name, AliasKind::NoEnumMembers, Surface::union());
 
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
     let docs_vec = get_enum_docs(&item_enum);
@@ -5203,7 +5314,7 @@ fn process_internally_tagged_enum(
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
     // Every other enum shape is written as a union of what its variants render as.
     let (module_name, module_ident) =
-        enum_module_idents(name, item_name, AliasKind::NoEnumMembers, Some("union"));
+        enum_module_idents(name, item_name, AliasKind::NoEnumMembers, Surface::union());
 
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
     let docs_vec = get_enum_docs(&item_enum);
@@ -5584,11 +5695,14 @@ fn field_json_schema_value(fld: &FieldDef) -> proc_macro2::TokenStream {
         | FieldDefType::I32
         | FieldDefType::I64
         | FieldDefType::Usize
-        | FieldDefType::Isize => quote! { serde_json::json!({ "type": "integer" }) },
-        FieldDefType::F32 | FieldDefType::F64 => {
-            quote! { serde_json::json!({ "type": "number" }) }
+        | FieldDefType::Isize
+        | FieldDefType::F32
+        | FieldDefType::F64
+        | FieldDefType::Boolean => {
+            // The arm has matched exactly the types the mapping answers a keyword for.
+            let keyword = scalar_json_type_keyword(&fld.field_type).unwrap();
+            quote! { serde_json::json!({ "type": #keyword }) }
         }
-        FieldDefType::Boolean => quote! { serde_json::json!({ "type": "boolean" }) },
         #[cfg(feature = "object_id")]
         FieldDefType::ObjectId => object_id_json_schema_value(&object_id_hex_json_schema()),
         #[cfg(feature = "chrono")]
@@ -5901,14 +6015,26 @@ fn zod_merge_branches(
 #[cfg(all(feature = "serde", feature = "zod"))]
 fn zod_member_leaves(fld: &FieldDef, rendered: &str) -> Vec<ZodUnionMember> {
     let nested = fld.zod_union_members();
-    let mut leaves = if nested.is_empty() {
+    let mut leaves = if !nested.is_empty() {
+        nested
+    } else if let Some(published) = named_wire_leaves(fld) {
+        // The name stands for a choice of its own. Its leaves carry the trail, and the spelling
+        // stays the member's: the operand a merge would join is still the one binding the name
+        // publishes, whatever the document behind it branches into.
+        published
+            .into_iter()
+            .map(|leaf| ZodUnionMember {
+                branch: leaf.branch,
+                non_object: leaf.non_object,
+                spelling: rendered.to_owned(),
+            })
+            .collect()
+    } else {
         vec![ZodUnionMember {
             branch: Vec::new(),
             non_object: zod_member_non_object(fld),
             spelling: rendered.to_owned(),
         }]
-    } else {
-        nested
     };
     if fld.is_optional() {
         for leaf in &mut leaves {
@@ -5937,33 +6063,76 @@ fn zod_member_non_object(fld: &FieldDef) -> Option<&'static str> {
     if fld.is_array() {
         return Some("array");
     }
-    match &fld.field_type {
-        FieldDefType::Boolean => Some("boolean"),
-        FieldDefType::F32 | FieldDefType::F64 => Some("number"),
-        FieldDefType::I8
-        | FieldDefType::I16
-        | FieldDefType::I32
-        | FieldDefType::I64
-        | FieldDefType::Isize
-        | FieldDefType::U8
-        | FieldDefType::U16
-        | FieldDefType::U32
-        | FieldDefType::U64
-        | FieldDefType::Usize => Some("integer"),
-        FieldDefType::String | FieldDefType::StringLiteral(_) => Some("string"),
-        #[cfg(feature = "chrono")]
-        FieldDefType::DateTime
-        | FieldDefType::NaiveDate
-        | FieldDefType::NaiveDateTime
-        | FieldDefType::NaiveTime => Some("string"),
-        FieldDefType::Tuple(_) => Some("array"),
-        FieldDefType::SiblingType(name, _) => is_sequence_wrapper(name)
-            .then_some("array")
-            .or_else(|| registered_non_object_wire(name)),
-        #[cfg(feature = "object_id")]
-        FieldDefType::ObjectId => None,
-        FieldDefType::Map(_, _) | FieldDefType::TypeParam(_) | FieldDefType::Unknown => None,
+    if matches!(fld.field_type, FieldDefType::Tuple(_)) {
+        return Some("array");
     }
+    if let FieldDefType::SiblingType(name, _) = &fld.field_type {
+        return is_sequence_wrapper(name)
+            .then_some("array")
+            .or_else(|| registered_non_object_wire(name));
+    }
+    // Everything the two structural questions above leave is a value one keyword describes or
+    // nothing here can name, which is exactly what the shared mapping answers.
+    scalar_json_type_keyword(&fld.field_type)
+}
+
+/// What a `#[model_schema()]` item publishes, as leaves in the merge's vocabulary — the answer
+/// [`crate::utils::record_wire_leaves`] stores for every name a flattened member can then reach
+/// through.
+///
+/// An optional surface is two choices and not one, exactly as an optional union member is: serde
+/// writes the value's own wire or writes nothing, and the merge descending the same document names
+/// the value `1` and the absence `2`. Recording them the same way is what keeps a member naming
+/// this item and a member written `Option<T>` refused at one position by one set of words.
+///
+/// Everything else publishes one leaf at no position of its own, read through the very dispatch a
+/// directly written member is read through, so what a name answers and what its target answers
+/// cannot come apart.
+#[cfg(all(feature = "serde", feature = "zod"))]
+fn published_wire_leaves(written: &FieldDef) -> Vec<WireLeaf> {
+    if written.is_optional() {
+        let mut bare = written.clone();
+        bare.nullable_levels
+            .retain(|&level| level != bare.array_depth);
+        let mut leaves = published_wire_leaves(&bare);
+        for leaf in &mut leaves {
+            leaf.branch.insert(0, 1);
+        }
+        leaves.push(WireLeaf {
+            branch: vec![2],
+            non_object: Some("null"),
+        });
+        return leaves;
+    }
+    named_wire_leaves(written).unwrap_or_else(|| {
+        vec![WireLeaf {
+            branch: Vec::new(),
+            non_object: zod_member_non_object(written),
+        }]
+    })
+}
+
+/// The leaves the item a field names published, where the field's whole wire *is* that name's and
+/// the name stands for more than one leaf — and `None` everywhere the one-leaf dispatch already
+/// answers.
+///
+/// Only a choice is spliced. A name publishing one leaf keeps flowing through the same single
+/// answer it always did, so nothing about a member naming an object, a scalar or a map moves; a
+/// name publishing a choice is the one thing that answer could not carry, its levels sitting below
+/// the member's own position rather than at it.
+///
+/// An array level is not one of those: what the field writes is the array around whatever the name
+/// publishes, and the leaves behind the name describe an item of it rather than the field.
+#[cfg(all(feature = "serde", feature = "zod"))]
+fn named_wire_leaves(written: &FieldDef) -> Option<Vec<WireLeaf>> {
+    if written.is_array() {
+        return None;
+    }
+    let FieldDefType::SiblingType(name, _) = &written.field_type else {
+        return None;
+    };
+    let leaves = lookup_alias_info(name)?.wire;
+    (leaves.len() > 1).then_some(leaves)
 }
 
 /// Builds the schema module's impl items for an untagged enum: its JSON schema, its `TypeScript`
@@ -6064,7 +6233,7 @@ fn process_untagged_enum(
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
     // Every other enum shape is written as a union of what its variants render as.
     let (module_name, module_ident) =
-        enum_module_idents(name, item_name, AliasKind::NoEnumMembers, Some("union"));
+        enum_module_idents(name, item_name, AliasKind::NoEnumMembers, Surface::union());
 
     // Extract docs early for example extraction
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
@@ -6662,9 +6831,15 @@ fn scalar_field_json_schema_item(fld: &FieldDef) -> Option<proc_macro2::TokenStr
         | FieldDefType::I32
         | FieldDefType::I64
         | FieldDefType::Usize
-        | FieldDefType::Isize => quote! { { "type": "integer" } },
-        FieldDefType::F32 | FieldDefType::F64 => quote! { { "type": "number" } },
-        FieldDefType::Boolean => quote! { { "type": "boolean" } },
+        | FieldDefType::Isize
+        | FieldDefType::F32
+        | FieldDefType::F64
+        | FieldDefType::Boolean => {
+            // The arm has matched exactly the types the mapping answers a keyword for, so the `?`
+            // never fires — it is how the chrono arm beside it reads its own mapping too.
+            let keyword = scalar_json_type_keyword(&fld.field_type)?;
+            quote! { { "type": #keyword } }
+        }
         #[cfg(feature = "chrono")]
         FieldDefType::NaiveDate
         | FieldDefType::NaiveTime
@@ -7731,9 +7906,12 @@ fn build_field_type_schema(fld: &FieldDef, field_name_str: &str) -> proc_macro2:
         | FieldDefType::I32
         | FieldDefType::I64
         | FieldDefType::Usize
-        | FieldDefType::Isize => build_numeric_field_schema(fld, field_name_str, "integer"),
-        FieldDefType::F32 | FieldDefType::F64 => {
-            build_numeric_field_schema(fld, field_name_str, "number")
+        | FieldDefType::Isize
+        | FieldDefType::F32
+        | FieldDefType::F64 => {
+            // The arm has matched exactly the types the mapping answers a keyword for.
+            let keyword = scalar_json_type_keyword(field_type).unwrap();
+            build_numeric_field_schema(fld, field_name_str, keyword)
         }
         FieldDefType::Boolean => build_boolean_field_schema(fld, field_name_str),
         #[cfg(feature = "object_id")]

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -21,7 +21,9 @@ use super::{
 };
 
 #[cfg(all(feature = "serde", feature = "zod"))]
-use super::{flattened_union_member_guard_error, record_zod_union_members};
+use super::{
+    WireLeaf, flattened_union_member_guard_error, record_wire_leaves, record_zod_union_members,
+};
 
 #[cfg(feature = "typescript")]
 use super::tuple_struct_ts_body;
@@ -3063,8 +3065,11 @@ fn a_brand_records_the_value_surface_its_inner_publishes() {
             #[serde(transparent)]
             struct Branded(pub #ty);
         };
-        let shape = super::branded_value_shape(&item.generics, item.fields.iter().next().unwrap());
-        assert_eq!(shape, expected, "for {inner}");
+        let surface = super::Surface::written(&super::branded_inner_value_surface(
+            &item.generics,
+            item.fields.iter().next().unwrap(),
+        ));
+        assert_eq!(surface.shape, expected, "for {inner}");
     }
 }
 
@@ -3085,7 +3090,7 @@ fn a_tuple_struct_records_the_value_surface_its_slots_publish() {
     ] {
         let item: syn::ItemStruct = syn::parse_str(decl).unwrap();
         assert_eq!(
-            super::tuple_struct_value_shape(&item.fields),
+            super::tuple_struct_surface(&item.fields).shape,
             expected,
             "for {decl}"
         );
@@ -6315,16 +6320,23 @@ fn recorded_member_trails(mut item: syn::ItemEnum) -> Vec<(String, Option<&'stat
 }
 
 /// Registers a name carrying both answers a `#[model_schema()]` item's own expansion records for
-/// it: what serde writes it as, and what it published as a value.
+/// it: what serde writes it as, and the JSON type keyword its published wire describes as where
+/// that wire is proved to be no object.
 #[cfg(all(feature = "serde", feature = "zod"))]
-fn seed_registered_wire(rust_ident: &str, kind: AliasKind, shape: Option<&'static str>) {
+fn seed_registered_wire(rust_ident: &str, kind: AliasKind, wire: Option<&'static str>) {
     register_alias_info(
         rust_ident,
         rust_ident,
         &ident_schema_module_name(rust_ident),
         kind,
     );
-    record_value_shape(rust_ident, shape);
+    record_wire_leaves(
+        rust_ident,
+        &[WireLeaf {
+            branch: Vec::new(),
+            non_object: wire,
+        }],
+    );
 }
 
 /// A member reached through an `Option` is two choices and not one: serde writes the value's own
@@ -6421,21 +6433,21 @@ fn an_optional_scalar_union_member_is_refused_below_the_option_it_was_written_un
     );
 }
 
-/// A member that names another item is asked of the registry rather than left unanswered: the
-/// named item recorded what serde writes it as and what it published as a value, and between them
-/// they name the JSON type keyword the other surface writes for the same member.
+/// A member that names another item is asked of the registry rather than left unanswered: the named
+/// item recorded the JSON type keyword its own published document carries, which is the word the
+/// other surface writes for the same member.
 ///
-/// `numeric` is not among them on purpose — see the guard's own note — and a name the registry
-/// cannot rule out keeps the emission it has always had.
+/// An object, a union and a name the registry cannot rule out are the three that stay unanswered,
+/// and each keeps the emission it has always had.
 #[cfg(all(feature = "serde", feature = "zod"))]
 #[test]
 fn a_union_member_naming_a_registered_non_object_wire_is_recorded_as_that_wire() {
-    seed_registered_wire("StringBrand", AliasKind::StringWire, None);
+    seed_registered_wire("StringBrand", AliasKind::StringWire, Some("string"));
     seed_registered_wire("SwitchBrand", AliasKind::Stringified, Some("boolean"));
-    seed_registered_wire("PlainEnum", AliasKind::EnumMembers, Some("enumerated"));
-    seed_registered_wire("NamedStruct", AliasKind::NoEnumMembers, Some("object"));
-    seed_registered_wire("TaggedEnum", AliasKind::NoEnumMembers, Some("union"));
-    seed_registered_wire("CountBrand", AliasKind::Stringified, Some("numeric"));
+    seed_registered_wire("PlainEnum", AliasKind::EnumMembers, Some("string"));
+    seed_registered_wire("NamedStruct", AliasKind::NoEnumMembers, None);
+    seed_registered_wire("TaggedEnum", AliasKind::NoEnumMembers, None);
+    seed_registered_wire("CountBrand", AliasKind::Stringified, Some("integer"));
     assert_eq!(
         recorded_member_trails(syn::parse_quote! {
             enum Choice {
@@ -6454,7 +6466,7 @@ fn a_union_member_naming_a_registered_non_object_wire_is_recorded_as_that_wire()
             ("3".to_owned(), Some("boolean")),
             ("4".to_owned(), Some("string")),
             ("5".to_owned(), None),
-            ("6".to_owned(), None),
+            ("6".to_owned(), Some("integer")),
             ("7".to_owned(), None),
         ]
     );
@@ -6467,7 +6479,7 @@ fn a_union_member_naming_a_registered_non_object_wire_is_recorded_as_that_wire()
 #[cfg(all(feature = "serde", feature = "zod"))]
 #[test]
 fn flattening_a_union_with_a_named_string_wire_member_is_refused_naming_the_branch() {
-    seed_registered_wire("Slug", AliasKind::StringWire, None);
+    seed_registered_wire("Slug", AliasKind::StringWire, Some("string"));
     let error = recorded_union_flatten_error(
         "SlugChoice",
         syn::parse_quote! {
@@ -6508,7 +6520,7 @@ fn flattening_a_union_with_a_named_stringified_or_enumerated_member_is_refused()
         "got: {switch}"
     );
 
-    seed_registered_wire("Hue", AliasKind::EnumMembers, Some("enumerated"));
+    seed_registered_wire("Hue", AliasKind::EnumMembers, Some("string"));
     let hue = recorded_union_flatten_error(
         "HueChoice",
         syn::parse_quote! {
@@ -6532,7 +6544,7 @@ fn flattening_a_union_with_a_named_stringified_or_enumerated_member_is_refused()
 #[cfg(all(feature = "serde", feature = "zod"))]
 #[test]
 fn a_union_member_naming_an_object_or_an_unregistered_type_stays_admitted() {
-    seed_registered_wire("Doc", AliasKind::NoEnumMembers, Some("object"));
+    seed_registered_wire("Doc", AliasKind::NoEnumMembers, None);
     assert!(
         recorded_union_flatten_error(
             "NamedChoice",
@@ -6546,6 +6558,249 @@ fn a_union_member_naming_an_object_or_an_unregistered_type_stays_admitted() {
             &syn::parse_quote! { #[serde(flatten)] either: NamedChoice },
         )
         .is_none()
+    );
+}
+
+/// Runs the registration a tuple struct's own expansion runs, so what the registry answers for the
+/// name is what a declaration put there rather than a word written by hand.
+#[cfg(all(feature = "serde", feature = "zod"))]
+fn seed_slot_registration(item: &syn::ItemStruct) {
+    let _: (String, String, syn::Ident) =
+        super::struct_module_idents(&item.ident, None, super::tuple_struct_surface(&item.fields));
+}
+
+/// The same for a branded newtype, whose wire is its inner's.
+#[cfg(all(feature = "serde", feature = "zod"))]
+fn seed_brand_registration(item: &syn::ItemStruct) {
+    let rust_ident = item.ident.to_string();
+    super::register_branded_newtype(
+        item,
+        &rust_ident,
+        &rust_ident,
+        &ident_schema_module_name(&rust_ident),
+    );
+}
+
+/// One `u32` is one wire, and every spelling of it publishes the one JSON type keyword that wire
+/// describes as. A field, the slot of a one-slot tuple struct and a brand all reach the same value,
+/// so a keyword read off one of them and not the others is the same wire named twice — and the
+/// merge that repeats the keyword cannot pick between two producers that disagree.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn every_spelling_of_one_value_publishes_one_json_type_keyword() {
+    for (inner, keyword) in [
+        ("u32", "integer"),
+        ("i64", "integer"),
+        ("usize", "integer"),
+        ("f32", "number"),
+        ("f64", "number"),
+        ("bool", "boolean"),
+        ("String", "string"),
+    ] {
+        let ty: syn::Type = syn::parse_str(inner).unwrap();
+        let written = super::get_field_def("v", &ty, "");
+        let named = format!("\"{keyword}\"");
+        let field = super::build_field_type_schema(&written, "v").to_string();
+        let slot = super::scalar_field_json_schema_item(&written)
+            .unwrap()
+            .to_string();
+        let brand = brand_json_schema_over(&ty);
+        assert!(field.contains(&named), "field {inner}, got: {field}");
+        assert!(slot.contains(&named), "slot {inner}, got: {slot}");
+        assert!(brand.contains(&named), "brand {inner}, got: {brand}");
+    }
+}
+
+/// A member naming a brand over an integer is recorded as the `integer` that brand publishes, and
+/// one naming a brand over a float as the `number` its own publishes. The two are one word to the
+/// shape vocabulary and two documents on the wire, which is the disagreement that left both
+/// unanswered.
+#[cfg(all(feature = "serde", feature = "zod"))]
+#[test]
+fn a_union_member_naming_a_numeric_registration_is_recorded_by_its_own_keyword() {
+    seed_brand_registration(&syn::parse_quote! {
+        #[serde(transparent)]
+        struct WireTicks(u32);
+    });
+    seed_brand_registration(&syn::parse_quote! {
+        #[serde(transparent)]
+        struct WireRatio(f64);
+    });
+    seed_slot_registration(&syn::parse_quote! { struct WireSlotTicks(u32); });
+    assert_eq!(
+        recorded_member_trails(syn::parse_quote! {
+            enum WireNumericChoice {
+                Obj(Holder),
+                Ticks(WireTicks),
+                Ratio(WireRatio),
+                Slot(WireSlotTicks),
+            }
+        }),
+        vec![
+            ("1".to_owned(), None),
+            ("2".to_owned(), Some("integer")),
+            ("3".to_owned(), Some("number")),
+            ("4".to_owned(), Some("integer")),
+        ]
+    );
+}
+
+/// So flattening a union whose member names one is refused where the field was written, naming the
+/// keyword the JSON-schema merge names the same member by.
+#[cfg(all(feature = "serde", feature = "zod"))]
+#[test]
+fn flattening_a_union_with_a_named_integer_wire_member_is_refused_naming_the_keyword() {
+    seed_brand_registration(&syn::parse_quote! {
+        #[serde(transparent)]
+        struct FlatWireTicks(u32);
+    });
+    let error = recorded_union_flatten_error(
+        "WireTickChoice",
+        syn::parse_quote! {
+            enum WireTickChoice {
+                Obj(Holder),
+                Ticks(FlatWireTicks),
+            }
+        },
+        &syn::parse_quote! { #[serde(flatten)] either: WireTickChoice },
+    )
+    .unwrap();
+    assert!(
+        error.contains("its branch 2 describes a `integer`"),
+        "got: {error}"
+    );
+}
+
+/// An array-shaped registration and a map-shaped one are one word to the shape vocabulary and
+/// opposite answers to the merge: serde flattens a map and writes an array as an array, which no
+/// object can be merged with. Each is recorded as the keyword its own published document carries.
+#[cfg(all(feature = "serde", feature = "zod"))]
+#[test]
+fn an_array_shaped_registration_is_recorded_apart_from_a_map_shaped_one() {
+    seed_slot_registration(&syn::parse_quote! { struct WireBag(Vec<String>); });
+    seed_slot_registration(
+        &syn::parse_quote! { struct WireBucket(std::collections::HashMap<String, String>); },
+    );
+    seed_slot_registration(&syn::parse_quote! { struct WirePair(String, u32); });
+    assert_eq!(
+        recorded_member_trails(syn::parse_quote! {
+            enum WireContainerChoice {
+                Obj(Holder),
+                Bag(WireBag),
+                Bucket(WireBucket),
+                Pair(WirePair),
+            }
+        }),
+        vec![
+            ("1".to_owned(), None),
+            ("2".to_owned(), Some("array")),
+            ("3".to_owned(), None),
+            ("4".to_owned(), Some("array")),
+        ]
+    );
+}
+
+/// So the array-shaped member is refused at the flatten site naming `array`, and the map-shaped one
+/// stays admitted: serde writes a map's keys straight into the object, which is what flattening is.
+#[cfg(all(feature = "serde", feature = "zod"))]
+#[test]
+fn flattening_a_union_with_a_named_array_wire_member_is_refused_while_a_map_stays_admitted() {
+    seed_slot_registration(&syn::parse_quote! { struct FlatWireBag(Vec<String>); });
+    seed_slot_registration(
+        &syn::parse_quote! { struct FlatWireBucket(std::collections::HashMap<String, String>); },
+    );
+    let bag = recorded_union_flatten_error(
+        "WireBagChoice",
+        syn::parse_quote! {
+            enum WireBagChoice {
+                Obj(Holder),
+                Bag(FlatWireBag),
+            }
+        },
+        &syn::parse_quote! { #[serde(flatten)] either: WireBagChoice },
+    )
+    .unwrap();
+    assert!(
+        bag.contains("its branch 2 describes a `array`"),
+        "got: {bag}"
+    );
+    assert!(
+        recorded_union_flatten_error(
+            "WireBucketChoice",
+            syn::parse_quote! {
+                enum WireBucketChoice {
+                    Obj(Holder),
+                    Bucket(FlatWireBucket),
+                }
+            },
+            &syn::parse_quote! { #[serde(flatten)] either: WireBucketChoice },
+        )
+        .is_none()
+    );
+}
+
+/// A member naming a registration whose own published surface is nullable carries that surface's
+/// null leaf, at the branch behind the name — the same two positions the member written
+/// `Option<T>` is recorded at, one module further in.
+#[cfg(all(feature = "serde", feature = "zod"))]
+#[test]
+fn a_union_member_naming_a_nullable_registration_carries_its_null_leaf() {
+    seed_slot_registration(&syn::parse_quote! { struct WireMaybeDoc(Option<Holder>); });
+    seed_slot_registration(&syn::parse_quote! { struct WireMaybeCount(Option<u32>); });
+    assert_eq!(
+        recorded_member_trails(syn::parse_quote! {
+            enum WireNullableChoice {
+                Obj(Holder),
+                Maybe(WireMaybeDoc),
+                Count(WireMaybeCount),
+            }
+        }),
+        vec![
+            ("1".to_owned(), None),
+            ("2.1".to_owned(), None),
+            ("2.2".to_owned(), Some("null")),
+            ("3.1".to_owned(), Some("integer")),
+            ("3.2".to_owned(), Some("null")),
+        ]
+    );
+}
+
+/// So flattening a union whose member names one is refused in the words the directly written
+/// `Option` member is refused in: serde writes the absent form and then refuses to read it back,
+/// whether the null sits on the member or one name away.
+#[cfg(all(feature = "serde", feature = "zod"))]
+#[test]
+fn flattening_a_union_with_a_named_nullable_member_is_refused_naming_the_trail() {
+    seed_slot_registration(&syn::parse_quote! { struct FlatWireMaybeDoc(Option<Holder>); });
+    let named = recorded_union_flatten_error(
+        "WireNamedNullableChoice",
+        syn::parse_quote! {
+            enum WireNamedNullableChoice {
+                Obj(Holder),
+                Maybe(FlatWireMaybeDoc),
+            }
+        },
+        &syn::parse_quote! { #[serde(flatten)] either: WireNamedNullableChoice },
+    )
+    .unwrap();
+    let written = recorded_union_flatten_error(
+        "WireWrittenNullableChoice",
+        syn::parse_quote! {
+            enum WireWrittenNullableChoice {
+                Obj(Holder),
+                Maybe(Option<Holder>),
+            }
+        },
+        &syn::parse_quote! { #[serde(flatten)] either: WireWrittenNullableChoice },
+    )
+    .unwrap();
+    assert!(
+        named.contains("its branch 2.2 describes a `null`"),
+        "got: {named}"
+    );
+    assert_eq!(
+        named.replace("WireNamedNullableChoice", "CHOICE"),
+        written.replace("WireWrittenNullableChoice", "CHOICE")
     );
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -165,6 +165,26 @@ impl ZodUnionMember {
     }
 }
 
+/// One leaf of the value surface a `#[model_schema()]` item published, in the vocabulary the
+/// flatten-member refusal names a wire by.
+///
+/// `branch` is the trail of one-based choices the leaf sits at behind the name, empty for a surface
+/// that offers no choice at all — so an item publishing `anyOf[value, null]` carries its null at
+/// `2`, and a member naming that item carries it at the member's own position followed by that `2`.
+/// `non_object` is the JSON type keyword the leaf describes as where the registration proves it is
+/// no object, and `None` where nothing there proves it — a map, an object, and a name nothing has
+/// classified alike.
+///
+/// Recorded and read under `serde` and `zod` together, which is the pair that reads
+/// `#[serde(untagged)]` and `#[serde(flatten)]` and multiplies one over the other: without both
+/// there is no merge to answer for and nothing asks.
+#[cfg(all(feature = "serde", feature = "zod"))]
+#[derive(Clone)]
+pub struct WireLeaf {
+    pub branch: Vec<usize>,
+    pub non_object: Option<&'static str>,
+}
+
 #[derive(Clone)]
 pub struct AliasInfo {
     pub export_name: String,
@@ -178,6 +198,16 @@ pub struct AliasInfo {
     /// registers.
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
     pub value_shape: Option<&'static str>,
+    /// What the value surface written under this name puts on the wire, one entry per leaf of it,
+    /// and empty when nothing has been recorded at all. Filled by [`record_wire_leaves`] as each
+    /// item registers.
+    ///
+    /// The shape above it answers the constrained-brand guard's question, which is what a check can
+    /// be appended to; this answers the merge's, which is whether an object can be joined to it —
+    /// two questions one word could not hold apart, an `integer` and a `number` being one shape and
+    /// two documents, and an array and a map one shape and opposite answers.
+    #[cfg(all(feature = "serde", feature = "zod"))]
+    pub wire: Vec<WireLeaf>,
     /// What an untagged enum's members are spelled as on the Zod surface, and empty for every other
     /// item. Filled by [`record_zod_union_members`] once the enum's own expansion has rendered
     /// them.
@@ -546,6 +576,8 @@ pub fn register_alias_info(
                 #[cfg(feature = "jsonschema")]
                 module_name: module_name.to_owned(),
                 value_shape: None,
+                #[cfg(all(feature = "serde", feature = "zod"))]
+                wire: Vec::new(),
                 #[cfg(feature = "zod")]
                 zod_union_members: Vec::new(),
             },
@@ -574,6 +606,32 @@ pub fn record_value_shape(rust_ident: &str, shape: Option<&'static str>) {
     ALIAS_INFO.with(|map| {
         if let Some(info) = map.borrow_mut().get_mut(rust_ident) {
             info.value_shape = shape;
+        }
+    });
+}
+
+/// Records what the value surface written under a name puts on the wire, on the entry that name has
+/// just registered.
+///
+/// The question is the flatten merge's: what serde writes for a member, named by the JSON type
+/// keyword the other surface writes for the same member, so the two refuse the same declaration in
+/// the same words. A name is the one member spelling the expansion reading it cannot answer for —
+/// the document lives in the module the *named* item published — so each item answers for itself as
+/// it registers.
+///
+/// Recorded as leaves rather than as one word because a published surface may be a choice: an item
+/// whose own surface is nullable publishes its value and a bare `null`, and the merge descending it
+/// names that `null` a level below the member. One word at the member's own position could not say
+/// where it sits, and naming it at the member's position would put the two merges into
+/// disagreement — the very thing the branch trail exists to prevent.
+///
+/// A chain resolves one link at a time and cannot cycle, because an entry is only ever built from
+/// entries registered before it.
+#[cfg(all(feature = "serde", feature = "zod"))]
+pub fn record_wire_leaves(rust_ident: &str, leaves: &[WireLeaf]) {
+    ALIAS_INFO.with(|map| {
+        if let Some(info) = map.borrow_mut().get_mut(rust_ident) {
+            info.wire = leaves.to_vec();
         }
     });
 }

--- a/tests/branded_newtype_tests/tests.rs
+++ b/tests/branded_newtype_tests/tests.rs
@@ -2216,6 +2216,93 @@ mod serde_tests {
     }
 }
 
+/// One value is one wire, and every spelling of that value publishes the one JSON type keyword the
+/// wire describes as.
+///
+/// `#[serde(transparent)]` puts the inner on the wire by itself, so a brand over a `u32` writes
+/// exactly what a field, a one-slot tuple struct and an alias of the same `u32` write. The four are
+/// pinned against each other because a keyword taken from the rendered TypeScript name instead of
+/// from the type spelled `integer` three times and `number` once — the same wire named twice, which
+/// the merge repeating the keyword cannot pick a side in.
+#[cfg(all(feature = "jsonschema", feature = "serde"))]
+mod branded_scalar_keyword_tests {
+    use super::*;
+
+    #[model_schema()]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct TickBrand(pub u32);
+
+    #[model_schema()]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    pub struct TickSlot(pub u32);
+
+    #[model_schema()]
+    pub type TickAlias = u32;
+
+    #[model_schema()]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    pub struct HoldsTick {
+        pub ticks: u32,
+    }
+
+    #[model_schema(no_display)]
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct RatioBrand(pub f64);
+
+    #[model_schema()]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct SwitchBrand(pub bool);
+
+    #[model_schema()]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct SlugBrand(pub String);
+
+    #[test]
+    fn every_spelling_of_one_integer_publishes_one_keyword() {
+        let integer = serde_json::json!({ "type": "integer" });
+        assert_eq!(TickBrand::json_schema(), integer);
+        assert_eq!(TickSlot::json_schema(), integer);
+        assert_eq!(tick_alias_schema::Schema::json_schema(), integer);
+        assert_eq!(HoldsTick::json_schema()["properties"]["ticks"], integer);
+
+        let aliased: TickAlias = 7;
+        assert_eq!(
+            serde_json::to_value(aliased).unwrap(),
+            serde_json::json!(7_u32)
+        );
+    }
+
+    /// And the brands whose inner is not an integer describe exactly what they described before:
+    /// a float is the `number` it always was, and a `bool` and a `String` are untouched.
+    #[test]
+    fn the_brands_over_every_other_scalar_are_byte_identical() {
+        assert_eq!(
+            RatioBrand::json_schema(),
+            serde_json::json!({ "type": "number" })
+        );
+        assert_eq!(
+            SwitchBrand::json_schema(),
+            serde_json::json!({ "type": "boolean" })
+        );
+        assert_eq!(
+            SlugBrand::json_schema(),
+            serde_json::json!({ "type": "string" })
+        );
+    }
+
+    /// The value the schema describes is the value serde writes: an integer keyword over a payload
+    /// serde renders with no fractional part.
+    #[test]
+    fn the_keyword_names_what_serde_writes() {
+        assert_eq!(serde_json::to_string(&TickBrand(7)).unwrap(), "7");
+        assert_eq!(serde_json::to_string(&RatioBrand(0.5)).unwrap(), "0.5");
+    }
+}
+
 #[cfg(any(
     feature = "serde",
     feature = "zod",

--- a/tests/flatten_tests/tests.rs
+++ b/tests/flatten_tests/tests.rs
@@ -1,4 +1,6 @@
 use serde::{Deserialize, Serialize};
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+use std::collections::HashMap;
 use tixschema::model_schema;
 
 #[model_schema()]
@@ -434,6 +436,121 @@ struct FlatOverLaterMemberSlugUntagged {
 enum LaterMemberSlugEither {
     Base(FlatFirst),
     Slug(MemberSlug),
+}
+
+/// Three more members that name another item rather than spelling a type out, all three of them one
+/// word to the shape vocabulary and three different answers to the merge: a registration whose wire
+/// is a JSON array, one whose wire is the object a map writes, and one whose own published surface
+/// is nullable. serde flattens the map and refuses the other two.
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct MemberBag(Vec<String>);
+
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct MemberBucket(HashMap<String, String>);
+
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct MemberMaybeSecond(Option<FlatSecond>);
+
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(untagged)]
+enum MemberBagEither {
+    Base(FlatFirst),
+    Items(MemberBag),
+}
+
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(untagged)]
+enum MemberBucketEither {
+    Base(FlatFirst),
+    Bucket(MemberBucket),
+}
+
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(untagged)]
+enum MemberMaybeEither {
+    Base(FlatFirst),
+    Maybe(MemberMaybeSecond),
+}
+
+#[cfg(all(feature = "jsonschema", not(feature = "zod")))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct FlatOverMemberBagUntagged {
+    #[serde(flatten)]
+    either: MemberBagEither,
+    own: String,
+}
+
+#[cfg(all(feature = "jsonschema", not(feature = "zod")))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct FlatOverMemberMaybeUntagged {
+    #[serde(flatten)]
+    either: MemberMaybeEither,
+    own: String,
+}
+
+/// The map-shaped member is the one of the three that stays where it was: serde writes a map's keys
+/// straight into the object being written, which is what flattening is, so the multiplication keeps
+/// its branch and the merge keeps its document.
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct FlatOverMemberBucketUntagged {
+    #[serde(flatten)]
+    either: MemberBucketEither,
+    own: String,
+}
+
+/// The array-shaped and nullable members in unions declared below the object that flattens them,
+/// which keeps the fallback: the recording holds nothing for either name, so the Zod merge writes
+/// the one operand it is while the JSON-schema merge refuses it wherever it was declared.
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct FlatOverLaterMemberBagUntagged {
+    #[serde(flatten)]
+    either: LaterMemberBagEither,
+    own: String,
+}
+
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(untagged)]
+enum LaterMemberBagEither {
+    Base(FlatFirst),
+    Items(MemberBag),
+}
+
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct FlatOverLaterMemberMaybeUntagged {
+    #[serde(flatten)]
+    either: LaterMemberMaybeEither,
+    own: String,
+}
+
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(untagged)]
+enum LaterMemberMaybeEither {
+    Base(FlatFirst),
+    Maybe(MemberMaybeSecond),
 }
 
 /// A union member that names itself, and the struct that flattens the union. The member describes
@@ -2209,5 +2326,162 @@ fn test_a_union_with_a_scalar_member_declared_below_is_still_named_as_one_operan
     assert!(
         !zod.contains(".and(z.lazy(() => z.string()))"),
         "the scalar member reached the intersection in: {zod}"
+    );
+}
+
+/// A member naming a registration whose wire is a JSON array is one serde refuses to flatten for
+/// the reason it refuses a directly written array: what it writes is the array its slot writes, and
+/// an array carries no keys to put into the object.
+#[test]
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+fn test_flattening_an_untagged_enum_over_a_named_array_member_is_unserializable() {
+    let refusal = serde_json::to_value(FlatOverLaterMemberBagUntagged {
+        own: "o".to_owned(),
+        either: LaterMemberBagEither::Items(MemberBag(vec!["x".to_owned()])),
+    })
+    .unwrap_err()
+    .to_string();
+    assert!(
+        refusal.contains("can only flatten structs and maps"),
+        "Got: {refusal}"
+    );
+}
+
+/// So the merge refuses the whole union, naming the array the member describes as — the keyword the
+/// registry now carries for the name, where before the one recorded word covered the array and the
+/// map alike and could rule neither out.
+#[test]
+#[cfg(all(feature = "jsonschema", not(feature = "zod")))]
+#[should_panic(
+    expected = "`FlatOverMemberBagUntagged`: `#[serde(flatten)]` of `MemberBagEither` writes a union member that is not an object — its branch 2 describes a `array`"
+)]
+fn test_a_named_array_member_of_a_flattened_untagged_enum_is_refused_by_the_merge() {
+    assert!(FlatOverMemberBagUntagged::json_schema().is_object());
+}
+
+/// And in those same words wherever the union was declared, which is the one reading of the
+/// declaration that survives the Zod surface refusing it at expansion.
+#[test]
+#[cfg(feature = "jsonschema")]
+#[should_panic(
+    expected = "`FlatOverLaterMemberBagUntagged`: `#[serde(flatten)]` of `LaterMemberBagEither` writes a union member that is not an object — its branch 2 describes a `array`"
+)]
+fn test_a_named_array_member_of_a_later_flattened_untagged_enum_is_refused_by_the_merge() {
+    assert!(FlatOverLaterMemberBagUntagged::json_schema().is_object());
+}
+
+/// A member naming a registration whose own published surface is nullable carries the same null the
+/// member written `Option<T>` carries, one name away — and serde's two directions describe
+/// different payload sets for it exactly as they do there: the absent form is written without an
+/// error and then matches no member on the way back.
+#[test]
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+fn test_a_named_nullable_flattened_union_member_is_written_and_then_not_read_back() {
+    let written = serde_json::to_value(FlatOverLaterMemberMaybeUntagged {
+        own: "o".to_owned(),
+        either: LaterMemberMaybeEither::Maybe(MemberMaybeSecond(None)),
+    })
+    .unwrap();
+    assert_eq!(written, serde_json::json!({ "own": "o" }));
+    let refusal = serde_json::from_value::<FlatOverLaterMemberMaybeUntagged>(written)
+        .unwrap_err()
+        .to_string();
+    assert!(
+        refusal.contains("did not match any variant"),
+        "Got: {refusal}"
+    );
+
+    let present = serde_json::to_value(FlatOverLaterMemberMaybeUntagged {
+        own: "o".to_owned(),
+        either: LaterMemberMaybeEither::Maybe(MemberMaybeSecond(Some(FlatSecond { b: true }))),
+    })
+    .unwrap();
+    assert_eq!(present, serde_json::json!({ "own": "o", "b": true }));
+    serde_json::from_value::<FlatOverLaterMemberMaybeUntagged>(present).unwrap();
+}
+
+/// So the merge refuses it at the leaf the null sits at — `2.2`, a position below the member, which
+/// is where the name's own choice puts it and not where the member stands.
+#[test]
+#[cfg(all(feature = "jsonschema", not(feature = "zod")))]
+#[should_panic(
+    expected = "`FlatOverMemberMaybeUntagged`: `#[serde(flatten)]` of `MemberMaybeEither` writes a union member that is not an object — its branch 2.2 describes a `null`"
+)]
+fn test_a_named_nullable_member_of_a_flattened_untagged_enum_is_refused_by_the_merge() {
+    assert!(FlatOverMemberMaybeUntagged::json_schema().is_object());
+}
+
+#[test]
+#[cfg(feature = "jsonschema")]
+#[should_panic(
+    expected = "`FlatOverLaterMemberMaybeUntagged`: `#[serde(flatten)]` of `LaterMemberMaybeEither` writes a union member that is not an object — its branch 2.2 describes a `null`"
+)]
+fn test_a_named_nullable_member_of_a_later_flattened_untagged_enum_is_refused_by_the_merge() {
+    assert!(FlatOverLaterMemberMaybeUntagged::json_schema().is_object());
+}
+
+/// The map-shaped member is admitted on every surface, and serde agrees in both directions: it
+/// writes the map's keys into the object and reads those same keys back. That is what the array
+/// and the map being one recorded word could not tell apart.
+#[test]
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+fn test_a_named_map_member_of_a_flattened_untagged_enum_round_trips() {
+    let written = serde_json::to_value(FlatOverMemberBucketUntagged {
+        own: "o".to_owned(),
+        either: MemberBucketEither::Bucket(MemberBucket(HashMap::from([(
+            "k".to_owned(),
+            "v".to_owned(),
+        )]))),
+    })
+    .unwrap();
+    assert_eq!(written, serde_json::json!({ "own": "o", "k": "v" }));
+    serde_json::from_value::<FlatOverMemberBucketUntagged>(written).unwrap();
+}
+
+/// And its Zod schema keeps the multiplication it always had, byte for byte.
+#[test]
+#[cfg(feature = "zod")]
+fn test_a_named_map_member_keeps_its_multiplication() {
+    let zod = FlatOverMemberBucketUntagged::zod_schema();
+    assert!(
+        zod.contains(
+            "z.union([\n  FlatOverMemberBucketUntagged$OwnSchema.and(z.lazy(() => FlatFirst$Schema)),\n  FlatOverMemberBucketUntagged$OwnSchema.and(z.lazy(() => MemberBucket$Schema)),\n])"
+        ),
+        "expected the map member's branch, got: {zod}"
+    );
+}
+
+/// And the JSON-schema merge writes its document rather than refusing it.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_a_named_map_member_keeps_its_merged_document() {
+    assert!(FlatOverMemberBucketUntagged::json_schema().is_object());
+}
+
+/// Standing on their own the three unions are unions like any other, spelled byte for byte as they
+/// were before the merge could tell the shapes apart.
+#[test]
+#[cfg(feature = "zod")]
+fn test_the_named_wire_unions_are_byte_identical_standing_alone() {
+    #[cfg(feature = "typescript")]
+    const EXPECTED: [&str; 3] = [
+        "const MemberBagEither$RawSchema = z.union([FlatFirst$Schema, MemberBag$Schema]);\n\nexport const MemberBagEither$Schema: ZodType<MemberBagEither> = MemberBagEither$RawSchema;",
+        "const MemberBucketEither$RawSchema = z.union([FlatFirst$Schema, MemberBucket$Schema]);\n\nexport const MemberBucketEither$Schema: ZodType<MemberBucketEither> = MemberBucketEither$RawSchema;",
+        "const MemberMaybeEither$RawSchema = z.union([FlatFirst$Schema, MemberMaybeSecond$Schema]);\n\nexport const MemberMaybeEither$Schema: ZodType<MemberMaybeEither> = MemberMaybeEither$RawSchema;",
+    ];
+    #[cfg(not(feature = "typescript"))]
+    const EXPECTED: [&str; 3] = [
+        "export const MemberBagEither$Schema = z.union([FlatFirst$Schema, MemberBag$Schema]);",
+        "export const MemberBucketEither$Schema = z.union([FlatFirst$Schema, MemberBucket$Schema]);",
+        "export const MemberMaybeEither$Schema = z.union([FlatFirst$Schema, MemberMaybeSecond$Schema]);",
+    ];
+
+    assert_eq!(
+        [
+            MemberBagEither::zod_schema(),
+            MemberBucketEither::zod_schema(),
+            MemberMaybeEither::zod_schema(),
+        ],
+        EXPECTED.map(str::to_owned)
     );
 }


### PR DESCRIPTION
Three vocabulary gaps in the flatten-member refusal, landed as one recorded fact — `AliasInfo.wire`, a leaf list built beside the constrained-brand guard's shape word from one reading of each declaration:

- A brand over an integer published `{"type":"number"}` while every other spelling of the same u32 published `integer` — the brand read the keyword off the TypeScript name. One `scalar_json_type_keyword` mapping now decides it at every consumer; all four spellings agree.
- The recorded `container` word bundled arrays with maps; the guard now reads the wire — a Vec-shaped registration refuses naming `array`, a map-shaped one keeps its multiplication (serde flattens maps), pinned by round-trip.
- A nullable registration records its null leaf a level below the name (the trail machinery reused), so a member reaching one through a name is refused at `2.2` in words character-identical to the direct-Option refusal; single-leaf names keep their answers untouched.

Two residuals filed with recorded verdicts: the tagged-enum unit-variant leaf, and the direct-flatten-of-nullable case where serde round-trips but both schema surfaces refuse — that one questions the JSON surface's own verdict and is specced accordingly.