### PR TITLE
publish a factory from every generic publisher, and write the JavaScript flavour without TypeScript syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -889,9 +889,9 @@ const createSchemaCache = <Cache extends object>(): Cache => new WeakMap() as un
 
 A cache maps an argument to the schema built from *that* argument, so its value type depends on its key type. TypeScript can declare that dependency -- each factory writes it out, one interface per parameter -- but cannot construct a map that satisfies it, since a `WeakMap` fixes both of its own parameters at construction. So the dependency is declared where it does the work and asserted exactly once, in the preamble: that line is the only assertion anywhere in the output. A module holding no generic type needs no preamble; one holding any needs it exactly once.
 
-#### The two items that still publish a `const`
+#### An alias is a factory too
 
-A generic alias and a generic branded newtype publish a plain `const`, so a parameter inside either has no argument to name and still renders as the opaque value -- `z.unknown()`, the same answer JSON Schema gives:
+Every generic item publishes a factory, an alias among them, so a parameter inside one is the argument that factory binds for it:
 
 ```rust
 #[model_schema(default_types(T = String))]
@@ -901,14 +901,15 @@ pub type Wrapper<T> = Vec<T>;
 ```typescript
 export type WrapperType<T> = Array<T>;
 
-const WrapperType$RawSchema = z.array(z.unknown());
-
-export const WrapperType$Schema: ZodType<WrapperType<unknown>> = WrapperType$RawSchema;
+const buildWrapperType$Schema = <T extends ZodType>(
+  t: T,
+) =>
+  z.array(t);
 ```
 
 Only the item's *own* parameters are read this way. A name the expansion cannot resolve because the type lives elsewhere keeps its `Name$Schema` reference, since that type publishes the binding.
 
-One consequence is worth stating outright: an opaque value carries no checks, so no `model_schema_prop` bound may be spelled against a type parameter. A branded newtype cannot apply `pattern`, `minLength`, or `maxLength` to one of its own — see [Branded Newtype Validation Constraints](#branded-newtype-validation-constraints) — and a *field* typed with one is refused for the same reason, at every depth the parameter is reached through:
+One consequence is worth stating outright: a parameter is a value only where a factory binds one for it, and the one JSON document an item publishes covers every filling it could be handed — so no `model_schema_prop` bound may be spelled against a type parameter. A branded newtype cannot apply `pattern`, `minLength`, or `maxLength` to one of its own — see [Branded Newtype Validation Constraints](#branded-newtype-validation-constraints) — and a *field* typed with one is refused for the same reason, at every depth the parameter is reached through:
 
 ```rust
 #[model_schema(default_types(IdType = String))]
@@ -918,7 +919,7 @@ pub struct Constrained<IdType> {
 }
 ```
 
-The value's type is whatever the instantiation supplies, so nothing here holds it to anything: Zod and the JSON schema describe the value as the opaque one, the generated validator emits no check for it, and serde reads the payload back untouched. Constrain the argument instead — declare the type the instantiation supplies as a branded newtype carrying the bound — or drop the key. The JSDoc says nothing about a bound the refusal turns away either, the sentence being written only where something holds the value to it.
+The value's type is whatever the instantiation supplies, so nothing here holds it to anything: Zod hands the check to a schema it has no bound on, the JSON schema describes the value as the permissive empty one, the generated validator emits no check for it, and serde reads the payload back untouched. Constrain the argument instead — declare the type the instantiation supplies as a branded newtype carrying the bound — or drop the key. The JSDoc says nothing about a bound the refusal turns away either, the sentence being written only where something holds the value to it.
 
 ### Branded Newtypes
 
@@ -945,11 +946,12 @@ Generated TypeScript (with `zod` feature):
 
 ```typescript
 export type UserId<ID_TYPE> = ID_TYPE & $brand<"UserId">;
-const UserId$RawSchema = ID_TYPE$Schema.brand<"UserId">().meta({
+const buildUserId$Schema = <ID_TYPE extends ZodType>(
+  iD_TYPE: ID_TYPE,
+) =>
+  iD_TYPE.meta({
   description: "UserId",
-});
-
-export const UserId$Schema: $ZodBranded<typeof ID_TYPE$Schema, "UserId"> = UserId$RawSchema;
+}).brand<"UserId">();
 
 export type CorrelationId = string & $brand<"CorrelationId">;
 const CorrelationId$RawSchema = z.string().brand<"CorrelationId">().meta({
@@ -973,7 +975,8 @@ Notes:
 
 - If the Rust type name ends with `Json`, the suffix is stripped in the generated TypeScript (e.g., `UserIdJson` becomes `UserId`). Otherwise, the Rust name is used as-is.
 - Generic parameter names (e.g., `ID_TYPE`) are preserved exactly in the TypeScript type.
-- A brand describes what its inner writes whether or not the inner names the brand's type parameters, so `TagList<T>(pub Vec<T>)` is an array on every surface — `Array<T>`, `z.array(z.unknown())`, `$ZodBranded<ZodArray, "TagList">`, `{"type": "array", "items": {}}` — and not the bare parameter. The parameter itself carries what an uninstantiated parameter carries anywhere else, under the rule in [Type Parameters](#type-parameters).
+- A generic brand publishes a factory, as every other generic item does, so the brand and its inner's shape land on the argument the caller supplied rather than on a value pinned at expansion. A parameter reaches it as the factory's own argument, under the rule in [Type Parameters](#type-parameters); a brand written over that parameter still describes what its inner writes, so `TagList<T>(pub Vec<T>)` is an array on every surface — `Array<T>`, `z.array(t)`, `{"type": "array", "items": {}}` — and not the bare parameter.
+- The description is written before the brand in a factory and after it in a `const`. Inside a factory the receiver is the parameter the caller filled, and Zod's `.meta()` returns `this` — which TypeScript resolves back to that bare parameter, dropping the marker `.brand<"Name">()` had just added. Both orders build the same schema.
 - Serde transparent serialization works normally -- the wrapper is invisible in JSON.
 - Use branded newtypes for opaque IDs and phantom types to prevent passing the wrong ID type across domain boundaries.
 
@@ -1201,12 +1204,13 @@ pub struct DocumentId<ID_TYPE>(pub ID_TYPE);
 Generated Zod:
 
 ```typescript
-const DocumentId$RawSchema = ID_TYPE$Schema.brand<"DocumentId">().meta({
+const buildDocumentId$Schema = <ID_TYPE extends ZodType>(
+  iD_TYPE: ID_TYPE,
+) =>
+  iD_TYPE.meta({
   description: "Generic document identifier.\n- `DocumentId<String>` for API/HTTP layer\n- `DocumentId<ObjectId>` for MongoDB layer",
   example: "64de3d95ff45b119e5b53a7e",
-});
-
-export const DocumentId$Schema: $ZodBranded<typeof ID_TYPE$Schema, "DocumentId"> = DocumentId$RawSchema;
+}).brand<"DocumentId">();
 ```
 
 ## Field Validation (`model_schema_prop`)

--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -388,11 +388,13 @@ impl FieldDef {
     /// enclosing item's *own* parameters are rewritten: a genuinely unresolved sibling type keeps
     /// its `$Schema` reference, because the type it names does publish that binding.
     ///
-    /// The rewrite carries into what a schema surface may then claim about the value. An opaque
-    /// value takes no string checks — Zod 4's `z.unknown()` carries no `.min`/`.max`, and
-    /// `.brand()` hands back the very same instance rather than a wrapper that could — so a
-    /// branded newtype constraining one of its own parameters is refused, through the opaque arm
-    /// of `non_string_inner_shape` this rewrite puts it in front of.
+    /// The rewrite carries into what a schema surface may then claim about the value. A parameter
+    /// is a value on one surface and no value at all on the other — Zod reaches it through the
+    /// argument the enclosing factory binds, while the one JSON document written covers every
+    /// instantiation and so describes it as `{}` — so a branded newtype constraining one of its
+    /// own parameters is refused, through the opaque arm of `non_string_inner_shape` this rewrite
+    /// puts it in front of. Three surfaces answering three ways is the refusal: `minLength` goes
+    /// inert beside a `{}`, while `validate()` still measures `Display`.
     ///
     /// Recurses through `SiblingType` generics, `Map` keys/values, and `Tuple` elements. Applied
     /// after the field guards have read the field, so every guard asks its question of the type
@@ -578,17 +580,6 @@ impl FieldDef {
             | FieldDefType::NaiveTime
             | FieldDefType::NaiveDateTime
             | FieldDefType::DateTime => Vec::new(),
-        }
-    }
-
-    #[cfg(feature = "zod")]
-    fn opaque_type_parameters(&mut self) {
-        if matches!(self.field_type, FieldDefType::TypeParam(_)) {
-            self.field_type = FieldDefType::Unknown;
-            return;
-        }
-        for nested in self.nested_type_positions() {
-            nested.opaque_type_parameters();
         }
     }
 
@@ -928,20 +919,6 @@ impl FieldDef {
         value
     }
 
-    /// The same def with every [`FieldDefType::TypeParam`] written back as the opaque value.
-    ///
-    /// Zod names a parameter through the argument the enclosing factory binds for it, which only a
-    /// type that publishes a factory has. An alias and a branded newtype publish a plain `const`,
-    /// so there is no argument for a parameter inside either to name and the opaque value is still
-    /// all either can write — the answer [`Self::erase_type_parameters`] describes, kept for the
-    /// two surfaces that have not moved off it.
-    #[cfg(feature = "zod")]
-    #[must_use]
-    pub fn with_opaque_type_parameters(mut self) -> Self {
-        self.opaque_type_parameters();
-        self
-    }
-
     /// The type match plus one `z.array(…)` per array level, each carrying the `z.nullable(…)` of
     /// the level it wraps and the `.length(N)` of a level written as a fixed-size `[T; N]`, before
     /// the preprocess wrap.
@@ -957,10 +934,9 @@ impl FieldDef {
     fn zod_array_base(&self) -> String {
         let result = match &self.field_type {
             FieldDefType::Unknown => "z.unknown()".to_owned(),
-            // A `const` cannot be parameterised, so a generic type publishes a factory and a
+            // A `const` cannot be parameterised, so every generic publisher writes a factory and a
             // parameter composes the argument that factory binds for it — see
-            // [`zod_factory_argument`]. A surface with no factory to bind one opaques the
-            // parameter first, through [`FieldDef::with_opaque_type_parameters`].
+            // [`zod_factory_argument`].
             FieldDefType::TypeParam(name) => zod_factory_argument(name),
             FieldDefType::Tuple(lst) => {
                 let elements = lst
@@ -977,11 +953,10 @@ impl FieldDef {
                     // The element carries this field's own array levels, so it applies the wrap.
                     return self.collection_element_field(element).zod_array_base();
                 } else if let Some(info) = lookup_alias_info(name) {
-                    // What the named type published is what this can name. A generic struct or
-                    // enum published a factory, so the arguments written here are the call's; an
-                    // alias and a branded newtype published the one `const` they have whatever
-                    // they were declared with, and that `const` is the whole of what a reference
-                    // to either can say.
+                    // What the named type published is what this can name: a factory where the
+                    // type declares parameters, and the one schema it has where it declares none.
+                    // Read off the registry rather than off the arguments written here, because a
+                    // name carrying arguments says nothing about which of the two it published.
                     if info.publishes_zod_factory {
                         zod_factory_call(&info.export_name, lst)
                     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -568,11 +568,11 @@ export const Document$Schema: ZodType<Document> = Document$RawSchema;
 /// non-`Display` type argument is rejected where the brand is used, not where it is declared.
 ///
 /// String constraints stop at the brand's own type parameters. TypeScript binds a parameter for
-/// real, but the two validating surfaces read it as the opaque value — one schema is written for
-/// every instantiation — and an opaque value takes no string checks: Zod 4's `z.unknown()` carries
-/// no `.min`/`.max`, and `.brand()` returns that same schema rather than a wrapper that could. So
-/// `#[model_schema(minLength = 3, default_types(T = String))] struct Slug<T>(pub T);` is refused at
-/// the inner field. Constrain a string-typed inner instead.
+/// real and Zod reaches it through the argument the brand's own factory binds, but the one JSON
+/// document a brand publishes covers every instantiation and so describes a parameter as `{}`,
+/// where `minLength` goes inert while `validate()` still measures `Display` — three surfaces, three
+/// answers. So `#[model_schema(minLength = 3, default_types(T = String))] struct Slug<T>(pub T);`
+/// is refused at the inner field. Constrain a string-typed inner instead.
 ///
 /// A named inner is judged by what that name publishes, since that is the schema the checks are
 /// appended to: `#[model_schema(minLength = 3)] struct Outer(pub Blob);` over

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -3189,24 +3189,6 @@ fn value_surface_field_def(generics: &syn::Generics, written: &FieldDef) -> Fiel
     erased
 }
 
-/// The TypeScript argument list a generic item's own name takes where a Zod binding's annotation
-/// names it: one `unknown` per parameter, and nothing at all for an item that declares none.
-///
-/// The annotation states the type of the value beside it, and that value was composed with every
-/// parameter erased — so the name it is written under has to be filled in the same way. Naming the
-/// generic bare instead is a TypeScript error in its own right, the type requiring its arguments.
-///
-/// Only an alias reaches this with parameters now: every other generic item publishes a factory,
-/// whose return type is read off the arguments the caller supplied rather than declared ahead of
-/// them.
-#[cfg(feature = "zod")]
-fn erased_type_arguments(parameters: &[String]) -> String {
-    if parameters.is_empty() {
-        return String::new();
-    }
-    format!("<{}>", vec!["unknown"; parameters.len()].join(", "))
-}
-
 /// The one def both validating surfaces read a branded newtype's inner off, so neither can render
 /// a type parameter the other has erased — see [`value_surface_field_def`].
 #[cfg(any(feature = "zod", feature = "jsonschema"))]
@@ -3457,49 +3439,110 @@ fn build_branded_ts_definition_method(
     }
 }
 
+/// The brand marker a build's flavour spells, appended to whatever schema the inner rendered.
+///
+/// The name is a *type* argument, which only TypeScript reads. Zod's runtime brand takes none — it
+/// hands the schema back and the marker exists in the type alone — so a build emitting no
+/// TypeScript writes the bare call, which is the same value under a spelling JavaScript parses.
+#[cfg(feature = "zod")]
+fn zod_brand_call(item_name: &str) -> String {
+    #[cfg(feature = "typescript")]
+    {
+        format!(".brand<\"{item_name}\">()")
+    }
+    #[cfg(not(feature = "typescript"))]
+    {
+        let _: &str = item_name;
+        ".brand()".to_owned()
+    }
+}
+
+/// The value a branded newtype's binding holds: the inner's own schema, the brand, and the
+/// description, in the order the receiver's type admits.
+///
+/// A brand that declares no parameter brands a schema this expansion wrote and describes the
+/// result. Inside a factory the receiver is the parameter the caller filled, and `.meta()` is
+/// declared to return `this` — which TypeScript resolves back to that bare parameter, dropping the
+/// marker `.brand<"Name">()` had just added and handing the caller an unbranded schema. Describing
+/// first and branding last is the same schema at runtime, and it is the order that keeps the brand
+/// in the type the factory hands back.
+#[cfg(feature = "zod")]
+fn branded_zod_expression(
+    args: &ModelSchemaArgs,
+    item_name: &str,
+    parameters: &[String],
+    inner: &FieldDef,
+    plain_description: &str,
+) -> String {
+    let value = branded_zod_inner(args, inner);
+    let brand = zod_brand_call(item_name);
+    let described = format!(".meta({{\n  description: \"{plain_description}\",\n}})");
+    if parameters.is_empty() {
+        format!("{value}{brand}{described}")
+    } else {
+        format!("{value}{described}{brand}")
+    }
+}
+
 /// Builds the `zod_schema()` method for a branded newtype's schema module.
 ///
-/// The value and the annotation are both read off the one erased inner, so the type the binding
-/// claims and the schema it holds cannot describe different things.
+/// A brand is a generic publisher like any other: it declares parameters or it does not, and the
+/// binding follows through [`zod_published_binding`]. So a parameter inside its inner composes the
+/// argument the factory binds for it and the brand lands on the caller's own filling, where before
+/// it landed on a value pinned to whatever the first instantiation happened to be.
 ///
-/// A brand publishes a `const` rather than a factory, so a parameter inside its inner has no
-/// argument to name and is opaqued before either is rendered — see
-/// [`FieldDef::with_opaque_type_parameters`].
+/// The `const` a brand that declares no parameter still publishes is annotated with the branded
+/// class read off its inner, rather than with the `ZodType<Name>` every other `const` carries: the
+/// brand is what the annotation has to state, and only the value it wraps says which class it is.
+/// A factory needs no such annotation — its return type is read back off the builder.
 #[cfg(feature = "zod")]
 fn build_branded_zod_schema_method(
     args: &ModelSchemaArgs,
     item_name: &str,
     rust_ident: &str,
+    parameters: &[String],
     inner: &FieldDef,
     plain_description: &str,
 ) -> proc_macro2::TokenStream {
-    let opaque_inner = &inner.clone().with_opaque_type_parameters();
-    let zod_inner = branded_zod_inner(args, opaque_inner);
-    let reexport = ident_reexport_zod(rust_ident, item_name, "$Schema");
+    let expression = branded_zod_expression(args, item_name, parameters, inner, plain_description);
+    let reexport = ident_reexport_zod(
+        rust_ident,
+        item_name,
+        zod_binding_suffix(rust_ident, parameters),
+    );
+    let body = if parameters.is_empty() {
+        branded_zod_const_block(item_name, inner, &expression, &reexport)
+    } else {
+        zod_factory_block(item_name, parameters, "", &expression, &reexport)
+    };
+    quote! {
+        pub fn zod_schema() -> String {
+            #body.to_owned()
+        }
+    }
+}
+
+/// The binding a brand that declares no parameter publishes: the raw schema, then the exported
+/// `const` annotated with the branded class the inner's own rendering produces.
+#[cfg(feature = "zod")]
+fn branded_zod_const_block(
+    item_name: &str,
+    inner: &FieldDef,
+    expression: &str,
+    reexport: &str,
+) -> String {
     #[cfg(feature = "typescript")]
     {
-        let zod_type_name = branded_zod_type_name(opaque_inner);
-        let zod_type_annotation = format!("$ZodBranded<{zod_type_name}, \"{item_name}\">");
-        quote! {
-            pub fn zod_schema() -> String {
-                format!(
-                    "const {0}$RawSchema = {1}.brand<\"{0}\">().meta({{\n  description: \"{3}\",\n}});\n\nexport const {0}$Schema: {2} = {0}$RawSchema;{4}",
-                    #item_name, #zod_inner, #zod_type_annotation, #plain_description, #reexport
-                )
-            }
-        }
+        format!(
+            "const {item_name}$RawSchema = {expression};\n\nexport const {item_name}$Schema: \
+             $ZodBranded<{}, \"{item_name}\"> = {item_name}$RawSchema;{reexport}",
+            branded_zod_type_name(inner)
+        )
     }
     #[cfg(not(feature = "typescript"))]
     {
-        let _: &_ = &inner;
-        quote! {
-            pub fn zod_schema() -> String {
-                format!(
-                    "export const {0}$Schema = {1}.brand<\"{0}\">().meta({{\n  description: \"{2}\",\n}});{3}",
-                    #item_name, #zod_inner, #plain_description, #reexport
-                )
-            }
-        }
+        let _: &FieldDef = inner;
+        format!("export const {item_name}$Schema = {expression};{reexport}")
     }
 }
 
@@ -3525,8 +3568,10 @@ fn build_branded_delegate_items(
             pub fn zod_schema() -> String {
                 let base_schema = #module_ident::Schema::zod_schema();
                 let example_json = serde_json::to_string(&Self::schema_example()).unwrap();
-                // Insert example into .meta() before the first closing \n});
-                if let Some(pos) = base_schema.find("\n});") {
+                // The one `.meta({` a brand writes closes on its own line, and it is the only
+                // place a newline precedes a `})` in what the module emitted — so the close is
+                // the anchor whether the brand or the description was written last.
+                if let Some(pos) = base_schema.find("\n})") {
                     let mut result = base_schema[..pos].to_string();
                     result.push_str(&format!("\n  example: {},", example_json));
                     result.push_str(&base_schema[pos..]);
@@ -3947,6 +3992,7 @@ fn process_branded_newtype(item_struct: syn::ItemStruct, args: &ModelSchemaArgs)
         args,
         &item_name,
         &rust_ident,
+        &generic_params,
         &value_inner,
         &plain_description,
     );
@@ -9836,24 +9882,16 @@ fn zod_factory_block(
 /// The annotation is the only place a TypeScript type is named, so a build without `typescript`
 /// writes the same value under a bare `const`.
 #[cfg(feature = "zod")]
-fn zod_const_block(
-    item_name: &str,
-    ts_type_args: &str,
-    preamble: &str,
-    expression: &str,
-    reexport: &str,
-) -> String {
+fn zod_const_block(item_name: &str, preamble: &str, expression: &str, reexport: &str) -> String {
     #[cfg(feature = "typescript")]
     {
         format!(
             "{preamble}const {item_name}$RawSchema = {expression};\n\nexport const \
-             {item_name}$Schema: ZodType<{item_name}{ts_type_args}> = \
-             {item_name}$RawSchema;{reexport}"
+             {item_name}$Schema: ZodType<{item_name}> = {item_name}$RawSchema;{reexport}"
         )
     }
     #[cfg(not(feature = "typescript"))]
     {
-        let _: &str = ts_type_args;
         format!("{preamble}export const {item_name}$Schema = {expression};{reexport}")
     }
 }
@@ -9861,8 +9899,9 @@ fn zod_const_block(
 /// The whole of what a type publishes on the Zod surface: a factory when it declares parameters,
 /// and the annotated `const` when it declares none.
 ///
-/// The one seam every declared item takes that decision at, so a struct, a tuple struct and an
-/// enum cannot come to answer it differently.
+/// The one seam every item takes that decision at, so a struct, a tuple struct, an enum and an
+/// alias cannot come to answer it differently. A branded newtype takes the same decision beside
+/// this one, because only its `const` half differs — see [`branded_zod_const_block`].
 #[cfg(feature = "zod")]
 fn zod_published_binding(
     item_name: &str,
@@ -9872,13 +9911,7 @@ fn zod_published_binding(
     reexport: &str,
 ) -> String {
     if parameters.is_empty() {
-        zod_const_block(
-            item_name,
-            &erased_type_arguments(parameters),
-            preamble,
-            expression,
-            reexport,
-        )
+        zod_const_block(item_name, preamble, expression, reexport)
     } else {
         zod_factory_block(item_name, parameters, preamble, expression, reexport)
     }
@@ -10336,12 +10369,16 @@ fn generate_alias_json_schema_method(
 
 /// Builds the alias module's `zod_schema()`, or nothing when `zod` is off.
 ///
-/// The value is rendered from the target read through [`value_surface_field_def`], for the reason
-/// [`FieldDef::erase_type_parameters`] records: a `const` cannot be parameterised, so a parameter
-/// left as the `Name$Schema` binding an unresolved type is named after would reference a binding
-/// no emitted module declares. The exported binding's annotation then follows the value, taking
-/// the same opaque argument the value was composed with — a generic alias named bare in it would
-/// be a TypeScript error of its own.
+/// The value is rendered from the target read through [`value_surface_field_def`], so a parameter
+/// is the argument the alias's own factory binds for it rather than the `Name$Schema` binding an
+/// unresolved type is named after — a binding no emitted module declares.
+///
+/// Which binding carries that value is [`zod_published_binding`]'s, the seam every declared item
+/// already takes the decision at: an alias that declares parameters publishes a factory, exactly
+/// as a struct of the same parameters does. The alternative is the `const` an alias used to
+/// publish whatever it was declared with, whose annotation had to erase every argument the
+/// declaration beside it keeps — and a field naming such an alias then fails to type-check against
+/// the very declaration it renders from.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn generate_alias_zod_method(
     alias: &ItemType,
@@ -10353,22 +10390,18 @@ fn generate_alias_zod_method(
     {
         // The alias's rendered Zod is its FieldDef expression (a tuple alias yields
         // the null-flavored `z.tuple([...])`, a scalar yields `z.string()`, a sibling
-        // yields `Name$Schema`). Bind it to `$RawSchema` and re-export the annotated
-        // `$Schema`, mirroring how struct/enum schemas expose their const.
-        let schema_code = value_surface_field_def(&alias.generics, field_def)
-            .with_opaque_type_parameters()
-            .zod_type();
-        let annotated_name = format!(
-            "{export_name}{}",
-            erased_type_arguments(&type_parameters_in_scope(&alias.generics))
+        // yields `Name$Schema`).
+        let schema_code = value_surface_field_def(&alias.generics, field_def).zod_type();
+        let parameters = type_parameters_in_scope(&alias.generics);
+        let reexport = ident_reexport_zod(
+            rust_ident,
+            export_name,
+            zod_binding_suffix(rust_ident, &parameters),
         );
-        let reexport = ident_reexport_zod(rust_ident, export_name, "$Schema");
+        let body = zod_published_binding(export_name, &parameters, "", &schema_code, &reexport);
         quote! {
             pub fn zod_schema() -> String {
-                format!(
-                    "const {}$RawSchema = {};\n\nexport const {}$Schema: ZodType<{}> = {}$RawSchema;{}",
-                    #export_name, #schema_code, #export_name, #annotated_name, #export_name, #reexport
-                )
+                #body.to_owned()
             }
         }
     }

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -2677,10 +2677,10 @@ fn an_alias_type_parameter_is_erased_at_every_depth() {
 }
 
 /// The same erasure at the same depths on the value surface, where the consequence of skipping it
-/// is louder: a Zod `const` cannot be parameterised, so a parameter left to render names a
-/// `$Schema` binding no emitted module declares and the pasted output throws before a payload is
-/// read. Asserted over the identical alias list the JSON test walks, so the two surfaces cannot
-/// erase at different depths.
+/// is louder: a parameter left to render names a `$Schema` binding no emitted module declares, and
+/// the pasted output throws before a payload is read. What it renders as instead is the argument
+/// the alias's own factory binds for it, at whatever depth it was written. Asserted over the
+/// identical alias list the JSON test walks, so the two surfaces cannot erase at different depths.
 #[cfg(feature = "zod")]
 #[test]
 fn an_alias_type_parameter_is_erased_at_every_depth_on_the_value_surface() {
@@ -2701,7 +2701,7 @@ fn an_alias_type_parameter_is_erased_at_every_depth_on_the_value_surface() {
             "for {alias_source}, got: {tokens}"
         );
         assert!(
-            tokens.contains("\"HolderType<unknown>\""),
+            tokens.contains("HolderType$SchemaFactory"),
             "for {alias_source}, got: {tokens}"
         );
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -615,11 +615,10 @@ pub fn record_zod_union_members(rust_ident: &str, members: &[ZodUnionMember]) {
 /// Records which of the two Zod bindings a name publishes, on the entry that name has already
 /// registered.
 ///
-/// A reference cannot read it off the spelling it was written in. `Held<String>` says a type named
-/// `Held` takes one argument and nothing about what `Held` published for it: a generic struct or
-/// enum publishes a factory that has to be called, while an alias and a branded newtype publish the
-/// one `const` they have whatever they were declared with. So each item answers for itself as it
-/// decides, and a reference reads the answer back rather than guessing from its own arguments.
+/// A reference reads this back rather than deciding for itself. The decision belongs to the named
+/// item and is taken in one place as it expands — see
+/// [`crate::model_schema::zod_binding_suffix`] — so the binding an item publishes and every
+/// reference written to it move together, whatever the reference was spelled with.
 ///
 /// A name not registered before the reference reading it leaves no answer at all, which is the same
 /// regime the export name already runs under — see [`ident_schema_module_name`].

--- a/tests/alias_reference_tests/tests.rs
+++ b/tests/alias_reference_tests/tests.rs
@@ -465,3 +465,20 @@ fn a_renamed_alias_publishes_its_zod_schema_from_the_module_named_for_its_ident(
         "got: {zod}"
     );
 }
+
+/// A build emitting no TypeScript writes an alias's binding as a bare `const`: the annotation
+/// naming the type it validates is a type, and a JavaScript parser reading one stops at the `:`
+/// with no initializer to read.
+#[cfg(all(feature = "zod", not(feature = "typescript")))]
+#[test]
+fn a_javascript_build_writes_an_alias_binding_with_no_annotation() {
+    for zod in [
+        referenced_document_id_schema::Schema::zod_schema(),
+        referenced_document_ids_schema::Schema::zod_schema(),
+        document_ids_by_name_schema::Schema::zod_schema(),
+    ] {
+        assert!(zod.contains("export const "), "got: {zod}");
+        assert!(!zod.contains("ZodType"), "got: {zod}");
+        assert!(!zod.contains("$Schema:"), "got: {zod}");
+    }
+}

--- a/tests/branded_newtype_tests/tests.rs
+++ b/tests/branded_newtype_tests/tests.rs
@@ -49,19 +49,21 @@ mod zod_ts_tests {
         );
     }
 
-    /// The parameter is what the brand wraps, and on a value surface that is the opaque value:
-    /// a `const` cannot be parameterised, so a binding named after the parameter would be one
-    /// nothing declares. The annotation follows the value, as it does for every other inner. The
-    /// TypeScript type beside it keeps `IdType`, its own declaration binding it for real.
+    /// The parameter is what the brand wraps, and a value surface reaches it through the argument
+    /// the enclosing factory binds for it — so the brand lands on the schema the caller supplied
+    /// rather than on a value that admits anything whatever it was filled with. The TypeScript
+    /// type beside it keeps `IdType`, its own declaration binding it for real.
     #[test]
     fn test_branded_newtype_zod_schema() {
         let zod = RoleId::<String>::zod_schema();
-        assert!(zod.contains("z.unknown().brand"), "Got: {zod}");
         assert!(
-            zod.contains("$ZodBranded<ZodUnknown, \"RoleId\">"),
+            zod.contains("export const RoleId$SchemaFactory = <IdType extends ZodType>("),
             "Got: {zod}"
         );
-        assert!(!zod.contains("IdType"), "Got: {zod}");
+        assert!(zod.contains("idType.meta({"), "Got: {zod}");
+        assert!(zod.contains("}).brand<\"RoleId\">();"), "Got: {zod}");
+        assert!(!zod.contains("z.unknown()"), "Got: {zod}");
+        assert!(!zod.contains("$ZodBranded"), "Got: {zod}");
     }
 
     #[test]
@@ -162,10 +164,15 @@ mod zod_ts_tests {
             zod.contains("example:"),
             "Should contain example from doc comment. Got:\n{zod}"
         );
-        // Must still have $Schema line
+        // The example lands inside the one `.meta({` the brand writes, and the binding the item
+        // publishes still stands after it.
         assert!(
-            zod.contains("export const DocumentId$Schema:"),
-            "Should have $Schema after example injection. Got:\n{zod}"
+            zod.contains("  example: \"64de3d95ff45b119e5b53a7e\",\n}).brand<\"DocumentId\">();"),
+            "Should have the example inside the described block. Got:\n{zod}"
+        );
+        assert!(
+            zod.contains("export const DocumentId$SchemaFactory = "),
+            "Should have the factory after example injection. Got:\n{zod}"
         );
     }
 
@@ -913,7 +920,7 @@ mod branded_no_display_tests {
     #[test]
     fn test_no_display_brand_still_generates_zod() {
         let zod = Tags::zod_schema();
-        assert!(zod.contains("brand<\"Tags\">"), "Got: {zod}");
+        assert!(zod.contains(&brand_marker("Tags")), "Got: {zod}");
     }
 }
 
@@ -1242,9 +1249,10 @@ mod branded_composite_inner_tests {
 /// carry the same rendering it does.
 ///
 /// The parameter itself carries what an uninstantiated parameter carries in every other position:
-/// its own name in TypeScript, where the declaration binds it for real, and the opaque value on
-/// both validating surfaces — `z.unknown()` in Zod and the permissive empty schema in JSON — where
-/// a parameter names no type to describe and nothing declares a binding for it.
+/// its own name in TypeScript, where the declaration binds it for real; the argument the enclosing
+/// factory binds in Zod, where a schema is a value the caller has to fill before anything can
+/// validate; and the permissive empty schema in JSON, where the one document written covers every
+/// filling and so can describe none of them.
 #[cfg(all(
     feature = "jsonschema",
     feature = "serde",
@@ -1318,12 +1326,10 @@ mod branded_generic_inner_tests {
             r#"export type TagList<T> = Array<T> & $brand<"TagList">;"#
         );
         let zod = TagList::<String>::zod_schema();
+        assert!(zod.contains("  z.array(t).meta({"), "Got:\n{zod}");
+        assert!(zod.contains(r#"}).brand<"TagList">();"#), "Got:\n{zod}");
         assert!(
-            zod.contains(r#"const TagList$RawSchema = z.array(z.unknown()).brand<"TagList">()"#),
-            "Got:\n{zod}"
-        );
-        assert!(
-            zod.contains(r#"TagList$Schema: $ZodBranded<ZodArray, "TagList">"#),
+            zod.contains("export const TagList$SchemaFactory = <T extends ZodType>("),
             "Got:\n{zod}"
         );
         assert_eq!(
@@ -1340,13 +1346,12 @@ mod branded_generic_inner_tests {
         );
         let zod = WeightIndex::<u32>::zod_schema();
         assert!(
-            zod.contains(
-                r#"const WeightIndex$RawSchema = z.record(z.string(), z.unknown()).brand<"WeightIndex">()"#
-            ),
+            zod.contains("  z.record(z.string(), t).meta({"),
             "Got:\n{zod}"
         );
+        assert!(zod.contains(r#"}).brand<"WeightIndex">();"#), "Got:\n{zod}");
         assert!(
-            zod.contains(r#"WeightIndex$Schema: $ZodBranded<ZodRecord, "WeightIndex">"#),
+            zod.contains("export const WeightIndex$SchemaFactory = <T extends ZodType>("),
             "Got:\n{zod}"
         );
         assert_eq!(
@@ -1364,12 +1369,10 @@ mod branded_generic_inner_tests {
             r#"export type BareTag<T> = T & $brand<"BareTag">;"#
         );
         let zod = BareTag::<String>::zod_schema();
+        assert!(zod.contains("  t.meta({"), "Got:\n{zod}");
+        assert!(zod.contains(r#"}).brand<"BareTag">();"#), "Got:\n{zod}");
         assert!(
-            zod.contains(r#"const BareTag$RawSchema = z.unknown().brand<"BareTag">()"#),
-            "Got:\n{zod}"
-        );
-        assert!(
-            zod.contains(r#"BareTag$Schema: $ZodBranded<ZodUnknown, "BareTag">"#),
+            zod.contains("export const BareTag$SchemaFactory = <T extends ZodType>("),
             "Got:\n{zod}"
         );
         assert_eq!(BareTag::<String>::json_schema(), serde_json::json!({}));
@@ -1402,7 +1405,7 @@ mod branded_generic_inner_tests {
             (
                 TagList::<String>::zod_schema(),
                 tag_seq_schema::Schema::zod_schema(),
-                "z.array(z.unknown())",
+                "z.array(t)",
             ),
             (
                 WeightIndex::<u32>::ts_definition(),
@@ -1412,7 +1415,7 @@ mod branded_generic_inner_tests {
             (
                 WeightIndex::<u32>::zod_schema(),
                 weight_seq_schema::Schema::zod_schema(),
-                "z.record(z.string(), z.unknown())",
+                "z.record(z.string(), t)",
             ),
             (
                 BareTag::<String>::ts_definition(),
@@ -1422,7 +1425,7 @@ mod branded_generic_inner_tests {
             (
                 BareTag::<String>::zod_schema(),
                 bare_seq_schema::Schema::zod_schema(),
-                "= z.unknown()",
+                "\n  t",
             ),
         ] {
             assert!(brand.contains(shared), "brand got:\n{brand}");
@@ -1451,29 +1454,28 @@ mod branded_generic_inner_tests {
         }
     }
 
-    /// The exported binding's annotation is read off the value it annotates, so the alias's
-    /// erasure has to reach it too: `ZodType<TagSeqType>` names a type TypeScript refuses without
-    /// its argument, and the argument the value was composed with is the opaque one.
+    /// A generic alias publishes a factory exactly as the brand beside it does, so neither has an
+    /// annotation left to erase an argument out of — the `const` each used to publish claimed
+    /// `ZodType<Name<unknown>>` while the declaration beside it kept the argument, which is a type
+    /// error at any field naming either.
     #[test]
-    fn a_generic_alias_annotation_carries_the_argument_its_value_was_composed_with() {
-        for (zod, annotation) in [
+    fn a_generic_alias_publishes_the_factory_the_brand_beside_it_publishes() {
+        for (zod, factory) in [
             (
                 tag_seq_schema::Schema::zod_schema(),
-                "export const TagSeqType$Schema: ZodType<TagSeqType<unknown>> = \
-                 TagSeqType$RawSchema;",
+                "export const TagSeqType$SchemaFactory = <T extends ZodType>(",
             ),
             (
                 weight_seq_schema::Schema::zod_schema(),
-                "export const WeightSeqType$Schema: ZodType<WeightSeqType<unknown>> = \
-                 WeightSeqType$RawSchema;",
+                "export const WeightSeqType$SchemaFactory = <T extends ZodType>(",
             ),
             (
                 bare_seq_schema::Schema::zod_schema(),
-                "export const BareSeqType$Schema: ZodType<BareSeqType<unknown>> = \
-                 BareSeqType$RawSchema;",
+                "export const BareSeqType$SchemaFactory = <T extends ZodType>(",
             ),
         ] {
-            assert!(zod.contains(annotation), "Got:\n{zod}");
+            assert!(zod.contains(factory), "Got:\n{zod}");
+            assert!(!zod.contains("<unknown>"), "Got:\n{zod}");
         }
     }
 }
@@ -1516,6 +1518,44 @@ mod branded_example_arity_tests {
     #[test]
     fn a_one_parameter_brand_renders_the_example_it_always_did() {
         assert_eq!(SoloId::<String>::schema_example(), serde_json::json!("a"));
+    }
+}
+
+/// What a build emitting no TypeScript writes for a brand.
+///
+/// The name a brand carries is a *type* argument to `.brand`, and the binding's annotation is a
+/// type — neither of which a JavaScript parser reads, and a module carrying either stops at load
+/// rather than at a payload. Zod's runtime brand takes no argument at all, so the bare call is the
+/// same value under a spelling JavaScript does read.
+#[cfg(all(feature = "zod", not(feature = "typescript")))]
+mod branded_javascript_flavour_tests {
+    use super::*;
+
+    #[model_schema()]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct PlainMark(pub String);
+
+    #[model_schema(default_types(T = String))]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct HeldMark<T>(pub T);
+
+    #[test]
+    fn a_brand_writes_the_marker_with_no_type_argument() {
+        for zod in [PlainMark::zod_schema(), HeldMark::<String>::zod_schema()] {
+            assert!(zod.contains(".brand()"), "Got:\n{zod}");
+            assert!(!zod.contains(".brand<"), "Got:\n{zod}");
+        }
+    }
+
+    #[test]
+    fn a_brand_binding_carries_no_annotation() {
+        for zod in [PlainMark::zod_schema(), HeldMark::<String>::zod_schema()] {
+            assert!(!zod.contains("ZodType"), "Got:\n{zod}");
+            assert!(!zod.contains("$ZodBranded"), "Got:\n{zod}");
+            assert!(!zod.contains("$Schema:"), "Got:\n{zod}");
+        }
     }
 }
 
@@ -1923,7 +1963,7 @@ mod constrained_path_brand_tests {
     fn test_the_zod_bound_on_a_path_brand_is_the_bound_the_wire_enforces() {
         let zod = AssetPath::zod_schema();
         assert!(zod.contains("z.string().min(3)"), "Got:\n{zod}");
-        assert!(zod.contains("brand<\"AssetPath\">"), "Got:\n{zod}");
+        assert!(zod.contains(&brand_marker("AssetPath")), "Got:\n{zod}");
         assert!(
             serde_json::from_str::<AssetPath>("\"/a\"").is_err(),
             "the rendered minimum admits no shorter value on the wire"
@@ -2230,3 +2270,18 @@ use serde::{Deserialize, Serialize};
     feature = "jsonschema"
 ))]
 use tixschema::model_schema;
+
+/// The marker a brand carries, as this build spells it: the name is a *type* argument, which only
+/// a build emitting TypeScript writes at all.
+#[cfg(feature = "zod")]
+fn brand_marker(item_name: &str) -> String {
+    #[cfg(feature = "typescript")]
+    {
+        format!(".brand<\"{item_name}\">()")
+    }
+    #[cfg(not(feature = "typescript"))]
+    {
+        let _: &str = item_name;
+        ".brand()".to_owned()
+    }
+}

--- a/tests/generic_types_tests/tests.rs
+++ b/tests/generic_types_tests/tests.rs
@@ -197,8 +197,8 @@ mod zod {
     use super::MixedArguments;
     use super::{
         Adjacent, Carried, Envelope, External, FolderTree, Holder, Internal, KeyedByParameter,
-        LifetimeStruct, Pair, PlainConst, Positional, Quintet, Referrer, Tagged, Untagged,
-        WireFolder, Wrapper,
+        LifetimeStruct, Pair, PlainConst, Positional, Quintet, Referrer, Summarised, Tagged,
+        Untagged, WireFolder, Wrapper,
     };
 
     /// A record key has to produce string keys, and serde says every instantiation this map has
@@ -529,20 +529,46 @@ mod zod {
         assert!(!zod.contains("ZodType"), "Got: {zod}");
     }
 
-    /// The two surfaces that publish a `const` rather than a factory have no argument for a
-    /// parameter inside them to name, so both still write the opaque value there.
+    /// The alias and the brand write the same untyped factory, and the brand's marker drops the
+    /// type argument only TypeScript reads — the two spellings that made this build's output stop
+    /// at load rather than at a payload.
+    #[cfg(not(feature = "typescript"))]
     #[test]
-    fn a_surface_publishing_no_factory_keeps_the_opaque_value() {
+    fn a_javascript_build_writes_the_alias_and_the_brand_untyped() {
         let alias = super::boxed_schema::Schema::zod_schema();
-        assert!(alias.contains("z.array(z.unknown())"), "Got: {alias}");
-        assert!(!alias.contains("$SchemaFactory"), "Got: {alias}");
+        assert!(
+            alias.contains("const buildBoxed$Schema = (\n  valueType,\n) =>"),
+            "Got: {alias}"
+        );
+        assert!(!alias.contains("ZodType"), "Got: {alias}");
+        assert!(!alias.contains("$Schema:"), "Got: {alias}");
+
+        let brand = Tagged::<String>::zod_schema();
+        assert!(brand.contains("}).brand();"), "Got: {brand}");
+        assert!(!brand.contains(".brand<"), "Got: {brand}");
+        assert!(!brand.contains("ZodType"), "Got: {brand}");
+    }
+
+    /// An alias and a branded newtype are generic publishers like any other, so each binds an
+    /// argument per parameter and composes it — the alias into the shape it names, the brand into
+    /// the value it marks.
+    #[test]
+    fn every_generic_publisher_binds_its_parameter_as_a_factory_argument() {
+        let alias = super::boxed_schema::Schema::zod_schema();
+        assert!(
+            alias.contains("export const Boxed$SchemaFactory = "),
+            "Got: {alias}"
+        );
+        assert!(alias.contains("z.array(valueType)"), "Got: {alias}");
+        assert!(!alias.contains("z.unknown()"), "Got: {alias}");
 
         let brand = Tagged::<String>::zod_schema();
         assert!(
-            brand.contains("z.unknown().brand<\"Tagged\">()"),
+            brand.contains("export const Tagged$SchemaFactory = "),
             "Got: {brand}"
         );
-        assert!(!brand.contains("$SchemaFactory"), "Got: {brand}");
+        assert!(brand.contains("  valueType.meta({"), "Got: {brand}");
+        assert!(!brand.contains("z.unknown()"), "Got: {brand}");
     }
 
     /// A field naming a generic type has no schema to name — the type publishes a factory — so it
@@ -611,15 +637,36 @@ mod zod {
         }
     }
 
-    /// A reference names what the type it names publishes. An alias and a branded newtype publish
-    /// a `const` whatever they were written with, so a field supplying either an argument still
-    /// names that `const` rather than calling a factory neither declares.
+    /// A reference names what the type it names publishes, and the seam saying which of the two it
+    /// was is the item's own registry entry — so an alias and a branded newtype joining the
+    /// factories moved every field naming either with them, no reference-site rule of its own.
     #[test]
-    fn a_reference_to_a_type_publishing_a_const_still_names_it() {
+    fn a_reference_to_an_alias_or_a_brand_calls_the_factory_it_publishes() {
         let zod = Referrer::zod_schema();
-        assert!(zod.contains("boxed: Boxed$Schema,"), "Got: {zod}");
-        assert!(zod.contains("tagged: Tagged$Schema,"), "Got: {zod}");
-        assert!(!zod.contains("$SchemaFactory("), "Got: {zod}");
+        assert!(
+            zod.contains("boxed: Boxed$SchemaFactory(z.number().int()),"),
+            "Got: {zod}"
+        );
+        assert!(
+            zod.contains("tagged: Tagged$SchemaFactory(z.string()),"),
+            "Got: {zod}"
+        );
+    }
+
+    /// The argument a containing factory was handed is what reaches the alias and the brand it
+    /// holds, so a caller filling the container fills what validates inside it — where before the
+    /// container took the filling and threw it away.
+    #[test]
+    fn a_forwarded_parameter_reaches_an_alias_and_a_brand_alike() {
+        let zod = Summarised::<String>::zod_schema();
+        assert!(
+            zod.contains("boxed: Boxed$SchemaFactory(valueType),"),
+            "Got: {zod}"
+        );
+        assert!(
+            zod.contains("tagged: Tagged$SchemaFactory(valueType),"),
+            "Got: {zod}"
+        );
     }
 
     /// The one helper every factory builds its cache with, and the only assertion in the output.
@@ -947,13 +994,24 @@ pub struct MixedArguments {
     pub stamped: Inner<DateTime<Utc>>,
 }
 
-/// The two surfaces that publish a `const` whatever they were written with, named from a field
-/// that supplies each of them an argument.
+/// An alias and a branded newtype, named from a field that supplies each of them a concrete
+/// argument.
 #[model_schema()]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Referrer {
     pub boxed: Boxed<u32>,
     pub tagged: Tagged<String>,
+}
+
+/// The same two, named from a field that forwards the referrer's own parameter into each. Read by
+/// the Zod surface alone, where an argument is a value that has to be passed on, so it exists only
+/// where that surface compiles.
+#[cfg(feature = "zod")]
+#[model_schema(default_types(ValueType = String))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Summarised<ValueType> {
+    pub boxed: Boxed<ValueType>,
+    pub tagged: Tagged<ValueType>,
 }
 
 #[cfg(not(feature = "jsonschema"))]


### PR DESCRIPTION
Three related closures of the Zod publication story:

- A generic branded newtype publishes `X$SchemaFactory` through the same binding seam a generic struct uses — reference sites followed with no second change — with the inner composing the factory argument instead of being opaqued; non-generic brands keep their const byte-for-byte.
- A generic alias does too: the alias arm hands its rendered value to the shared publisher, erasing the alias-const special case and the `Name<unknown>` annotation filling with it (`tsc --strict` verified at three instantiations, including an $oid filling).
- The zod-without-typescript build stops writing TypeScript syntax: the brand marker forks to `.brand()` and the alias inherits the const block's existing fork; both captured SyntaxErrors are gone and the full JS-flavour emission loads under node and validates.

One forced spelling change, verified: inside a factory the description is written before the brand — `.meta()` returns `this`, which TypeScript resolves back to the bare parameter, dropping the marker if it came first; the example anchor follows the meta block's close under either order.