### PR TITLE
Render generic examples at the declared default filling

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -1172,11 +1172,13 @@ fn enum_schema_example_method(
     docs_vec: Option<&[String]>,
     name: &syn::Ident,
     generics: &syn::Generics,
+    args: &ModelSchemaArgs,
 ) -> Option<proc_macro2::TokenStream> {
     item_schema_example_method(
         docs_vec.and_then(extract_example_from_docs).as_ref(),
         name,
         generics,
+        args,
     )
 }
 
@@ -1188,19 +1190,26 @@ const fn enum_schema_example_method(
     _docs_vec: Option<&[String]>,
     _name: &syn::Ident,
     _generics: &syn::Generics,
+    _args: &ModelSchemaArgs,
 ) -> Option<proc_macro2::TokenStream> {
     None
 }
 
-/// The type a doc example's value is annotated with: the item's own name, with every parameter it
-/// declares instantiated at `String`.
+/// The type a doc example's value is annotated with: the item's own name, with every type parameter
+/// it declares instantiated at the type `default_types` declares for it, or at `String` where it
+/// declares none.
 ///
 /// The example is Rust the expansion has to compile, and a parameter names no type to compile it
-/// at — a bare ident is `E0107` before anything runs. Nothing in the attribute says which filling
-/// to pick and the example code itself names only one, so the convention is `String`: the one
-/// concrete type every example can be written against, whatever the item holds. The argument list
-/// is as long as the parameter list rather than one long, so an item declaring two parameters is
-/// annotated with two arguments.
+/// at — a bare ident is `E0107` before anything runs. `default_types` is the one argument that
+/// names a concrete type per parameter, so a parameter it fills is annotated at the author's own
+/// statement of what the item holds: an annotation picked over that filling would contradict it
+/// (`E0308`) and would fail any bound the filling satisfies and the picked type does not
+/// (`E0277`). Where the filling itself fails a bound, the item is refused on the declaration that
+/// named it rather than here. A parameter with no filling falls back to `String`, the one concrete
+/// type an example can be written against absent a statement of what the item holds; with
+/// `jsonschema` on the fillings are already required for every parameter, so the fallback is
+/// reached only in a build without it. The argument list is as long as the parameter list rather
+/// than one long, so an item declaring two parameters is annotated with two arguments.
 ///
 /// Lifetimes and consts are not here, [`type_parameters_in_scope`] leaving both out: a lifetime in
 /// a `let` annotation elides, and a const has no filling this convention could name.
@@ -1208,11 +1217,17 @@ const fn enum_schema_example_method(
 fn schema_example_value_type(
     name: &syn::Ident,
     generic_params: &[String],
+    default_types: &[(syn::Ident, syn::Type)],
 ) -> proc_macro2::TokenStream {
     if generic_params.is_empty() {
         return quote! { #name };
     }
-    let args = generic_params.iter().map(|_| quote! { String });
+    let args = generic_params.iter().map(|param| {
+        default_types
+            .iter()
+            .find(|(declared, _)| declared == param.as_str())
+            .map_or_else(|| quote! { String }, |(_, ty)| quote! { #ty })
+    });
     quote! { #name<#(#args),*> }
 }
 
@@ -1227,10 +1242,15 @@ fn item_schema_example_method(
     example_code: Option<&String>,
     name: &syn::Ident,
     generics: &syn::Generics,
+    args: &ModelSchemaArgs,
 ) -> Option<proc_macro2::TokenStream> {
     let code = example_code?;
     let code_tokens: proc_macro2::TokenStream = code.parse().unwrap();
-    let value_ty = schema_example_value_type(name, &type_parameters_in_scope(generics));
+    let value_ty = schema_example_value_type(
+        name,
+        &type_parameters_in_scope(generics),
+        &args.default_types,
+    );
     Some(quote! {
         pub fn schema_example() -> serde_json::Value {
             let value: #value_ty = {
@@ -1249,6 +1269,7 @@ const fn item_schema_example_method(
     _example_code: Option<&String>,
     _name: &syn::Ident,
     _generics: &syn::Generics,
+    _args: &ModelSchemaArgs,
 ) -> Option<proc_macro2::TokenStream> {
     None
 }
@@ -1969,12 +1990,13 @@ fn missing_default_message(name: &syn::Ident, declared: &[&syn::Ident]) -> Strin
 /// const.
 ///
 /// A doc example is Rust the expansion has to compile, so its value is annotated with the item's
-/// own name at one instantiation — every parameter filled in, `String` being the filling for a type
-/// parameter. A const takes no filling from that convention: `String` names a type, and a const is
-/// a value. Nor can one be read off the item, since no value is the one every const-parameterised
-/// example is written at, and picking one here would render the example at a length the author
-/// never wrote. So the example is refused where it was written, rather than expanded into an
-/// annotation that fails `E0107` before anything runs.
+/// own name at one instantiation — every parameter filled in, a type parameter taking the type
+/// `default_types` declares for it or `String` where it declares none. A const takes no filling
+/// from that convention: both spellings name a type, and a const is a value. Nor can one be read
+/// off the item, since `default_types` declares types and no value is the one every
+/// const-parameterised example is written at, so one picked here would render the example at a
+/// length the author never wrote. So the example is refused where it was written, rather than
+/// expanded into an annotation that fails `E0107` before anything runs.
 ///
 /// Answered at the one seam every expanded shape is dispatched from, so a struct and an enum cannot
 /// come to answer differently, and a branded newtype is answered before the struct path splits it
@@ -2037,13 +2059,13 @@ fn const_parameter_example_message(consts: &[&syn::Ident]) -> String {
         "`#[model_schema]` cannot build a `schema_example()` for an item that declares a const \
          parameter, and this item declares {names}. The example is Rust compiled at one \
          instantiation, so its value is annotated with this item's own name and every parameter \
-         filled in: a type parameter is filled at `String`, the one concrete type every example can \
-         be written against, and a const takes no filling from that convention — `String` names a \
-         type, a const is a value, and no value is the one every const-parameterised example is \
-         written at, so one chosen here would render the example at a length this item's author \
-         never wrote. This is refused because the `zod` feature is enabled, `zod` being the only \
-         surface that reads an example. Remove the ` ```rust example ` block, or the const \
-         parameter, whichever this item can do without."
+         filled in: a type parameter is filled at the type `default_types` declares for it, or at \
+         `String` where it declares none, and a const takes no filling from that convention — both \
+         spellings name a type, a const is a value, and no value is the one every \
+         const-parameterised example is written at, so one chosen here would render the example at \
+         a length this item's author never wrote. This is refused because the `zod` feature is \
+         enabled, `zod` being the only surface that reads an example. Remove the ` ```rust example \
+         ` block, or the const parameter, whichever this item can do without."
     )
 }
 
@@ -2855,8 +2877,12 @@ fn process_struct(mut item_struct: syn::ItemStruct, args: &ModelSchemaArgs) -> T
     // schema_example must be directly on the type (not in the module) because the example code
     // uses type names that may not be accessible from the nested module.
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-    let schema_example_method =
-        item_schema_example_method(docs_and_example.1.as_ref(), &name, &item_struct.generics);
+    let schema_example_method = item_schema_example_method(
+        docs_and_example.1.as_ref(),
+        &name,
+        &item_struct.generics,
+        args,
+    );
 
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
     let validate_method = struct_validate_method(&collected.3, &module_ident);
@@ -3117,8 +3143,12 @@ fn process_tuple_struct(
 
     // schema_example must be directly on the type (not in the module) because the example code
     // uses type names that may not be accessible from the nested module.
-    let schema_example_method =
-        item_schema_example_method(docs_and_example.1.as_ref(), &name, &item_struct.generics);
+    let schema_example_method = item_schema_example_method(
+        docs_and_example.1.as_ref(),
+        &name,
+        &item_struct.generics,
+        args,
+    );
 
     let delegate_impl_items = build_struct_delegate_items(
         &module_ident,
@@ -4013,12 +4043,13 @@ fn build_branded_schema_example(
     example_code: Option<&String>,
     name: &Ident,
     generic_params: &[String],
+    args: &ModelSchemaArgs,
 ) -> proc_macro2::TokenStream {
     let Some(code) = example_code else {
         return quote! {};
     };
     let code_tokens: proc_macro2::TokenStream = code.parse().unwrap();
-    let value_ty = schema_example_value_type(name, generic_params);
+    let value_ty = schema_example_value_type(name, generic_params, &args.default_types);
     quote! {
         pub fn schema_example() -> serde_json::Value {
             let value: #value_ty = {
@@ -4292,7 +4323,7 @@ fn process_branded_newtype(item_struct: syn::ItemStruct, args: &ModelSchemaArgs)
 
     #[cfg(feature = "zod")]
     let schema_example_tokens =
-        build_branded_schema_example(example_code.as_ref(), &name, &generic_params);
+        build_branded_schema_example(example_code.as_ref(), &name, &generic_params, args);
     #[cfg(not(feature = "zod"))]
     let schema_example_tokens = quote! {};
 
@@ -4393,11 +4424,11 @@ fn process_enum(item_enum: syn::ItemEnum, args: &ModelSchemaArgs) -> TokenStream
         #[cfg(not(feature = "serde"))]
         let rename_all = None;
 
-        process_plain_enum(item_enum, &name, rename_all, &item_name)
+        process_plain_enum(item_enum, &name, rename_all, &item_name, args)
     } else {
         #[cfg(feature = "serde")]
         if serde_type_meta.untagged {
-            return process_untagged_enum(item_enum, &name, &item_name);
+            return process_untagged_enum(item_enum, &name, &item_name, args);
         }
 
         // Neither tagging key named, so serde writes the externally tagged form and that is what
@@ -4410,6 +4441,7 @@ fn process_enum(item_enum: syn::ItemEnum, args: &ModelSchemaArgs) -> TokenStream
                 &name,
                 serde_type_meta.rename_all.as_deref(),
                 &item_name,
+                args,
             );
         }
 
@@ -4426,6 +4458,7 @@ fn process_enum(item_enum: syn::ItemEnum, args: &ModelSchemaArgs) -> TokenStream
                 tag,
                 serde_type_meta.rename_all.as_deref(),
                 &item_name,
+                args,
             );
         }
 
@@ -4453,6 +4486,7 @@ fn process_enum(item_enum: syn::ItemEnum, args: &ModelSchemaArgs) -> TokenStream
             &content_name,
             rename_all.as_deref(),
             &item_name,
+            args,
         )
     }
 }
@@ -4674,6 +4708,7 @@ fn process_plain_enum(
     name: &syn::Ident,
     rename_all: Option<&str>,
     item_name: &str,
+    args: &ModelSchemaArgs,
 ) -> TokenStream {
     // Compute the schema module name and register the enum so other types can find it.
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
@@ -4739,9 +4774,12 @@ fn process_plain_enum(
 
     // schema_example must be directly on the type (not in the module) because the example code
     // uses type names that may not be accessible from the nested module.
+    #[cfg(not(any(feature = "typescript", feature = "zod", feature = "jsonschema")))]
+    let _: &_ = &args;
+
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
     let schema_example_method =
-        enum_schema_example_method(docs_vec.as_deref(), name, &item_enum.generics);
+        enum_schema_example_method(docs_vec.as_deref(), name, &item_enum.generics, args);
 
     // Build schema module impl items (without schema_example)
     #[cfg(any(feature = "zod", feature = "typescript", feature = "jsonschema"))]
@@ -4974,6 +5012,7 @@ fn process_discriminated_enum(
     content_name: &str,
     rename_all: Option<&str>,
     item_name: &str,
+    args: &ModelSchemaArgs,
 ) -> TokenStream {
     // Compute the schema module name and register the enum so other types can find it.
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
@@ -5000,7 +5039,7 @@ fn process_discriminated_enum(
     }
     let rendered = render_discriminated_variants(tag_name, content_name, item_name, &variants.0);
     #[cfg(not(any(feature = "typescript", feature = "zod", feature = "jsonschema")))]
-    let _: &_ = &(name, &rendered);
+    let _: &_ = &(name, &rendered, args);
 
     #[cfg(feature = "jsonschema")]
     let main_schema_code = discriminated_main_schema_code(&rendered.2);
@@ -5054,7 +5093,7 @@ fn process_discriminated_enum(
     // uses type names that may not be accessible from the nested module.
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
     let schema_example_method =
-        enum_schema_example_method(docs_vec.as_deref(), name, &item_enum.generics);
+        enum_schema_example_method(docs_vec.as_deref(), name, &item_enum.generics, args);
 
     // Build schema module impl items (without schema_example)
     #[cfg(any(feature = "zod", feature = "typescript", feature = "jsonschema"))]
@@ -5394,6 +5433,7 @@ fn process_externally_tagged_enum(
     name: &syn::Ident,
     rename_all: Option<&str>,
     item_name: &str,
+    args: &ModelSchemaArgs,
 ) -> TokenStream {
     // Compute the schema module name and register the enum so other types can find it.
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
@@ -5429,7 +5469,7 @@ fn process_externally_tagged_enum(
     #[cfg(not(feature = "zod"))]
     let _: &_ = &schema_code;
     #[cfg(not(any(feature = "typescript", feature = "zod", feature = "jsonschema")))]
-    let _: &_ = &name;
+    let _: &_ = &(name, args);
 
     #[cfg(feature = "typescript")]
     let docs = build_jsdoc_body(docs_vec.as_deref(), item_name);
@@ -5460,7 +5500,7 @@ fn process_externally_tagged_enum(
 
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
     let schema_example_method =
-        enum_schema_example_method(docs_vec.as_deref(), name, &item_enum.generics);
+        enum_schema_example_method(docs_vec.as_deref(), name, &item_enum.generics, args);
 
     #[cfg(any(feature = "zod", feature = "typescript", feature = "jsonschema"))]
     let schema_impl_items: Vec<proc_macro2::TokenStream> = vec![
@@ -5794,6 +5834,7 @@ fn process_internally_tagged_enum(
     tag_name: &str,
     rename_all: Option<&str>,
     item_name: &str,
+    args: &ModelSchemaArgs,
 ) -> TokenStream {
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
     // Every other enum shape is written as a union of what its variants render as.
@@ -5836,7 +5877,7 @@ fn process_internally_tagged_enum(
     #[cfg(not(feature = "zod"))]
     let _: &_ = &schema_code;
     #[cfg(not(any(feature = "typescript", feature = "zod", feature = "jsonschema")))]
-    let _: &_ = &name;
+    let _: &_ = &(name, args);
 
     #[cfg(feature = "typescript")]
     let docs = build_jsdoc_body(docs_vec.as_deref(), item_name);
@@ -5867,7 +5908,7 @@ fn process_internally_tagged_enum(
 
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
     let schema_example_method =
-        enum_schema_example_method(docs_vec.as_deref(), name, &item_enum.generics);
+        enum_schema_example_method(docs_vec.as_deref(), name, &item_enum.generics, args);
 
     #[cfg(any(feature = "zod", feature = "typescript", feature = "jsonschema"))]
     let schema_impl_items: Vec<proc_macro2::TokenStream> = vec![
@@ -6715,6 +6756,7 @@ fn process_untagged_enum(
     mut item_enum: syn::ItemEnum,
     name: &syn::Ident,
     item_name: &str,
+    args: &ModelSchemaArgs,
 ) -> TokenStream {
     // Compute the schema module name and register the enum so other types can find it.
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
@@ -6755,11 +6797,11 @@ fn process_untagged_enum(
     let _: &_ = &zod_merge_parts;
 
     #[cfg(not(any(feature = "typescript", feature = "zod", feature = "jsonschema")))]
-    let _: &_ = &(name, item_name, &ts_parts, &zod_parts, &json_parts);
+    let _: &_ = &(name, item_name, &ts_parts, &zod_parts, &json_parts, args);
 
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
     let schema_example_method =
-        enum_schema_example_method(docs_vec.as_deref(), name, &item_enum.generics);
+        enum_schema_example_method(docs_vec.as_deref(), name, &item_enum.generics, args);
 
     // Build schema module impl items (without schema_example)
     #[cfg(any(feature = "zod", feature = "typescript", feature = "jsonschema"))]

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -2523,15 +2523,20 @@ fn the_cfg_probe_sees_an_emitted_cfg_attribute() {
 fn struct_schema_example_carries_no_cfg_attribute() {
     let name: syn::Ident = syn::parse_quote!(Report);
     let generics = syn::Generics::default();
-    let tokens =
-        super::item_schema_example_method(Some(&"Report { id: 1 }".to_owned()), &name, &generics)
-            .unwrap();
+    let tokens = super::item_schema_example_method(
+        Some(&"Report { id: 1 }".to_owned()),
+        &name,
+        &generics,
+        &super::ModelSchemaArgs::default(),
+    )
+    .unwrap();
     assert_no_cfg_attribute(&tokens, "item_schema_example_method");
 }
 
 /// The type the example is bound at carries one argument per declared parameter, the way a brand's
 /// already does — a bare ident on a generic item is `E0107` before the example is ever read. A
 /// lifetime and a const are not parameters a filling is chosen for, so neither reaches the list.
+/// With nothing declared, every argument is the `String` fallback.
 #[cfg(feature = "zod")]
 #[test]
 fn struct_schema_example_instantiates_every_type_parameter() {
@@ -2546,11 +2551,71 @@ fn struct_schema_example_instantiates_every_type_parameter() {
         ),
         (syn::parse_quote!(<'a>), "let value : Report ="),
     ] {
-        let rendered = super::item_schema_example_method(Some(&example), &name, &generics)
+        let rendered = super::item_schema_example_method(
+            Some(&example),
+            &name,
+            &generics,
+            &super::ModelSchemaArgs::default(),
+        )
+        .unwrap()
+        .to_string();
+        assert!(rendered.contains(expected), "Got: {rendered}");
+    }
+}
+
+/// Each argument is read off the `default_types` entry naming that parameter, so an item is
+/// annotated at the concrete types its author declared and in the order the parameters were
+/// written. A parameter no entry names keeps the `String` fallback, which is why a partly declared
+/// item mixes the two.
+#[cfg(feature = "zod")]
+#[test]
+fn struct_schema_example_instantiates_each_parameter_at_its_declared_filling() {
+    let name: syn::Ident = syn::parse_quote!(Report);
+    let example = "Report { id: 1 }".to_owned();
+    let generics: syn::Generics = syn::parse_quote!(<A, B>);
+    let count: (syn::Ident, syn::Type) = (syn::parse_quote!(A), syn::parse_quote!(u32));
+    let held: (syn::Ident, syn::Type) = (syn::parse_quote!(B), syn::parse_quote!(Vec<u8>));
+    for (default_types, expected) in [
+        (vec![count.clone()], "let value : Report < u32 , String > ="),
+        (
+            vec![held.clone()],
+            "let value : Report < String , Vec < u8 > > =",
+        ),
+        (
+            vec![held, count],
+            "let value : Report < u32 , Vec < u8 > > =",
+        ),
+    ] {
+        let args = super::ModelSchemaArgs {
+            default_types,
+            ..Default::default()
+        };
+        let rendered = super::item_schema_example_method(Some(&example), &name, &generics, &args)
             .unwrap()
             .to_string();
         assert!(rendered.contains(expected), "Got: {rendered}");
     }
+}
+
+/// A filling written as `String` is exactly what an unfilled parameter falls back to, so an item
+/// declaring one and an item declaring none are annotated with the same tokens — reading the
+/// declaration leaves every item the old convention already got right byte for byte as it was.
+#[cfg(feature = "zod")]
+#[test]
+fn a_string_filling_annotates_the_example_as_no_filling_does() {
+    let name: syn::Ident = syn::parse_quote!(Report);
+    let example = "Report { id: 1 }".to_owned();
+    let generics: syn::Generics = syn::parse_quote!(<A>);
+    let filled = super::ModelSchemaArgs {
+        default_types: vec![(syn::parse_quote!(A), syn::parse_quote!(String))],
+        ..Default::default()
+    };
+    let render = |args: &super::ModelSchemaArgs| {
+        super::item_schema_example_method(Some(&example), &name, &generics, args)
+            .unwrap()
+            .to_string()
+    };
+    assert_eq!(render(&filled), render(&super::ModelSchemaArgs::default()));
 }
 
 #[cfg(feature = "jsonschema")]
@@ -2591,7 +2656,12 @@ fn branded_schema_example_carries_no_cfg_attribute() {
         vec!["A".to_owned()],
         vec!["A".to_owned(), "B".to_owned()],
     ] {
-        let tokens = super::build_branded_schema_example(Some(&example), &name, &generic_params);
+        let tokens = super::build_branded_schema_example(
+            Some(&example),
+            &name,
+            &generic_params,
+            &super::ModelSchemaArgs::default(),
+        );
         assert_no_cfg_attribute(&tokens, "build_branded_schema_example");
     }
 }
@@ -2611,10 +2681,39 @@ fn branded_schema_example_instantiates_every_parameter() {
             "let value : DocumentId < String , String > =",
         ),
     ] {
-        let rendered =
-            super::build_branded_schema_example(Some(&example), &name, &generic_params).to_string();
+        let rendered = super::build_branded_schema_example(
+            Some(&example),
+            &name,
+            &generic_params,
+            &super::ModelSchemaArgs::default(),
+        )
+        .to_string();
         assert!(rendered.contains(expected), "Got: {rendered}");
     }
+}
+
+/// A brand reads its declaration through the same seam a declared struct does, so its example is
+/// annotated at the fillings its author wrote rather than at the fallback.
+#[cfg(feature = "zod")]
+#[test]
+fn branded_schema_example_instantiates_each_parameter_at_its_declared_filling() {
+    let name: syn::Ident = syn::parse_quote!(DocumentId);
+    let example = "DocumentId(\"abc\".to_string())".to_owned();
+    let args = super::ModelSchemaArgs {
+        default_types: vec![(syn::parse_quote!(A), syn::parse_quote!(u32))],
+        ..Default::default()
+    };
+    let rendered = super::build_branded_schema_example(
+        Some(&example),
+        &name,
+        &["A".to_owned(), "B".to_owned()],
+        &args,
+    )
+    .to_string();
+    assert!(
+        rendered.contains("let value : DocumentId < u32 , String > ="),
+        "Got: {rendered}"
+    );
 }
 
 #[cfg(feature = "typescript")]

--- a/tests/example_tests/tests.rs
+++ b/tests/example_tests/tests.rs
@@ -453,11 +453,12 @@ fn test_description_escapes_quotes() {
 }
 
 /// A doc example on a generic item is Rust the expansion has to compile, and a parameter names no
-/// type to compile it at, so every parameter the item declares is instantiated at `String` — the
-/// convention a generic brand's example already follows.
+/// type to compile it at, so every parameter the item declares is instantiated at the filling
+/// `default_types` declares for it — here `String`, which is also what an undeclared parameter
+/// falls back to, so this item is annotated exactly as it was before the filling was read.
 #[cfg(feature = "zod")]
 #[test]
-fn a_generic_struct_renders_its_example_at_the_string_instantiation() {
+fn a_generic_struct_renders_its_example_at_its_declared_filling() {
     /// A generic type carrying an example block.
     ///
     /// ```rust example
@@ -476,10 +477,10 @@ fn a_generic_struct_renders_its_example_at_the_string_instantiation() {
 }
 
 /// The arity is whatever the item declares, so a two-parameter item takes two arguments and not
-/// one.
+/// one, each read off the entry that names it.
 #[cfg(feature = "zod")]
 #[test]
-fn a_generic_enum_renders_its_example_at_the_string_instantiation() {
+fn a_generic_enum_renders_its_example_at_its_declared_fillings() {
     /// A generic enum carrying an example block.
     ///
     /// ```rust example
@@ -494,6 +495,111 @@ fn a_generic_enum_renders_its_example_at_the_string_instantiation() {
     assert_eq!(
         Tagged::<String, String>::schema_example(),
         serde_json::json!({ "Held": { "held": "x", "tag": "t" } })
+    );
+}
+
+/// `default_types` is the one argument that names a concrete type per parameter, so the example is
+/// annotated at what the author already declared. A parameter bounded by a trait `String` does not
+/// satisfy then compiles, and the value the example builds is the one the filling admits rather
+/// than one an annotation picked over it contradicts.
+#[cfg(feature = "zod")]
+#[test]
+fn a_bounded_parameter_renders_its_example_at_its_declared_filling() {
+    /// A generic type whose parameter carries a bound `String` does not satisfy.
+    ///
+    /// ```rust example
+    /// Counted { count: 7u32 }
+    /// ```
+    #[model_schema(default_types(CountType = u32))]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct Counted<CountType: Copy> {
+        pub count: CountType,
+    }
+
+    assert_eq!(
+        Counted::<u32>::schema_example(),
+        serde_json::json!({ "count": 7_u32 })
+    );
+}
+
+/// Every enum shape reads the filling the same way, the seam that annotates the value being the one
+/// the struct path reaches too — so a parameter filled at something other than `String` renders the
+/// value that filling builds here as well.
+#[cfg(feature = "zod")]
+#[test]
+fn a_generic_enum_renders_its_example_at_a_filling_that_is_not_a_string() {
+    /// A generic enum carrying an example block.
+    ///
+    /// ```rust example
+    /// Measured::Held { held: 7u32 }
+    /// ```
+    #[model_schema(default_types(HeldType = u32))]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub enum Measured<HeldType> {
+        Held { held: HeldType },
+    }
+
+    assert_eq!(
+        Measured::<u32>::schema_example(),
+        serde_json::json!({ "Held": { "held": 7_u32 } })
+    );
+}
+
+/// A parameter no entry names keeps the `String` fallback: the convention holds wherever nothing was
+/// declared to replace it. Only a build without `jsonschema` reaches it — with that feature on, a
+/// filling is required for every parameter before an example is ever built.
+#[cfg(all(feature = "zod", not(feature = "jsonschema")))]
+#[test]
+fn an_unfilled_parameter_keeps_the_string_instantiation() {
+    /// A generic type declaring no filling.
+    ///
+    /// ```rust example
+    /// Unfilled { value: "x".to_owned() }
+    /// ```
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct Unfilled<ValueType> {
+        pub value: ValueType,
+    }
+
+    assert_eq!(
+        Unfilled::<String>::schema_example(),
+        serde_json::json!({ "value": "x" })
+    );
+}
+
+/// A filling written as `String` is exactly what an unfilled parameter falls back to, so the two
+/// items write the same schema down to the byte once their names are read as one — reading the
+/// declaration leaves every item the convention already got right untouched. Names of equal length
+/// so nothing but the name itself differs.
+#[cfg(all(feature = "zod", not(feature = "jsonschema")))]
+#[test]
+fn a_string_filling_and_no_filling_write_the_same_schema() {
+    /// A generic type declaring its filling.
+    ///
+    /// ```rust example
+    /// Written { value: "x".to_owned() }
+    /// ```
+    #[model_schema(default_types(ValueType = String))]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct Written<ValueType> {
+        pub value: ValueType,
+    }
+
+    /// A generic type declaring its filling.
+    ///
+    /// ```rust example
+    /// Omitted { value: "x".to_owned() }
+    /// ```
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug, Clone)]
+    pub struct Omitted<ValueType> {
+        pub value: ValueType,
+    }
+
+    assert_eq!(
+        Written::<String>::zod_schema().replace("Written", "Item"),
+        Omitted::<String>::zod_schema().replace("Omitted", "Item")
     );
 }
 


### PR DESCRIPTION
A generic item's schema example now resolves each type parameter against the filling its default_types entry declares, falling back to String only where no filling is named. The example annotation threads the item's arguments through the branded, struct, and enum example builders so the rendered value matches the instantiation the declaration itself fixes.