### PR TITLE
refuse a doc example on an item declaring a const parameter, naming every const and the remedy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1615,6 +1615,7 @@ Key points:
 - If multiple examples are present, only the **first one** is used.
 - Examples respect Serde attributes (field renaming, etc.).
 - Being Rust source, the example block is dropped from the JSDoc comment above the generated `export type`, whatever the type is declared as. On a struct or an enum it reaches the Zod `example` field; on a type alias, which publishes no `example` field, it reaches no generated surface at all.
+- A generic struct or enum has its example built at one instantiation, with every type parameter filled at `String`. A lifetime elides there and needs no filling, but a **const parameter takes none** -- `String` names a type, a const is a value, and no value is the one every example would be written at. So a struct or an enum that declares a const parameter and writes an example is refused, naming the const; drop the example or the const parameter. Nothing is owed where no example is written, on a type alias, or with the `zod` feature off, `zod` being the only surface that reads one.
 - The example code is executed at compile time and serialized to JSON.
 - Wrong types produce compile errors, ensuring examples stay in sync with your types.
 

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -97,8 +97,10 @@ use crate::utils::{compute_alias_export_name, ident_schema_module_name};
 
 use crate::utils::compute_item_export_name;
 
+#[cfg(any(feature = "typescript", feature = "zod"))]
+use crate::utils::get_item_docs;
 #[cfg(feature = "typescript")]
-use crate::utils::{get_item_docs, ident_reexport_ts};
+use crate::utils::ident_reexport_ts;
 
 #[cfg(feature = "zod")]
 use crate::utils::ident_reexport_zod;
@@ -945,6 +947,16 @@ pub fn exec_model_schema(args: TokenStream, input: TokenStream) -> TokenStream {
         &item,
         item_schema_ident(&item),
         &default_types_guard_errors(&item, &parsed_args),
+    ) {
+        return output;
+    }
+    // A doc example is compiled at one instantiation, and a const parameter takes no filling from
+    // the convention that names one, so an item writing both is refused here — ahead of every
+    // shape, and of the branded split inside the struct path.
+    if let Some(output) = guard_failure_output(
+        &item,
+        item_schema_ident(&item),
+        &const_parameter_example_errors(&item),
     ) {
         return output;
     }
@@ -1949,6 +1961,89 @@ fn missing_default_message(name: &syn::Ident, declared: &[&syn::Ident]) -> Strin
          because the `jsonschema` feature is enabled. Declare one for every parameter of this item, \
          each with the type its document should be generated from: \
          `#[model_schema(default_types({sample}))]`."
+    )
+}
+
+/// The `compile_error!` tokens an item earns for carrying a ` ```rust example ` block while
+/// declaring a const parameter, or none where it carries no example and none where it declares no
+/// const.
+///
+/// A doc example is Rust the expansion has to compile, so its value is annotated with the item's
+/// own name at one instantiation — every parameter filled in, `String` being the filling for a type
+/// parameter. A const takes no filling from that convention: `String` names a type, and a const is
+/// a value. Nor can one be read off the item, since no value is the one every const-parameterised
+/// example is written at, and picking one here would render the example at a length the author
+/// never wrote. So the example is refused where it was written, rather than expanded into an
+/// annotation that fails `E0107` before anything runs.
+///
+/// Answered at the one seam every expanded shape is dispatched from, so a struct and an enum cannot
+/// come to answer differently, and a branded newtype is answered before the struct path splits it
+/// off. An alias reaches here too and is deliberately left out: it publishes no `schema_example()`
+/// at all, so its example is already unread and a const on it costs nothing.
+///
+/// Only a build that reads an example owes the refusal, which is why this is `zod`-gated: without
+/// it no `schema_example()` is emitted and an example on a const-declaring item is exactly as
+/// unread as an example on any other item.
+#[cfg(feature = "zod")]
+fn const_parameter_example_errors(item: &Item) -> Vec<proc_macro2::TokenStream> {
+    let (generics, attrs) = if let Item::Struct(item_struct) = item {
+        (&item_struct.generics, &item_struct.attrs)
+    } else if let Item::Enum(item_enum) = item {
+        (&item_enum.generics, &item_enum.attrs)
+    } else {
+        return Vec::new();
+    };
+    let consts: Vec<&syn::Ident> = generics
+        .params
+        .iter()
+        .filter_map(|param| match param {
+            syn::GenericParam::Const(const_param) => Some(&const_param.ident),
+            syn::GenericParam::Type(_) | syn::GenericParam::Lifetime(_) => None,
+        })
+        .collect();
+    let Some(first) = consts.first() else {
+        return Vec::new();
+    };
+    if get_item_docs(attrs)
+        .and_then(|docs| extract_example_from_docs(&docs))
+        .is_none()
+    {
+        return Vec::new();
+    }
+    vec![attr_guard_error(
+        &syn::Error::new_spanned(first, const_parameter_example_message(&consts)),
+        &item_label(item),
+    )]
+}
+
+/// Nothing, in a build that reads no example: the method the refusal is owed for is never built,
+/// so the block sits unread the way it does on every other item here.
+#[cfg(not(feature = "zod"))]
+const fn const_parameter_example_errors(_item: &Item) -> Vec<proc_macro2::TokenStream> {
+    Vec::new()
+}
+
+/// Why a doc example on a const-declaring item is refused: what the example has to be, why the
+/// convention that fills a type parameter reaches no const, what the feature has to do with it, and
+/// the two ways out.
+#[cfg(feature = "zod")]
+fn const_parameter_example_message(consts: &[&syn::Ident]) -> String {
+    let names = consts
+        .iter()
+        .map(|name| format!("`{name}`"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "`#[model_schema]` cannot build a `schema_example()` for an item that declares a const \
+         parameter, and this item declares {names}. The example is Rust compiled at one \
+         instantiation, so its value is annotated with this item's own name and every parameter \
+         filled in: a type parameter is filled at `String`, the one concrete type every example can \
+         be written against, and a const takes no filling from that convention — `String` names a \
+         type, a const is a value, and no value is the one every const-parameterised example is \
+         written at, so one chosen here would render the example at a length this item's author \
+         never wrote. This is refused because the `zod` feature is enabled, `zod` being the only \
+         surface that reads an example. Remove the ` ```rust example ` block, or the const \
+         parameter, whichever this item can do without."
     )
 }
 

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -39,6 +39,16 @@ use syn::spanned::Spanned as _;
 /// The variants of [`rendered_discriminated_union`]'s enum, in the order they are declared.
 const DECLARED_VARIANTS: [&str; 6] = ["Upload", "Generate", "Delete", "Rename", "Move", "Archive"];
 
+/// The doc attributes carrying a ` ```rust example ` block that the const-parameter probes are
+/// written under. Held apart from them so every probe writes the same block and only the
+/// declaration beneath it varies.
+#[cfg(feature = "zod")]
+const EXAMPLE_DOC_BLOCK: &str = "/// An item carrying an example block.\n\
+                                 ///\n\
+                                 /// ```rust example\n\
+                                 /// Probe::Held\n\
+                                 /// ```\n";
+
 /// Every pattern the `pattern` guards must decide, invalid ones first, then the valid shapes the
 /// shipped tests write.
 const PROBE_PATTERNS: [&str; 10] = [
@@ -3832,6 +3842,107 @@ fn a_parameter_with_no_default_is_accepted_where_no_json_document_is_built() {
         );
         assert!(messages.is_empty(), "for {args:?}: {messages:?}");
     }
+}
+
+/// The `compile_error!` tokens `source` earns for the example it carries against the parameters it
+/// declares. Parsed from text so the tokens carry file locations and each refusal's span can be
+/// read back as the source it points at.
+#[cfg(feature = "zod")]
+fn const_example_refusals(source: &str) -> Vec<proc_macro2::TokenStream> {
+    super::const_parameter_example_errors(&syn::parse_str(source).unwrap())
+}
+
+/// The refusals `source` earns, rendered.
+#[cfg(feature = "zod")]
+fn const_example_messages(source: &str) -> Vec<String> {
+    const_example_refusals(source)
+        .iter()
+        .map(ToString::to_string)
+        .collect()
+}
+
+/// A doc example is Rust compiled at one instantiation, and no value is the one every
+/// const-parameterised example is written at, so an item that writes one while declaring a const
+/// is refused instead of expanded into a `schema_example()` that cannot compile. Both shapes that
+/// publish an example answer alike, the branded newtype among them.
+#[cfg(feature = "zod")]
+#[test]
+fn a_doc_example_on_a_const_declaring_item_is_refused() {
+    for (source, label) in [
+        (
+            format!("{EXAMPLE_DOC_BLOCK}pub enum Probe<const WIDTH: usize> {{ Held }}"),
+            "type `Probe`",
+        ),
+        (
+            format!("{EXAMPLE_DOC_BLOCK}pub struct Probe<const WIDTH: usize>(pub String);"),
+            "type `Probe`",
+        ),
+    ] {
+        let messages = const_example_messages(&source);
+        assert_eq!(messages.len(), 1, "for {source}: {messages:?}");
+        for needle in [
+            "compile_error",
+            "WIDTH",
+            "const parameter",
+            "```rust example",
+            "`zod` feature",
+            label,
+        ] {
+            assert!(
+                messages[0].contains(needle),
+                "{needle} missing for {source}: {}",
+                messages[0]
+            );
+        }
+    }
+}
+
+/// The refusal is the one the item earned, not one per parameter: an item writes a single example,
+/// so a second const adds a name to the message rather than a second diagnostic. It points at the
+/// first const declared, the example itself having no one token to sit on.
+#[cfg(feature = "zod")]
+#[test]
+fn a_doc_example_is_refused_once_and_names_every_const_declared() {
+    let source = format!(
+        "{EXAMPLE_DOC_BLOCK}pub struct Probe<'label, ValueType, const WIDTH: usize, const DEPTH: \
+         usize> {{ pub value: ValueType }}"
+    );
+    let refusals = const_example_refusals(&source);
+    assert_eq!(refusals.len(), 1, "got: {refusals:?}");
+    assert_eq!(refusals[0].span().source_text().as_deref(), Some("WIDTH"));
+    let rendered = refusals[0].to_string();
+    for needle in ["WIDTH", "DEPTH"] {
+        assert!(rendered.contains(needle), "{needle} missing: {rendered}");
+    }
+}
+
+/// What a const costs is the example, not the declaration: an item that writes none is expanded
+/// exactly as before, and so is one whose parameters are all kinds a filling exists for — a
+/// lifetime elides in the annotation and a type parameter takes `String`.
+#[cfg(feature = "zod")]
+#[test]
+fn an_item_the_example_convention_covers_earns_no_refusal() {
+    for source in [
+        "pub enum Probe<const WIDTH: usize> { Held }".to_owned(),
+        "pub struct Probe<const WIDTH: usize>(pub String);".to_owned(),
+        format!("{EXAMPLE_DOC_BLOCK}pub struct Probe<'label> {{ pub label: &'label str }}"),
+        format!("{EXAMPLE_DOC_BLOCK}pub struct Probe<ValueType> {{ pub value: ValueType }}"),
+        format!("{EXAMPLE_DOC_BLOCK}pub enum Probe {{ Held }}"),
+        format!("{EXAMPLE_DOC_BLOCK}pub struct Probe {{ pub value: String }}"),
+    ] {
+        let messages = const_example_messages(&source);
+        assert!(messages.is_empty(), "for {source}: {messages:?}");
+    }
+}
+
+/// An alias publishes no `schema_example()` — the expansion never reads its example — so a const
+/// on one costs nothing and is left alone. The refusal is owed exactly where the method is built.
+#[cfg(feature = "zod")]
+#[test]
+fn a_const_declaring_alias_is_left_alone() {
+    let source = format!("{EXAMPLE_DOC_BLOCK}pub type Probe<const WIDTH: usize> = [u8; WIDTH];");
+    let messages = const_example_messages(&source);
+    assert!(messages.is_empty(), "got: {messages:?}");
 }
 
 /// Builds the `Display` assertion for the sole field of `source`, parsed from text so its spans

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -922,7 +922,10 @@ pub fn get_field_docs(field: &Field) -> Option<Vec<String>> {
     collect_doc_lines(&field.attrs)
 }
 
-#[cfg(feature = "typescript")]
+/// The doc lines of anything carrying attributes. Read by the `TypeScript` surface for the prose it
+/// publishes, and by the guard that answers for a ` ```rust example ` block written on an item no
+/// annotation can be spelled for.
+#[cfg(any(feature = "typescript", feature = "zod"))]
 pub fn get_item_docs(attrs: &[Attribute]) -> Option<Vec<String>> {
     collect_doc_lines(attrs)
 }

--- a/tests/example_tests/tests.rs
+++ b/tests/example_tests/tests.rs
@@ -561,3 +561,49 @@ fn a_plain_const_still_carries_its_example_on_the_exported_binding() {
         "Got: {zod}"
     );
 }
+
+/// A lifetime takes no filling and needs none: it elides in the value's annotation, so an item
+/// binding one is annotated exactly as an item binding nothing and its example is built as
+/// written.
+#[cfg(feature = "zod")]
+#[test]
+fn a_lifetime_item_renders_its_example_with_the_lifetime_elided() {
+    /// A borrowing type carrying an example block.
+    ///
+    /// ```rust example
+    /// Labelled { label: "x" }
+    /// ```
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct Labelled<'label> {
+        pub label: &'label str,
+    }
+
+    assert_eq!(
+        Labelled::schema_example(),
+        serde_json::json!({ "label": "x" })
+    );
+}
+
+/// An example on a const-declaring item is only unwritable where an example is written out at all,
+/// and `zod` is the only surface that writes one. Without it the block sits unread exactly as it
+/// does on every other item here, so the item expands and its own contract is untouched.
+#[cfg(not(feature = "zod"))]
+#[test]
+fn a_const_declaring_item_keeps_its_example_where_no_example_is_read() {
+    /// A const-bearing type carrying an example block.
+    ///
+    /// ```rust example
+    /// Slotted { label: "x".to_owned() }
+    /// ```
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct Slotted<const WIDTH: usize> {
+        pub label: String,
+    }
+
+    let slotted = Slotted::<3> {
+        label: "x".to_owned(),
+    };
+    assert_eq!(slotted.label, "x");
+}


### PR DESCRIPTION
A doc example on a const-declaring struct or enum expanded to E0107 pointing at the author's declaration with a rustc suggestion that is not valid Rust. The narrower rule lands, chosen after the epic's design document proved silent on parameter kinds for examples (searched via the vault, hits recorded): an example is optional, and a `default_consts`-style filling would put a VALUE the author never wrote into the emitted example — a const is a value, not a type a String convention can stand in for.

The guard sits at the dispatch seam right after the default-fillings check, fires only for struct/enum shapes carrying an example block, once per item, spanned on the first const and naming them all. Its boundaries were set by capture, not guessed: a const-declaring ALIAS emits no example and stays legal, and a typescript-only build reads no example and stays legal. Lifetime-only items re-pinned compiling; type-parameter and non-generic examples untouched at the seam level. The String convention's own contradictions (trait bounds it cannot satisfy; declared fillings it ignores) are specced separately.