### PR TITLE
drop a skipped slot from the described tuple, refuse the halves no arity can describe, and tell the README's skip story from captures

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ A bare `#[serde(skip)]` is not that. serde writes the key into no payload *and* 
 
 `#[serde(skip_deserializing)]` on its own drops neither surface's key: serde writes it in every payload, so the member keeps a required key, and the value a payload supplies under it is discarded on the way in.
 
+A positional slot answers by that same wire, read in the place a tuple writes rather than under a key. A slot carrying a bare `#[serde(skip)]` is absent from the array serde writes *and* from every array serde reads, and the slots behind it move up: `struct Pair(#[serde(skip)] Option<String>, String)` holding `(Some("s"), "x")` writes `["x"]`, reads that back, and refuses `["s","x"]`. So the described tuple is the slots that remain — `[string]` in TypeScript, `z.tuple([z.string()])` in Zod, and one `prefixItems` entry under `minItems`/`maxItems` of 1. Dropping every slot leaves `[]`, which is the array serde writes there.
+
+A slot dropped from only one of the two directions has no such description and is refused where it is declared. `skip_serializing` alone writes `["x"]` and reads only `["s","x"]`; `skip_deserializing` alone writes `["s","x"]` and reads only `["x"]`. A named field in that position is still describable — the key is absent from one payload and present in the other, which an optional key covers — but a slot is written by its place, so the two payloads differ in their arity and no fixed-arity tuple describes both.
+
+A struct declaring a single slot keeps it whatever these attributes say: serde writes and reads a newtype struct's only slot regardless, so nothing there is dropped.
+
 Which key a field writes is read off the attribute in every build, `serde` feature or not — one declaration describes one wire under every toggle. What the feature buys is the renaming, the tagging and the guards.
 
 ```rust
@@ -1910,7 +1916,12 @@ Supported Serde attributes:
 - `#[serde(untagged)]` -- untagged enums generate a union (`A | B`) / Zod `z.union([...])` / JSON Schema `anyOf`
 - `#[serde(flatten)]` -- flatten a field into the parent as an intersection type (`A & B`) / Zod `.and(...)`
 - `#[serde(transparent)]` -- transparent wrappers (used for branded newtypes)
-- `#[serde(skip_serializing_if = "...")]` -- respected but does not affect generated types
+- `#[serde(skip_serializing_if = "...")]` -- the key is left out of the payload when the predicate fires, so the member is described under an optional key: `roles?: Array<string>;` in TypeScript, `roles: z.array(z.string()).optional(),` in Zod, and no `required` entry in the JSON Schema
+- `#[serde(skip)]` -- the key is written into no payload and read out of none, so no surface describes the member at all: no TypeScript member, no Zod key, and neither a `properties` nor a `required` entry. On a tuple-struct slot it takes the slot out of the described tuple, which shortens the arity
+- `#[serde(skip_serializing)]` -- the write half of `skip`: the key is left out of every payload while a supplied one is still read, so the member is described under an optional key, as `skip_serializing_if` is
+- `#[serde(skip_deserializing)]` -- the read half: the key is written into every payload while a supplied one is discarded, so the member keeps a required key
+
+The three `skip` spellings are three different wires, and [Optional Fields](#optional-fields) reads each one in both directions, positional slots included.
 
 If the `serde` feature is disabled but serde attributes are present, you will see compile-time warnings and field names will not be transformed.
 

--- a/src/features/serde.rs
+++ b/src/features/serde.rs
@@ -41,6 +41,29 @@ pub struct SerdeKeyOmission {
     pub skips_deserializing: bool,
 }
 
+impl SerdeKeyOmission {
+    /// Whether the attributes take the member out of both of serde's directions at once: nothing
+    /// serde writes carries it, and nothing serde reads keeps what a payload put there.
+    ///
+    /// The conjunction is what is read rather than the word `skip`, because `skip_serializing` and
+    /// `skip_deserializing` written side by side are that same wire spelled out.
+    pub const fn absent_from_wire(self) -> bool {
+        self.omits_key && self.skips_deserializing
+    }
+
+    /// Whether the attributes take the member out of exactly one of serde's two directions, which
+    /// leaves what serde writes and what serde reads two different payloads.
+    ///
+    /// Where the member has a key, the two payloads still overlap — the key is simply absent from
+    /// one of them, which an optional key describes. Where it has only a place in a tuple there is
+    /// no such spelling, and the two payloads differ in their arity. So the question is asked only
+    /// by the builds that describe a tuple, which is what the gate below says.
+    #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+    pub const fn drops_one_direction_only(self) -> bool {
+        self.omits_key != self.skips_deserializing
+    }
+}
+
 /// Metadata for serde attributes applied to a struct or enum.
 #[cfg(feature = "serde")]
 #[derive(Clone, Debug, Default)]

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -59,6 +59,10 @@ use crate::utils::{TrivialPattern, trivial_pattern};
 #[cfg(feature = "serde")]
 use crate::features::serde::{SerdeFieldMeta, SerdeTypeMeta};
 use crate::features::serde::{has_serde_default, parse_serde_key_omission};
+// The type is named only where a slot's own omission is read, which is where a surface describes
+// the tuple that slot sits in.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+use crate::features::serde::SerdeKeyOmission;
 
 #[cfg(feature = "serde")]
 use crate::field_type::{parse_serde_field_attributes, parse_serde_type_attributes};
@@ -560,6 +564,23 @@ struct Surface {
 enum RecordedWire {
     Leaves(Vec<WireLeaf>),
     Named(Option<&'static str>),
+}
+
+/// What a tuple struct publishes, which is not always the tuple of its declared slots.
+///
+/// serde writes a struct declaring exactly one slot as that slot's value alone, with nothing around
+/// it, and every other arity as an array of the slots it still carries. The two are separated here,
+/// at the one place that knows both how many slots were declared and which of them reach the wire,
+/// so no renderer downstream has to guess which shape a slot list stands for — a distinction the
+/// list alone cannot carry, since a two-slot struct with one slot off the wire writes a one-element
+/// array while a one-slot struct writes a bare value.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+enum TupleStructShape {
+    /// The fixed-arity array serde writes for every other declared arity, holding the slots the
+    /// wire carries.
+    Array(Vec<FieldDef>),
+    /// The bare value serde writes for a struct declaring exactly one slot.
+    BareValue(Box<FieldDef>),
 }
 
 /// What the item around a field says about it: everything [`process_field`] needs that is not the
@@ -2807,13 +2828,79 @@ const fn is_tuple_struct(item_struct: &syn::ItemStruct) -> bool {
     matches!(item_struct.fields, syn::Fields::Unnamed(_))
 }
 
-/// Walks a tuple struct's slots, returning their field defs in declaration order and the
-/// `compile_error!` tokens of every guard a slot violates.
+/// Whether the slot at `index` of a tuple struct declaring `declared_slots` slots carries serde
+/// attributes the wire answers for.
+///
+/// Captured from serde: a struct declaring exactly one slot writes and reads that slot's value
+/// whatever `skip`, `skip_serializing` or `skip_deserializing` says about it — a one-slot
+/// `#[serde(skip)]` struct holding `"s"` writes `"s"` and reads `"s"` back. So the slot spellings
+/// below are read only where serde reads them, which is a struct declaring more than one.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+const fn slot_attributes_reach_the_wire(declared_slots: usize) -> bool {
+    declared_slots > 1
+}
+
+/// Rejects a tuple-struct slot whose serde attributes drop it out of one of serde's two directions
+/// and not the other.
+///
+/// Captured from serde, on `struct S(#[serde(...)] Option<String>, String)` holding
+/// `(Some("s"), "x")`:
+/// - `skip_serializing` alone writes `["x"]` and reads only `["s","x"]`, refusing `["x"]` as
+///   `invalid length 1, expected tuple struct S with 2 elements`;
+/// - `skip_deserializing` alone writes `["s","x"]` and reads only `["x"]`, refusing `["s","x"]` as
+///   `trailing characters`;
+/// - `skip_serializing_if` writes `["s","x"]` or `["x"]` as its predicate decides, and reads only
+///   `["s","x"]`.
+///
+/// In each of them the array serde writes is not an array serde reads. A named field in the same
+/// position is describable — the key is simply absent from one payload and present in the other,
+/// which an optional key covers — but a slot is written by its place, so the two payloads differ in
+/// their arity and no fixed-arity tuple describes both. The declaration is refused rather than
+/// described, the way the named field whose omitted key serde cannot read back already is.
+///
+/// Not gated on the `serde` feature, and neither is the drop this stands beside: both read only the
+/// omission walk, which every build performs, and a toggle that changed the answer would leave one
+/// declaration refused in one build and described in another.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn check_slot_wire_is_readable(
+    field: &Field,
+    index: usize,
+    declared_slots: usize,
+    type_name: &str,
+    omission: SerdeKeyOmission,
+) -> Result<(), syn::Error> {
+    if !slot_attributes_reach_the_wire(declared_slots) || !omission.drops_one_direction_only() {
+        return Ok(());
+    }
+    Err(syn::Error::new_spanned(
+        field,
+        format!(
+            "model_schema: slot {index} of tuple struct `{type_name}` carries a serde attribute \
+             that drops it from only one of serde's two directions, so the array serde writes is \
+             not an array serde reads — one of them carries the slot and the other does not. A \
+             slot is written by its place rather than under a key, so there is no optional \
+             spelling to describe both and no schema can be written for the pair. Use \
+             #[serde(skip)] to take the slot off the wire in both directions, or drop the \
+             attribute so the slot is written and read in its place."
+        ),
+    ))
+}
+
+/// Walks a tuple struct's slots, returning the shape they publish and the `compile_error!` tokens
+/// of every guard a slot violates.
 ///
 /// Unlike [`collect_struct_fields`] the walk does not split on `#[serde(flatten)]`: a positional
 /// slot has no key for a flattened member to merge into, and dropping one here would silently
 /// change the arity the surfaces describe. The per-slot validators are dropped because a
 /// positional slot cannot carry a constraint — the guard that says so is what comes back instead.
+///
+/// A slot serde carries in neither direction is the one thing that does leave the walk. Captured:
+/// `struct S(#[serde(skip)] Option<String>, String)` holding `(Some("s"), "x")` writes `["x"]` and
+/// reads `["x"]` back, refusing `["s","x"]` as `trailing characters` — the slot is absent from the
+/// array in both directions, and the slots after it move up. So the described tuple is the slots
+/// that remain, which shrinks its arity, its `prefixItems` and its element types together. Every
+/// slot's def is still built before that decision, so a slot leaves the wire without taking the
+/// guards it violates with it.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn collect_tuple_slots(
     fields: &mut syn::Fields,
@@ -2822,12 +2909,19 @@ fn collect_tuple_slots(
     type_name: &str,
     generics: &syn::Generics,
     container_defaulted: bool,
-) -> (Vec<FieldDef>, Vec<proc_macro2::TokenStream>) {
+) -> (TupleStructShape, Vec<proc_macro2::TokenStream>) {
+    let declared_slots = fields.len();
     let type_parameters = type_parameters_in_scope(generics);
     let mut slots: Vec<FieldDef> = Vec::new();
     let mut guard_errors: Vec<proc_macro2::TokenStream> = Vec::new();
     let mut deferred_attrs: Vec<Vec<syn::Attribute>> = Vec::new();
-    for field in fields.iter_mut() {
+    for (index, field) in fields.iter_mut().enumerate() {
+        let omission = parse_serde_key_omission(&field.attrs);
+        if let Err(rejection) =
+            check_slot_wire_is_readable(field, index, declared_slots, type_name, omission)
+        {
+            guard_errors.push(rejection.to_compile_error());
+        }
         let (slot, _, _, slot_guard_errors) = process_field(
             &FieldContext {
                 container_defaulted,
@@ -2841,59 +2935,74 @@ fn collect_tuple_slots(
             &mut deferred_attrs,
         );
         guard_errors.extend(slot_guard_errors);
+        if slot_attributes_reach_the_wire(declared_slots) && omission.absent_from_wire() {
+            continue;
+        }
         slots.push(slot);
     }
     if guard_errors.is_empty() {
         apply_deferred_field_attrs(fields.iter_mut(), deferred_attrs);
     }
-    (slots, guard_errors)
+    (tuple_struct_shape(declared_slots, slots), guard_errors)
+}
+
+/// The shape a tuple struct's declared arity and described slots amount to.
+///
+/// The bare value is keyed on the *declared* arity, not on how many slots came back described: a
+/// struct declaring two slots with one of them off the wire writes a one-element array, and reading
+/// the described count would collapse it to the bare value serde does not write there.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn tuple_struct_shape(declared_slots: usize, mut slots: Vec<FieldDef>) -> TupleStructShape {
+    if declared_slots == 1 && slots.len() == 1 {
+        return TupleStructShape::BareValue(Box::new(slots.remove(0)));
+    }
+    TupleStructShape::Array(slots)
 }
 
 /// The TypeScript type a tuple struct describes as.
 ///
-/// A single slot is the slot's own type: serde writes a newtype struct as that value alone, with
-/// nothing around it. Every other arity — the empty one included, which writes `[]` — is the fixed
-/// tuple the same slots describe as when they are written as a tuple field.
+/// The bare value is the slot's own type: serde writes a newtype struct as that value alone, with
+/// nothing around it. Every array — the empty one included, which writes `[]` — is the fixed tuple
+/// the slots on the wire describe as when they are written as a tuple field.
 #[cfg(feature = "typescript")]
-fn tuple_struct_ts_body(slots: &[FieldDef]) -> String {
-    if let [slot] = slots {
-        return slot.typescript_slot_typename();
+fn tuple_struct_ts_body(shape: &TupleStructShape) -> String {
+    match shape {
+        TupleStructShape::Array(slots) => format!(
+            "[{}]",
+            slots
+                .iter()
+                .map(FieldDef::typescript_slot_typename)
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+        TupleStructShape::BareValue(slot) => slot.typescript_slot_typename(),
     }
-    format!(
-        "[{}]",
-        slots
-            .iter()
-            .map(FieldDef::typescript_slot_typename)
-            .collect::<Vec<_>>()
-            .join(", ")
-    )
 }
 
 /// [`tuple_struct_ts_body`] for the Zod surface.
 #[cfg(feature = "zod")]
-fn tuple_struct_zod_body(slots: &[FieldDef]) -> String {
-    if let [slot] = slots {
-        return slot.zod_slot_type();
+fn tuple_struct_zod_body(shape: &TupleStructShape) -> String {
+    match shape {
+        TupleStructShape::Array(slots) => format!(
+            "z.tuple([{}])",
+            slots
+                .iter()
+                .map(FieldDef::zod_slot_type)
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+        TupleStructShape::BareValue(slot) => slot.zod_slot_type(),
     }
-    format!(
-        "z.tuple([{}])",
-        slots
-            .iter()
-            .map(FieldDef::zod_slot_type)
-            .collect::<Vec<_>>()
-            .join(", ")
-    )
 }
 
 /// [`tuple_struct_ts_body`] for the JSON-schema surface, as a standalone `serde_json::Value`
 /// expression, or the diagnostic naming the type when a slot holds a value the dispatch cannot
 /// render.
 #[cfg(feature = "jsonschema")]
-fn tuple_struct_json_body(item_name: &str, slots: &[FieldDef]) -> proc_macro2::TokenStream {
-    let described = if let [slot] = slots {
-        build_tuple_element_json_schema(slot)
-    } else {
-        tuple_json_schema_value(slots)
+fn tuple_struct_json_body(item_name: &str, shape: &TupleStructShape) -> proc_macro2::TokenStream {
+    let described = match shape {
+        TupleStructShape::Array(slots) => tuple_json_schema_value(slots),
+        TupleStructShape::BareValue(slot) => build_tuple_element_json_schema(slot),
     };
     match described {
         Ok(value) => value,
@@ -2980,7 +3089,7 @@ fn process_tuple_struct(
         tuple_struct_surface(&item_struct.fields),
     );
 
-    let (slots, guard_errors) = collect_tuple_slots(
+    let (shape, guard_errors) = collect_tuple_slots(
         &mut item_struct.fields,
         rename_all,
         &module_name,
@@ -3002,21 +3111,21 @@ fn process_tuple_struct(
 
     let schema_impl_items: Vec<proc_macro2::TokenStream> = vec![
         #[cfg(feature = "jsonschema")]
-        json_schema_methods(&item_name, &tuple_struct_json_body(&item_name, &slots)),
+        json_schema_methods(&item_name, &tuple_struct_json_body(&item_name, &shape)),
         #[cfg(feature = "typescript")]
         build_tuple_struct_ts_definition_method(
             &build_jsdoc_body(docs_and_example.0.as_deref(), &item_name),
             &item_name,
             &name.to_string(),
             &ts_generic_params(&item_struct.generics),
-            &tuple_struct_ts_body(&slots),
+            &tuple_struct_ts_body(&shape),
         ),
         #[cfg(feature = "zod")]
         build_tuple_struct_zod_schema_method(
             &item_name,
             &name.to_string(),
             &type_parameters_in_scope(&item_struct.generics),
-            &tuple_struct_zod_body(&slots),
+            &tuple_struct_zod_body(&shape),
         ),
     ];
 
@@ -9002,7 +9111,7 @@ fn field_ident_string(field: &Field) -> String {
 fn apply_serde_key_omission(field_def: &mut FieldDef, field: &Field) {
     let omission = parse_serde_key_omission(&field.attrs);
     field_def.omits_value = field.ident.is_some() && omission.omits_key;
-    field_def.absent_from_wire = field_def.omits_value && omission.skips_deserializing;
+    field_def.absent_from_wire = field.ident.is_some() && omission.absent_from_wire();
 }
 
 /// Adds the field to the list every surface is built from, unless the wire carries its key in

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -34,6 +34,9 @@ use super::tuple_struct_zod_body;
 #[cfg(feature = "jsonschema")]
 use super::tuple_struct_json_body;
 
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+use super::{check_slot_wire_is_readable, parse_serde_key_omission, tuple_struct_shape};
+
 use syn::spanned::Spanned as _;
 
 /// The variants of [`rendered_discriminated_union`]'s enum, in the order they are declared.
@@ -67,6 +70,19 @@ const UNPORTABLE_PROBE_PATTERNS: [(&str, &str); 6] = [
     ("^[[:alpha:]]+$", "POSIX class"),
     (r"[\w&&\d]", "`&&` class intersection"),
     (r"\x{41}", "braced code point escape"),
+];
+
+/// Every slot spelling the refusal reads, beside whether it is refused. A slot dropped from one of
+/// serde's directions and not the other is; the pair that drops both is the wire the description
+/// already answers for, and everything else is a slot written in its place.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+const SLOT_OMISSION_SPELLINGS: [(&str, bool); 6] = [
+    ("skip_serializing", true),
+    ("skip_serializing_if = \"Option::is_none\"", true),
+    ("skip_deserializing", true),
+    ("skip", false),
+    ("skip_serializing, skip_deserializing", false),
+    ("default", false),
 ];
 
 /// The covered wrappers, under the names a dispatch reads them by.
@@ -6408,15 +6424,21 @@ fn tuple_slots(spellings: &[&str]) -> Vec<super::FieldDef> {
         .collect()
 }
 
+/// The shape a struct declaring exactly the given slots publishes, none of them off the wire.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn whole_tuple(spellings: &[&str]) -> super::TupleStructShape {
+    tuple_struct_shape(spellings.len(), tuple_slots(spellings))
+}
+
 /// One slot is the slot's own type — serde writes a newtype struct as that value alone — and every
 /// other arity is the fixed tuple serde writes as an array.
 #[cfg(feature = "typescript")]
 #[test]
 fn a_tuple_struct_describes_as_its_arity_in_typescript() {
-    assert_eq!(tuple_struct_ts_body(&tuple_slots(&[])), "[]");
-    assert_eq!(tuple_struct_ts_body(&tuple_slots(&["String"])), "string");
+    assert_eq!(tuple_struct_ts_body(&whole_tuple(&[])), "[]");
+    assert_eq!(tuple_struct_ts_body(&whole_tuple(&["String"])), "string");
     assert_eq!(
-        tuple_struct_ts_body(&tuple_slots(&["String", "u32"])),
+        tuple_struct_ts_body(&whole_tuple(&["String", "u32"])),
         "[string, number]"
     );
 }
@@ -6425,13 +6447,13 @@ fn a_tuple_struct_describes_as_its_arity_in_typescript() {
 #[cfg(feature = "zod")]
 #[test]
 fn a_tuple_struct_describes_as_its_arity_in_zod() {
-    assert_eq!(tuple_struct_zod_body(&tuple_slots(&[])), "z.tuple([])");
+    assert_eq!(tuple_struct_zod_body(&whole_tuple(&[])), "z.tuple([])");
     assert_eq!(
-        tuple_struct_zod_body(&tuple_slots(&["String"])),
+        tuple_struct_zod_body(&whole_tuple(&["String"])),
         "z.string()"
     );
     assert_eq!(
-        tuple_struct_zod_body(&tuple_slots(&["String", "u32"])),
+        tuple_struct_zod_body(&whole_tuple(&["String", "u32"])),
         "z.tuple([z.string(), z.number().int()])"
     );
 }
@@ -6441,17 +6463,101 @@ fn a_tuple_struct_describes_as_its_arity_in_zod() {
 #[cfg(feature = "jsonschema")]
 #[test]
 fn a_tuple_struct_describes_as_its_arity_in_json_schema() {
-    let empty = tuple_struct_json_body("Nothing", &tuple_slots(&[])).to_string();
+    let empty = tuple_struct_json_body("Nothing", &whole_tuple(&[])).to_string();
     assert!(empty.contains("prefixItems"), "Got: {empty}");
     assert!(empty.contains("minItems"), "Got: {empty}");
 
-    let single = tuple_struct_json_body("Plain", &tuple_slots(&["String"])).to_string();
+    let single = tuple_struct_json_body("Plain", &whole_tuple(&["String"])).to_string();
     assert!(single.contains("string"), "Got: {single}");
     assert!(!single.contains("prefixItems"), "Got: {single}");
 
-    let pair = tuple_struct_json_body("Pair", &tuple_slots(&["String", "u32"])).to_string();
+    let pair = tuple_struct_json_body("Pair", &whole_tuple(&["String", "u32"])).to_string();
     assert!(pair.contains("prefixItems"), "Got: {pair}");
     assert!(pair.contains("maxItems"), "Got: {pair}");
+}
+
+/// The bare value is the *declared* arity's, not the described list's. Captured from serde: a
+/// struct declaring two slots with the first one taken off the wire writes `["x"]` — a one-element
+/// array, not the bare `"x"` a struct declaring one slot writes — so a described list that has
+/// shrunk to one still describes as an array.
+#[cfg(feature = "typescript")]
+#[test]
+fn a_slot_dropped_off_the_wire_leaves_the_tuple_an_array() {
+    let shrunk = tuple_struct_shape(2, tuple_slots(&["String"]));
+    assert_eq!(tuple_struct_ts_body(&shrunk), "[string]");
+    assert_eq!(
+        tuple_struct_ts_body(&tuple_struct_shape(1, tuple_slots(&["String"]))),
+        "string"
+    );
+}
+
+/// The same reading on the JSON surface, where the arity is written twice as its own bounds.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_slot_dropped_off_the_wire_shrinks_the_described_arity() {
+    let shrunk = tuple_struct_json_body("Pair", &tuple_struct_shape(2, tuple_slots(&["u32"])));
+    let rendered = shrunk.to_string();
+    assert!(rendered.contains("prefixItems"), "Got: {rendered}");
+    assert!(rendered.contains("1usize"), "Got: {rendered}");
+    assert!(!rendered.contains("2usize"), "Got: {rendered}");
+}
+
+/// A two-slot struct whose second slot is written at the given spelling.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn slot_pair(spelling: &str) -> syn::ItemStruct {
+    syn::parse_str(&format!(
+        "struct Pair(String, #[serde({spelling})] Option<String>);"
+    ))
+    .unwrap()
+}
+
+/// Runs the slot refusal over that struct's second slot, with the declared arity supplied rather
+/// than counted, so the lone-slot exemption can be read off the same declaration.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn slot_guard_result(item: &syn::ItemStruct, declared_slots: usize) -> Result<(), syn::Error> {
+    let field = item.fields.iter().nth(1).unwrap();
+    check_slot_wire_is_readable(
+        field,
+        1,
+        declared_slots,
+        "Pair",
+        parse_serde_key_omission(&field.attrs),
+    )
+}
+
+/// The refusal message for the slot at that spelling, and `None` where it is left alone.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn slot_refusal(spelling: &str, declared_slots: usize) -> Option<String> {
+    slot_guard_result(&slot_pair(spelling), declared_slots)
+        .err()
+        .map(|err| err.to_string())
+}
+
+/// Captured from serde on `struct S(#[serde(...)] Option<String>, String)`: `skip_serializing`
+/// alone writes `["x"]` and reads only `["s","x"]`, `skip_deserializing` alone writes `["s","x"]`
+/// and reads only `["x"]`. The array serde writes is not an array serde reads, and a slot has no
+/// optional spelling to describe both, so the declaration is refused.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn a_slot_dropped_from_one_direction_only_is_refused() {
+    for (spelling, refused) in SLOT_OMISSION_SPELLINGS {
+        let refusal = slot_refusal(spelling, 2);
+        assert_eq!(refusal.is_some(), refused, "{spelling}: {refusal:?}");
+        if let Some(message) = refusal {
+            assert!(message.contains("slot 1"), "{spelling}: {message}");
+            assert!(message.contains("`Pair`"), "{spelling}: {message}");
+        }
+    }
+}
+
+/// Captured from serde: a struct declaring exactly one slot writes and reads that slot's value
+/// whatever the skip spellings say, so none of them has a wire to be refused for there.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn a_lone_slot_is_refused_for_no_spelling() {
+    for (spelling, _) in SLOT_OMISSION_SPELLINGS {
+        assert_eq!(slot_refusal(spelling, 1), None, "for: {spelling}");
+    }
 }
 
 /// A path writes a string on the wire, which is the value the rendered constraint describes, so

--- a/tests/readme_example_tests/tests.rs
+++ b/tests/readme_example_tests/tests.rs
@@ -22,6 +22,55 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use tixschema::model_schema;
 
+/// The predicate bullet: the key goes missing when the predicate fires, so the member is described
+/// under an optional key rather than left untouched.
+const PREDICATE_BULLET: &str = "- `#[serde(skip_serializing_if = \"...\")]` -- the key is left out of the payload when the predicate fires, so the member is described under an optional key: `roles?: Array<string>;` in TypeScript, `roles: z.array(z.string()).optional(),` in Zod, and no `required` entry in the JSON Schema";
+
+/// The bare-`skip` bullet, whose claim is an absence on every surface.
+const SKIP_BULLET: &str = "- `#[serde(skip)]` -- the key is written into no payload and read out of none, so no surface describes the member at all: no TypeScript member, no Zod key, and neither a `properties` nor a `required` entry. On a tuple-struct slot it takes the slot out of the described tuple, which shortens the arity";
+
+/// The write-half bullet, which lands where the predicate bullet does.
+const WRITE_HALF_BULLET: &str = "- `#[serde(skip_serializing)]` -- the write half of `skip`: the key is left out of every payload while a supplied one is still read, so the member is described under an optional key, as `skip_serializing_if` is";
+
+/// The read-half bullet, the one spelling of the three that keeps a required key.
+const READ_HALF_BULLET: &str = "- `#[serde(skip_deserializing)]` -- the read half: the key is written into every payload while a supplied one is discarded, so the member keeps a required key";
+
+/// The predicate spelling the bullet names, declared as the bullet describes it.
+#[model_schema()]
+#[derive(Serialize, Deserialize)]
+pub struct PredicateOmittedKey {
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub roles: Vec<String>,
+}
+
+/// The bare `skip`, whose member no surface carries.
+#[model_schema()]
+#[derive(Serialize, Deserialize)]
+pub struct FullySkipped {
+    pub id: String,
+    #[serde(skip)]
+    pub roles: Vec<String>,
+}
+
+/// The write half alone.
+#[model_schema()]
+#[derive(Serialize, Deserialize)]
+pub struct WriteHalfDropped {
+    pub id: String,
+    #[serde(default, skip_serializing)]
+    pub roles: Vec<String>,
+}
+
+/// The read half alone.
+#[model_schema()]
+#[derive(Serialize, Deserialize)]
+pub struct ReadHalfDropped {
+    pub id: String,
+    #[serde(skip_deserializing)]
+    pub roles: Vec<String>,
+}
+
 fn readme() -> &'static str {
     include_str!("../../README.md")
 }
@@ -76,6 +125,114 @@ fn test_the_optional_fields_example_is_declarable_and_shows_what_it_emits() {
             "};",
         ],
     );
+}
+
+/// A bullet from the "Supported Serde attributes" list, held to what it claims the generator
+/// writes.
+///
+/// Three things have to agree: the README still carries the bullet as its own line, the bullet
+/// still quotes each spelling, and the generator still writes it. A bullet summarising an attribute
+/// it no longer describes correctly is what this catches — the list stated for a long time that
+/// `skip_serializing_if` did not affect the generated types, which the omitted-key contract had
+/// already made false.
+fn assert_readme_bullet_shows(bullet: &str, emission: &str, spellings: &[&str]) {
+    assert!(
+        readme().lines().any(|line| line == bullet),
+        "the README no longer carries this bullet verbatim:\n{bullet}"
+    );
+    for spelling in spellings {
+        assert!(
+            bullet.contains(spelling),
+            "the bullet no longer quotes this spelling: {spelling}"
+        );
+        assert!(
+            emission.contains(spelling),
+            "the generator no longer writes this spelling: {spelling}\nGot: {emission}"
+        );
+    }
+}
+
+/// The predicate bullet quotes two spellings, and both are read off a real emission.
+#[test]
+fn test_the_predicate_bullet_shows_the_optional_key_it_claims() {
+    assert_readme_bullet_shows(
+        PREDICATE_BULLET,
+        &PredicateOmittedKey::ts_definition(),
+        &["roles?: Array<string>;"],
+    );
+
+    #[cfg(feature = "zod")]
+    assert_readme_bullet_shows(
+        PREDICATE_BULLET,
+        &PredicateOmittedKey::zod_schema(),
+        &["roles: z.array(z.string()).optional(),"],
+    );
+}
+
+/// The three `skip` spellings are three different answers, and the bullets separating them are held
+/// to each one: no member, an optional key, a required key. Each is read against the wire the
+/// bullet claims for it, so a bullet cannot drift from the payload it summarises either.
+#[test]
+fn test_the_skip_bullets_show_the_three_answers_they_separate() {
+    assert_readme_bullet_shows(SKIP_BULLET, &FullySkipped::ts_definition(), &[]);
+    let written = serde_json::to_string(&FullySkipped {
+        id: "1".to_owned(),
+        roles: vec!["x".to_owned()],
+    })
+    .unwrap();
+    assert_eq!(written, r#"{"id":"1"}"#);
+    let read_back = serde_json::from_str::<FullySkipped>(r#"{"id":"1","roles":["x"]}"#).unwrap();
+    assert_eq!(read_back.roles, Vec::<String>::new());
+    let skipped = FullySkipped::ts_definition();
+    assert!(!skipped.contains("roles"), "Got: {skipped}");
+
+    assert_readme_bullet_shows(WRITE_HALF_BULLET, &WriteHalfDropped::ts_definition(), &[]);
+    let supplied = serde_json::from_str::<WriteHalfDropped>(r#"{"id":"1","roles":["x"]}"#).unwrap();
+    assert_eq!(supplied.roles, vec!["x".to_owned()]);
+    let write_half = WriteHalfDropped::ts_definition();
+    assert!(
+        write_half.contains("roles?: Array<string>;"),
+        "Got: {write_half}"
+    );
+
+    assert_readme_bullet_shows(READ_HALF_BULLET, &ReadHalfDropped::ts_definition(), &[]);
+    let read_half = ReadHalfDropped::ts_definition();
+    assert!(
+        read_half.contains("roles: Array<string>;"),
+        "Got: {read_half}"
+    );
+    assert!(!read_half.contains("roles?"), "Got: {read_half}");
+}
+
+/// The slot spellings the "Optional Fields" section quotes for a dropped tuple-struct slot, read
+/// off the declaration it shows them for.
+#[test]
+fn test_the_optional_fields_section_shows_the_slot_tuple_it_claims() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize)]
+    pub struct Pair(#[serde(skip)] pub Option<String>, pub String);
+
+    assert_readme_declares_and_shows(
+        "`struct Pair(#[serde(skip)] Option<String>, String)`",
+        &Pair::ts_definition(),
+        &[],
+    );
+
+    let written = serde_json::to_string(&Pair(Some("s".to_owned()), "x".to_owned())).unwrap();
+    assert_eq!(written, r#"["x"]"#);
+    assert_eq!(serde_json::from_str::<Pair>(r#"["x"]"#).unwrap().0, None);
+    assert!(readme().contains(r#"writes `["x"]`, reads that back, and refuses `["s","x"]`"#));
+
+    let ts = Pair::ts_definition();
+    assert!(ts.contains("= [string];"), "Got: {ts}");
+    assert!(readme().contains("`[string]` in TypeScript"));
+
+    #[cfg(feature = "zod")]
+    {
+        let zod = Pair::zod_schema();
+        assert!(zod.contains("= z.tuple([z.string()]);"), "Got: {zod}");
+        assert!(readme().contains("`z.tuple([z.string()])` in Zod"));
+    }
 }
 
 /// The "Collections and Maps" example. It shows no emission of its own — the section is about what

--- a/tests/tuple_struct_tests/tests.rs
+++ b/tests/tuple_struct_tests/tests.rs
@@ -17,6 +17,40 @@ pub struct Pair(pub String, pub u32);
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct MaybeName(pub Option<String>);
 
+/// A slot serde carries in neither direction: it is absent from the array serde writes and from
+/// every array serde reads, and the slot behind it moves up into its place.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct SkippedLeadSlot(#[serde(skip)] pub Option<String>, pub String);
+
+/// The same wire, written as the two halves rather than the word abbreviating them.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct BothHalvesDroppedSlot(
+    #[serde(skip_serializing, skip_deserializing)] pub Option<String>,
+    pub String,
+);
+
+/// A dropped slot at the end, where nothing moves up behind it and only the arity changes.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct SkippedTrailingSlot(pub String, #[serde(skip)] pub u32);
+
+/// A dropped slot between two carried ones, which is where renumbering is visible.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct SkippedMiddleSlot(pub String, #[serde(skip)] pub Option<String>, pub u32);
+
+/// Every slot dropped, which serde writes as the empty array rather than as nothing at all.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct EverySlotSkipped(#[serde(skip)] pub String, #[serde(skip)] pub u32);
+
+/// The lone slot of a newtype struct, which serde writes and reads whatever the attribute says.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct SkippedLoneSlot(#[serde(skip)] pub String);
+
 /// The wire criterion the newtype surfaces are read against.
 #[test]
 fn test_serde_writes_a_newtype_struct_as_the_inner_value_alone() {
@@ -177,6 +211,199 @@ fn test_an_optional_slot_describes_the_null_it_writes_in_json_schema() {
     assert_eq!(
         MaybeName::json_schema(),
         serde_json::json!({ "anyOf": [{ "type": "string" }, { "type": "null" }] })
+    );
+}
+
+/// The wire criterion every dropped-slot surface below is read against, in both directions: the
+/// slot is absent from the array serde writes, and the full-arity array — the one the surfaces used
+/// to describe — is refused on the way in.
+#[test]
+fn test_serde_writes_and_reads_a_dropped_slot_in_neither_direction() {
+    let written =
+        serde_json::to_value(SkippedLeadSlot(Some("s".to_owned()), "x".to_owned())).unwrap();
+    assert_eq!(written, serde_json::json!(["x"]));
+
+    assert_eq!(
+        serde_json::from_value::<SkippedLeadSlot>(written).unwrap(),
+        SkippedLeadSlot(None, "x".to_owned())
+    );
+    assert!(
+        serde_json::from_str::<SkippedLeadSlot>(r#"["s","x"]"#).is_err(),
+        "the full-arity array must not read back"
+    );
+}
+
+/// The halves written side by side are that same wire, so they owe the same surfaces.
+#[test]
+fn test_the_two_halves_written_together_are_the_same_slot_wire() {
+    assert_eq!(
+        serde_json::to_value(BothHalvesDroppedSlot(Some("s".to_owned()), "x".to_owned())).unwrap(),
+        serde_json::json!(["x"])
+    );
+    assert!(
+        serde_json::from_str::<BothHalvesDroppedSlot>(r#"["s","x"]"#).is_err(),
+        "the full-arity array must not read back"
+    );
+}
+
+/// The wire criterion for the remaining positions: a trailing drop only shortens the array, a
+/// middle one moves the slot behind it up, and dropping every slot still writes an array.
+#[test]
+fn test_serde_writes_the_slots_it_still_carries_in_their_new_places() {
+    assert_eq!(
+        serde_json::to_value(SkippedTrailingSlot("s".to_owned(), 1_u32)).unwrap(),
+        serde_json::json!(["s"])
+    );
+    assert_eq!(
+        serde_json::to_value(SkippedMiddleSlot(
+            "a".to_owned(),
+            Some("s".to_owned()),
+            7_u32
+        ))
+        .unwrap(),
+        serde_json::json!(["a", 7_u32])
+    );
+    assert_eq!(
+        serde_json::to_value(EverySlotSkipped("s".to_owned(), 1_u32)).unwrap(),
+        serde_json::json!([])
+    );
+}
+
+/// The wire criterion the lone slot's surfaces are read against: serde writes and reads a newtype
+/// struct's only slot whatever the attribute on it says, so nothing is dropped there.
+#[test]
+fn test_serde_writes_a_lone_slot_whatever_the_skip_says() {
+    assert_eq!(
+        serde_json::to_value(SkippedLoneSlot("s".to_owned())).unwrap(),
+        serde_json::json!("s")
+    );
+    assert_eq!(
+        serde_json::from_str::<SkippedLoneSlot>(r#""s""#).unwrap(),
+        SkippedLoneSlot("s".to_owned())
+    );
+}
+
+/// The described tuple is the slots the wire carries: the dropped one is not an element, and the
+/// arity is the one serde writes rather than the one the struct declares.
+#[cfg(feature = "typescript")]
+#[test]
+fn test_a_dropped_slot_is_no_element_of_the_typescript_tuple() {
+    let wire = serde_json::to_value(SkippedLeadSlot(Some("s".to_owned()), "x".to_owned())).unwrap();
+    assert_eq!(wire, serde_json::json!(["x"]));
+
+    let ts = SkippedLeadSlot::ts_definition();
+    assert!(
+        ts.contains("export type SkippedLeadSlot = [string];"),
+        "Got: {ts}"
+    );
+    assert!(!ts.contains("null"), "Got: {ts}");
+}
+
+/// The halves written apart are one wire, so they are one emission.
+#[cfg(feature = "typescript")]
+#[test]
+fn test_typescript_answers_the_two_slot_halves_the_way_it_answers_the_word() {
+    let ts = BothHalvesDroppedSlot::ts_definition();
+    assert!(
+        ts.contains("export type BothHalvesDroppedSlot = [string];"),
+        "Got: {ts}"
+    );
+}
+
+/// Every remaining position, each read against the array serde writes for it.
+#[cfg(feature = "typescript")]
+#[test]
+fn test_typescript_describes_the_arity_each_drop_leaves() {
+    for (ts, expected) in [
+        (SkippedTrailingSlot::ts_definition(), "[string]"),
+        (SkippedMiddleSlot::ts_definition(), "[string, number]"),
+        (EverySlotSkipped::ts_definition(), "[]"),
+        (SkippedLoneSlot::ts_definition(), "string"),
+    ] {
+        assert!(ts.contains(&format!("= {expected};")), "Got: {ts}");
+    }
+}
+
+/// The Zod tuple is the one the payload serde writes satisfies. Recorded against zod 4.1.8 under
+/// node v26.2.0: `z.tuple([z.string()])` accepts `["x"]` and rejects `["s","x"]` with `too_big`,
+/// which is the pair serde writes and refuses. The two-element tuple this used to emit,
+/// `z.tuple([z.nullable(z.string()), z.string()])`, rejects `["x"]` with `invalid_type` — the only
+/// payload serde writes.
+#[cfg(feature = "zod")]
+#[test]
+fn test_a_dropped_slot_is_no_element_of_the_zod_tuple() {
+    let wire = serde_json::to_value(SkippedLeadSlot(Some("s".to_owned()), "x".to_owned())).unwrap();
+    assert_eq!(wire, serde_json::json!(["x"]));
+
+    let zod = SkippedLeadSlot::zod_schema();
+    assert!(zod.contains("= z.tuple([z.string()]);"), "Got: {zod}");
+    assert!(!zod.contains("nullable"), "Got: {zod}");
+}
+
+/// [`test_typescript_describes_the_arity_each_drop_leaves`] for the Zod surface.
+#[cfg(feature = "zod")]
+#[test]
+fn test_zod_describes_the_arity_each_drop_leaves() {
+    for (zod, expected) in [
+        (SkippedTrailingSlot::zod_schema(), "z.tuple([z.string()])"),
+        (
+            SkippedMiddleSlot::zod_schema(),
+            "z.tuple([z.string(), z.number().int()])",
+        ),
+        (EverySlotSkipped::zod_schema(), "z.tuple([])"),
+        (SkippedLoneSlot::zod_schema(), "z.string()"),
+    ] {
+        assert!(zod.contains(&format!("= {expected};")), "Got: {zod}");
+    }
+}
+
+/// The JSON surface carries the arity twice more, as its own bounds, and both move with the drop.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn test_a_dropped_slot_leaves_the_json_schema_prefix_and_its_bounds() {
+    let wire = serde_json::to_value(SkippedLeadSlot(Some("s".to_owned()), "x".to_owned())).unwrap();
+    assert_eq!(wire, serde_json::json!(["x"]));
+
+    assert_eq!(
+        SkippedLeadSlot::json_schema(),
+        serde_json::json!({
+            "type": "array",
+            "prefixItems": [{ "type": "string" }],
+            "items": false,
+            "minItems": 1_u32,
+            "maxItems": 1_u32
+        })
+    );
+}
+
+/// [`test_typescript_describes_the_arity_each_drop_leaves`] for the JSON-schema surface, where the
+/// empty array is the one shape that keeps `prefixItems` and drops every element from it.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn test_the_json_schema_describes_the_arity_each_drop_leaves() {
+    assert_eq!(
+        SkippedMiddleSlot::json_schema(),
+        serde_json::json!({
+            "type": "array",
+            "prefixItems": [{ "type": "string" }, { "type": "integer" }],
+            "items": false,
+            "minItems": 2_u32,
+            "maxItems": 2_u32
+        })
+    );
+    assert_eq!(
+        EverySlotSkipped::json_schema(),
+        serde_json::json!({
+            "type": "array",
+            "prefixItems": [],
+            "items": false,
+            "minItems": 0_u32,
+            "maxItems": 0_u32
+        })
+    );
+    assert_eq!(
+        SkippedLoneSlot::json_schema(),
+        serde_json::json!({ "type": "string" })
     );
 }
 


### PR DESCRIPTION
The captured slot wires overturned the spec's own guess: a bare `#[serde(skip)]` slot (and both halves together) drops from the described tuple — arity bounds, `prefixItems`, and the TS/Zod tuple types shrink together at the one collection seam — while each HALF alone puts serde's write shape and read shape at different arities, which no fixed-arity tuple can describe; both are refused at expansion, the treatment the named-field landing already established for unreadable omissions (`skip_serializing_if` on a slot falls under the same captured reason). A single-slot struct is exempt in both directions — serde writes and reads a newtype's only slot whatever the attribute says — and the newtype collapse now keys on DECLARED arity so a two-slot struct with one slot dropped stays `[string]` rather than collapsing to the bare value serde does not write. Recorded zod verdicts: the old emission rejected the only payload serde writes.

The README's serde-attribute bullets now state each spelling's captured contract — the false 'does not affect generated types' line replaced — with a pin holding README line, quoted spelling, and generator emission together. The tuple-variant seam's same defect is filed with captures.