### PR TITLE
Refuse constrained brands over parameterised inners; alias TS reads the erasure seam; README factory blocks pinned whole

### DIFF
--- a/README.md
+++ b/README.md
@@ -938,10 +938,10 @@ use tixschema::model_schema;
 use serde::{Deserialize, Serialize};
 
 // Generic branded newtype (good for parameterized IDs)
-#[model_schema(default_types(ID_TYPE = String))]
+#[model_schema(default_types(IdType = String))]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct UserId<ID_TYPE>(pub ID_TYPE);
+pub struct UserId<IdType>(pub IdType);
 
 // Non-generic branded newtype
 #[model_schema()]
@@ -953,13 +953,35 @@ pub struct CorrelationId(pub String);
 Generated TypeScript (with `zod` feature):
 
 ```typescript
-export type UserId<ID_TYPE> = ID_TYPE & $brand<"UserId">;
-const buildUserId$Schema = <ID_TYPE extends ZodType>(
-  iD_TYPE: ID_TYPE,
+export type UserId<IdType> = IdType & $brand<"UserId">;
+const buildUserId$Schema = <IdType extends ZodType>(
+  idType: IdType,
 ) =>
-  iD_TYPE.meta({
+  idType.meta({
   description: "UserId",
 }).brand<"UserId">();
+
+type UserId$SchemaOf<IdType extends ZodType> = ReturnType<
+  typeof buildUserId$Schema<IdType>
+>;
+
+interface UserId$SchemaFactoryCache {
+  get<IdType extends ZodType>(key: IdType): UserId$SchemaOf<IdType> | undefined;
+  set<IdType extends ZodType>(key: IdType, value: UserId$SchemaOf<IdType>): this;
+}
+
+const UserId$SchemaFactoryCache = createSchemaCache<UserId$SchemaFactoryCache>();
+
+export const UserId$SchemaFactory = <IdType extends ZodType>(
+  idType: IdType,
+): UserId$SchemaOf<IdType> => {
+  const hit = UserId$SchemaFactoryCache.get(idType);
+  if (hit) return hit;
+
+  const schema = buildUserId$Schema(idType);
+  UserId$SchemaFactoryCache.set(idType, schema);
+  return schema;
+};
 
 export type CorrelationId = string & $brand<"CorrelationId">;
 const CorrelationId$RawSchema = z.string().brand<"CorrelationId">().meta({
@@ -973,7 +995,7 @@ Generated TypeScript (without `zod` feature):
 
 ```typescript
 declare const __brand_UserId: unique symbol;
-export type UserId<ID_TYPE> = ID_TYPE & { readonly [__brand_UserId]: true };
+export type UserId<IdType> = IdType & { readonly [__brand_UserId]: true };
 
 declare const __brand_CorrelationId: unique symbol;
 export type CorrelationId = string & { readonly [__brand_CorrelationId]: true };
@@ -982,7 +1004,7 @@ export type CorrelationId = string & { readonly [__brand_CorrelationId]: true };
 Notes:
 
 - If the Rust type name ends with `Json`, the suffix is stripped in the generated TypeScript (e.g., `UserIdJson` becomes `UserId`). Otherwise, the Rust name is used as-is.
-- Generic parameter names (e.g., `ID_TYPE`) are preserved exactly in the TypeScript type.
+- Generic parameter names (e.g., `IdType`) are preserved exactly in the TypeScript type.
 - A generic brand publishes a factory, as every other generic item does, so the brand and its inner's shape land on the argument the caller supplied rather than on a value pinned at expansion. A parameter reaches it as the factory's own argument, under the rule in [Type Parameters](#type-parameters); a brand written over that parameter still describes what its inner writes, so `TagList<T>(pub Vec<T>)` is an array on every surface — `Array<T>`, `z.array(t)`, `{"type": "array", "items": {}}` — and not the bare parameter.
 - The description is written before the brand in a factory and after it in a `const`. Inside a factory the receiver is the parameter the caller filled, and Zod's `.meta()` returns `this` — which TypeScript resolves back to that bare parameter, dropping the marker `.brand<"Name">()` had just added. Both orders build the same schema.
 - Serde transparent serialization works normally -- the wrapper is invisible in JSON.
@@ -1069,6 +1091,23 @@ pub struct GenericSlug<T>(pub T);
 #[serde(transparent)]
 pub struct Slug(pub String);
 ```
+
+**A name written over one of those parameters is rejected too**, whether or not the named type has expanded yet. `Tagged<T>` is not a type the declaration fixed — the instantiation fixes it — so the checks land on whatever the caller supplies: Zod appends them to a schema the call site decides the shape of, the one JSON document written for every instantiation still holds the `{}` a parameter describes as, and `validate()` measures the inner's `Display` rendering, which rejects `TaggedSlug(Tagged(7))` for having one decimal digit rather than for its value. This is the one place the registry's silence is not read as consent, and it is what keeps declaration order out of the diagnostic: the same two declarations written in the other order are rejected through the registry, so admitting this order would decide one program two ways.
+
+```rust
+// Rejected: the checks would measure whatever the instantiation supplies for `T`.
+#[model_schema(minLength = 3, default_types(T = String))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct TaggedSlug<T>(pub Tagged<T>);
+
+#[model_schema(default_types(T = String))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Tagged<T>(pub T);
+```
+
+Brand a string-typed inner instead. The bound belongs on a declaration that writes a string — a `String` brand of its own, which the parameterised type can then be instantiated with (`Tagged<BoundedSlug>`), so the check sits where every surface can read it.
 
 **The inner type also has to implement `Display`,** since validation runs against `to_string()`. That holds whether or not the brand passes `no_display`: the flag drops the `Display` impl, not the requirement.
 
@@ -1203,22 +1242,44 @@ Branded newtypes support doc comments (for Zod `.meta({ description })`) and com
 /// ```rust example
 /// DocumentId("64de3d95ff45b119e5b53a7e".to_string())
 /// ```
-#[model_schema(default_types(ID_TYPE = String))]
+#[model_schema(default_types(IdType = String))]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct DocumentId<ID_TYPE>(pub ID_TYPE);
+pub struct DocumentId<IdType>(pub IdType);
 ```
 
 Generated Zod:
 
 ```typescript
-const buildDocumentId$Schema = <ID_TYPE extends ZodType>(
-  iD_TYPE: ID_TYPE,
+const buildDocumentId$Schema = <IdType extends ZodType>(
+  idType: IdType,
 ) =>
-  iD_TYPE.meta({
+  idType.meta({
   description: "Generic document identifier.\n- `DocumentId<String>` for API/HTTP layer\n- `DocumentId<ObjectId>` for MongoDB layer",
   example: "64de3d95ff45b119e5b53a7e",
 }).brand<"DocumentId">();
+
+type DocumentId$SchemaOf<IdType extends ZodType> = ReturnType<
+  typeof buildDocumentId$Schema<IdType>
+>;
+
+interface DocumentId$SchemaFactoryCache {
+  get<IdType extends ZodType>(key: IdType): DocumentId$SchemaOf<IdType> | undefined;
+  set<IdType extends ZodType>(key: IdType, value: DocumentId$SchemaOf<IdType>): this;
+}
+
+const DocumentId$SchemaFactoryCache = createSchemaCache<DocumentId$SchemaFactoryCache>();
+
+export const DocumentId$SchemaFactory = <IdType extends ZodType>(
+  idType: IdType,
+): DocumentId$SchemaOf<IdType> => {
+  const hit = DocumentId$SchemaFactoryCache.get(idType);
+  if (hit) return hit;
+
+  const schema = buildDocumentId$Schema(idType);
+  DocumentId$SchemaFactoryCache.set(idType, schema);
+  return schema;
+};
 ```
 
 ## Field Validation (`model_schema_prop`)

--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -237,6 +237,61 @@ impl PartialEq for FieldDef {
 }
 
 impl FieldDef {
+    /// The enclosing item's own type parameter this field reaches *below* its own position — the
+    /// `T` a `Later<T>` hands to the type it names, and the same `T` inside a tuple or a map.
+    ///
+    /// [`Self::parameter_shape_name`] answers for the field itself, this for everything it is
+    /// written over, and a field answering either one describes a value the expansion never sees a
+    /// type for. What differs is what can still be said about it: a field that *is* a parameter has
+    /// no shape at all, while one merely written over a parameter keeps the shape it was written
+    /// with — an array stays an array — and only the leaf goes opaque. So a bound written against
+    /// the shape still reaches something, and a bound written against the leaf reaches nothing on
+    /// any surface however the instantiation fills it.
+    ///
+    /// The first such parameter in declaration order is the one named; a field reaching two names
+    /// them both for the same reason, and one is enough to say what the answer is.
+    ///
+    /// Reads a def already rewritten by [`Self::erase_type_parameters`], for the reason
+    /// `parameter_shape_name` does.
+    #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+    pub fn argument_parameter_name(&self) -> Option<&str> {
+        match &self.field_type {
+            FieldDefType::SiblingType(_, arguments) => arguments
+                .iter()
+                .find_map(|argument| argument.parameter_or_argument_name()),
+            FieldDefType::Map(key, value) => key
+                .parameter_or_argument_name()
+                .or_else(|| value.parameter_or_argument_name()),
+            FieldDefType::Tuple(elements) => {
+                elements.iter().find_map(Self::parameter_or_argument_name)
+            }
+            FieldDefType::TypeParam(_)
+            | FieldDefType::Unknown
+            | FieldDefType::StringLiteral(_)
+            | FieldDefType::Boolean
+            | FieldDefType::String
+            | FieldDefType::U8
+            | FieldDefType::U16
+            | FieldDefType::U32
+            | FieldDefType::U64
+            | FieldDefType::I8
+            | FieldDefType::I16
+            | FieldDefType::I32
+            | FieldDefType::I64
+            | FieldDefType::Usize
+            | FieldDefType::Isize
+            | FieldDefType::F32
+            | FieldDefType::F64 => None,
+            #[cfg(feature = "object_id")]
+            FieldDefType::ObjectId => None,
+            #[cfg(feature = "chrono")]
+            FieldDefType::NaiveDate
+            | FieldDefType::NaiveTime
+            | FieldDefType::NaiveDateTime
+            | FieldDefType::DateTime => None,
+        }
+    }
+
     /// The element of a collection wrapper, as the field the wrapper's own serialization makes it.
     ///
     /// A `Vec<T>` and a set of `T` both write a JSON array of `T`, so the element carries the
@@ -650,6 +705,14 @@ impl FieldDef {
             | FieldDefType::NaiveDateTime
             | FieldDefType::DateTime => None,
         }
+    }
+
+    /// The parameter this field is or reaches, which is what a nested position is asked for: below
+    /// the top level the two questions have one answer.
+    #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+    fn parameter_or_argument_name(&self) -> Option<&str> {
+        self.parameter_shape_name()
+            .or_else(|| self.argument_parameter_name())
     }
 
     /// The enclosing item's own type parameter this field renders as, when a bound spelled against

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -2041,11 +2041,23 @@ fn branded_option_inner_error(
 ///
 /// One of the brand's *own* type parameters is not such a name: it says its shape outright too,
 /// because both validating surfaces have already settled that it has none. Reading the inner off
-/// [`value_surface_field_def`] puts it in front of the opaque arm, where it belongs — Zod 4's
+/// [`surface_field_def`] puts it in front of the opaque arm, where it belongs — Zod 4's
 /// `z.unknown()` carries no `.min`/`.max` at all, and `.brand()` returns the same instance rather
 /// than a wrapper that could, so there is nothing for the checks to attach to; JSON Schema's
 /// string keywords go inert beside the `{}` a parameter describes as; and `validate()` still
 /// measures `Display`. Three surfaces, three answers — the disagreement this guard exists to stop.
+///
+/// A name written *over* one of those parameters is the same answer reached one module out, and is
+/// the one absence the registry's silence must not be read as consent for. `Later<T>` names a type
+/// whose schema the brand composes from the argument the caller supplies, so the checks land on
+/// whatever that argument turns out to be: Zod appends them to a shape the call site decides, the
+/// one JSON document written for every instantiation still holds the `{}` a parameter describes as,
+/// and `validate()` still measures `Display` — a numeric filling being rejected for its digit count
+/// rather than for its value. Refusing it is what keeps the guard's answer a fact about the
+/// declaration: the same two items written in the other order already refuse, the registry having
+/// classified the inner by then, and an author cannot act on a diagnostic that fires on where a
+/// type is written. What stays admitted is the unresolved *concrete* name, whose instantiation the
+/// declaration has already fixed.
 ///
 /// Resolved through the same `get_field_def` call the renderers make, so the guard and the
 /// contract cannot disagree about what a shape is.
@@ -2060,9 +2072,8 @@ fn branded_constraint_inner_error(
         return None;
     }
     let inner = branded_inner_value_surface(generics, inner_field);
-    let shape = non_string_inner_shape(&inner)?;
-    let message = if let FieldDefType::SiblingType(inner_name, _) = &inner.field_type {
-        format!(
+    let message = match (&inner.field_type, non_string_inner_shape(&inner)) {
+        (FieldDefType::SiblingType(inner_name, _), Some(shape)) => format!(
             "model_schema: branded newtype `{name}` applies string constraints (pattern, \
              minLength, maxLength) to `{inner_name}`, which this crate writes as the {shape} \
              value the checks are then appended to — and that binding carries no string for them \
@@ -2071,16 +2082,29 @@ fn branded_constraint_inner_error(
              outside `\"type\": \"string\"`, and `validate()` measures the inner's `Display` \
              rendering — three surfaces, three answers. Brand a string-typed inner, or drop the \
              constraints."
-        )
-    } else {
-        format!(
+        ),
+        (FieldDefType::SiblingType(inner_name, _), None) => {
+            let parameter = inner.argument_parameter_name()?;
+            format!(
+                "model_schema: branded newtype `{name}` applies string constraints (pattern, \
+                 minLength, maxLength) to `{inner_name}`, whose schema this crate builds from the \
+                 type parameter `{parameter}` — so the checks land on whatever the instantiation \
+                 supplies for it, and one declaration covers every instantiation: Zod appends \
+                 `.min`/`.max` to a schema the call site decides the shape of, JSON Schema writes \
+                 them beside the `{{}}` a parameter describes as, where they go inert, and \
+                 `validate()` measures the inner's `Display` rendering — three surfaces, three \
+                 answers. Brand a string-typed inner, or drop the constraints."
+            )
+        }
+        (_, Some(shape)) => format!(
             "model_schema: branded newtype `{name}` applies string constraints (pattern, \
              minLength, maxLength) to a {shape} inner type, which cannot carry them: Zod reads \
              `.min`/`.max` as bounds on the value itself and has no regex check for a non-string \
              schema, JSON Schema ignores `minLength`/`maxLength`/`pattern` outside `\"type\": \
              \"string\"`, and `validate()` measures the inner's `Display` rendering — three \
              surfaces, three answers. Brand a string-typed inner, or drop the constraints."
-        )
+        ),
+        (_, None) => return None,
     };
     Some(syn::Error::new_spanned(inner_field, message).to_compile_error())
 }
@@ -2285,7 +2309,7 @@ fn branded_pattern_error(name: &Ident, args: &ModelSchemaArgs) -> Option<proc_ma
 /// for and what it records for the next brand to read cannot come apart.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn branded_inner_value_surface(generics: &syn::Generics, inner_field: &Field) -> FieldDef {
-    value_surface_field_def(generics, &get_field_def("_inner", &inner_field.ty, ""))
+    surface_field_def(generics, &get_field_def("_inner", &inner_field.ty, ""))
 }
 
 /// What the registry records for a brand.
@@ -3356,24 +3380,30 @@ fn build_branded_json_schema_method(
     json_schema_methods(def_name, &body)
 }
 
-/// The `FieldDef` a value-level surface renders from: the written one with every reference to the
-/// enclosing item's own type parameters replaced by the opaque type.
+/// The `FieldDef` every surface renders from: the written one with each name that is one of the
+/// enclosing item's own type parameters classified as the parameter it is.
 ///
-/// The one seam the Zod and JSON surfaces share for a parameter, and so the reason an alias and a
-/// brand cannot drift apart over one — see [`FieldDef::erase_type_parameters`] for the rule and
-/// for why TypeScript reads the written def instead.
+/// All three surfaces read this one def, which is why a parameter cannot come to mean two things
+/// about one declaration. What each of them then makes of it differs — the two validating surfaces
+/// describe it as the opaque value, TypeScript renders the name its own declaration binds — and
+/// that difference is [`FieldDef::erase_type_parameters`]'s to state rather than this seam's. A
+/// name left unclassified reads as a reference to a generated type of that name on every surface at
+/// once, which is what puts a parameter in a `Record<…>` key position TypeScript cannot bind.
+///
+/// A struct reaches the same def by erasing each field as it is collected; this is where the item
+/// shapes holding a single written target — an alias, a brand — reach it.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-fn value_surface_field_def(generics: &syn::Generics, written: &FieldDef) -> FieldDef {
+fn surface_field_def(generics: &syn::Generics, written: &FieldDef) -> FieldDef {
     let mut erased = written.clone();
     erased.erase_type_parameters(&type_parameters_in_scope(generics));
     erased
 }
 
 /// The one def both validating surfaces read a branded newtype's inner off, so neither can render
-/// a type parameter the other has erased — see [`value_surface_field_def`].
+/// a type parameter the other has erased — see [`surface_field_def`].
 #[cfg(any(feature = "zod", feature = "jsonschema"))]
 fn branded_value_inner(generics: &syn::Generics, inner_ty: &syn::Type) -> FieldDef {
-    value_surface_field_def(generics, &get_field_def("_inner", inner_ty, ""))
+    surface_field_def(generics, &get_field_def("_inner", inner_ty, ""))
 }
 
 /// Resolves the TypeScript inner type name and generic parameter list for a branded newtype.
@@ -3402,7 +3432,7 @@ fn branded_ts_type_and_generics(
 }
 
 /// Resolves the JSON schema shape for a branded newtype's inner field, read off the def
-/// [`value_surface_field_def`] has already erased the brand's own type parameters out of.
+/// [`surface_field_def`] has already erased the brand's own type parameters out of.
 ///
 /// So a parameter admits any value while the shape it sits in — an array, a map's keys, a tuple's
 /// arity — is still described, which is what `#[serde(transparent)]` puts on the wire.
@@ -3531,7 +3561,7 @@ fn branded_inner_composite(inner: &FieldDef) -> Option<BrandedComposite> {
 /// `ObjectId` is the value the schema itself describes. An `ObjectId` writes `{"$oid": hex}`, so
 /// its `Display` is the `$oid` member and the checks land there.
 ///
-/// The inner is the def [`value_surface_field_def`] has already erased the brand's own type
+/// The inner is the def [`surface_field_def`] has already erased the brand's own type
 /// parameters out of, so a parameter composes into the value as `z.unknown()` rather than as a
 /// binding nothing declares. The checks never land on one: an opaque inner carries no string for
 /// them to measure and is refused by [`branded_constraint_inner_error`] before this.
@@ -10603,6 +10633,13 @@ fn generate_discriminated_enum_zod_schema_method(
 /// Builds the alias module's `ts_definition()`, or nothing when `typescript` is off. The doc
 /// block and the generic parameter list are only meaningful to TypeScript, so they are gathered
 /// inside the gate rather than by the caller.
+///
+/// The target is read through [`surface_field_def`], the same seam the two validating methods
+/// beside this one read it through, so the alias classifies its own parameters exactly as a struct
+/// classifies its fields. TypeScript still renders each parameter as the name the declaration binds
+/// — that is what a classified parameter renders as here — with the one exception the declaration
+/// itself forces: a parameter reached in a map's key position states the string keys serde writes,
+/// because `Record<K, V>` binds `K extends keyof any` and a parameter satisfies no such bound.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn generate_alias_ts_definition_method(
     alias: &ItemType,
@@ -10618,7 +10655,7 @@ fn generate_alias_ts_definition_method(
             export_name,
             &alias.ident.to_string(),
             &ts_generic_params(&alias.generics),
-            field_def,
+            &surface_field_def(&alias.generics, field_def),
         )
     }
     #[cfg(not(feature = "typescript"))]
@@ -10688,9 +10725,8 @@ fn generate_alias_json_schema_method(
 ) -> proc_macro2::TokenStream {
     #[cfg(feature = "jsonschema")]
     {
-        let body =
-            build_tuple_element_json_schema(&value_surface_field_def(&alias.generics, field_def))
-                .unwrap_or_else(|rejection| alias_json_schema_rejection(export_name, &rejection));
+        let body = build_tuple_element_json_schema(&surface_field_def(&alias.generics, field_def))
+            .unwrap_or_else(|rejection| alias_json_schema_rejection(export_name, &rejection));
         json_schema_methods(export_name, &body)
     }
     #[cfg(not(feature = "jsonschema"))]
@@ -10704,7 +10740,7 @@ fn generate_alias_json_schema_method(
 
 /// Builds the alias module's `zod_schema()`, or nothing when `zod` is off.
 ///
-/// The value is rendered from the target read through [`value_surface_field_def`], so a parameter
+/// The value is rendered from the target read through [`surface_field_def`], so a parameter
 /// is the argument the alias's own factory binds for it rather than the `Name$Schema` binding an
 /// unresolved type is named after — a binding no emitted module declares.
 ///
@@ -10726,7 +10762,7 @@ fn generate_alias_zod_method(
         // The alias's rendered Zod is its FieldDef expression (a tuple alias yields
         // the null-flavored `z.tuple([...])`, a scalar yields `z.string()`, a sibling
         // yields `Name$Schema`).
-        let schema_code = value_surface_field_def(&alias.generics, field_def).zod_type();
+        let schema_code = surface_field_def(&alias.generics, field_def).zod_type();
         let parameters = type_parameters_in_scope(&alias.generics);
         let reexport = ident_reexport_zod(
             rust_ident,

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -3136,11 +3136,103 @@ fn string_constraints_over_a_named_inner_the_registry_calls_a_string_pass() {
 /// a diagnostic out of declaration order: moving a declaration would turn a compiling program into
 /// a refused one without changing what it means. The `Display` assertion still bounds the Rust
 /// surface either way.
+///
+/// Both of them name a type the declaration has already fixed, which is what the admission rests
+/// on; a name written over one of the brand's own parameters has not, and is refused below.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
 fn string_constraints_over_a_name_the_registry_cannot_answer_for_pass() {
-    let errors = brand_over_named_inner_errors("SiblingRegisteredNowhere");
-    assert!(errors.is_empty(), "got: {errors:?}");
+    let bare = brand_over_named_inner_errors("SiblingRegisteredNowhere");
+    assert!(bare.is_empty(), "got: {bare:?}");
+
+    for inner in ["UnregisteredGeneric<String>", "UnregisteredGeneric<u32>"] {
+        let ty: syn::Type = syn::parse_str(inner).unwrap();
+        let carrying_a_fixed_argument = branded_errors_with(
+            &syn::parse_quote! {
+                #[serde(transparent)]
+                struct Branded<T>(pub #ty);
+            },
+            &pattern_args(),
+        );
+        assert!(
+            carrying_a_fixed_argument.is_empty(),
+            "for {inner}, got: {carrying_a_fixed_argument:?}"
+        );
+    }
+}
+
+/// A name written over one of the brand's own type parameters is refused, wherever the parameter
+/// sits inside it.
+///
+/// The registry's silence is not consent here. The brand composes the named type's schema from the
+/// argument the caller supplies, so the checks land on whatever that argument turns out to be: Zod
+/// appends them to a shape the call site decides, the one JSON document written for every
+/// instantiation still holds the `{}` a parameter describes as, and `validate()` measures the
+/// inner's `Display` — a numeric filling rejected for its digit count rather than for its value.
+/// The same two items written in the other order already refuse through the registry, so admitting
+/// this one puts the diagnostic back on declaration order the long way round.
+///
+/// The refusal names the brand, the inner and the parameter, so the author reads which declaration
+/// to fix and which name in it.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn string_constraints_over_a_name_written_over_the_brands_own_parameter_are_rejected() {
+    for inner in [
+        "UnregisteredGeneric<T>",
+        "UnregisteredGeneric<Vec<T>>",
+        "UnregisteredGeneric<String, U>",
+        "UnregisteredGeneric<HashMap<String, T>>",
+        "UnregisteredGeneric<(u32, U)>",
+    ] {
+        let ty: syn::Type = syn::parse_str(inner).unwrap();
+        let errors = branded_errors_with(
+            &syn::parse_quote! {
+                #[serde(transparent)]
+                struct Branded<T, U>(pub #ty);
+            },
+            &pattern_args(),
+        );
+        assert_eq!(errors.len(), 1, "for {inner}, got: {errors:?}");
+        assert!(errors[0].contains("compile_error"), "got: {}", errors[0]);
+        assert!(errors[0].contains("`Branded`"), "got: {}", errors[0]);
+        assert!(
+            errors[0].contains("UnregisteredGeneric"),
+            "for {inner}, got: {}",
+            errors[0]
+        );
+        assert!(
+            errors[0].contains("type parameter"),
+            "for {inner}, got: {}",
+            errors[0]
+        );
+    }
+}
+
+/// A name the registry calls a string publisher is refused too, once one of the brand's own
+/// parameters is written into it.
+///
+/// That registration answers for the declaration, and the declaration here is one whose value the
+/// filling supplies: `Later<T>` publishes a string for a `Later<String>` and something else for
+/// every other filling, so the checks still land on whatever the call site handed over. The
+/// registry's own arm cannot tell this case from an unregistered one — a string publisher records
+/// no shape, exactly as an absence records none — which is why it is the parameter that decides.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn string_constraints_over_a_registered_name_carrying_the_brands_parameter_are_rejected() {
+    seed_value_shape("RegisteredStringGeneric", None);
+    let errors = branded_errors_with(
+        &syn::parse_quote! {
+            #[serde(transparent)]
+            struct Branded<T>(pub RegisteredStringGeneric<T>);
+        },
+        &pattern_args(),
+    );
+    assert_eq!(errors.len(), 1, "got: {errors:?}");
+    assert!(
+        errors[0].contains("RegisteredStringGeneric"),
+        "got: {}",
+        errors[0]
+    );
 }
 
 /// What a brand records for the next brand written over it: whatever its own inner publishes, read

--- a/tests/branded_newtype_tests/tests.rs
+++ b/tests/branded_newtype_tests/tests.rs
@@ -1642,6 +1642,28 @@ mod branded_sibling_inner_tests {
     #[serde(transparent)]
     pub struct LateSlug(pub String);
 
+    // The same forward declaration with the inner's argument fixed where it is written, which is
+    // what the refusal for a parameterised inner does not reach. Written above `LateTag` on
+    // purpose: what the registry records for a generic publisher is one shape for every
+    // instantiation, so the same pair written in the other order is refused for the recorded shape
+    // instead — a difference this fixture keeps in view rather than papering over.
+    #[model_schema(minLength = 3)]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct FixedTag(pub LateTag<String>);
+
+    // The same inner reached through a parameter instead, unconstrained — which is what a generic
+    // brand publishes a factory for.
+    #[model_schema(default_types(TagType = String))]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct OpenTag<TagType>(pub LateTag<TagType>);
+
+    #[model_schema(default_types(TagType = String))]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct LateTag<TagType>(pub TagType);
+
     #[test]
     fn a_sibling_brand_writes_the_object_its_inner_writes() {
         let part = Part {
@@ -1767,6 +1789,54 @@ mod branded_sibling_inner_tests {
             zod.contains(
                 r#"const EarlySlug$RawSchema = LateSlug$Schema.min(3).brand<"EarlySlug">()"#
             ),
+            "Got:\n{zod}"
+        );
+    }
+
+    /// A fixed argument is not a parameter, so the refusal beside it leaves this declaration where
+    /// it was: the checks are appended to the factory call, and every surface holds the string the
+    /// declaration fixed. This is the admission the guard makes for a name the registry has no
+    /// answer for, reached by a name that carries an argument.
+    #[test]
+    fn a_constrained_brand_over_a_fixed_instantiation_carries_its_checks() {
+        assert_eq!(
+            FixedTag::json_schema(),
+            serde_json::json!({ "allOf": [{}, { "minLength": 3_u32 }] })
+        );
+        let zod = FixedTag::zod_schema();
+        assert!(
+            zod.contains(
+                r#"const FixedTag$RawSchema = LateTag$SchemaFactory(z.string()).min(3).brand<"FixedTag">()"#
+            ),
+            "Got:\n{zod}"
+        );
+        FixedTag(LateTag("abcd".to_owned())).validate().unwrap();
+        assert_eq!(
+            FixedTag(LateTag("ab".to_owned())).validate().unwrap_err(),
+            vec!["value is too short: minimum length is 3, got 2".to_owned()]
+        );
+    }
+
+    /// Nothing the refusal added reaches a brand carrying no checks: it still publishes the
+    /// factory, still composes the inner's own factory inside it, and still binds the parameter it
+    /// was declared with.
+    #[test]
+    fn an_unconstrained_generic_brand_over_a_parameterised_inner_is_unchanged() {
+        assert_eq!(
+            OpenTag::<String>::ts_definition(),
+            r#"export type OpenTag<TagType> = LateTag<TagType> & $brand<"OpenTag">;"#
+        );
+        let zod = OpenTag::<String>::zod_schema();
+        assert!(
+            zod.contains("const buildOpenTag$Schema = <TagType extends ZodType>("),
+            "Got:\n{zod}"
+        );
+        assert!(
+            zod.contains("  LateTag$SchemaFactory(tagType).meta({"),
+            "Got:\n{zod}"
+        );
+        assert!(
+            zod.contains("export const OpenTag$SchemaFactory = <TagType extends ZodType>("),
             "Got:\n{zod}"
         );
     }

--- a/tests/generic_types_tests/tests.rs
+++ b/tests/generic_types_tests/tests.rs
@@ -21,7 +21,8 @@
 mod typescript {
     use super::{
         Adjacent, External, FolderTree, Holder, Internal, KeyedByParameter, LifetimeStruct, Pair,
-        PlainConst, Positional, Untagged, WireFolder, Wrapper,
+        PlainConst, Positional, Untagged, WireFolder, Wrapper, concrete_alias_schema,
+        keyed_alias_schema,
     };
 
     /// The key states the string keys serde writes, the way the two validating surfaces already
@@ -54,6 +55,42 @@ mod typescript {
             "Got: {ts}"
         );
         assert!(!ts.contains("Record<KeyType"), "Got: {ts}");
+    }
+
+    /// An alias reaches the same rule, its own target being classified the way a struct's fields
+    /// are. Both members of the declaration are held: the target and the re-export written from it,
+    /// the second binding the parameters the first spends.
+    #[test]
+    fn a_parameter_keyed_map_alias_states_the_string_key_and_keeps_the_value_parameter() {
+        let ts = keyed_alias_schema::Schema::ts_definition();
+        assert!(
+            ts.contains(
+                "export type KeyedAliasType<KeyType, ValueType> = \
+                 Partial<Record<string, ValueType>>;"
+            ),
+            "Got: {ts}"
+        );
+        assert!(
+            ts.contains(
+                "export type KeyedAlias<KeyType, ValueType> = KeyedAliasType<KeyType, ValueType>;"
+            ),
+            "Got: {ts}"
+        );
+        assert!(!ts.contains("Record<KeyType"), "Got: {ts}");
+    }
+
+    /// Nothing parameterised, nothing to classify: the alias renders what it always rendered.
+    #[test]
+    fn an_alias_declaring_no_parameter_renders_its_target_as_written() {
+        let ts = concrete_alias_schema::Schema::ts_definition();
+        assert!(
+            ts.contains("export type ConcreteAliasType = Partial<Record<string, number>>;"),
+            "Got: {ts}"
+        );
+        assert!(
+            ts.contains("export type ConcreteAlias = ConcreteAliasType;"),
+            "Got: {ts}"
+        );
     }
 
     /// The declaration binds what the fields under it are written with, so a field typed with a
@@ -203,7 +240,7 @@ mod zod {
     use super::{
         Adjacent, Carried, Envelope, External, FolderTree, Holder, Internal, KeyedByParameter,
         LifetimeStruct, Pair, PlainConst, Positional, Quintet, Referrer, Summarised, Tagged,
-        Untagged, WireFolder, Wrapper,
+        Untagged, WireFolder, Wrapper, keyed_alias_schema,
     };
 
     /// A record key has to produce string keys, and serde says every instantiation this map has
@@ -228,6 +265,36 @@ mod zod {
         // appear is the parameter standing where the KEY schema goes.
         assert!(!zod.contains("z.record(keyType"), "Got: {zod}");
         assert!(!zod.contains("KeyType$Schema"), "Got: {zod}");
+    }
+
+    /// The alias reaches the same two answers through the same classification, and the factory it
+    /// publishes is where they compose: the parameter written as the map's VALUE is the argument
+    /// the factory binds, while the one written as its KEY states the string guarantee and so
+    /// leaves its own argument unspent — the signature still binds it, the declaration having
+    /// written it.
+    #[test]
+    fn a_parameter_keyed_map_alias_composes_the_factory_argument_with_the_string_key() {
+        let zod = keyed_alias_schema::Schema::zod_schema();
+        assert!(
+            zod.contains("const buildKeyedAliasType$Schema = "),
+            "Got: {zod}"
+        );
+        assert!(
+            zod.contains("  z.record(z.string(), valueType);"),
+            "Got: {zod}"
+        );
+        // The key's argument is still bound where the declaration wrote it, spent or not; only a
+        // build that declares types spells the binding out.
+        #[cfg(feature = "typescript")]
+        assert!(
+            zod.contains(
+                "const buildKeyedAliasType$Schema = \
+                 <KeyType extends ZodType, ValueType extends ZodType>(\n  keyType: KeyType,"
+            ),
+            "Got: {zod}"
+        );
+        assert!(!zod.contains("z.record(z.unknown()"), "Got: {zod}");
+        assert!(!zod.contains("z.record(keyType"), "Got: {zod}");
     }
 
     /// A concrete key keeps its own answer: a bare string opens the object, and a key serde
@@ -913,8 +980,9 @@ pub struct Envelope {
     pub trace: String,
 }
 
-/// A generic alias, and a generic branded newtype: the two surfaces that publish a `const` rather
-/// than a factory, and so the two a parameter inside still reaches as the opaque value.
+/// A generic alias, and a generic branded newtype: the two item shapes holding a single written
+/// target rather than a list of fields, and so the two whose parameters are classified at that
+/// target rather than one field at a time.
 #[model_schema(name = "Boxed", default_types(ValueType = String))]
 pub type Boxed<ValueType> = Vec<ValueType>;
 
@@ -922,6 +990,19 @@ pub type Boxed<ValueType> = Vec<ValueType>;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct Tagged<ValueType>(pub ValueType);
+
+/// One parameter in a map's key position, one in its value position — what
+/// [`KeyedByParameter`] holds for a struct, held here for an alias. Consumed only by the surface
+/// modules, so it exists only where one of them compiles.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[model_schema(default_types(KeyType = String, ValueType = u32))]
+pub type KeyedAlias<KeyType, ValueType> = HashMap<KeyType, ValueType>;
+
+/// The same target with nothing parameterised, held beside the one above so the classification
+/// cannot move a non-generic alias.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[model_schema()]
+pub type ConcreteAlias = HashMap<String, u32>;
 
 /// A generic type that also flattens, which is the one shape where the parameters and the deferred
 /// read of another type's binding have to hold at once.
@@ -1023,6 +1104,18 @@ pub struct Summarised<ValueType> {
 #[test]
 fn a_parameter_with_no_default_still_expands_where_no_json_document_is_built() {
     assert_eq!(Undefaulted { id: 1_u32 }.id, 1);
+}
+
+/// Each alias named by a value, the way every other declaration shape here is: an alias that binds
+/// parameters is still the type it names, and a filling of it is a map serde writes as an object.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn a_generic_alias_expands_to_rust_that_compiles() {
+    let keyed: KeyedAlias<String, u32> = HashMap::from([("k".to_owned(), 1_u32)]);
+    assert_eq!(keyed["k"], 1);
+
+    let concrete: ConcreteAlias = HashMap::from([("k".to_owned(), 2_u32)]);
+    assert_eq!(concrete["k"], 2);
 }
 
 /// The pair the attribute used to produce on any generic item: `E0107` on the emitted `impl`,

--- a/tests/readme_example_tests/tests.rs
+++ b/tests/readme_example_tests/tests.rs
@@ -10,7 +10,9 @@
 //! Each type is declared with its fields ordered alphabetically, as this crate's lints require of
 //! Rust source; the README orders its examples for reading. Only the order the members are written
 //! in differs, so every member is held as a whole line rather than as part of a block — what is
-//! pinned is the spelling of each, which is what an omitted key changes.
+//! pinned is the spelling of each, which is what an omitted key changes. A derive list is widened
+//! here for the same reason and to the same effect on the emission, which is none: the generator
+//! reads no derive but serde's.
 //!
 //! The README's `ts_optional` example is not here. The flag decides the key only where no serde
 //! attribute is read, so the section shows a declaration this module's build cannot compile; the
@@ -192,5 +194,125 @@ fn test_the_chrono_example_is_declarable_and_shows_what_it_emits() {
             "  created_at: z.coerce.date(),",
             "  updated_at: z.union([z.coerce.date(), z.undefined()]).prefault(undefined),",
         ],
+    );
+}
+
+/// The README declares this, and the block beside it is the emission whole.
+///
+/// Held as one block rather than line by line, which is what a truncated paste needs: an emission
+/// shown down to its seventh line matches every line it shows and still leaves the reader without
+/// the factory the rest of the block declares.
+fn assert_readme_declares_and_shows_whole(declaration: &str, emission: &str) {
+    assert!(
+        readme().contains(declaration),
+        "the README no longer declares this verbatim:\n{declaration}"
+    );
+    assert!(
+        readme().contains(emission.trim_end()),
+        "the README no longer shows this emission whole:\n{emission}"
+    );
+}
+
+/// The "Branded Newtypes" example: a generic brand beside a non-generic one, and the whole of what
+/// each publishes.
+///
+/// A generic brand publishes a factory, so its emission runs well past the builder the block used
+/// to stop at — the type alias reading the builder's return back, the two-method cache interface,
+/// the cache itself and the exported factory. All of it is what a reader pastes.
+#[test]
+#[cfg(feature = "zod")]
+fn test_the_branded_newtype_example_is_declarable_and_shows_what_it_emits() {
+    #[model_schema(default_types(IdType = String))]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct UserId<IdType>(pub IdType);
+
+    #[model_schema()]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct CorrelationId(pub String);
+
+    assert_readme_declares_and_shows_whole(
+        "pub struct UserId<IdType>(pub IdType);",
+        &UserId::<String>::ts_definition(),
+    );
+    assert_readme_declares_and_shows_whole(
+        "pub struct UserId<IdType>(pub IdType);",
+        &UserId::<String>::zod_schema(),
+    );
+    assert_readme_declares_and_shows_whole(
+        "pub struct CorrelationId(pub String);",
+        &CorrelationId::ts_definition(),
+    );
+    assert_readme_declares_and_shows_whole(
+        "pub struct CorrelationId(pub String);",
+        &CorrelationId::zod_schema(),
+    );
+}
+
+/// The same two declarations in a build with no `zod`, where the brand is a `unique symbol` the
+/// type is intersected with rather than a marker Zod's `.brand()` carries — the block the README
+/// shows under "without `zod` feature", and the one this build is the only one that can run.
+#[test]
+#[cfg(not(feature = "zod"))]
+fn test_the_branded_newtype_example_shows_what_a_build_without_zod_emits() {
+    #[model_schema(default_types(IdType = String))]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct UserId<IdType>(pub IdType);
+
+    #[model_schema()]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct CorrelationId(pub String);
+
+    assert_readme_declares_and_shows_whole(
+        "pub struct UserId<IdType>(pub IdType);",
+        &UserId::<String>::ts_definition(),
+    );
+    assert_readme_declares_and_shows_whole(
+        "pub struct CorrelationId(pub String);",
+        &CorrelationId::ts_definition(),
+    );
+}
+
+/// The "Doc Comments and Examples on Branded Newtypes" example, whose docs and `rust example` block
+/// reach the factory's builder as a description and an example — and whose factory below them is
+/// the same whole block the plain generic brand publishes.
+#[test]
+#[cfg(feature = "zod")]
+fn test_the_documented_branded_newtype_example_is_declarable_and_shows_what_it_emits() {
+    /// Generic document identifier.
+    ///
+    /// - `DocumentId<String>` for API/HTTP layer
+    /// - `DocumentId<ObjectId>` for MongoDB layer
+    ///
+    /// ```rust example
+    /// DocumentId("64de3d95ff45b119e5b53a7e".to_string())
+    /// ```
+    #[model_schema(default_types(IdType = String))]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct DocumentId<IdType>(pub IdType);
+
+    assert_readme_declares_and_shows_whole(
+        "pub struct DocumentId<IdType>(pub IdType);",
+        &DocumentId::<String>::zod_schema(),
+    );
+}
+
+/// The rejected half of the constrained-brand rule for an inner written over a parameter. Only its
+/// spelling can be held here — the declaration itself is a `compile_error!` by construction, which
+/// is what the rule says it should be — so what this pins is that the README still shows the two
+/// declarations the refusal is written about.
+#[test]
+fn test_the_constrained_brand_over_a_parameterised_inner_example_is_still_shown() {
+    assert!(
+        readme().contains("pub struct TaggedSlug<T>(pub Tagged<T>);"),
+        "the README no longer shows the rejected declaration"
+    );
+    assert!(
+        readme().contains("pub struct Tagged<T>(pub T);"),
+        "the README no longer shows the inner the rejected declaration is written over"
     );
 }


### PR DESCRIPTION
Three related fixes to the generic surfaces.

A constrained brand over a sibling type carrying one of the brand's own type parameters is now refused at the declaration, naming the brand, the inner, and the parameter: the checks would land on whatever each instantiation supplies, the one JSON document still holds the empty schema a parameter describes as, and validation measures the inner's Display rendering — while the same pair written in the other declaration order was already refused through the registry. A fixed instantiation (a concrete argument) keeps its admission, and its checks now have pinned coverage on all three surfaces.

The alias module's TypeScript definition now reads its target through the same parameter-classification seam the Zod and JSON methods use, so a type parameter written in a map's key position states the string keys serde writes instead of failing the Record key constraint under tsc.

The README's generic-brand blocks were truncated at the brand call, dropping the factory the emission publishes after it; both blocks are now byte-equal to a run and pinned whole, with the example fixture renamed to satisfy the camel-case lint the runnable pin requires.