### PR TITLE
Answer the flatten edge for a directly named source on all three surfaces

### DIFF
--- a/src/features/jsonschema.rs
+++ b/src/features/jsonschema.rs
@@ -218,6 +218,19 @@ fn merge_readers() -> proc_macro2::TokenStream {
             }
             None
         }
+
+        // The variant name a branch of an externally tagged enum's `oneOf` pins, and `None` for
+        // every branch that pins none.
+        //
+        // The two spellings a union is written under say which enum wrote it: `oneOf` is the
+        // exclusive choice a tagged enum publishes, where a branch describing a bare string is a
+        // unit variant and the description pins the name serde writes it as. `anyOf` is the
+        // first-match choice an untagged enum publishes and a nullable value's own, where a string
+        // branch is a value serde writes as that string and nothing tags.
+        fn tagged_unit_variant(schema: &serde_json::Value) -> Option<&str> {
+            (described_type(schema)? == "string").then_some(())?;
+            schema.get("const")?.as_str()
+        }
     }
 }
 
@@ -243,6 +256,10 @@ fn merged_tree() -> proc_macro2::TokenStream {
             // members, so the branch names exactly the keys the object writes on its own.
             Absent,
             Object(&'defs serde_json::Map<String, serde_json::Value>),
+            // An externally tagged enum's unit variant, which the description pins as the bare name
+            // serde writes for it standing alone. Merged, serde writes that name as a key holding
+            // `null` — one member, which the branch carries as the name it is.
+            Tagged(&'defs str),
             Union(&'static str, Vec<Branches<'defs>>),
         }
 
@@ -264,6 +281,23 @@ fn merged_tree() -> proc_macro2::TokenStream {
                         Merged::Object(merge_object_schemas(base, &serde_json::Map::new()))
                     }
                     Self::Object(members) => Merged::Object(merge_object_schemas(base, members)),
+                    Self::Tagged(name) => {
+                        let mut properties = serde_json::Map::new();
+                        properties
+                            .insert(name.to_string(), serde_json::json!({ "type": "null" }));
+                        let mut written = serde_json::Map::new();
+                        written.insert(
+                            "properties".to_string(),
+                            serde_json::Value::Object(properties),
+                        );
+                        written.insert(
+                            "required".to_string(),
+                            serde_json::Value::Array(vec![serde_json::Value::String(
+                                name.to_string(),
+                            )]),
+                        );
+                        Merged::Object(merge_object_schemas(base, &written))
+                    }
                     Self::Union(spelling, ref branches) => {
                         let mut merged: Vec<Merged> = branches
                             .iter()
@@ -476,7 +510,19 @@ fn branch_expansion() -> proc_macro2::TokenStream {
             let mut expanded: Vec<Branches<'defs>> = Vec::new();
             for (index, branch) in branches.iter().enumerate() {
                 position.push(index + 1);
-                let below = expanded_branches(branch, hoisted_defs, expanding, position, label);
+                // A unit variant of the choice the flatten edge itself offers, which is the one
+                // depth at which the enum being flattened *is* the source. serde writes the
+                // variant's name into the object being merged there, so the branch is a key set
+                // like any other. One level down the enum is a member of a choice serde matched by
+                // shape, where the same value is the bare string it was written as and joins
+                // nothing — the refusal that position already carries.
+                let tagged = (position.len() == 1 && spelling == "oneOf")
+                    .then(|| tagged_unit_variant(branch))
+                    .flatten();
+                let below = match tagged {
+                    Some(name) => Some(Branches::Tagged(name)),
+                    None => expanded_branches(branch, hoisted_defs, expanding, position, label),
+                };
                 position.pop();
                 expanded.extend(below);
             }

--- a/src/features/jsonschema/tests.rs
+++ b/src/features/jsonschema/tests.rs
@@ -120,7 +120,7 @@ fn test_the_merge_expands_branches_to_a_fixed_point_under_a_path_terminator() {
 
     assert!(
         merge.contains(
-            "let below = expanded_branches (branch , hoisted_defs , expanding , position , label)"
+            "None => expanded_branches (branch , hoisted_defs , expanding , position , label)"
         ),
         "{merge}"
     );
@@ -130,6 +130,36 @@ fn test_the_merge_expands_branches_to_a_fixed_point_under_a_path_terminator() {
     );
     assert!(
         merge.contains("closes a flatten cycle through nested unions"),
+        "{merge}"
+    );
+}
+
+/// One branch of the choice the edge itself offers is read before the descent rather than by it: a
+/// unit variant of an exclusive union is the one key set the description does not spell out, serde
+/// writing the variant's name as a key where the document pins it as a bare string.
+#[test]
+fn test_the_merge_reads_a_tagged_unit_variant_at_the_edges_own_depth() {
+    let merge = generate_struct_json_schema_method(
+        &[],
+        &[MergedSource {
+            label: "Base".to_owned(),
+            optional: false,
+            value: quote::quote! { serde_json::json!({ "type": "object" }) },
+        }],
+        "Node",
+    )
+    .to_string();
+
+    assert!(
+        merge.contains("(position . len () == 1 && spelling == \"oneOf\")"),
+        "{merge}"
+    );
+    assert!(
+        merge.contains("Some (name) => Some (Branches :: Tagged (name))"),
+        "{merge}"
+    );
+    assert!(
+        merge.contains("schema . get (\"const\") ? . as_str ()"),
         "{merge}"
     );
 }

--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -1075,6 +1075,27 @@ impl FieldDef {
         }
     }
 
+    /// What an object flattening this field joins for each variant of the externally tagged enum it
+    /// names, as that enum recorded them, and nothing for a field that names no such enum.
+    ///
+    /// Answered under the same bound [`Self::zod_union_members`] is answered under, and for the same
+    /// reason: what is spliced in the name's place has to be the whole of what the operand
+    /// validates.
+    #[cfg(all(feature = "serde", feature = "zod"))]
+    pub fn zod_flatten_variants(&self) -> Vec<String> {
+        let wrapped = self
+            .model_schema_prop_meta
+            .as_ref()
+            .is_some_and(|meta| !meta.preprocess.is_empty());
+        if self.array_depth > 0 || wrapped {
+            return Vec::new();
+        }
+        let FieldDefType::SiblingType(name, _) = &self.field_type else {
+            return Vec::new();
+        };
+        lookup_alias_info(name).map_or_else(Vec::new, |info| info.zod_flatten_variants)
+    }
+
     /// The key schema a `z.record(…)` is written with: the key's own, except where the key is one
     /// of the enclosing item's type parameters.
     ///

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -106,9 +106,15 @@ use crate::utils::ident_reexport_ts;
 use crate::utils::ident_reexport_zod;
 
 #[cfg(feature = "zod")]
-use crate::utils::{ZodUnionMember, record_zod_union_members};
+use crate::utils::record_zod_union_members;
 
 #[cfg(all(feature = "serde", feature = "zod"))]
+use crate::utils::ZodUnionMember;
+
+#[cfg(all(feature = "serde", feature = "zod"))]
+use crate::utils::record_zod_flatten_variants;
+
+#[cfg(all(feature = "serde", any(feature = "zod", feature = "typescript")))]
 use crate::utils::{WireLeaf, record_wire_leaves};
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
@@ -527,14 +533,56 @@ struct ModelSchemaArgs {
 /// keys alone. Where that choice is spelled is each surface's to answer.
 #[cfg(any(feature = "typescript", feature = "zod"))]
 struct MergedOperand {
-    /// What the source contributes to each branch when it names an untagged union the registry has
-    /// recorded — one member per branch — and empty for every other source, which contributes
+    absence: SourceAbsence,
+    /// What the source contributes to each branch when it names a choice the registry recorded the
+    /// branches of — one operand per branch — and empty for every other source, which contributes
     /// `spelling`. Zod only: TypeScript distributes an intersection over a union on its own, so
-    /// there the union is spelled as the one operand it is.
+    /// there the choice is spelled as the one operand it is.
     #[cfg(feature = "zod")]
-    members: Vec<ZodUnionMember>,
-    optional: bool,
+    branches: Vec<String>,
     spelling: String,
+}
+
+/// Which absence a merged source offers beside its members, and none where it always writes them.
+///
+/// One question to the merge that only counts key sets, and two to the surface that has to name the
+/// keys the absent branch leaves out. A source written `Option<T>` is spelled as the `T` inside it,
+/// so those keys are the spelling's own; a source naming an item whose published surface is nullable
+/// is spelled as that name, whose keys are the ones its value side names and not the name's — a
+/// choice has no keys of its own to read.
+#[cfg(any(feature = "typescript", feature = "zod"))]
+#[derive(Clone, Copy)]
+enum SourceAbsence {
+    /// The field's own `Option` says the source writes all of its members or none of them.
+    Field,
+    /// The source writes its members for every value it holds.
+    Never,
+    /// The item the source names publishes the absence beside its value, one name away.
+    Published,
+}
+
+#[cfg(any(feature = "typescript", feature = "zod"))]
+impl SourceAbsence {
+    /// Which of the two the source offers, for the merge that only has to count the key sets.
+    #[cfg(feature = "zod")]
+    const fn offered(self) -> bool {
+        !matches!(self, Self::Never)
+    }
+
+    /// What a flattened source offers, read off the two spellings that reach the same absence: the
+    /// field's own `Option`, and the leaves the name it holds recorded. The `Option` is asked first
+    /// because it is the outer of the two — a source written `Option<Name>` writes nothing for its
+    /// own `None` whatever the name goes on to publish, and the spelling the merge holds is the one
+    /// inside the `Option`.
+    fn written(fld: &FieldDef) -> Self {
+        if fld.is_optional() {
+            Self::Field
+        } else if flattened_name_offers_absence(fld) {
+            Self::Published
+        } else {
+            Self::Never
+        }
+    }
 }
 
 /// Both answers the registry holds about what a `#[model_schema()]` item publishes, built together
@@ -548,7 +596,7 @@ struct MergedOperand {
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 struct Surface {
     shape: Option<&'static str>,
-    #[cfg(all(feature = "serde", feature = "zod"))]
+    #[cfg(all(feature = "serde", any(feature = "zod", feature = "typescript")))]
     wire: RecordedWire,
 }
 
@@ -558,7 +606,7 @@ struct Surface {
 /// The two are one recording — [`Surface::record`] writes either as leaves — and are held apart
 /// only so a surface named outright can be built without one, which is what lets the four fixed
 /// surfaces be `const`.
-#[cfg(all(feature = "serde", feature = "zod"))]
+#[cfg(all(feature = "serde", any(feature = "zod", feature = "typescript")))]
 enum RecordedWire {
     Leaves(Vec<WireLeaf>),
     Named(Option<&'static str>),
@@ -643,7 +691,7 @@ impl Surface {
     ///
     /// The tagged shapes that write an object for every variant keep [`Self::union`]: their leaves
     /// would be unmarked to the last one, which is what the single unmarked leaf already says.
-    #[cfg(all(feature = "serde", feature = "zod"))]
+    #[cfg(all(feature = "serde", any(feature = "zod", feature = "typescript")))]
     fn externally_tagged(variants: &Punctuated<syn::Variant, Token![,]>) -> Self {
         Self {
             shape: Self::union().shape,
@@ -651,21 +699,21 @@ impl Surface {
         }
     }
 
-    /// The same union where no merge reads its leaves. `serde` and `zod` together are the pair that
-    /// flattens one over the other; without both, nothing asks what the variants write and the
-    /// union is the union every other enum shape registers.
-    #[cfg(all(feature = "serde", not(feature = "zod")))]
+    /// The same union where no merge reads its leaves. `serde` beside a surface that merges is the
+    /// pair that flattens one over the other; without both, nothing asks what the variants write and
+    /// the union is the union every other enum shape registers.
+    #[cfg(all(feature = "serde", not(any(feature = "zod", feature = "typescript"))))]
     const fn externally_tagged(_variants: &Punctuated<syn::Variant, Token![,]>) -> Self {
         Self::union()
     }
 
     /// A surface neither answer is read off a written type for.
     const fn named(shape: Option<&'static str>, wire: Option<&'static str>) -> Self {
-        #[cfg(not(all(feature = "serde", feature = "zod")))]
+        #[cfg(not(all(feature = "serde", any(feature = "zod", feature = "typescript"))))]
         let _: Option<&'static str> = wire;
         Self {
             shape,
-            #[cfg(all(feature = "serde", feature = "zod"))]
+            #[cfg(all(feature = "serde", any(feature = "zod", feature = "typescript")))]
             wire: RecordedWire::Named(wire),
         }
     }
@@ -679,7 +727,7 @@ impl Surface {
     /// surface is built for one registration and spent on it.
     fn record(self, rust_ident: &str) {
         record_value_shape(rust_ident, self.shape);
-        #[cfg(all(feature = "serde", feature = "zod"))]
+        #[cfg(all(feature = "serde", any(feature = "zod", feature = "typescript")))]
         match self.wire {
             RecordedWire::Leaves(leaves) => record_wire_leaves(rust_ident, &leaves),
             RecordedWire::Named(non_object) => record_wire_leaves(
@@ -701,7 +749,7 @@ impl Surface {
     fn written(written: &FieldDef) -> Self {
         Self {
             shape: published_value_shape(written),
-            #[cfg(all(feature = "serde", feature = "zod"))]
+            #[cfg(all(feature = "serde", any(feature = "zod", feature = "typescript")))]
             wire: RecordedWire::Leaves(published_wire_leaves(written)),
         }
     }
@@ -1567,9 +1615,9 @@ fn compute_flatten_outputs(
     let ts_types = flattened_fields
         .iter()
         .map(|fld| MergedOperand {
+            absence: SourceAbsence::written(fld),
             #[cfg(feature = "zod")]
-            members: Vec::new(),
-            optional: fld.is_optional(),
+            branches: Vec::new(),
             spelling: fld.typescript_merged_typename(),
         })
         .collect();
@@ -1580,8 +1628,8 @@ fn compute_flatten_outputs(
     let zod_schemas = flattened_fields
         .iter()
         .map(|fld| MergedOperand {
-            members: fld.zod_union_members(),
-            optional: fld.is_optional() || flattened_name_offers_absence(fld),
+            absence: SourceAbsence::written(fld),
+            branches: flattened_zod_branches(fld),
             spelling: fld.zod_merged_schema(),
         })
         .collect();
@@ -1604,7 +1652,7 @@ fn compute_flatten_outputs(
 /// The name has to be the whole of what the source writes. An array level is the array around
 /// whatever the name publishes, and the choice behind the name is one its items offer rather than
 /// one the source does.
-#[cfg(all(feature = "serde", feature = "zod"))]
+#[cfg(all(feature = "serde", any(feature = "zod", feature = "typescript")))]
 fn flattened_name_offers_absence(fld: &FieldDef) -> bool {
     if fld.is_array() {
         return false;
@@ -1617,9 +1665,47 @@ fn flattened_name_offers_absence(fld: &FieldDef) -> bool {
 
 /// No source offers one where nothing reads `#[serde(flatten)]`: without `serde` no field reaches
 /// the merge to begin with, and the registry records no wire for a name to publish an absence in.
-#[cfg(all(feature = "zod", not(feature = "serde")))]
+#[cfg(all(any(feature = "zod", feature = "typescript"), not(feature = "serde")))]
 const fn flattened_name_offers_absence(_fld: &FieldDef) -> bool {
     false
+}
+
+/// The operands an object joins one per branch for a flattened source, and none for a source that
+/// contributes one key set and is joined as the one operand it is.
+///
+/// Two recordings answer here, one per choice a source can name. An untagged enum's members are the
+/// alternatives the source itself offers and are recorded as those. An externally tagged enum's
+/// variants are recorded in the spelling a merge joins, which is not the one the union publishes —
+/// serde writes a unit variant as a bare name standing alone and as that name holding `null` where
+/// the enum is flattened.
+///
+/// The tagged variants are read only where the same enum's recorded leaves prove one of them is no
+/// object, which is the bound those leaves are already spliced under one position further in. A
+/// tagged enum every variant of which serde writes as an object publishes one operand per branch
+/// that names what the enum's own binding names, and is left as the one operand it was.
+///
+/// A source declared below the object has recorded neither, and takes the fallback the merge
+/// documents.
+#[cfg(all(feature = "serde", feature = "zod"))]
+fn flattened_zod_branches(fld: &FieldDef) -> Vec<String> {
+    let members = fld.zod_union_members();
+    if !members.is_empty() {
+        return members.into_iter().map(|member| member.spelling).collect();
+    }
+    if named_wire_leaves(fld).is_none() {
+        return Vec::new();
+    }
+    fld.zod_flatten_variants()
+}
+
+/// No source names branches where nothing reads `#[serde(flatten)]`, for the reason no source offers
+/// an absence there.
+#[cfg(all(feature = "zod", not(feature = "serde")))]
+fn flattened_zod_branches(fld: &FieldDef) -> Vec<String> {
+    fld.zod_union_members()
+        .into_iter()
+        .map(|member| member.spelling)
+        .collect()
 }
 
 /// The schema methods a struct's module publishes — the JSON-schema document, the TypeScript
@@ -2315,7 +2401,7 @@ fn registered_value_shape(rust_ident: &str) -> Option<&'static str> {
 /// sitting below the name rather than at it — and is spliced by [`named_wire_leaves`] instead. A
 /// map, an object and a name nothing has classified answer alike, which is the fallback the merge
 /// already documents for a source declared below the object that flattens it.
-#[cfg(all(feature = "serde", feature = "zod"))]
+#[cfg(all(feature = "serde", any(feature = "zod", feature = "typescript")))]
 fn registered_non_object_wire(rust_ident: &str) -> Option<&'static str> {
     match lookup_alias_info(rust_ident)?.wire.as_slice() {
         [only] => only.non_object,
@@ -2335,7 +2421,10 @@ fn registered_non_object_wire(rust_ident: &str) -> Option<&'static str> {
 ///
 /// Named exhaustively rather than caught by a wildcard: a new variant must be classified here, not
 /// silently collapsed into whichever arm sits last.
-#[cfg(any(feature = "jsonschema", all(feature = "serde", feature = "zod")))]
+#[cfg(any(
+    feature = "jsonschema",
+    all(feature = "serde", any(feature = "zod", feature = "typescript"))
+))]
 const fn scalar_json_type_keyword(field_type: &FieldDefType) -> Option<&'static str> {
     match *field_type {
         FieldDefType::Boolean => Some("boolean"),
@@ -2588,20 +2677,23 @@ fn apply_deferred_field_attrs<'field>(
     }
 }
 
-/// The `compile_error!` tokens for a `#[serde(flatten)]` field naming an untagged union one of
-/// whose recorded members serde does not write as an object, or `None` for every other field.
+/// The `compile_error!` tokens for a `#[serde(flatten)]` field whose recorded wire proves serde
+/// does not write an object where the merge needs one, or `None` for every other field.
+///
+/// Both operands the edge reaches are answered here, in the two wordings the JSON-schema merge
+/// already refuses the same declaration in: a member of an untagged union the field names, named by
+/// the branch it sits at, and the field's own operand, named at no position at all. What the
+/// multiplication would write for either is the object intersected with a scalar, a branch no
+/// payload satisfies and nothing reports; serde refuses the value outright. Refused at expansion
+/// because that is the only place holding the field the author would have to change.
 ///
 /// The union itself is left alone — an untagged enum may hold a scalar, and it is only the merge
-/// that has no object to join one to. What the multiplication would write for such a member is the
-/// object intersected with the scalar, a branch no payload satisfies and nothing reports; serde
-/// refuses the value outright, and the JSON-schema merge refuses the declaration in the words
-/// repeated here. Refused at expansion because that is the only place holding the field the author
-/// would have to change.
+/// that has no object to join one to.
 ///
-/// A union declared below the object has recorded nothing, so this answers for no member of it —
-/// the same bound the multiplication itself has, and the same one the merge's fallback documents.
+/// A name declared below the object has recorded nothing, so this answers for neither operand of it
+/// — the same bound the multiplication itself has, and the same one the merge's fallback documents.
 #[cfg(all(feature = "serde", feature = "zod"))]
-fn flattened_union_member_guard_error(
+fn flatten_edge_guard_error(
     field: &syn::Field,
     type_name: &str,
 ) -> Option<proc_macro2::TokenStream> {
@@ -2609,25 +2701,49 @@ fn flattened_union_member_guard_error(
     let FieldDefType::SiblingType(inner_name, _) = &inner.field_type else {
         return None;
     };
-    let member = inner
+    let refused = inner
         .zod_union_members()
         .into_iter()
-        .find(|member| member.non_object.is_some())?;
-    let named = member.non_object?;
-    let branch = member.branch_path();
-    Some(
-        syn::Error::new_spanned(
-            &field.ty,
-            format!(
-                "model_schema: `{type_name}`: `#[serde(flatten)]` of `{inner_name}` writes a \
-                 union member that is not an object — its branch {branch} describes a `{named}`, \
-                 which has no members to merge, and what serde writes for that member does not \
-                 join the object being written; write the field as a named member so the value \
-                 gets a key of its own."
-            ),
+        .find_map(|member| member.non_object.map(|named| (member.branch_path(), named)));
+    let message = if let Some((branch, named)) = refused {
+        format!(
+            "model_schema: `{type_name}`: `#[serde(flatten)]` of `{inner_name}` writes a \
+             union member that is not an object — its branch {branch} describes a `{named}`, \
+             which has no members to merge, and what serde writes for that member does not \
+             join the object being written; write the field as a named member so the value \
+             gets a key of its own."
         )
-        .to_compile_error(),
-    )
+    } else {
+        let named = flattened_name_non_object_wire(&inner)?;
+        format!(
+            "model_schema: `{type_name}`: `#[serde(flatten)]` of `{inner_name}` is not written \
+             as an object — its schema describes a `{named}`, which has no members to merge, \
+             and what serde writes for it does not join the object being written; write the \
+             field as a named member so the value gets a key of its own."
+        )
+    };
+    Some(syn::Error::new_spanned(&field.ty, message).to_compile_error())
+}
+
+/// The JSON type keyword the item a flattened field names publishes, where the name is the whole of
+/// what the field writes and the registry proves that wire is no object — and `None` everywhere the
+/// declaration is left as it stands.
+///
+/// A plain enum publishes the same proof, its member name being a `string`, and is left to the guard
+/// written for it: those words name the variant key serde writes rather than the keyword, which is
+/// what an author of that declaration has to act on. An array level is the array around whatever the
+/// name publishes, and an object can be joined to no array either — but it is the array the field
+/// wrote rather than anything the name proves, so it is left where every other directly written
+/// shape is left, to the merge that reads the document.
+#[cfg(all(feature = "serde", feature = "zod"))]
+fn flattened_name_non_object_wire(inner: &FieldDef) -> Option<&'static str> {
+    if inner.is_array() || flattened_plain_enum(inner).is_some() {
+        return None;
+    }
+    let FieldDefType::SiblingType(name, _) = &inner.field_type else {
+        return None;
+    };
+    registered_non_object_wire(name)
 }
 
 /// Processes every field of a struct, returning the regular field defs, the `#[serde(flatten)]`
@@ -2666,7 +2782,7 @@ fn collect_struct_fields(
 
         #[cfg(all(feature = "serde", feature = "zod"))]
         if is_flatten {
-            guard_errors.extend(flattened_union_member_guard_error(field, type_name));
+            guard_errors.extend(flatten_edge_guard_error(field, type_name));
         }
 
         let (f_def, validation_fn, validate_body, field_guard_errors) = process_field(
@@ -5384,6 +5500,37 @@ fn render_external_variant(
     )
 }
 
+/// Records what an object flattening an externally tagged enum joins for each of its variants, in
+/// the order the union writes them.
+///
+/// A data-carrying variant contributes the single-key object it already renders as: serde writes
+/// exactly that into the object being merged, and the member is the operand. A unit variant renders
+/// as the bare name it is written as standing alone, which no object joins — flattened, serde writes
+/// that name as a key holding `null`, so the operand is written here instead of taken from the
+/// member.
+#[cfg(all(feature = "serde", feature = "zod"))]
+fn record_external_flatten_operands(
+    rust_ident: &str,
+    variants: &[DiscriminatedVariant],
+    members: &[(String, String, proc_macro2::TokenStream)],
+) {
+    let operands: Vec<String> = variants
+        .iter()
+        .zip(members)
+        .map(|(variant, (_, zod, _))| {
+            if matches!(variant.kind, VariantKind::Unit) {
+                format!(
+                    "z.strictObject({{\n  \"{}\": z.null(),\n}})",
+                    variant.discriminator_value
+                )
+            } else {
+                zod.clone()
+            }
+        })
+        .collect();
+    record_zod_flatten_variants(rust_ident, &operands);
+}
+
 /// Joins an externally tagged enum's rendered members into its three union surfaces: the
 /// JSON-schema body, the TypeScript union, and the Zod union.
 ///
@@ -5482,6 +5629,11 @@ fn process_externally_tagged_enum(
         .iter()
         .map(|variant| render_external_variant(variant, &self_type_name))
         .collect();
+
+    // Recorded once the variants have rendered, because the flatten-edge spelling of a data-carrying
+    // one is the member's own and only this expansion holds it.
+    #[cfg(all(feature = "serde", feature = "zod"))]
+    record_external_flatten_operands(&name.to_string(), &variants.0, &members);
 
     let (main_schema_code, type_code, schema_code) = join_external_union(&members);
     #[cfg(not(feature = "jsonschema"))]
@@ -6581,7 +6733,7 @@ fn zod_member_leaves(fld: &FieldDef, rendered: &str) -> Vec<ZodUnionMember> {
     } else {
         vec![ZodUnionMember {
             branch: Vec::new(),
-            non_object: zod_member_non_object(fld),
+            non_object: written_non_object_wire(fld),
             spelling: rendered.to_owned(),
         }]
     };
@@ -6598,17 +6750,18 @@ fn zod_member_leaves(fld: &FieldDef, rendered: &str) -> Vec<ZodUnionMember> {
     leaves
 }
 
-/// What serde writes an untagged union's member as, when the member's own written type proves that
-/// is not an object, and `None` when nothing here proves it.
+/// What serde writes a written type as, when that type proves it is not an object, and `None` when
+/// nothing here proves it. Asked of an untagged union's member and of the whole surface an item
+/// publishes alike, which is what keeps a member and the name standing for it on one answer.
 ///
-/// Named by the JSON type keyword the JSON-schema surface writes for the same member, so the two
-/// merges refuse the same member in the same words. That surface reads the keyword off a document
-/// it has already built; here there is the type, and for a name the registry's answer for what the
-/// named item published — so the answer is still a partial one by construction, a map and a name
-/// nothing has classified being left to the merge that does read the document, and a union member
-/// not being asked at all, its own leaves having already been recorded.
-#[cfg(all(feature = "serde", feature = "zod"))]
-fn zod_member_non_object(fld: &FieldDef) -> Option<&'static str> {
+/// Named by the JSON type keyword the JSON-schema surface writes for the same value, so the two
+/// merges refuse the same declaration in the same words. That surface reads the keyword off a
+/// document it has already built; here there is the type, and for a name the registry's answer for
+/// what the named item published — so the answer is still a partial one by construction, a map and a
+/// name nothing has classified being left to the merge that does read the document, and a union
+/// member not being asked at all, its own leaves having already been recorded.
+#[cfg(all(feature = "serde", any(feature = "zod", feature = "typescript")))]
+fn written_non_object_wire(fld: &FieldDef) -> Option<&'static str> {
     if fld.is_array() {
         return Some("array");
     }
@@ -6637,7 +6790,7 @@ fn zod_member_non_object(fld: &FieldDef) -> Option<&'static str> {
 /// Everything else publishes one leaf at no position of its own, read through the very dispatch a
 /// directly written member is read through, so what a name answers and what its target answers
 /// cannot come apart.
-#[cfg(all(feature = "serde", feature = "zod"))]
+#[cfg(all(feature = "serde", any(feature = "zod", feature = "typescript")))]
 fn published_wire_leaves(written: &FieldDef) -> Vec<WireLeaf> {
     if written.is_optional() {
         let mut bare = written.clone();
@@ -6656,7 +6809,7 @@ fn published_wire_leaves(written: &FieldDef) -> Vec<WireLeaf> {
     named_wire_leaves(written).unwrap_or_else(|| {
         vec![WireLeaf {
             branch: Vec::new(),
-            non_object: zod_member_non_object(written),
+            non_object: written_non_object_wire(written),
         }]
     })
 }
@@ -6668,7 +6821,7 @@ fn published_wire_leaves(written: &FieldDef) -> Vec<WireLeaf> {
 /// [`render_external_variant`] writes each variant from — so what is recorded and what is emitted
 /// read the declaration the same way, and a variant that renders as a bare string is a leaf that
 /// says so.
-#[cfg(all(feature = "serde", feature = "zod"))]
+#[cfg(all(feature = "serde", any(feature = "zod", feature = "typescript")))]
 fn external_variant_wire_leaves(variants: &Punctuated<syn::Variant, Token![,]>) -> Vec<WireLeaf> {
     variants
         .iter()
@@ -6694,7 +6847,7 @@ fn external_variant_wire_leaves(variants: &Punctuated<syn::Variant, Token![,]>) 
 ///
 /// An array level is not one of those: what the field writes is the array around whatever the name
 /// publishes, and the leaves behind the name describe an item of it rather than the field.
-#[cfg(all(feature = "serde", feature = "zod"))]
+#[cfg(all(feature = "serde", any(feature = "zod", feature = "typescript")))]
 fn named_wire_leaves(written: &FieldDef) -> Option<Vec<WireLeaf>> {
     if written.is_array() {
         return None;
@@ -10031,18 +10184,29 @@ fn flatten_merged_source(fld: &FieldDef) -> MergedSource {
 
 /// What one merged source is written as inside the intersection.
 ///
-/// A source reached through an `Option` writes all of its members or none of them, so what it
+/// A source that offers its absence writes all of its members or none of them, so what it
 /// contributes is a choice: the source itself, or an object carrying no member of it. The second
 /// branch is the source's own keys mapped to `never`, which is the spelling that excludes a source
 /// written in part — `{}` is every object, so a payload carrying some of the source's members
 /// passes through it, and that payload is one the object never writes.
+///
+/// Which type those keys are read off is what the two absences differ on. A source written
+/// `Option<T>` is spelled as the `T`, and `keyof` it names the members serde writes. A source naming
+/// an item whose published surface is nullable is spelled as that name, and the name is a choice:
+/// `keyof` a union is the members its branches share, which for a value beside `null` is none at all
+/// — an empty mapped type, and one that admits the base written in part. `NonNullable` is the value
+/// side of that choice, whose keys are the ones serde writes together or not at all. The value
+/// branch keeps the name itself: an intersection distributes over the choice behind it and the
+/// `null` side carries no key an object could be joined to, so that branch is already the value's.
 #[cfg(feature = "typescript")]
 fn ts_merged_operand(operand: &MergedOperand) -> String {
     let spelling = &operand.spelling;
-    if operand.optional {
-        format!("({spelling} | {{ [K in keyof {spelling}]?: never }})")
-    } else {
-        spelling.clone()
+    match operand.absence {
+        SourceAbsence::Never => spelling.clone(),
+        SourceAbsence::Field => format!("({spelling} | {{ [K in keyof {spelling}]?: never }})"),
+        SourceAbsence::Published => {
+            format!("({spelling} | {{ [K in keyof NonNullable<{spelling}>]?: never }})")
+        }
     }
 }
 
@@ -10434,18 +10598,14 @@ fn zod_example_injection(item_name: &str, parameters: &[String]) -> proc_macro2:
     }
 }
 
-/// What one merged source contributes to each branch: one schema per member of the untagged union
-/// it names, and the source itself when it names none.
+/// What one merged source contributes to each branch: one schema per branch of the choice it names,
+/// and the source itself when it names none.
 #[cfg(feature = "zod")]
 fn zod_operand_contributions(operand: &MergedOperand) -> Vec<&str> {
-    if operand.members.is_empty() {
+    if operand.branches.is_empty() {
         vec![operand.spelling.as_str()]
     } else {
-        operand
-            .members
-            .iter()
-            .map(|member| member.spelling.as_str())
-            .collect()
+        operand.branches.iter().map(String::as_str).collect()
     }
 }
 
@@ -10491,7 +10651,7 @@ fn zod_merged_statements(
                     .into_iter()
                     .map(|schema| format!("{join}.and({})", deferred_zod_operand(schema)))
                     .collect();
-                if operand.optional {
+                if operand.absence.offered() {
                     grown.push(join.clone());
                 }
                 grown

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -21,9 +21,7 @@ use super::{
 };
 
 #[cfg(all(feature = "serde", feature = "zod"))]
-use super::{
-    WireLeaf, flattened_union_member_guard_error, record_wire_leaves, record_zod_union_members,
-};
+use super::{WireLeaf, flatten_edge_guard_error, record_wire_leaves, record_zod_union_members};
 
 #[cfg(feature = "typescript")]
 use super::tuple_struct_ts_body;
@@ -6786,7 +6784,7 @@ fn flattening_a_union_of_objects_is_not_refused() {
         .is_none()
     );
     let unrecorded: syn::Field = syn::parse_quote! { #[serde(flatten)] base: NeverRecorded };
-    assert!(flattened_union_member_guard_error(&unrecorded, "Host").is_none());
+    assert!(flatten_edge_guard_error(&unrecorded, "Host").is_none());
 }
 
 /// Records an untagged enum's members the way its own expansion does, then asks the flatten guard
@@ -6807,7 +6805,7 @@ fn recorded_union_flatten_error(
         AliasKind::NoEnumMembers,
     );
     record_zod_union_members(rust_ident, &merge_parts);
-    flattened_union_member_guard_error(field, "Host").map(|error| error.to_string())
+    flatten_edge_guard_error(field, "Host").map(|error| error.to_string())
 }
 
 /// The branch trails one untagged enum's members are recorded at, beside what each is proved to
@@ -7061,6 +7059,100 @@ fn a_union_member_naming_an_object_or_an_unregistered_type_stays_admitted() {
             &syn::parse_quote! { #[serde(flatten)] either: NamedChoice },
         )
         .is_none()
+    );
+}
+
+/// What the flatten guard is asked about a field naming one item directly, with no union between.
+#[cfg(all(feature = "serde", feature = "zod"))]
+fn direct_flatten_error(field: &syn::Field) -> Option<String> {
+    flatten_edge_guard_error(field, "Host").map(|error| error.to_string())
+}
+
+/// The same refusal one position further out. A `#[serde(flatten)]` field naming an item whose own
+/// published wire is no object is the shape the member-position refusal was landed to stop, with the
+/// intersection written directly rather than through a union: serde refuses the value at runtime and
+/// the JSON-schema merge refuses the declaration, so the guard names it in the words that merge uses
+/// for a source at no position of its own.
+#[cfg(all(feature = "serde", feature = "zod"))]
+#[test]
+fn flattening_a_registered_scalar_wire_is_refused_where_the_field_was_written() {
+    seed_registered_wire("Counted", AliasKind::NoEnumMembers, Some("integer"));
+    let error = direct_flatten_error(&syn::parse_quote! { #[serde(flatten)] c: Counted }).unwrap();
+    assert!(
+        error.contains("`#[serde(flatten)]` of `Counted` is not written as an object"),
+        "got: {error}"
+    );
+    assert!(
+        error.contains("its schema describes a `integer`"),
+        "got: {error}"
+    );
+    assert!(
+        error.contains("write the field as a named member so the value gets a key of its own"),
+        "got: {error}"
+    );
+}
+
+/// Every keyword a registration can prove reaches the same refusal, each named by the word its own
+/// published document carries — the array a fixed-arity tuple struct writes among them, which serde
+/// refuses to flatten for the reason it refuses the scalar.
+#[cfg(all(feature = "serde", feature = "zod"))]
+#[test]
+fn flattening_a_registered_string_boolean_or_array_wire_is_refused_by_its_own_keyword() {
+    for (rust_ident, kind, keyword) in [
+        ("DirectSlug", AliasKind::StringWire, "string"),
+        ("DirectSwitch", AliasKind::Stringified, "boolean"),
+        ("DirectPair", AliasKind::NoEnumMembers, "array"),
+    ] {
+        seed_registered_wire(rust_ident, kind, Some(keyword));
+        let named: syn::Type = syn::parse_str(rust_ident).unwrap();
+        let error =
+            direct_flatten_error(&syn::parse_quote! { #[serde(flatten)] v: #named }).unwrap();
+        assert!(
+            error.contains(&format!("its schema describes a `{keyword}`")),
+            "got: {error}"
+        );
+    }
+}
+
+/// The three the direct position leaves exactly as they stand: an item the registry says publishes
+/// an object, a name it has never seen — the declaration-order fallback, which answers for a source
+/// written below the object no differently than for a foreign type — and an array of a proved
+/// scalar, where the array is what the field wrote rather than anything the name proves.
+#[cfg(all(feature = "serde", feature = "zod"))]
+#[test]
+fn a_direct_flatten_of_an_object_an_unregistered_name_or_an_array_stays_admitted() {
+    seed_registered_wire("DirectDoc", AliasKind::NoEnumMembers, None);
+    seed_registered_wire("DirectCount", AliasKind::NoEnumMembers, Some("integer"));
+    for admitted in [
+        syn::parse_quote! { #[serde(flatten)] base: DirectDoc },
+        syn::parse_quote! { #[serde(flatten)] base: NeverRegisteredDirectly },
+        syn::parse_quote! { #[serde(flatten)] counts: Vec<DirectCount> },
+    ] {
+        let field: syn::Field = admitted;
+        assert!(
+            direct_flatten_error(&field).is_none(),
+            "got a rejection for {}",
+            quote::ToTokens::to_token_stream(&field)
+        );
+    }
+}
+
+/// A plain enum proves the same `string` and keeps the refusal written for it: those words name the
+/// variant key serde writes into the object, which is what the author of that declaration acts on.
+/// Two guards firing on one field would put two diagnostics on one line, each answering for the same
+/// thing in different words.
+#[cfg(all(feature = "serde", feature = "zod"))]
+#[test]
+fn a_direct_flatten_of_a_plain_enum_is_left_to_the_guard_written_for_it() {
+    seed_registered_wire("DirectHue", AliasKind::EnumMembers, Some("string"));
+    let field: syn::Field = syn::parse_quote! { #[serde(flatten)] tone: DirectHue };
+    assert!(direct_flatten_error(&field).is_none());
+    let written = super::flattened_field_guard_error(&field, "Host")
+        .map(|error| error.to_string())
+        .unwrap();
+    assert!(
+        written.contains("a plain enum writes its"),
+        "got: {written}"
     );
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -175,17 +175,18 @@ impl ZodUnionMember {
 /// no object, and `None` where nothing there proves it — a map, an object, and a name nothing has
 /// classified alike.
 ///
-/// Recorded and read under `serde` and `zod` together, which is the pair that reads
-/// `#[serde(untagged)]` and `#[serde(flatten)]` and multiplies one over the other: without both
-/// there is no merge to answer for and nothing asks.
-#[cfg(all(feature = "serde", feature = "zod"))]
+/// Recorded and read wherever `serde` meets a surface that writes a merge of its own — `zod`, which
+/// multiplies the object over the source's branches, and `typescript`, which spells the source's
+/// absence beside it. Without `serde` no field reaches a merge at all, and without either surface
+/// there is nothing that would ask.
+#[cfg(all(feature = "serde", any(feature = "zod", feature = "typescript")))]
 #[derive(Clone)]
 pub struct WireLeaf {
     pub branch: Vec<usize>,
     pub non_object: Option<&'static str>,
 }
 
-#[cfg(all(feature = "serde", feature = "zod"))]
+#[cfg(all(feature = "serde", any(feature = "zod", feature = "typescript")))]
 impl WireLeaf {
     /// Whether this leaf is the absence the name itself offers: the `null` of a choice the
     /// registration publishes at its own top level, one position in from the name and no deeper.
@@ -226,8 +227,13 @@ pub struct AliasInfo {
     /// be appended to; this answers the merge's, which is whether an object can be joined to it —
     /// two questions one word could not hold apart, an `integer` and a `number` being one shape and
     /// two documents, and an array and a map one shape and opposite answers.
-    #[cfg(all(feature = "serde", feature = "zod"))]
+    #[cfg(all(feature = "serde", any(feature = "zod", feature = "typescript")))]
     pub wire: Vec<WireLeaf>,
+    /// What an externally tagged enum's variants are spelled as where an object flattens the enum
+    /// itself, one per variant in the order the union writes them, and empty for every other item.
+    /// Filled by [`record_zod_flatten_variants`] once that enum's own expansion has rendered them.
+    #[cfg(all(feature = "serde", feature = "zod"))]
+    pub zod_flatten_variants: Vec<String>,
     /// What an untagged enum's members are spelled as on the Zod surface, and empty for every other
     /// item. Filled by [`record_zod_union_members`] once the enum's own expansion has rendered
     /// them.
@@ -598,8 +604,10 @@ pub fn register_alias_info(
                 #[cfg(feature = "zod")]
                 publishes_zod_factory: false,
                 value_shape: None,
-                #[cfg(all(feature = "serde", feature = "zod"))]
+                #[cfg(all(feature = "serde", any(feature = "zod", feature = "typescript")))]
                 wire: Vec::new(),
+                #[cfg(all(feature = "serde", feature = "zod"))]
+                zod_flatten_variants: Vec::new(),
                 #[cfg(feature = "zod")]
                 zod_union_members: Vec::new(),
             },
@@ -649,7 +657,7 @@ pub fn record_value_shape(rust_ident: &str, shape: Option<&'static str>) {
 ///
 /// A chain resolves one link at a time and cannot cycle, because an entry is only ever built from
 /// entries registered before it.
-#[cfg(all(feature = "serde", feature = "zod"))]
+#[cfg(all(feature = "serde", any(feature = "zod", feature = "typescript")))]
 pub fn record_wire_leaves(rust_ident: &str, leaves: &[WireLeaf]) {
     ALIAS_INFO.with(|map| {
         if let Some(info) = map.borrow_mut().get_mut(rust_ident) {
@@ -681,6 +689,28 @@ pub fn record_zod_union_members(rust_ident: &str, members: &[ZodUnionMember]) {
     ALIAS_INFO.with(|map| {
         if let Some(info) = map.borrow_mut().get_mut(rust_ident) {
             info.zod_union_members = members.to_vec();
+        }
+    });
+}
+
+/// Records what an externally tagged enum's variants are spelled as where an object flattens the
+/// enum itself, on the entry that enum has already registered.
+///
+/// A variant standing alone and the same variant written into an object being merged are two
+/// spellings of one wire. serde writes a data-carrying variant as the single-key object its name
+/// tags, which is what the union already publishes; it writes a unit variant as that name alone
+/// standing on its own, and as that name holding `null` where the enum is flattened — a key set,
+/// where the union publishes a bare string no object joins. So the flatten-edge spelling is recorded
+/// beside the union's rather than read back off it.
+///
+/// Recorded for every externally tagged enum and read only where the same enum's leaves prove the
+/// merge would otherwise write a branch no payload satisfies, which is the bound the leaves are
+/// already spliced under one position further in.
+#[cfg(all(feature = "serde", feature = "zod"))]
+pub fn record_zod_flatten_variants(rust_ident: &str, variants: &[String]) {
+    ALIAS_INFO.with(|map| {
+        if let Some(info) = map.borrow_mut().get_mut(rust_ident) {
+            info.zod_flatten_variants = variants.to_vec();
         }
     });
 }

--- a/tests/flatten_tests/tests.rs
+++ b/tests/flatten_tests/tests.rs
@@ -159,13 +159,16 @@ struct FlatOverEnum {
     tone: FlatHue,
 }
 
-/// A newtype over a `String` flattened into a struct: serde writes it as the string it wraps, and
-/// the registry cannot tell it apart from a struct — both register as having no enum members. So
-/// the declaration compiles and the divergence is left for the merge to catch.
+/// A newtype over a `String` flattened into a struct: serde writes it as the string it wraps, which
+/// is no object and which the merge has nothing to join its own keys to. The name records that wire
+/// as it expands, so a build carrying the Zod merge refuses the declaration where it was written and
+/// only a build without one gets as far as the merge.
+#[cfg(not(feature = "zod"))]
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct FlatSlug(String);
 
+#[cfg(not(feature = "zod"))]
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct FlatOverBrand {
@@ -173,6 +176,24 @@ struct FlatOverBrand {
     #[serde(flatten)]
     slug: FlatSlug,
 }
+
+/// The same newtype declared *below* the object that flattens it. The recording holds what has
+/// already expanded, so this one proves nothing about its wire and the guard keeps the
+/// declaration-order fallback — while the JSON-schema merge, which reads the document back at run
+/// time, refuses it wherever it is declared.
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct FlatOverLaterBrand {
+    own: String,
+    #[serde(flatten)]
+    slug: LaterFlatSlug,
+}
+
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct LaterFlatSlug(String);
 
 /// An untagged enum every member of which serde writes as an object, and the struct that flattens
 /// it. serde writes whichever member matched into the object the struct is writing, so what the
@@ -604,6 +625,20 @@ enum LaterMemberExtBareEither {
     Ext(MemberExtBare),
 }
 
+/// The same tagged enum flattened directly, with no union between. That position asks what the
+/// member position asks — can serde read the payload back — and answers the other way: serde writes
+/// a unit variant as its name holding `null` into the object being written rather than as the bare
+/// string it is standing alone, and reads that payload back as the variant. One declaration, both
+/// directions, so the merges owe it one branch per variant.
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct ExtBareDirectHolder {
+    #[serde(flatten)]
+    ext: MemberExtBare,
+    own: String,
+}
+
 /// And a tagged enum whose every variant carries data, which serde writes as the object its name
 /// tags in every case — admitted where it always was, on every surface.
 #[cfg(any(feature = "jsonschema", feature = "zod"))]
@@ -629,6 +664,18 @@ enum MemberExtObjEither {
 struct FlatOverMemberExtObjUntagged {
     #[serde(flatten)]
     either: MemberExtObjEither,
+    own: String,
+}
+
+/// And that enum flattened directly. No branch of it proves anything the name did not — the operand
+/// a merge joins is the name's own binding whichever variant matched — so it stays the one operand
+/// it always was.
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct ExtObjDirectHolder {
+    #[serde(flatten)]
+    ext: MemberExtObjects,
     own: String,
 }
 
@@ -844,12 +891,12 @@ struct NamedMaybeHolder {
 
 /// And a name whose published surface is not nullable, which offers no absence and stays the one
 /// operand it always was.
-#[cfg(any(feature = "jsonschema", feature = "zod"))]
+#[cfg(any(feature = "jsonschema", feature = "zod", feature = "typescript"))]
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct PlainOptBase(OptBase);
 
-#[cfg(any(feature = "jsonschema", feature = "zod"))]
+#[cfg(any(feature = "jsonschema", feature = "zod", feature = "typescript"))]
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct NamedPlainHolder {
@@ -1337,9 +1384,10 @@ fn test_flattening_a_plain_enum_writes_a_key_the_struct_does_not_name() {
     );
 }
 
-/// And what serde writes for a flattened newtype that reaches the wire as a string — nothing. A
-/// name got this one past the declaration guard; the value never reaches the wire at all.
+/// And what serde writes for a flattened newtype that reaches the wire as a string — nothing. The
+/// value never reaches the wire at all, wherever the name was declared.
 #[test]
+#[cfg(not(feature = "zod"))]
 fn test_flattening_a_string_newtype_is_unserializable() {
     let refusal = serde_json::to_value(FlatOverBrand {
         own: "o".to_owned(),
@@ -1353,9 +1401,24 @@ fn test_flattening_a_string_newtype_is_unserializable() {
     );
 }
 
+#[test]
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+fn test_flattening_a_later_string_newtype_is_unserializable() {
+    let refusal = serde_json::to_value(FlatOverLaterBrand {
+        own: "o".to_owned(),
+        slug: LaterFlatSlug("s".to_owned()),
+    })
+    .unwrap_err()
+    .to_string();
+    assert!(
+        refusal.contains("can only flatten structs and maps"),
+        "Got: {refusal}"
+    );
+}
+
 /// So the merge refuses it too, rather than closing the object around the fields that are left.
 #[test]
-#[cfg(feature = "jsonschema")]
+#[cfg(all(feature = "jsonschema", not(feature = "zod")))]
 #[should_panic(
     expected = "`FlatOverBrand`: `#[serde(flatten)]` of `FlatSlug` is not written as an object"
 )]
@@ -1363,12 +1426,36 @@ fn test_flattening_a_string_newtype_is_refused_by_the_merge() {
     assert!(FlatOverBrand::json_schema().is_object());
 }
 
+/// And in those same words wherever the newtype was declared, which is the one reading of the
+/// declaration that survives the Zod surface refusing it at expansion.
+#[test]
+#[cfg(feature = "jsonschema")]
+#[should_panic(
+    expected = "`FlatOverLaterBrand`: `#[serde(flatten)]` of `LaterFlatSlug` is not written as an object"
+)]
+fn test_flattening_a_later_string_newtype_is_refused_by_the_merge() {
+    assert!(FlatOverLaterBrand::json_schema().is_object());
+}
+
 /// The remedy the refusal names is one the author can act on.
 #[test]
 #[cfg(feature = "jsonschema")]
 #[should_panic(expected = "write the field as a named member so the value gets a key of its own")]
 fn test_the_flatten_merge_refusal_names_the_remedy() {
-    assert!(FlatOverBrand::json_schema().is_object());
+    assert!(FlatOverLaterBrand::json_schema().is_object());
+}
+
+/// And a source the registry could answer for is refused where it was written instead, in those
+/// same words: the guard names the wire the newtype recorded rather than waiting for a document
+/// nothing on the Zod surface would ever build.
+#[test]
+#[cfg(feature = "zod")]
+fn test_the_later_string_newtype_keeps_the_declaration_order_fallback() {
+    let zod = FlatOverLaterBrand::zod_schema();
+    assert!(
+        zod.contains("z.lazy(() => LaterFlatSlug$Schema)"),
+        "expected the name as the one operand it is, got: {zod}"
+    );
 }
 
 /// What serde writes for a flattened untagged enum: the struct's own fields, and beside them the
@@ -2246,9 +2333,43 @@ fn test_the_named_nullable_flatten_schema_offers_the_base_and_its_absence() {
     );
 }
 
+/// And TypeScript writes the same choice over the same two key sets. The name itself carries the
+/// value branch — an intersection distributes over the choice behind it and the `null` side takes no
+/// key, so that branch is already the base's — while the branch carrying none of the base's members
+/// reads them off the value side by name, a choice having no key of its own for `keyof` to find.
+///
+/// Read off tsc 7.0.2 under `--strict`, the emitted declarations compiled as written: this type
+/// accepts `{ own: "o", left: "l", right: true }` and `{ own: "o" }`, and rejects
+/// `{ own: "o", left: "l" }` — payload for payload what the `Option`-typed field's own type answers.
+#[test]
+#[cfg(feature = "typescript")]
+fn test_the_named_nullable_flatten_type_offers_the_base_and_its_absence() {
+    let ts = NamedMaybeHolder::ts_definition();
+    assert!(
+        ts.contains("} & (MaybeOptBase | { [K in keyof NonNullable<MaybeOptBase>]?: never });"),
+        "expected the base beside its absence, got: {ts}"
+    );
+    assert!(
+        !ts.contains("| undefined"),
+        "the whole value is offered as absent in: {ts}"
+    );
+}
+
 /// The absence is a question about what the name published and nothing else, so a direct flatten
 /// naming an item whose surface is not nullable is spelled exactly as it was before there was a
-/// second branch to spell — one intersection, and one closed object.
+/// second branch to spell — one intersection on Zod, one closed object on the document, and the
+/// bare name on TypeScript.
+#[test]
+#[cfg(feature = "typescript")]
+fn test_a_named_non_nullable_flatten_type_is_byte_identical() {
+    let ts = NamedPlainHolder::ts_definition();
+    let declared = &ts[ts.find("export type").unwrap()..];
+    assert_eq!(
+        declared,
+        "export type NamedPlainHolder = {\n  /**\n   * own\n   * \n   */\n  own: string;\n} & PlainOptBase;"
+    );
+}
+
 #[test]
 #[cfg(feature = "zod")]
 fn test_a_named_non_nullable_flatten_schema_is_byte_identical() {
@@ -2824,5 +2945,121 @@ fn test_the_tagged_enums_are_byte_identical_standing_alone() {
     assert_eq!(
         [MemberExtBare::zod_schema(), MemberExtObjects::zod_schema(),],
         EXPECTED.map(str::to_owned)
+    );
+}
+
+/// The direct position asks the round-trip question the member position asks and gets the other
+/// answer. serde writes the unit variant as its name holding `null` into the object being written —
+/// not the bare string it is standing alone — and reads that payload back as the variant, so the
+/// declaration is one serde admits in both directions.
+#[test]
+#[cfg(any(feature = "jsonschema", feature = "zod"))]
+fn test_a_directly_flattened_tagged_enum_round_trips_every_variant() {
+    let forms = [
+        (
+            MemberExtBare::Bare,
+            serde_json::json!({ "Bare": null, "own": "o" }),
+        ),
+        (
+            MemberExtBare::Wrapped(FlatSecond { b: true }),
+            serde_json::json!({ "Wrapped": { "b": true }, "own": "o" }),
+        ),
+    ];
+    for (ext, expected) in forms {
+        let holder = ExtBareDirectHolder {
+            ext,
+            own: "o".to_owned(),
+        };
+        let written = serde_json::to_value(&holder).unwrap();
+        assert_eq!(written, expected);
+        let back: ExtBareDirectHolder = serde_json::from_value(written).unwrap();
+        assert_eq!(back, holder);
+    }
+}
+
+/// So the document distributes the object over the variants rather than refusing at the branch the
+/// bare string sits at: one branch per variant, the unit one carrying the single key serde writes
+/// for it.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_the_direct_tagged_flatten_document_writes_one_branch_per_variant() {
+    assert_eq!(
+        serde_json::to_string(&ExtBareDirectHolder::json_schema()).unwrap(),
+        r#"{"type":"object","oneOf":[{"type":"object","properties":{"own":{"type":"string"},"Bare":{"type":"null"}},"required":["own","Bare"],"additionalProperties":false},{"type":"object","properties":{"own":{"type":"string"},"Wrapped":{"type":"object","additionalProperties":false,"properties":{"b":{"type":"boolean"}},"required":["b"]}},"required":["own","Wrapped"],"additionalProperties":false}]}"#
+    );
+}
+
+/// And it admits exactly the payloads serde writes, and no payload carrying two variants at once or
+/// none.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_the_direct_tagged_flatten_document_admits_the_captured_payloads() {
+    let schema = ExtBareDirectHolder::json_schema();
+    for payload in [
+        serde_json::json!({ "Bare": null, "own": "o" }),
+        serde_json::json!({ "Wrapped": { "b": true }, "own": "o" }),
+    ] {
+        assert!(
+            closed_document_accepts(&schema, &payload),
+            "{payload} is rejected by {schema}"
+        );
+    }
+    for payload in [
+        serde_json::json!({ "own": "o" }),
+        serde_json::json!({ "Bare": null, "Wrapped": { "b": true }, "own": "o" }),
+        serde_json::json!({ "Bare": null }),
+    ] {
+        assert!(
+            !closed_document_accepts(&schema, &payload),
+            "{payload} is accepted by {schema}"
+        );
+    }
+}
+
+/// And Zod multiplies the object over the same variants, each written in the spelling a merge joins
+/// rather than the one the union publishes: the unit variant is the key serde writes for it, not the
+/// literal the enum's own schema names.
+///
+/// Read off zod 4.4.3, the emitted spelling transcribed: this union accepts `{"own":"o","Bare":null}`
+/// and `{"own":"o","Wrapped":{"b":true}}`, and rejects `{"own":"o"}`, `{"own":"o","Bare":"Bare"}`,
+/// `{"own":"o","Bare":null,"Wrapped":{"b":true}}`, `{"Bare":null}` and any payload carrying a key
+/// neither the object nor the matched variant names.
+#[test]
+#[cfg(feature = "zod")]
+fn test_the_direct_tagged_flatten_schema_multiplies_the_object_over_the_variants() {
+    let zod = ExtBareDirectHolder::zod_schema();
+    assert!(
+        zod.contains(
+            "z.union([\n  ExtBareDirectHolder$OwnSchema.and(z.lazy(() => z.strictObject({\n  \"Bare\": z.null(),\n}))),\n  ExtBareDirectHolder$OwnSchema.and(z.lazy(() => z.strictObject({\n  \"Wrapped\": FlatSecond$Schema,\n}))),\n])"
+        ),
+        "expected one operand per variant, got: {zod}"
+    );
+    assert!(
+        !zod.contains("MemberExtBare$Schema"),
+        "the union is named as an operand in: {zod}"
+    );
+}
+
+/// The multiplication is a question about the branches a name proves no object, so a direct flatten
+/// of a tagged enum every variant of which carries data is spelled exactly as it was before there
+/// was a second branch to spell — one intersection on Zod, and the document its own distribution
+/// already wrote.
+#[test]
+#[cfg(feature = "zod")]
+fn test_an_all_object_tagged_direct_flatten_schema_is_byte_identical() {
+    #[cfg(feature = "typescript")]
+    const EXPECTED: &str = "const ExtObjDirectHolder$RawSchema = z.strictObject({\n  own: z.string(),\n}).and(z.lazy(() => MemberExtObjects$Schema));\n\nexport const ExtObjDirectHolder$Schema: ZodType<ExtObjDirectHolder> = ExtObjDirectHolder$RawSchema;";
+    #[cfg(not(feature = "typescript"))]
+    const EXPECTED: &str = "export const ExtObjDirectHolder$Schema = z.strictObject({\n  own: z.string(),\n}).and(z.lazy(() => MemberExtObjects$Schema));";
+
+    assert_eq!(ExtObjDirectHolder::zod_schema(), EXPECTED);
+}
+
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_an_all_object_tagged_direct_flatten_document_is_byte_identical() {
+    assert_eq!(
+        serde_json::to_string(&ExtObjDirectHolder::json_schema()).unwrap(),
+        r#"{"type":"object","oneOf":[{"type":"object","properties":{"own":{"type":"string"},"One":{"type":"object","additionalProperties":false,"properties":{"a":{"type":"string"}},"required":["a"]}},"required":["own","One"],"additionalProperties":false},{"type":"object","properties":{"own":{"type":"string"},"Two":{"type":"object","additionalProperties":false,"properties":{"b":{"type":"boolean"}},"required":["b"]}},"required":["own","Two"],"additionalProperties":false}]}"#
     );
 }


### PR DESCRIPTION
Three related fixes where a struct flattens a named item directly, with no union between.

A field flattening a name whose registered wire proves it is no object is now refused at the declaration, in the words the JSON-schema merge already uses at run time: the scalar has no members to merge and what serde writes for it never joins the object. Plain enums keep the guard written for them, arrays stay admitted (the array is the field's own shape, not the name's), and a name declared below the object keeps the declaration-order fallback the merge documents.

A flattened name whose published surface is nullable now spells its absence on the TypeScript surface too: the operand becomes the name beside a branch mapping the value side's keys to never, read through NonNullable because keyof a union with null is empty and would admit a base written in part. The wire recording that feeds this was widened from the serde-and-zod pair to any merging surface.

A directly flattened externally tagged enum with a unit variant now gets one branch per variant: the JSON-schema merge reads a oneOf branch pinning a bare string by const as the key set serde actually writes (the variant name holding null), and the Zod surface records a per-variant flatten operand as each variant renders, splicing them where the enum's recorded leaves prove the single-operand intersection would otherwise be unsatisfiable. Tagged enums whose every variant carries data are byte-identical, as are all non-flatten emissions.