### PR TITLE
record a tagged enum's leaves where its oneOf writes them, and let a nullable name's absence multiply where serde reads it back

### DIFF
--- a/src/features/jsonschema.rs
+++ b/src/features/jsonschema.rs
@@ -238,7 +238,8 @@ fn merge_readers() -> proc_macro2::TokenStream {
 fn merged_tree() -> proc_macro2::TokenStream {
     quote::quote! {
         enum Branches<'defs> {
-            // What a source reached through an `Option` contributes when it is not there: no
+            // What a source contributes when it is not there — reached through an `Option`, or
+            // naming an item whose own published surface offers a `null` beside its value: no
             // members, so the branch names exactly the keys the object writes on its own.
             Absent,
             Object(&'defs serde_json::Map<String, serde_json::Value>),
@@ -448,6 +449,16 @@ fn branch_expansion() -> proc_macro2::TokenStream {
             };
 
             if let Some(named) = described_type(body) {
+                // A `null` among the choices the flatten edge itself offers is the absence rather
+                // than a refusal: the source is nullable, serde writes no member of it for that
+                // value, and the payload carrying none of them is the one serde reads back as that
+                // value — the same two key sets a source reached through an `Option` writes. A
+                // `null` below that level is a member of a choice serde matched by shape, where the
+                // absent form is one serde writes and then matches no member for, and the refusal
+                // stands.
+                if named == "null" && position.len() == 1 {
+                    return Some(Branches::Absent);
+                }
                 if named != "object" {
                     refuse_non_object(label, position, named);
                 }
@@ -496,8 +507,9 @@ fn branch_expansion() -> proc_macro2::TokenStream {
 /// always tell which types those are — a name reaches the merge without saying what it writes. The
 /// schema it produces does say, so the merge reads it there: a description naming any type but
 /// `object` is refused rather than merged, which is the last point at which the wrong schema can
-/// still be stopped. A flatten edge that closes a cycle is refused on the same terms, named for the
-/// frame that read it.
+/// still be stopped. The one exception is the `null` of a choice the edge itself offers, which is
+/// the source's own absence written out and is read as that. A flatten edge that closes a cycle is
+/// refused on the same terms, named for the frame that read it.
 ///
 /// The reading itself is the tokens [`merge_readers`] emits, and what the multiplication is carried
 /// in is [`merged_tree`]; both are written into the block this returns, so the whole merge is one

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -628,6 +628,33 @@ impl Surface {
         Self::named(Some("enumerated"), Some("string"))
     }
 
+    /// The union an externally tagged enum writes, as the leaves a merge descending it reaches.
+    ///
+    /// serde writes a data-carrying variant as the single-key object the variant's name tags, and
+    /// writes a unit variant as that name alone — a bare string, which carries no members and which
+    /// no object can be merged with. The JSON-schema merge descends the `oneOf` this publishes and
+    /// names such a variant by its position in it, so the leaves are recorded at those same
+    /// positions: what a flattened member naming the enum is refused at on one surface is what it
+    /// is refused at on the other, in one set of words.
+    ///
+    /// The tagged shapes that write an object for every variant keep [`Self::union`]: their leaves
+    /// would be unmarked to the last one, which is what the single unmarked leaf already says.
+    #[cfg(all(feature = "serde", feature = "zod"))]
+    fn externally_tagged(variants: &Punctuated<syn::Variant, Token![,]>) -> Self {
+        Self {
+            shape: Self::union().shape,
+            wire: RecordedWire::Leaves(external_variant_wire_leaves(variants)),
+        }
+    }
+
+    /// The same union where no merge reads its leaves. `serde` and `zod` together are the pair that
+    /// flattens one over the other; without both, nothing asks what the variants write and the
+    /// union is the union every other enum shape registers.
+    #[cfg(all(feature = "serde", not(feature = "zod")))]
+    const fn externally_tagged(_variants: &Punctuated<syn::Variant, Token![,]>) -> Self {
+        Self::union()
+    }
+
     /// A surface neither answer is read off a written type for.
     const fn named(shape: Option<&'static str>, wire: Option<&'static str>) -> Self {
         #[cfg(not(all(feature = "serde", feature = "zod")))]
@@ -1507,7 +1534,7 @@ fn compute_flatten_outputs(
         .iter()
         .map(|fld| MergedOperand {
             members: fld.zod_union_members(),
-            optional: fld.is_optional(),
+            optional: fld.is_optional() || flattened_name_offers_absence(fld),
             spelling: fld.zod_merged_schema(),
         })
         .collect();
@@ -1515,6 +1542,37 @@ fn compute_flatten_outputs(
     let zod_schemas = Vec::new();
 
     (ts_types, zod_schemas)
+}
+
+/// Whether the registration a flattened source names offers its own absence, which is the second
+/// key set the merge owes it.
+///
+/// The two spellings of reaching a nullable source are one declaration to serde: it writes the
+/// value's own keys or writes nothing, and reads the payload carrying none of them back as the
+/// absent value either way. A source written `Option<T>` says so in the type and is read through
+/// [`FieldDef::is_optional`]; one naming an item whose published surface is nullable says so a name
+/// away, and this is where that is read — off the leaves the name recorded, so the two spellings
+/// reach the multiplication by one answer.
+///
+/// The name has to be the whole of what the source writes. An array level is the array around
+/// whatever the name publishes, and the choice behind the name is one its items offer rather than
+/// one the source does.
+#[cfg(all(feature = "serde", feature = "zod"))]
+fn flattened_name_offers_absence(fld: &FieldDef) -> bool {
+    if fld.is_array() {
+        return false;
+    }
+    let FieldDefType::SiblingType(name, _) = &fld.field_type else {
+        return false;
+    };
+    lookup_alias_info(name).is_some_and(|info| info.wire.iter().any(WireLeaf::is_published_absence))
+}
+
+/// No source offers one where nothing reads `#[serde(flatten)]`: without `serde` no field reaches
+/// the merge to begin with, and the registry records no wire for a name to publish an absence in.
+#[cfg(all(feature = "zod", not(feature = "serde")))]
+const fn flattened_name_offers_absence(_fld: &FieldDef) -> bool {
+    false
 }
 
 /// The schema methods a struct's module publishes — the JSON-schema document, the TypeScript
@@ -5222,8 +5280,12 @@ fn process_externally_tagged_enum(
     // Compute the schema module name and register the enum so other types can find it.
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
     // Every other enum shape is written as a union of what its variants render as.
-    let (module_name, module_ident) =
-        enum_module_idents(name, item_name, AliasKind::NoEnumMembers, Surface::union());
+    let (module_name, module_ident) = enum_module_idents(
+        name,
+        item_name,
+        AliasKind::NoEnumMembers,
+        Surface::externally_tagged(&item_enum.variants),
+    );
 
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
     let docs_vec = get_enum_docs(&item_enum);
@@ -6423,14 +6485,36 @@ fn published_wire_leaves(written: &FieldDef) -> Vec<WireLeaf> {
     })
 }
 
-/// The leaves the item a field names published, where the field's whole wire *is* that name's and
-/// the name stands for more than one leaf — and `None` everywhere the one-leaf dispatch already
-/// answers.
+/// The leaves an externally tagged enum's variants write, one per variant and in the order the
+/// `oneOf` it publishes writes them.
 ///
-/// Only a choice is spliced. A name publishing one leaf keeps flowing through the same single
-/// answer it always did, so nothing about a member naming an object, a scalar or a map moves; a
-/// name publishing a choice is the one thing that answer could not carry, its levels sitting below
-/// the member's own position rather than at it.
+/// The classification is [`classify_variant`]'s, which is the one
+/// [`render_external_variant`] writes each variant from — so what is recorded and what is emitted
+/// read the declaration the same way, and a variant that renders as a bare string is a leaf that
+/// says so.
+#[cfg(all(feature = "serde", feature = "zod"))]
+fn external_variant_wire_leaves(variants: &Punctuated<syn::Variant, Token![,]>) -> Vec<WireLeaf> {
+    variants
+        .iter()
+        .enumerate()
+        .map(|(index, variant)| WireLeaf {
+            branch: vec![index + 1],
+            non_object: matches!(classify_variant(variant), VariantKind::Unit).then_some("string"),
+        })
+        .collect()
+}
+
+/// The leaves the item a field names published, where the field's whole wire *is* that name's and
+/// one of those leaves proves serde writes no object at its position — and `None` everywhere the
+/// one-leaf dispatch already answers.
+///
+/// Only a refusable choice is spliced. A name publishing one leaf keeps flowing through the same
+/// single answer it always did, so nothing about a member naming an object, a scalar or a map
+/// moves; and a choice whose every leaf is an object is that same answer written once per branch —
+/// the operand a merge joins is the name whichever branch matched, so splicing it would put one
+/// member where one stood and say nothing the single leaf did not. What only the leaves can carry
+/// is a branch serde writes as something no object joins, sitting below the member's own position
+/// rather than at it.
 ///
 /// An array level is not one of those: what the field writes is the array around whatever the name
 /// publishes, and the leaves behind the name describe an item of it rather than the field.
@@ -6443,7 +6527,10 @@ fn named_wire_leaves(written: &FieldDef) -> Option<Vec<WireLeaf>> {
         return None;
     };
     let leaves = lookup_alias_info(name)?.wire;
-    (leaves.len() > 1).then_some(leaves)
+    leaves
+        .iter()
+        .any(|leaf| leaf.non_object.is_some())
+        .then_some(leaves)
 }
 
 /// Builds the schema module's impl items for an untagged enum: its JSON schema, its `TypeScript`

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -7128,6 +7128,125 @@ fn flattening_a_union_with_a_named_nullable_member_is_refused_naming_the_trail()
     );
 }
 
+/// A member naming an externally tagged enum carries one leaf per variant, at the positions the
+/// JSON-schema merge names the same variants by. serde writes a data-carrying variant as the
+/// single-key object its name tags and writes a unit variant as that name alone — a bare string —
+/// so the choice behind the member holds a leaf no object can be merged with, one level in from
+/// where the member stands.
+#[cfg(all(feature = "serde", feature = "zod"))]
+#[test]
+fn a_union_member_naming_a_tagged_enum_carries_one_leaf_per_variant() {
+    seed_external_registration(&syn::parse_quote! {
+        enum WireExtBare {
+            Bare,
+            Wrapped(Holder),
+        }
+    });
+    assert_eq!(
+        recorded_member_trails(syn::parse_quote! {
+            enum WireExtBareChoice {
+                Obj(Holder),
+                Ext(WireExtBare),
+            }
+        }),
+        vec![
+            ("1".to_owned(), None),
+            ("2.1".to_owned(), Some("string")),
+            ("2.2".to_owned(), None),
+        ]
+    );
+}
+
+/// And a tagged enum whose every variant carries data keeps the one unmarked leaf it always had.
+/// Every branch of that choice is an object the merge joins, and the operand it would join is the
+/// name whichever branch matched — so writing one member per branch would put three where one stood
+/// and say nothing the single leaf did not.
+#[cfg(all(feature = "serde", feature = "zod"))]
+#[test]
+fn a_union_member_naming_an_all_object_tagged_enum_keeps_its_one_leaf() {
+    seed_external_registration(&syn::parse_quote! {
+        enum WireExtObjects {
+            One(Holder),
+            Two(Other),
+        }
+    });
+    assert_eq!(
+        recorded_member_trails(syn::parse_quote! {
+            enum WireExtObjChoice {
+                Obj(Holder),
+                Ext(WireExtObjects),
+            }
+        }),
+        vec![("1".to_owned(), None), ("2".to_owned(), None)]
+    );
+}
+
+/// So flattening a union whose member names one is refused at the leaf the bare string sits at —
+/// `2.1`, a position below the member, which is where the enum's own choice puts it and not where
+/// the member stands — and in the words the JSON-schema merge refuses the same declaration in.
+#[cfg(all(feature = "serde", feature = "zod"))]
+#[test]
+fn flattening_a_union_with_a_tagged_enum_member_is_refused_naming_the_trail() {
+    seed_external_registration(&syn::parse_quote! {
+        enum FlatWireExtBare {
+            Bare,
+            Wrapped(Holder),
+        }
+    });
+    let refusal = recorded_union_flatten_error(
+        "WireExtFlatChoice",
+        syn::parse_quote! {
+            enum WireExtFlatChoice {
+                Obj(Holder),
+                Ext(FlatWireExtBare),
+            }
+        },
+        &syn::parse_quote! { #[serde(flatten)] either: WireExtFlatChoice },
+    )
+    .unwrap();
+    assert!(
+        refusal
+            .contains("`#[serde(flatten)]` of `WireExtFlatChoice` writes a union member that is"),
+        "got: {refusal}"
+    );
+    assert!(
+        refusal.contains("its branch 2.1 describes a `string`, which has no members to merge"),
+        "got: {refusal}"
+    );
+    seed_external_registration(&syn::parse_quote! {
+        enum FlatWireExtObjects {
+            One(Holder),
+            Two(Other),
+        }
+    });
+    assert!(
+        recorded_union_flatten_error(
+            "WireExtObjFlatChoice",
+            syn::parse_quote! {
+                enum WireExtObjFlatChoice {
+                    Obj(Holder),
+                    Ext(FlatWireExtObjects),
+                }
+            },
+            &syn::parse_quote! { #[serde(flatten)] either: WireExtObjFlatChoice },
+        )
+        .is_none()
+    );
+}
+
+/// Runs the registration an externally tagged enum's own expansion runs, so the leaves the registry
+/// answers with for the name are ones a declaration put there rather than words written by hand.
+#[cfg(all(feature = "serde", feature = "zod"))]
+fn seed_external_registration(item: &syn::ItemEnum) {
+    let rust_ident = item.ident.to_string();
+    let _: (String, syn::Ident) = super::enum_module_idents(
+        &item.ident,
+        &rust_ident,
+        AliasKind::NoEnumMembers,
+        super::Surface::externally_tagged(&item.variants),
+    );
+}
+
 /// `^$` is the empty-string check, not a degenerate pattern: it pins both ends of the value to one
 /// position. It keeps the `is_empty()` call it has been emitted as, byte for byte, now that the
 /// shapes written out of the same two anchors are refused.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -185,6 +185,21 @@ pub struct WireLeaf {
     pub non_object: Option<&'static str>,
 }
 
+#[cfg(all(feature = "serde", feature = "zod"))]
+impl WireLeaf {
+    /// Whether this leaf is the absence the name itself offers: the `null` of a choice the
+    /// registration publishes at its own top level, one position in from the name and no deeper.
+    ///
+    /// That depth is what the answer turns on. serde writes no member at all for this leaf and
+    /// reads the payload carrying none of them back as the absent value, so a source reached this
+    /// way writes two key sets and the merge owes it both. A `null` further down sits under a
+    /// choice serde matched a member on, where the same payload is one serde writes and then
+    /// matches no member for — the refusal a member position already carries.
+    pub fn is_published_absence(&self) -> bool {
+        self.branch.len() == 1 && self.non_object == Some("null")
+    }
+}
+
 #[derive(Clone)]
 pub struct AliasInfo {
     pub export_name: String,

--- a/tests/flatten_tests/tests.rs
+++ b/tests/flatten_tests/tests.rs
@@ -553,6 +553,85 @@ enum LaterMemberMaybeEither {
     Maybe(MemberMaybeSecond),
 }
 
+/// A member naming a tagged enum. serde writes a data-carrying variant as the single-key object the
+/// variant's name tags, and writes a unit variant as that name alone — a bare string — so the choice
+/// this member stands for holds a leaf no object can be merged with, one level in from where the
+/// member stands.
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+enum MemberExtBare {
+    Bare,
+    Wrapped(FlatSecond),
+}
+
+#[cfg(all(feature = "jsonschema", not(feature = "zod")))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(untagged)]
+enum MemberExtBareEither {
+    Base(FlatFirst),
+    Ext(MemberExtBare),
+}
+
+#[cfg(all(feature = "jsonschema", not(feature = "zod")))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct FlatOverMemberExtBareUntagged {
+    #[serde(flatten)]
+    either: MemberExtBareEither,
+    own: String,
+}
+
+/// The same enum in a union declared below the object that flattens it, which keeps the fallback:
+/// the recording holds nothing for the union's name, so the Zod merge writes the one operand it is
+/// while the JSON-schema merge refuses it wherever it was declared.
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct FlatOverLaterMemberExtBareUntagged {
+    #[serde(flatten)]
+    either: LaterMemberExtBareEither,
+    own: String,
+}
+
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(untagged)]
+enum LaterMemberExtBareEither {
+    Base(FlatFirst),
+    Ext(MemberExtBare),
+}
+
+/// And a tagged enum whose every variant carries data, which serde writes as the object its name
+/// tags in every case — admitted where it always was, on every surface.
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+enum MemberExtObjects {
+    One(FlatFirst),
+    Two(FlatSecond),
+}
+
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(untagged)]
+enum MemberExtObjEither {
+    Base(FlatFirst),
+    Ext(MemberExtObjects),
+}
+
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct FlatOverMemberExtObjUntagged {
+    #[serde(flatten)]
+    either: MemberExtObjEither,
+    own: String,
+}
+
 /// A union member that names itself, and the struct that flattens the union. The member describes
 /// as a reference into the definitions, and the body it points at is written by the time the merge
 /// asks for it.
@@ -744,6 +823,39 @@ struct OptHolder {
     #[serde(flatten, skip_serializing_if = "Option::is_none", default)]
     maybe: Option<OptBase>,
     own: String,
+}
+
+/// The other spelling of reaching that same absence: a registration whose own published surface is
+/// nullable, flattened directly with no union between. serde writes the base's members beside the
+/// object's own or writes the object's own alone, exactly as the `Option`-typed field does, and
+/// reads both forms back — so the two spellings are one declaration and the merge owes them one
+/// answer.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct MaybeOptBase(Option<OptBase>);
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct NamedMaybeHolder {
+    #[serde(flatten)]
+    maybe: MaybeOptBase,
+    own: String,
+}
+
+/// And a name whose published surface is not nullable, which offers no absence and stays the one
+/// operand it always was.
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct PlainOptBase(OptBase);
+
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct NamedPlainHolder {
+    own: String,
+    #[serde(flatten)]
+    plain: PlainOptBase,
 }
 
 /// The same absence over a source that is itself a union: serde writes the matched member's keys or
@@ -2038,6 +2150,125 @@ fn test_the_optional_flatten_schema_binds_the_objects_own_keys_once() {
     );
 }
 
+/// The same two payloads reached through a name rather than through an `Option` in the field's own
+/// type: serde writes the base's members beside the object's own or writes the object's own alone,
+/// and reads both back as the value that wrote them. One declaration, both directions — which is
+/// what says the merge owes it the two key sets rather than a refusal.
+#[test]
+fn test_a_named_nullable_flattened_base_writes_its_members_or_nothing() {
+    let forms: [(Option<OptBase>, serde_json::Value); 2] = [
+        (
+            Some(OptBase {
+                left: "l".to_owned(),
+                right: true,
+            }),
+            serde_json::json!({ "left": "l", "right": true, "own": "o" }),
+        ),
+        (None, serde_json::json!({ "own": "o" })),
+    ];
+    for (maybe, expected) in forms {
+        let holder = NamedMaybeHolder {
+            maybe: MaybeOptBase(maybe),
+            own: "o".to_owned(),
+        };
+        let written = serde_json::to_value(&holder).unwrap();
+        assert_eq!(written, expected);
+        let back: NamedMaybeHolder = serde_json::from_value(written).unwrap();
+        assert_eq!(back, holder);
+    }
+}
+
+/// So the merged document is the one the `Option`-typed field's own writes, key for key: the base's
+/// members joined to the object's under one branch and the object's own alone under another. The two
+/// spellings reach the same absence, so they describe as one document.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_the_named_nullable_flatten_document_is_the_optional_flattens_own() {
+    assert_eq!(
+        serde_json::to_string(&NamedMaybeHolder::json_schema()).unwrap(),
+        serde_json::to_string(&OptHolder::json_schema()).unwrap(),
+    );
+    assert_eq!(
+        serde_json::to_string(&NamedMaybeHolder::json_schema()).unwrap(),
+        r#"{"type":"object","anyOf":[{"type":"object","properties":{"own":{"type":"string"},"left":{"type":"string"},"right":{"type":"boolean"}},"required":["own","left","right"],"additionalProperties":false},{"type":"object","properties":{"own":{"type":"string"}},"required":["own"],"additionalProperties":false}]}"#
+    );
+}
+
+/// And it accepts every payload serde writes and no base written in part, which is what the two
+/// branches say and folding them into one key set could not.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_the_named_nullable_flatten_document_admits_the_captured_payloads() {
+    let schema = NamedMaybeHolder::json_schema();
+    for payload in [
+        serde_json::json!({ "left": "l", "right": true, "own": "o" }),
+        serde_json::json!({ "own": "o" }),
+    ] {
+        assert!(
+            closed_document_accepts(&schema, &payload),
+            "{payload} is rejected by {schema}"
+        );
+    }
+    for payload in [
+        serde_json::json!({ "left": "l", "own": "o" }),
+        serde_json::json!({ "right": true, "own": "o" }),
+    ] {
+        assert!(
+            !closed_document_accepts(&schema, &payload),
+            "{payload} is accepted by {schema}"
+        );
+    }
+}
+
+/// And Zod writes the same choice around the same intersection: the object's own keys merged with
+/// the name, or the object's own keys alone. The name is left spelled as the nullable binding it is
+/// — the null side of it carries no key an intersection could take, so the branch that names it
+/// admits exactly the payload the base writes.
+///
+/// Read off zod 4.4.3, the emitted spelling transcribed: this union accepts
+/// `{"left":"l","right":true,"own":"o"}` and `{"own":"o"}`, and rejects `{"left":"l","own":"o"}`,
+/// `{"right":true,"own":"o"}` and any payload carrying a key neither the object nor the base names
+/// — payload for payload what the `Option`-typed field's own schema answers.
+#[test]
+#[cfg(feature = "zod")]
+fn test_the_named_nullable_flatten_schema_offers_the_base_and_its_absence() {
+    let zod = NamedMaybeHolder::zod_schema();
+    assert!(
+        zod.contains(
+            "z.union([\n  NamedMaybeHolder$OwnSchema.and(z.lazy(() => MaybeOptBase$Schema)),\n  NamedMaybeHolder$OwnSchema,\n])"
+        ),
+        "expected the base beside its absence, got: {zod}"
+    );
+    assert_eq!(
+        zod.matches("MaybeOptBase$Schema").count(),
+        1,
+        "the base is named more than once in: {zod}"
+    );
+}
+
+/// The absence is a question about what the name published and nothing else, so a direct flatten
+/// naming an item whose surface is not nullable is spelled exactly as it was before there was a
+/// second branch to spell — one intersection, and one closed object.
+#[test]
+#[cfg(feature = "zod")]
+fn test_a_named_non_nullable_flatten_schema_is_byte_identical() {
+    #[cfg(feature = "typescript")]
+    const EXPECTED: &str = "const NamedPlainHolder$RawSchema = z.strictObject({\n  own: z.string(),\n}).and(z.lazy(() => PlainOptBase$Schema));\n\nexport const NamedPlainHolder$Schema: ZodType<NamedPlainHolder> = NamedPlainHolder$RawSchema;";
+    #[cfg(not(feature = "typescript"))]
+    const EXPECTED: &str = "export const NamedPlainHolder$Schema = z.strictObject({\n  own: z.string(),\n}).and(z.lazy(() => PlainOptBase$Schema));";
+
+    assert_eq!(NamedPlainHolder::zod_schema(), EXPECTED);
+}
+
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_a_named_non_nullable_flatten_document_is_byte_identical() {
+    assert_eq!(
+        serde_json::to_string(&NamedPlainHolder::json_schema()).unwrap(),
+        r#"{"type":"object","properties":{"own":{"type":"string"},"left":{"type":"string"},"right":{"type":"boolean"}},"required":["own","left","right"],"additionalProperties":false}"#
+    );
+}
+
 /// The absence is a question about the `Option` and nothing else, so a base written without one is
 /// spelled exactly as it was before there was a second branch to spell — byte for byte, on both
 /// surfaces.
@@ -2482,6 +2713,116 @@ fn test_the_named_wire_unions_are_byte_identical_standing_alone() {
             MemberBucketEither::zod_schema(),
             MemberMaybeEither::zod_schema(),
         ],
+        EXPECTED.map(str::to_owned)
+    );
+}
+
+/// What serde writes for a member naming a tagged enum: the single-key object the variant's name
+/// tags for a data-carrying variant, and the variant's name as a key holding null for a unit one —
+/// the flattened form of the bare string that variant is written as.
+#[test]
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+fn test_a_tagged_enum_member_writes_the_unit_variant_as_a_bare_name() {
+    let forms = [
+        (
+            MemberExtBare::Bare,
+            serde_json::json!({ "own": "o", "Bare": null }),
+        ),
+        (
+            MemberExtBare::Wrapped(FlatSecond { b: true }),
+            serde_json::json!({ "own": "o", "Wrapped": { "b": true } }),
+        ),
+    ];
+    for (variant, expected) in forms {
+        let written = serde_json::to_value(FlatOverLaterMemberExtBareUntagged {
+            own: "o".to_owned(),
+            either: LaterMemberExtBareEither::Ext(variant),
+        })
+        .unwrap();
+        assert_eq!(written, expected);
+    }
+}
+
+/// And the merge refuses the declaration at the leaf the bare string sits at — `2.1`, a position
+/// below the member, which is where the enum's own choice puts it and not where the member stands.
+#[test]
+#[cfg(all(feature = "jsonschema", not(feature = "zod")))]
+#[should_panic(
+    expected = "`FlatOverMemberExtBareUntagged`: `#[serde(flatten)]` of `MemberExtBareEither` writes a union member that is not an object — its branch 2.1 describes a `string`"
+)]
+fn test_a_tagged_enum_member_of_a_flattened_untagged_enum_is_refused_by_the_merge() {
+    assert!(FlatOverMemberExtBareUntagged::json_schema().is_object());
+}
+
+/// And in those same words wherever the union was declared, which is the one reading of the
+/// declaration that survives the Zod surface refusing it at expansion.
+#[test]
+#[cfg(feature = "jsonschema")]
+#[should_panic(
+    expected = "`FlatOverLaterMemberExtBareUntagged`: `#[serde(flatten)]` of `LaterMemberExtBareEither` writes a union member that is not an object — its branch 2.1 describes a `string`"
+)]
+fn test_a_tagged_enum_member_of_a_later_flattened_untagged_enum_is_refused_by_the_merge() {
+    assert!(FlatOverLaterMemberExtBareUntagged::json_schema().is_object());
+}
+
+/// A tagged enum whose every variant carries data writes an object for each of them, so serde joins
+/// it to the object being written and reads it back — and every surface admits it exactly where it
+/// always did.
+#[test]
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+fn test_an_all_object_tagged_enum_member_round_trips() {
+    let written = serde_json::to_value(FlatOverMemberExtObjUntagged {
+        own: "o".to_owned(),
+        either: MemberExtObjEither::Ext(MemberExtObjects::One(FlatFirst { a: "x".to_owned() })),
+    })
+    .unwrap();
+    assert_eq!(
+        written,
+        serde_json::json!({ "own": "o", "One": { "a": "x" } })
+    );
+    serde_json::from_value::<FlatOverMemberExtObjUntagged>(written).unwrap();
+}
+
+/// And its Zod schema keeps the multiplication it always had, byte for byte: one branch per member
+/// of the union, with the tagged enum named as the one operand it is rather than written out once
+/// per variant.
+#[test]
+#[cfg(feature = "zod")]
+fn test_an_all_object_tagged_enum_member_keeps_its_multiplication() {
+    let zod = FlatOverMemberExtObjUntagged::zod_schema();
+    assert!(
+        zod.contains(
+            "z.union([\n  FlatOverMemberExtObjUntagged$OwnSchema.and(z.lazy(() => FlatFirst$Schema)),\n  FlatOverMemberExtObjUntagged$OwnSchema.and(z.lazy(() => MemberExtObjects$Schema)),\n])"
+        ),
+        "expected the tagged enum's branch, got: {zod}"
+    );
+}
+
+/// And the JSON-schema merge writes its document rather than refusing it.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_an_all_object_tagged_enum_member_keeps_its_merged_document() {
+    assert!(FlatOverMemberExtObjUntagged::json_schema().is_object());
+}
+
+/// Standing on their own the two tagged enums are written exactly as they were: the leaves are what
+/// a merge reads about them and say nothing about what either publishes.
+#[test]
+#[cfg(feature = "zod")]
+fn test_the_tagged_enums_are_byte_identical_standing_alone() {
+    #[cfg(feature = "typescript")]
+    const EXPECTED: [&str; 2] = [
+        "const MemberExtBare$RawSchema = z.union([z.literal(\"Bare\"), z.strictObject({\n  \"Wrapped\": FlatSecond$Schema,\n})]);\n\nexport const MemberExtBare$Schema: ZodType<MemberExtBare> = MemberExtBare$RawSchema;",
+        "const MemberExtObjects$RawSchema = z.union([z.strictObject({\n  \"One\": FlatFirst$Schema,\n}), z.strictObject({\n  \"Two\": FlatSecond$Schema,\n})]);\n\nexport const MemberExtObjects$Schema: ZodType<MemberExtObjects> = MemberExtObjects$RawSchema;",
+    ];
+    #[cfg(not(feature = "typescript"))]
+    const EXPECTED: [&str; 2] = [
+        "export const MemberExtBare$Schema = z.union([z.literal(\"Bare\"), z.strictObject({\n  \"Wrapped\": FlatSecond$Schema,\n})]);",
+        "export const MemberExtObjects$Schema = z.union([z.strictObject({\n  \"One\": FlatFirst$Schema,\n}), z.strictObject({\n  \"Two\": FlatSecond$Schema,\n})]);",
+    ];
+
+    assert_eq!(
+        [MemberExtBare::zod_schema(), MemberExtObjects::zod_schema(),],
         EXPECTED.map(str::to_owned)
     );
 }


### PR DESCRIPTION
Two wire-leaf follow-ons, both settled by round-trip captures:

- A tagged enum's registration now records one leaf per variant at the positions its published `oneOf` writes them, keyword decided by the same classifier the variants render from — so a flattened MEMBER naming one with a unit variant is refused at `2.1` naming `string`, character-identical to the JSON merge's panic; all-object tagged enums collapse to the single unmarked leaf and stay byte-identical.
- The DIRECT flatten of a nullable name: serde writes AND reads back the absent form, so the declaration is admissible and jsonschema's own refusal was wrong — it now emits the same two-branch `anyOf` its Option-typed flatten emits (asserted equal between the two spellings), and Zod multiplies to the union whose recorded verdicts match serde payload for payload. Depth carries the rule: the name's own top-level absence multiplies; a null below a choice keeps the member-position refusal. One evidence correction recorded: the bead's transcribed union was actually `z.nullable(…)`, making the pre-change defect a strict subset, not unsatisfiability — defect and fix unaffected.

Three residuals filed with captures: the direct tagged-unit case, the unguarded direct scalar on Zod, and TypeScript as the fourth surface still dropping the absent payload.