### PR TITLE
Extend the skipped-slot contract to tuple variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ A slot dropped from only one of the two directions has no such description and i
 
 A struct declaring a single slot keeps it whatever these attributes say: serde writes and reads a newtype struct's only slot regardless, so nothing there is dropped.
 
+A tuple *variant*'s slots read the same way, with one difference at the lone-slot arity. `enum E { One(#[serde(skip)] String, u32) }` holding `("s", 7)` writes `{"One":[7]}`, reads that back, and refuses `{"One":["s",7]}`, so the described tuple shrinks exactly as a struct's does — under the content key when one is named, and to `{"One":[]}` when every slot is dropped. Where a variant differs is that it has its own name to fall back on: a variant declaring one slot and dropping it is written as a unit variant, `"One"` externally, `{"type":"One"}` under a tag and `null` untagged, and each surface describes it as the unit it has become. Because serde does read a variant slot's attributes at every arity, the one-directional halves are refused there at every arity too — `One(#[serde(skip_serializing)] String)` writes `"One"` and reads only `{"One":"s"}`.
+
 Which key a field writes is read off the attribute in every build, `serde` feature or not — one declaration describes one wire under every toggle. What the feature buys is the renaming, the tagging and the guards.
 
 ```rust
@@ -1922,7 +1924,7 @@ Supported Serde attributes:
 - `#[serde(flatten)]` -- flatten a field into the parent as an intersection type (`A & B`) / Zod `.and(...)`
 - `#[serde(transparent)]` -- transparent wrappers (used for branded newtypes)
 - `#[serde(skip_serializing_if = "...")]` -- the key is left out of the payload when the predicate fires, so the member is described under an optional key: `roles?: Array<string>;` in TypeScript, `roles: z.array(z.string()).optional(),` in Zod, and no `required` entry in the JSON Schema
-- `#[serde(skip)]` -- the key is written into no payload and read out of none, so no surface describes the member at all: no TypeScript member, no Zod key, and neither a `properties` nor a `required` entry. On a tuple-struct slot it takes the slot out of the described tuple, which shortens the arity
+- `#[serde(skip)]` -- the key is written into no payload and read out of none, so no surface describes the member at all: no TypeScript member, no Zod key, and neither a `properties` nor a `required` entry. On a tuple-struct or tuple-variant slot it takes the slot out of the described tuple, which shortens the arity -- and a variant declaring one slot becomes a unit variant, which is what serde writes for it
 - `#[serde(skip_serializing)]` -- the write half of `skip`: the key is left out of every payload while a supplied one is still read, so the member is described under an optional key, as `skip_serializing_if` is
 - `#[serde(skip_deserializing)]` -- the read half: the key is written into every payload while a supplied one is discarded, so the member keeps a required key
 

--- a/src/features/serde.rs
+++ b/src/features/serde.rs
@@ -56,9 +56,11 @@ impl SerdeKeyOmission {
     ///
     /// Where the member has a key, the two payloads still overlap — the key is simply absent from
     /// one of them, which an optional key describes. Where it has only a place in a tuple there is
-    /// no such spelling, and the two payloads differ in their arity. So the question is asked only
-    /// by the builds that describe a tuple, which is what the gate below says.
-    #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+    /// no such spelling, so the question is the positional seams' to ask.
+    ///
+    /// Not gated on any feature, for the reason [`Self::absent_from_wire`] is not: the variant walk
+    /// that reads it runs in every build, and a toggle that changed the answer would leave one
+    /// declaration refused in one build and described in another.
     pub const fn drops_one_direction_only(self) -> bool {
         self.omits_key != self.skips_deserializing
     }

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -59,9 +59,8 @@ use crate::utils::{TrivialPattern, trivial_pattern};
 #[cfg(feature = "serde")]
 use crate::features::serde::{SerdeFieldMeta, SerdeTypeMeta};
 use crate::features::serde::{has_serde_default, parse_serde_key_omission};
-// The type is named only where a slot's own omission is read, which is where a surface describes
-// the tuple that slot sits in.
-#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+// The type is named where a positional slot's own omission is read: the tuple-struct walk, which
+// only a describing build performs, and the variant walk, which every build performs.
 use crate::features::serde::SerdeKeyOmission;
 
 #[cfg(feature = "serde")]
@@ -583,6 +582,19 @@ enum TupleStructShape {
     Array(Vec<FieldDef>),
     /// The bare value serde writes for a struct declaring exactly one slot.
     BareValue(Box<FieldDef>),
+}
+
+/// What one untagged variant's member walk produces: the members its surfaces are rendered from,
+/// the bindings its constrained members are checked under, and the three enum-wide lists the walk
+/// adds to, which the caller joins onto its own in declaration order.
+#[cfg(feature = "serde")]
+struct UntaggedVariantMembers {
+    bound: Vec<(proc_macro2::Ident, proc_macro2::Ident)>,
+    checks: Vec<proc_macro2::TokenStream>,
+    deferred_attrs: Vec<Vec<syn::Attribute>>,
+    field_defs: Vec<FieldDef>,
+    guard_errors: Vec<proc_macro2::TokenStream>,
+    validation_fns: Vec<proc_macro2::TokenStream>,
 }
 
 /// What the item around a field says about it: everything [`process_field`] needs that is not the
@@ -4984,6 +4996,92 @@ fn process_plain_enum(
     TokenStream::from(output)
 }
 
+/// The kind a variant publishes, which is not always the kind it declares.
+///
+/// A variant declaring exactly one slot and taking that slot off the wire is written as a unit
+/// variant, whatever tagging the enum carries. Captured on `V(#[serde(skip)] String)` holding
+/// `"s"`: externally tagged it writes `"One"` and reads `"One"` and `{"One":null}` back; under
+/// `#[serde(tag = "type")]` it writes and reads `{"type":"One"}`; untagged it writes and reads
+/// `null`. Those are the three payloads a declared unit variant writes in the same three places.
+///
+/// This is where the variant seam parts from the tuple-struct one. A one-slot *struct* was captured
+/// ignoring the attribute outright — it writes and reads its slot's value whatever `skip` says — so
+/// there the lone slot's spellings go unread. A one-slot *variant* has the variant name to fall
+/// back on, and serde uses it.
+///
+/// Every other declared arity keeps the kind it declared: captured, a two-slot variant with one
+/// slot off the wire writes `{"One":[7]}` and with both off writes `{"One":[]}` — a shorter array
+/// and then an empty one, never a bare value and never the bare name.
+fn variant_wire_kind(variant: &syn::Variant) -> VariantKind {
+    let kind = classify_variant(variant);
+    // `classify_variant` names `TupleSingle` for a variant of exactly one unnamed field, so the
+    // first field is the lone slot whose omission decides this.
+    let publishes_no_slot = matches!(kind, VariantKind::TupleSingle)
+        && variant
+            .fields
+            .iter()
+            .next()
+            .is_some_and(|field| parse_serde_key_omission(&field.attrs).absent_from_wire());
+    if publishes_no_slot {
+        VariantKind::Unit
+    } else {
+        kind
+    }
+}
+
+/// Rejects a tuple-variant slot whose serde attributes drop it out of one of serde's two directions
+/// and not the other.
+///
+/// Captured from serde on `enum E { One(#[serde(...)] String, u32) }` holding `("s", 7)`, and the
+/// same three attributes tell the same story under every tagging:
+/// - `skip_serializing` alone writes `{"One":[7]}` and reads only `{"One":["s",7]}`;
+/// - `skip_deserializing` alone writes `{"One":["s",7]}` and reads only `{"One":[7]}`;
+/// - `skip_serializing_if` writes `{"One":[7]}` or `{"One":["s",7]}` as its predicate decides, and
+///   reads only `{"One":["s",7]}`.
+///
+/// A lone slot splits the same way, into payloads further apart still: `One(#[serde(skip_
+/// serializing)] String)` writes the bare name `"One"` and reads only `{"One":"s"}`, and
+/// `skip_deserializing` writes `{"One":"s"}` and reads only `{"One":null}`. So unlike the
+/// tuple-struct seam, where serde ignores a lone slot's spellings, every declared arity of a
+/// variant is asked.
+///
+/// In each of them what serde writes is not what serde reads. A named field in the same position is
+/// describable — the key is simply absent from one payload and present in the other, which an
+/// optional key covers — but a slot is written by its place, so the two payloads have no common
+/// spelling. The declaration is refused rather than described, the way the named field whose
+/// omitted key serde cannot read back already is.
+///
+/// A named field of a struct variant is left alone here, its key being the spelling that describes
+/// both payloads; the subject is read off the field itself for that reason, the way the omission a
+/// key carries already is.
+///
+/// Not gated on the `serde` feature, and neither is the drop this stands beside: both read only the
+/// omission walk, which every build performs, and a toggle that changed the answer would leave one
+/// declaration refused in one build and described in another.
+fn check_variant_slot_wire_is_readable(
+    field: &Field,
+    index: usize,
+    variant_name: &str,
+    type_name: &str,
+    omission: SerdeKeyOmission,
+) -> Result<(), syn::Error> {
+    if field.ident.is_some() || !omission.drops_one_direction_only() {
+        return Ok(());
+    }
+    Err(syn::Error::new_spanned(
+        field,
+        format!(
+            "model_schema: slot {index} of variant `{variant_name}` of enum `{type_name}` carries \
+             a serde attribute that drops it from only one of serde's two directions, so what \
+             serde writes for the variant is not what serde reads for it — one of them carries the \
+             slot and the other does not. A slot is written by its place rather than under a key, \
+             so there is no optional spelling to describe both and no schema can be written for \
+             the pair. Use #[serde(skip)] to take the slot off the wire in both directions, or \
+             drop the attribute so the slot is written and read in its place."
+        ),
+    ))
+}
+
 /// Processes each variant of a discriminated enum, returning per-variant field defs, doc strings,
 /// and variant kinds in declaration order, plus the collected serde validation functions and the
 /// `validate()` arms those functions are run from.
@@ -4991,6 +5089,14 @@ fn process_plain_enum(
 /// A member's check is generated here whatever the enum's tagging, so the accessor built from these
 /// arms exists on all three tagged flavors alike — the tag decides how the value is written, not
 /// which of its members carry a bound.
+///
+/// A slot serde carries in neither direction leaves the walk, the way a named field whose key
+/// reaches no payload already does. Captured: `One(#[serde(skip)] String, u32)` holding `("s", 7)`
+/// writes `{"One":[7]}` and reads `{"One":[7]}` back, refusing `{"One":["s",7]}` — the slot is
+/// absent from the array in both directions and the slots after it move up, so the described tuple
+/// is the slots that remain, which shrinks its arity, its `prefixItems` and its element types
+/// together. The def is still built before that decision, so a slot leaves the wire without taking
+/// the guards it violates with it.
 fn collect_discriminated_variants(
     item_enum: &mut syn::ItemEnum,
     rename_all: Option<&str>,
@@ -5014,7 +5120,10 @@ fn collect_discriminated_variants(
         let variant_ident = item.ident.to_string();
         let final_name =
             get_final_variant_name(&variant_ident, field_rename.as_deref(), rename_all);
-        let variant_kind = classify_variant(item);
+        // The Rust shape the `validate()` arm is matched by, beside the wire shape the surfaces
+        // describe: a variant that publishes no slot is still declared holding one.
+        let declared_kind = classify_variant(item);
+        let wire_kind = variant_wire_kind(item);
         // A struct variant is where serde accepts a container-level `default`, so it is the
         // container its own fields' omissions are read against.
         let variant_defaulted = has_serde_default(&item.attrs);
@@ -5023,7 +5132,18 @@ fn collect_discriminated_variants(
         let mut bound: Vec<(proc_macro2::Ident, proc_macro2::Ident)> = Vec::new();
         let mut checks: Vec<proc_macro2::TokenStream> = Vec::new();
         let total_fields = item.fields.len();
-        for field in &mut item.fields {
+        for (index, field) in item.fields.iter_mut().enumerate() {
+            let omission = parse_serde_key_omission(&field.attrs);
+            let positional = field.ident.is_none();
+            if let Err(rejection) = check_variant_slot_wire_is_readable(
+                field,
+                index,
+                &variant_ident,
+                &enum_type_name,
+                omission,
+            ) {
+                guard_errors.push(rejection.to_compile_error());
+            }
             let (f_def, validation_fn, validate_body, field_guard_errors) = process_field(
                 &FieldContext {
                     container_defaulted: variant_defaulted,
@@ -5047,10 +5167,13 @@ fn collect_discriminated_variants(
                 checks.push(body);
             }
             guard_errors.extend(field_guard_errors);
+            if positional && omission.absent_from_wire() {
+                continue;
+            }
             push_described_field(&mut field_defs, f_def);
         }
         per_variant_checks.push((
-            variant_check_pattern(&item.ident, &variant_kind, total_fields, &bound),
+            variant_check_pattern(&item.ident, &declared_kind, total_fields, &bound),
             checks,
         ));
 
@@ -5059,7 +5182,7 @@ fn collect_discriminated_variants(
             discriminator_value: final_name,
             docs: discriminator_docs,
             field_defs,
-            kind: variant_kind,
+            kind: wire_kind,
         });
     }
 
@@ -5761,8 +5884,14 @@ fn internally_tagged_guard_errors(
                 );
             }
             // An empty tuple variant carries nothing: serde writes it as the tag alone, which is
-            // what the unit arm already describes.
+            // what the unit arm already describes. So does a variant whose lone slot is off the
+            // wire — captured, `One(#[serde(skip)] String)` writes and reads `{"type":"One"}`
+            // whatever the slot holds, so what the inner type would have written beside the tag is
+            // never asked.
             let field = unnamed.unnamed.first()?;
+            if parse_serde_key_omission(&field.attrs).absent_from_wire() {
+                return None;
+            }
             let inner = get_field_def("_inner", &field.ty, "");
             let message = match tagged_content(&inner) {
                 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
@@ -6095,9 +6224,14 @@ fn process_internally_tagged_enum(
 /// every other shape is refused as an error spanned on the variant, which the caller collects so
 /// one expansion reports every offender rather than stopping at the first.
 ///
-/// The single-member pattern is what rules out a `TupleSingle` carrying no field. That shape is
-/// unreachable — [`classify_variant`] sends an empty `Foo()` to `Unit` — and a slice pattern says
-/// so structurally, where a length assertion would have to be written and then never fire.
+/// The single-member pattern is what rules out a `TupleSingle` carrying no member. That shape is
+/// unreachable — [`variant_wire_kind`] sends both an empty `Foo()` and a lone slot taken off the
+/// wire to `Unit` — and a slice pattern says so structurally, where a length assertion would have
+/// to be written and then never fire.
+///
+/// The arity a refused tuple variant is named by is the one the author declared, not the one that
+/// reached the wire: a slot dropped from the description is still a slot the union has no member
+/// spelling for.
 #[cfg(feature = "serde")]
 fn render_untagged_variant(
     kind: &VariantKind,
@@ -6112,10 +6246,10 @@ fn render_untagged_variant(
             variant,
             "a unit variant",
         )),
-        (VariantKind::TupleSingle | VariantKind::TupleMultiple, fields) => {
+        (VariantKind::TupleSingle | VariantKind::TupleMultiple, _) => {
             Err(unsupported_untagged_variant_error(
                 variant,
-                &format!("a tuple variant with {} fields", fields.len()),
+                &format!("a tuple variant with {} fields", variant.fields.len()),
             ))
         }
     }
@@ -6500,6 +6634,90 @@ fn untagged_member_field_def(
 /// sentence. That is what the member's schema already means on the other two surfaces, where the
 /// same declaration is one branch of an `anyOf` and one member of a `z.union`; leaving the hook out
 /// is what would have made the Rust side the odd one, reading back values both schemas reject.
+/// Walks one untagged variant's members, stamping each with its validation and collecting the
+/// guards it earns.
+///
+/// A slot serde carries in neither direction leaves the walk, the way it does on every other
+/// positional seam, and a slot dropped from one direction only is refused there. Untagged, a
+/// multi-element tuple variant has no member spelling at all — the caller refuses it whole — so
+/// what the drop reaches here is the lone slot, which takes the variant to the unit it is written
+/// as.
+#[cfg(feature = "serde")]
+fn collect_untagged_variant_members(
+    variant: &mut syn::Variant,
+    enum_type_name: &str,
+    schema_module_name: Option<&str>,
+    type_parameters: &[String],
+) -> UntaggedVariantMembers {
+    let variant_name = variant.ident.to_string();
+    let variant_defaulted = has_serde_default(&variant.attrs);
+    let mut walked = UntaggedVariantMembers {
+        bound: Vec::new(),
+        checks: Vec::new(),
+        deferred_attrs: Vec::new(),
+        field_defs: Vec::new(),
+        guard_errors: Vec::new(),
+        validation_fns: Vec::new(),
+    };
+
+    for (index, field) in variant.fields.iter_mut().enumerate() {
+        let omission = parse_serde_key_omission(&field.attrs);
+        let positional = field.ident.is_none();
+        if let Err(rejection) = check_variant_slot_wire_is_readable(
+            field,
+            index,
+            &variant_name,
+            enum_type_name,
+            omission,
+        ) {
+            walked.guard_errors.push(rejection.to_compile_error());
+        }
+        let field_name = field_ident_string(field);
+        let prop_meta = parse_model_schema_prop_attributes(&field.attrs);
+        let serde_field_meta = parse_serde_field_attributes(&field.attrs);
+
+        let new_attrs = declaration_attrs(field);
+        let mut injected_attrs: Vec<syn::Attribute> = Vec::new();
+        let (validation_fn, validate_body, positional_constraint_error) = generate_field_validation(
+            field,
+            schema_module_name,
+            &field_name,
+            Some(&variant_name),
+            &prop_meta,
+            &mut injected_attrs,
+        );
+        field.attrs = new_attrs;
+        walked.deferred_attrs.push(injected_attrs);
+        walked.validation_fns.extend(validation_fn);
+        if let (Some(body), Some(ident)) = (validate_body, field.ident.as_ref()) {
+            walked.bound.push((ident.clone(), member_binding(ident)));
+            walked.checks.push(body);
+        }
+
+        let member_ctx = untagged_variant_context(
+            variant_defaulted,
+            schema_module_name,
+            enum_type_name,
+            type_parameters,
+            &variant_name,
+        );
+        let (member_def, member_guard_errors) = untagged_member_field_def(
+            &member_ctx,
+            field,
+            &field_name,
+            prop_meta,
+            &serde_field_meta,
+            positional_constraint_error,
+        );
+        walked.guard_errors.extend(member_guard_errors);
+        if positional && omission.absent_from_wire() {
+            continue;
+        }
+        push_described_field(&mut walked.field_defs, member_def);
+    }
+    walked
+}
+
 #[cfg(feature = "serde")]
 fn collect_untagged_members(
     item_enum: &mut syn::ItemEnum,
@@ -6521,60 +6739,23 @@ fn collect_untagged_members(
     let mut deferred_attrs: Vec<Vec<syn::Attribute>> = Vec::new();
 
     for variant in &mut item_enum.variants {
-        let kind = classify_variant(variant);
-        let variant_name = variant.ident.to_string();
-        let variant_defaulted = has_serde_default(&variant.attrs);
-
-        let mut field_defs: Vec<FieldDef> = Vec::new();
-        let mut bound: Vec<(proc_macro2::Ident, proc_macro2::Ident)> = Vec::new();
-        let mut checks: Vec<proc_macro2::TokenStream> = Vec::new();
+        let declared_kind = classify_variant(variant);
+        let kind = variant_wire_kind(variant);
         let total_fields = variant.fields.len();
-        for field in &mut variant.fields {
-            let field_name = field_ident_string(field);
-            let prop_meta = parse_model_schema_prop_attributes(&field.attrs);
-            let serde_field_meta = parse_serde_field_attributes(&field.attrs);
-
-            let new_attrs = declaration_attrs(field);
-            let mut injected_attrs: Vec<syn::Attribute> = Vec::new();
-            let (validation_fn, validate_body, positional_constraint_error) =
-                generate_field_validation(
-                    field,
-                    schema_module_name,
-                    &field_name,
-                    Some(&variant_name),
-                    &prop_meta,
-                    &mut injected_attrs,
-                );
-            field.attrs = new_attrs;
-            deferred_attrs.push(injected_attrs);
-            validation_fns.extend(validation_fn);
-            if let (Some(body), Some(ident)) = (validate_body, field.ident.as_ref()) {
-                bound.push((ident.clone(), member_binding(ident)));
-                checks.push(body);
-            }
-
-            let member_ctx = untagged_variant_context(
-                variant_defaulted,
-                schema_module_name,
-                &enum_type_name,
-                &type_parameters,
-                &variant_name,
-            );
-            let (member_def, member_guard_errors) = untagged_member_field_def(
-                &member_ctx,
-                field,
-                &field_name,
-                prop_meta,
-                &serde_field_meta,
-                positional_constraint_error,
-            );
-            guard_errors.extend(member_guard_errors);
-            push_described_field(&mut field_defs, member_def);
-        }
+        let mut walked = collect_untagged_variant_members(
+            variant,
+            &enum_type_name,
+            schema_module_name,
+            &type_parameters,
+        );
+        guard_errors.append(&mut walked.guard_errors);
+        validation_fns.append(&mut walked.validation_fns);
+        deferred_attrs.append(&mut walked.deferred_attrs);
+        let field_defs = walked.field_defs;
 
         per_variant_checks.push((
-            variant_check_pattern(&variant.ident, &kind, total_fields, &bound),
-            checks,
+            variant_check_pattern(&variant.ident, &declared_kind, total_fields, &walked.bound),
+            walked.checks,
         ));
 
         match render_untagged_variant(&kind, variant, &field_defs, &enum_type_name) {
@@ -6773,10 +6954,10 @@ fn published_wire_leaves(written: &FieldDef) -> Vec<WireLeaf> {
 /// The leaves an externally tagged enum's variants write, one per variant and in the order the
 /// `oneOf` it publishes writes them.
 ///
-/// The classification is [`classify_variant`]'s, which is the one
+/// The classification is [`variant_wire_kind`]'s, which is the one
 /// [`render_external_variant`] writes each variant from — so what is recorded and what is emitted
 /// read the declaration the same way, and a variant that renders as a bare string is a leaf that
-/// says so.
+/// says so. A variant whose lone slot is off the wire is one of those: serde writes its name alone.
 #[cfg(all(feature = "serde", feature = "zod"))]
 fn external_variant_wire_leaves(variants: &Punctuated<syn::Variant, Token![,]>) -> Vec<WireLeaf> {
     variants
@@ -6784,7 +6965,7 @@ fn external_variant_wire_leaves(variants: &Punctuated<syn::Variant, Token![,]>) 
         .enumerate()
         .map(|(index, variant)| WireLeaf {
             branch: vec![index + 1],
-            non_object: matches!(classify_variant(variant), VariantKind::Unit).then_some("string"),
+            non_object: matches!(variant_wire_kind(variant), VariantKind::Unit).then_some("string"),
         })
         .collect()
 }

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -11,7 +11,7 @@ use super::{
     collect_untagged_members, constrained_shape, enum_cfg_attr_guard_errors,
     generate_field_validation, generate_numeric_validation_code, generate_string_validation_code,
     has_serde_default, helper_name_stem, internally_tagged_guard_errors, needs_injected_default,
-    parse_serde_field_attributes, parse_serde_type_attributes,
+    parse_serde_field_attributes, parse_serde_type_attributes, render_untagged_variant,
 };
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
@@ -35,7 +35,11 @@ use super::tuple_struct_zod_body;
 use super::tuple_struct_json_body;
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-use super::{check_slot_wire_is_readable, parse_serde_key_omission, tuple_struct_shape};
+use super::{check_slot_wire_is_readable, tuple_struct_shape};
+
+use super::{
+    VariantKind, check_variant_slot_wire_is_readable, parse_serde_key_omission, variant_wire_kind,
+};
 
 use syn::spanned::Spanned as _;
 
@@ -85,7 +89,8 @@ const UNPORTABLE_PROBE_PATTERNS: [(&str, &str); 6] = [
 /// Every slot spelling the refusal reads, beside whether it is refused. A slot dropped from one of
 /// serde's directions and not the other is; the pair that drops both is the wire the description
 /// already answers for, and everything else is a slot written in its place.
-#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+///
+/// Ungated because the variant seam reads the same list in every build.
 const SLOT_OMISSION_SPELLINGS: [(&str, bool); 6] = [
     ("skip_serializing", true),
     ("skip_serializing_if = \"Option::is_none\"", true),
@@ -6669,6 +6674,159 @@ fn a_lone_slot_is_refused_for_no_spelling() {
     for (spelling, _) in SLOT_OMISSION_SPELLINGS {
         assert_eq!(slot_refusal(spelling, 1), None, "for: {spelling}");
     }
+}
+
+/// The variant a declaration's first (and here only) variant parses to.
+fn declared_variant(declaration: &str) -> syn::Variant {
+    let item: syn::ItemEnum = syn::parse_str(declaration).unwrap();
+    item.variants.into_iter().next().unwrap()
+}
+
+/// Every refusal that declaration's variant earns, one per slot that earns one.
+fn variant_slot_refusals(declaration: &str) -> Vec<String> {
+    let variant = declared_variant(declaration);
+    let variant_name = variant.ident.to_string();
+    variant
+        .fields
+        .iter()
+        .enumerate()
+        .filter_map(|(index, field)| {
+            check_variant_slot_wire_is_readable(
+                field,
+                index,
+                &variant_name,
+                "Wire",
+                parse_serde_key_omission(&field.attrs),
+            )
+            .err()
+            .map(|err| err.to_string())
+        })
+        .collect()
+}
+
+/// Captured from serde on `enum E { One(#[serde(...)] String, u32) }`: `skip_serializing` alone
+/// writes `{"One":[7]}` and reads only `{"One":["s",7]}`, `skip_deserializing` alone writes
+/// `{"One":["s",7]}` and reads only `{"One":[7]}`. What serde writes is not what serde reads, and
+/// a slot has no optional spelling to describe both, so the declaration is refused.
+#[test]
+fn a_variant_slot_dropped_from_one_direction_only_is_refused() {
+    for (spelling, refused) in SLOT_OMISSION_SPELLINGS {
+        let refusals = variant_slot_refusals(&format!(
+            "enum Wire {{ One(#[serde({spelling})] Option<String>, u32) }}"
+        ));
+        assert_eq!(
+            refusals.len(),
+            usize::from(refused),
+            "{spelling}: {refusals:?}"
+        );
+        for message in refusals {
+            assert!(message.contains("slot 0"), "{spelling}: {message}");
+            assert!(message.contains("`One`"), "{spelling}: {message}");
+            assert!(message.contains("`Wire`"), "{spelling}: {message}");
+        }
+    }
+}
+
+/// A named member of a struct variant is left alone by the same walk: its key is absent from one
+/// payload and present in the other, which an optional key describes.
+#[test]
+fn a_named_variant_member_is_refused_for_no_spelling() {
+    for (spelling, _) in SLOT_OMISSION_SPELLINGS {
+        let refusals = variant_slot_refusals(&format!(
+            "enum Wire {{ One {{ #[serde({spelling})] a: Option<String> }} }}"
+        ));
+        assert!(refusals.is_empty(), "{spelling}: {refusals:?}");
+    }
+}
+
+/// The lone slot of a variant is asked the same question, which is where this seam parts from the
+/// tuple-struct one. Captured: `One(#[serde(skip_serializing)] String)` writes the bare name
+/// `"One"` and reads only `{"One":"s"}`, so the halves split a variant at every declared arity
+/// where a newtype struct ignored them outright.
+#[test]
+fn a_lone_variant_slot_is_refused_for_the_same_spellings() {
+    for (spelling, refused) in SLOT_OMISSION_SPELLINGS {
+        let refusals = variant_slot_refusals(&format!(
+            "enum Wire {{ One(#[serde({spelling})] Option<String>) }}"
+        ));
+        assert_eq!(
+            refusals.len(),
+            usize::from(refused),
+            "{spelling}: {refusals:?}"
+        );
+    }
+}
+
+/// Captured from serde: a variant declaring one slot and taking it off the wire is written as a
+/// unit variant — `"One"` externally, `{"type":"One"}` under a tag, `null` untagged — which are the
+/// payloads a declared unit variant writes in the same three places.
+#[test]
+fn a_variant_taking_its_lone_slot_off_the_wire_publishes_a_unit() {
+    for spelling in ["skip", "skip_serializing, skip_deserializing"] {
+        let variant =
+            declared_variant(&format!("enum Wire {{ One(#[serde({spelling})] String) }}"));
+        assert_eq!(variant_wire_kind(&variant), VariantKind::Unit, "{spelling}");
+    }
+}
+
+/// Every other declared arity keeps the kind it declared. Captured: a two-slot variant with one
+/// slot off the wire writes `{"One":[7]}` and with both off writes `{"One":[]}` — a shorter array
+/// and then an empty one, never the bare name a unit writes.
+#[test]
+fn every_other_declared_arity_keeps_the_kind_it_declared() {
+    for (declaration, expected) in [
+        (
+            "enum Wire { One(#[serde(skip)] String, u32) }",
+            VariantKind::TupleMultiple,
+        ),
+        (
+            "enum Wire { One(#[serde(skip)] String, #[serde(skip)] u32) }",
+            VariantKind::TupleMultiple,
+        ),
+        ("enum Wire { One(String) }", VariantKind::TupleSingle),
+        (
+            "enum Wire { One { #[serde(skip)] a: String } }",
+            VariantKind::Named,
+        ),
+        ("enum Wire { One }", VariantKind::Unit),
+    ] {
+        assert_eq!(
+            variant_wire_kind(&declared_variant(declaration)),
+            expected,
+            "for: {declaration}"
+        );
+    }
+}
+
+/// The member spelling an untagged variant is refused with, run over the kind it publishes.
+#[cfg(feature = "serde")]
+fn untagged_refusal(declaration: &str, members: &[super::FieldDef]) -> String {
+    let variant = declared_variant(declaration);
+    render_untagged_variant(&variant_wire_kind(&variant), &variant, members, "Wire")
+        .map_or_else(|err| err.to_string(), |_| String::new())
+}
+
+/// Captured from serde: an untagged variant whose lone slot is off the wire writes and reads `null`
+/// — the payload a declared unit variant writes there — so it takes the refusal a unit variant
+/// takes rather than describing the value nothing carries.
+#[cfg(feature = "serde")]
+#[test]
+fn an_untagged_variant_whose_lone_slot_is_dropped_is_refused_as_a_unit() {
+    let refusal = untagged_refusal("enum Wire { One(#[serde(skip)] String) }", &[]);
+    assert!(refusal.contains("is a unit variant"), "Got: {refusal}");
+}
+
+/// A refused tuple variant is named by the arity the author declared, not by the slots that reached
+/// the wire: a slot dropped from the description is still a slot the union has no spelling for.
+#[cfg(feature = "serde")]
+#[test]
+fn a_refused_untagged_tuple_variant_is_named_by_its_declared_arity() {
+    let carried = get_field_def("_1", &syn::parse_str::<syn::Type>("u32").unwrap(), "");
+    let refusal = untagged_refusal("enum Wire { One(#[serde(skip)] String, u32) }", &[carried]);
+    assert!(
+        refusal.contains("a tuple variant with 2 fields"),
+        "Got: {refusal}"
+    );
 }
 
 /// A path writes a string on the wire, which is the value the rendered constraint describes, so

--- a/tests/readme_example_tests/tests.rs
+++ b/tests/readme_example_tests/tests.rs
@@ -27,7 +27,7 @@ use tixschema::model_schema;
 const PREDICATE_BULLET: &str = "- `#[serde(skip_serializing_if = \"...\")]` -- the key is left out of the payload when the predicate fires, so the member is described under an optional key: `roles?: Array<string>;` in TypeScript, `roles: z.array(z.string()).optional(),` in Zod, and no `required` entry in the JSON Schema";
 
 /// The bare-`skip` bullet, whose claim is an absence on every surface.
-const SKIP_BULLET: &str = "- `#[serde(skip)]` -- the key is written into no payload and read out of none, so no surface describes the member at all: no TypeScript member, no Zod key, and neither a `properties` nor a `required` entry. On a tuple-struct slot it takes the slot out of the described tuple, which shortens the arity";
+const SKIP_BULLET: &str = "- `#[serde(skip)]` -- the key is written into no payload and read out of none, so no surface describes the member at all: no TypeScript member, no Zod key, and neither a `properties` nor a `required` entry. On a tuple-struct or tuple-variant slot it takes the slot out of the described tuple, which shortens the arity -- and a variant declaring one slot becomes a unit variant, which is what serde writes for it";
 
 /// The write-half bullet, which lands where the predicate bullet does.
 const WRITE_HALF_BULLET: &str = "- `#[serde(skip_serializing)]` -- the write half of `skip`: the key is left out of every payload while a supplied one is still read, so the member is described under an optional key, as `skip_serializing_if` is";

--- a/tests/tuple_variant_tests/tests.rs
+++ b/tests/tuple_variant_tests/tests.rs
@@ -203,6 +203,65 @@ pub enum RecursiveExternal {
     Txt(String),
 }
 
+/// The positions a dropped slot can sit in, beside the variant that drops none. A leading drop is
+/// the one the slots behind move up into, a trailing one only shortens the array, a middle one is
+/// where the renumbering shows, every slot dropped still writes an array, and a lone slot dropped
+/// leaves the variant a unit.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub enum ExternalDroppedSlots {
+    Every(#[serde(skip)] String, #[serde(skip)] u32),
+    Kept(u8, bool),
+    Lead(#[serde(skip)] String, u32),
+    Lone(#[serde(skip)] String),
+    Middle(String, #[serde(skip)] Option<String>, u32),
+    Trailing(String, #[serde(skip)] u32),
+}
+
+/// The kept variant on its own, which is what the enum above must still render it as.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub enum ExternalKeptOnly {
+    Kept(u8, bool),
+}
+
+/// The same drops under a content key, where the array is written under `value` rather than under
+/// the variant's own name.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(tag = "type", content = "value")]
+pub enum AdjacentDroppedSlots {
+    Every(#[serde(skip)] String, #[serde(skip)] u32),
+    Kept(u8, bool),
+    Lead(#[serde(skip)] String, u32),
+    Lone(#[serde(skip)] String),
+}
+
+/// The kept variant on its own, for the same reading in the adjacent form.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(tag = "type", content = "value")]
+pub enum AdjacentKeptOnly {
+    Kept(u8, bool),
+}
+
+/// A value serde writes as an object, which is the only content a bare tag can carry beside it.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
+pub struct DroppedSlotInner {
+    pub a: u32,
+}
+
+/// The bare-tag form, where the only tuple variant serde accepts is the newtype one — and where a
+/// lone slot taken off the wire leaves nothing to sit beside the tag, whatever the slot held.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(tag = "type")]
+pub enum InternalDroppedSlot {
+    Kept(DroppedSlotInner),
+    Lone(#[serde(skip)] String),
+}
+
 /// The `oneOf` member an externally tagged variant renders as: the one whose sole required key is
 /// the variant's name.
 #[cfg(feature = "jsonschema")]
@@ -1901,4 +1960,292 @@ fn test_bare_tag_over_an_untagged_enum_requires_every_key_serde_writes() {
 )]
 fn test_a_string_member_of_a_tagged_untagged_enum_is_refused_by_the_merge() {
     assert!(InternalOverScalarUntagged::json_schema().is_object());
+}
+
+/// The wire criterion every external surface below is read against, in both directions: the slot is
+/// absent from the array serde writes under the variant's key, and the full-arity array — the one
+/// the surfaces used to describe — is refused on the way in.
+#[test]
+fn test_serde_writes_and_reads_a_dropped_variant_slot_in_neither_direction() {
+    let written = serde_json::to_value(ExternalDroppedSlots::Lead("s".to_owned(), 7_u32)).unwrap();
+    assert_eq!(written, serde_json::json!({ "Lead": [7_u32] }));
+
+    assert_eq!(
+        serde_json::from_value::<ExternalDroppedSlots>(written).unwrap(),
+        ExternalDroppedSlots::Lead(String::new(), 7_u32)
+    );
+    assert!(
+        serde_json::from_str::<ExternalDroppedSlots>(r#"{"Lead":["s",7]}"#).is_err(),
+        "the full-arity array must not read back"
+    );
+}
+
+/// The wire criterion for the remaining positions: a trailing drop only shortens the array, a
+/// middle one moves the slot behind it up, and dropping every slot still writes an array.
+#[test]
+fn test_serde_writes_the_variant_slots_it_still_carries_in_their_new_places() {
+    assert_eq!(
+        serde_json::to_value(ExternalDroppedSlots::Trailing("s".to_owned(), 1_u32)).unwrap(),
+        serde_json::json!({ "Trailing": ["s"] })
+    );
+    assert_eq!(
+        serde_json::to_value(ExternalDroppedSlots::Middle(
+            "a".to_owned(),
+            Some("s".to_owned()),
+            7_u32
+        ))
+        .unwrap(),
+        serde_json::json!({ "Middle": ["a", 7_u32] })
+    );
+    assert_eq!(
+        serde_json::to_value(ExternalDroppedSlots::Every("s".to_owned(), 1_u32)).unwrap(),
+        serde_json::json!({ "Every": [] })
+    );
+}
+
+/// The wire criterion the lone slot's surfaces are read against, and the one place this seam parts
+/// from the tuple-struct one: a newtype struct ignores the attribute and keeps writing its value,
+/// while a variant has its own name to fall back on and serde writes that name alone.
+#[test]
+fn test_serde_writes_a_variant_whose_lone_slot_is_dropped_as_its_name_alone() {
+    assert_eq!(
+        serde_json::to_value(ExternalDroppedSlots::Lone("s".to_owned())).unwrap(),
+        serde_json::json!("Lone")
+    );
+    assert_eq!(
+        serde_json::from_str::<ExternalDroppedSlots>(r#""Lone""#).unwrap(),
+        ExternalDroppedSlots::Lone(String::new())
+    );
+    assert!(
+        serde_json::from_str::<ExternalDroppedSlots>(r#"{"Lone":"s"}"#).is_err(),
+        "the slot's own value must not read back"
+    );
+}
+
+/// The same three readings under a content key: the array shrinks under `value`, and the variant
+/// whose lone slot is gone writes the tag with no content key at all.
+#[test]
+fn test_serde_writes_a_dropped_variant_slot_the_same_way_under_a_content_key() {
+    assert_eq!(
+        serde_json::to_value(AdjacentDroppedSlots::Lead("s".to_owned(), 7_u32)).unwrap(),
+        serde_json::json!({ "type": "Lead", "value": [7_u32] })
+    );
+    assert_eq!(
+        serde_json::to_value(AdjacentDroppedSlots::Every("s".to_owned(), 1_u32)).unwrap(),
+        serde_json::json!({ "type": "Every", "value": [] })
+    );
+    assert_eq!(
+        serde_json::to_value(AdjacentDroppedSlots::Lone("s".to_owned())).unwrap(),
+        serde_json::json!({ "type": "Lone" })
+    );
+}
+
+/// The bare-tag form writes and reads the tag alone for a variant whose lone slot is dropped —
+/// whatever that slot held, including the values no bare tag can otherwise carry beside it.
+#[test]
+fn test_serde_writes_a_dropped_lone_slot_as_the_tag_alone_under_a_bare_tag() {
+    let written = serde_json::to_value(InternalDroppedSlot::Lone("s".to_owned())).unwrap();
+    assert_eq!(written, serde_json::json!({ "type": "Lone" }));
+    assert_eq!(
+        serde_json::from_value::<InternalDroppedSlot>(written).unwrap(),
+        InternalDroppedSlot::Lone(String::new())
+    );
+}
+
+/// The described tuple is the slots the wire still carries: the arity, the element types and the
+/// positions shrink together, and a lone slot gone leaves the variant's name as the whole member.
+#[cfg(feature = "typescript")]
+#[test]
+fn test_a_dropped_variant_slot_leaves_the_described_tuple_in_typescript() {
+    let ts = ExternalDroppedSlots::ts_definition();
+    assert!(ts.contains("\"Lead\": [number];"), "Got: {ts}");
+    assert!(ts.contains("\"Trailing\": [string];"), "Got: {ts}");
+    assert!(ts.contains("\"Middle\": [string, number];"), "Got: {ts}");
+    assert!(ts.contains("\"Every\": [];"), "Got: {ts}");
+    assert!(!ts.contains("\"Lone\":"), "Got: {ts}");
+}
+
+/// The lone slot gone leaves the variant describing as the bare name serde writes, which is the
+/// member a declared unit variant already renders as.
+#[cfg(feature = "typescript")]
+#[test]
+fn test_a_variant_whose_lone_slot_is_dropped_describes_as_its_name_in_typescript() {
+    let ts = ExternalDroppedSlots::ts_definition();
+    assert!(ts.contains("\"Lone\""), "Got: {ts}");
+    assert!(!ts.contains("\"Lone\":"), "Got: {ts}");
+}
+
+/// The same shrink on the Zod surface, where the arity is the tuple's own member list.
+#[cfg(feature = "zod")]
+#[test]
+fn test_a_dropped_variant_slot_leaves_the_described_tuple_in_zod() {
+    let zod = ExternalDroppedSlots::zod_schema();
+    assert!(
+        zod.contains("\"Lead\": z.tuple([z.number().int()])"),
+        "Got: {zod}"
+    );
+    assert!(zod.contains("\"Every\": z.tuple([])"), "Got: {zod}");
+    assert!(zod.contains("z.literal(\"Lone\")"), "Got: {zod}");
+}
+
+/// The same shrink on the JSON surface, where the arity is written twice as its own bounds and the
+/// element types are the `prefixItems` beside them.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn test_a_dropped_variant_slot_shrinks_the_described_arity_in_json_schema() {
+    let schema = ExternalDroppedSlots::json_schema();
+    assert_eq!(
+        external_member(&schema, "Lead")["properties"]["Lead"],
+        serde_json::json!({
+            "type": "array",
+            "prefixItems": [{ "type": "integer" }],
+            "items": false,
+            "minItems": 1_u32,
+            "maxItems": 1_u32
+        }),
+        "Got: {schema}"
+    );
+    assert_eq!(
+        external_member(&schema, "Every")["properties"]["Every"],
+        serde_json::json!({
+            "type": "array",
+            "prefixItems": [],
+            "items": false,
+            "minItems": 0_u32,
+            "maxItems": 0_u32
+        }),
+        "Got: {schema}"
+    );
+}
+
+/// A variant whose lone slot is gone is the bare string serde writes, not an object keyed by the
+/// variant's name.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn test_a_variant_whose_lone_slot_is_dropped_describes_as_a_string_in_json_schema() {
+    let schema = ExternalDroppedSlots::json_schema();
+    assert!(
+        schema["oneOf"]
+            .as_array()
+            .unwrap()
+            .contains(&serde_json::json!({ "type": "string", "const": "Lone" })),
+        "Got: {schema}"
+    );
+}
+
+/// The adjacent form describes the same shrink under its content key, and drops the key entirely
+/// for the variant whose lone slot is gone — which is the object serde writes for it.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn test_a_dropped_variant_slot_shrinks_the_content_key_in_json_schema() {
+    let schema = AdjacentDroppedSlots::json_schema();
+    let members = schema["oneOf"].as_array().unwrap();
+    let lead = members
+        .iter()
+        .find(|member| member["properties"]["type"]["const"] == "Lead")
+        .unwrap();
+    assert_eq!(
+        lead["properties"]["value"]["maxItems"], 1_u32,
+        "Got: {schema}"
+    );
+    let lone = members
+        .iter()
+        .find(|member| member["properties"]["type"]["const"] == "Lone")
+        .unwrap();
+    assert_eq!(
+        lone["required"],
+        serde_json::json!(["type"]),
+        "Got: {schema}"
+    );
+    assert!(lone["properties"]["value"].is_null(), "Got: {schema}");
+}
+
+/// The bare tag carries nothing beside it for a variant whose lone slot is gone, so the value the
+/// slot held is never asked to be an object — which is the only content that form accepts.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn test_a_dropped_lone_slot_leaves_the_bare_tag_alone_in_json_schema() {
+    let schema = InternalDroppedSlot::json_schema();
+    let lone = schema["oneOf"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|member| member["properties"]["type"]["const"] == "Lone")
+        .unwrap();
+    assert_eq!(
+        lone["required"],
+        serde_json::json!(["type"]),
+        "Got: {schema}"
+    );
+}
+
+/// A variant carrying no dropped slot renders character for character what it renders on its own,
+/// so nothing about the surfaces of an untouched declaration moves.
+#[cfg(feature = "typescript")]
+#[test]
+fn test_a_variant_carrying_no_dropped_slot_describes_unchanged_in_typescript() {
+    for (dropped, kept) in [
+        (
+            ExternalDroppedSlots::ts_definition(),
+            ExternalKeptOnly::ts_definition(),
+        ),
+        (
+            AdjacentDroppedSlots::ts_definition(),
+            AdjacentKeptOnly::ts_definition(),
+        ),
+    ] {
+        let member = kept
+            .rsplit_once('{')
+            .unwrap()
+            .1
+            .rsplit_once('}')
+            .unwrap()
+            .0
+            .to_owned();
+        assert!(
+            dropped.contains(&member),
+            "Missing:\n{member}\nGot:\n{dropped}"
+        );
+    }
+}
+
+/// The same reading on the Zod surface.
+#[cfg(feature = "zod")]
+#[test]
+fn test_a_variant_carrying_no_dropped_slot_describes_unchanged_in_zod() {
+    assert!(
+        ExternalDroppedSlots::zod_schema()
+            .contains("\"Kept\": z.tuple([z.number().int(), z.boolean()])"),
+        "Got: {}",
+        ExternalDroppedSlots::zod_schema()
+    );
+    assert!(
+        AdjacentDroppedSlots::zod_schema()
+            .contains("value: z.tuple([z.number().int(), z.boolean()])"),
+        "Got: {}",
+        AdjacentDroppedSlots::zod_schema()
+    );
+}
+
+/// The same reading on the JSON surface, where the whole member is comparable at once.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn test_a_variant_carrying_no_dropped_slot_describes_unchanged_in_json_schema() {
+    assert_eq!(
+        external_member(&ExternalDroppedSlots::json_schema(), "Kept"),
+        external_member(&ExternalKeptOnly::json_schema(), "Kept")
+    );
+    let adjacent_member = |schema: &serde_json::Value| {
+        schema["oneOf"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|member| member["properties"]["type"]["const"] == "Kept")
+            .cloned()
+            .unwrap()
+    };
+    assert_eq!(
+        adjacent_member(&AdjacentDroppedSlots::json_schema()),
+        adjacent_member(&AdjacentKeptOnly::json_schema())
+    );
 }


### PR DESCRIPTION
A tuple variant's slots now read the same omission contract a tuple struct's do, with the one difference the wire itself imposes at the lone-slot arity.

A slot taken off the wire in both directions leaves the described tuple, shrinking its arity, prefixItems and element types together, under every tagging flavor — captured per flavor before writing, since the tagging can change the arity story. A variant declaring exactly one slot and dropping it is written by serde as a unit variant (the bare name externally, the tag alone under a tag, null untagged), so each surface now describes the unit it has become; the validate() arm still matches the declared Rust shape, which keeps holding a value. A slot dropped from only one of serde's two directions is refused at every arity — serde reads a variant slot's attributes everywhere, unlike the one-slot struct that ignores them — with the landed refusal's words and remedy. Unskipped variants are byte-identical, asserted against control enums on all three surfaces.