### PR TITLE
Refuse the collapsed variants whose wire serde splits or the union cannot describe

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -5365,20 +5365,28 @@ fn process_plain_enum(
 /// slot off the wire writes `{"One":[7]}` and with both off writes `{"One":[]}` — a shorter array
 /// and then an empty one, never a bare value and never the bare name.
 fn variant_wire_kind(variant: &syn::Variant) -> VariantKind {
-    let kind = classify_variant(variant);
+    if lone_slot_off_wire(variant) {
+        VariantKind::Unit
+    } else {
+        classify_variant(variant)
+    }
+}
+
+/// Whether the variant declares exactly one slot and takes that slot off the wire in both
+/// directions — the collapse [`variant_wire_kind`] publishes a unit for.
+///
+/// Held apart from the kind it produces because two seams need the declaration back: what the
+/// collapse is written as is a unit, and what it was *declared* as is what the refusals reading this
+/// have to name. A declared unit and a collapsed one share every wire and part only here.
+fn lone_slot_off_wire(variant: &syn::Variant) -> bool {
     // `classify_variant` names `TupleSingle` for a variant of exactly one unnamed field, so the
     // first field is the lone slot whose omission decides this.
-    let publishes_no_slot = matches!(kind, VariantKind::TupleSingle)
+    matches!(classify_variant(variant), VariantKind::TupleSingle)
         && variant
             .fields
             .iter()
             .next()
-            .is_some_and(|field| parse_serde_key_omission(&field.attrs).absent_from_wire());
-    if publishes_no_slot {
-        VariantKind::Unit
-    } else {
-        kind
-    }
+            .is_some_and(|field| parse_serde_key_omission(&field.attrs).absent_from_wire())
 }
 
 /// Rejects a tuple-variant slot whose serde attributes drop it out of one of serde's two directions
@@ -5608,6 +5616,74 @@ fn discriminated_main_schema_code(
     }
 }
 
+/// Refuses every variant of an adjacently tagged enum whose declared lone slot is off the wire in
+/// both directions, one error per offender so the expansion names them all.
+///
+/// This is the one tagging where the collapse has no payload to be described by. Captured on
+/// `#[serde(tag = "type", content = "value")] enum E { One(#[serde(skip)] String) }` holding `"s"`:
+/// serde writes `{"type":"One"}` and then refuses to read that very payload back — `missing field
+/// value` — while only `{"type":"One","value":null}` reads. The write set and the read set are
+/// disjoint, so there is no payload a schema could hold for the pair, exactly the property that
+/// already refuses a slot dropped from one direction only. The remedy is the control: the same
+/// variant declared as a unit writes the identical `{"type":"One"}` and reads it back.
+///
+/// The other three taggings are untouched, their captured collapses round-tripping — externally
+/// `"One"`, under a bare tag `{"type":"One"}`, untagged `null` — and every other declared arity
+/// keeps the shrink, a two-slot variant with one slot off the wire writing and reading
+/// `{"type":"One","value":[7]}`.
+///
+/// Read against the tag and content keys the declaration named, so the payloads the author is shown
+/// are their own. Gated on the `serde` feature because the tagging flavor is: without it no
+/// declaration can be told apart and the adjacent form stands for all of them, which is the same
+/// reason the untagged refusals are gated.
+#[cfg(feature = "serde")]
+fn adjacent_collapsed_slot_guard_errors(
+    item_enum: &syn::ItemEnum,
+    tag_name: &str,
+    content_name: &str,
+) -> Vec<proc_macro2::TokenStream> {
+    let type_name = &item_enum.ident;
+    item_enum
+        .variants
+        .iter()
+        .filter(|variant| lone_slot_off_wire(variant))
+        .map(|variant| {
+            let variant_name = &variant.ident;
+            syn::Error::new_spanned(
+                variant,
+                format!(
+                    "model_schema: variant `{variant_name}` of enum `{type_name}` declares one \
+                     slot and takes it off the wire in both directions, so serde writes it as \
+                     `{{\"{tag_name}\":\"{variant_name}\"}}` — the payload a unit variant writes — \
+                     and then refuses to read that same payload back, asking for the \
+                     `{content_name}` key it never wrote. Only \
+                     `{{\"{tag_name}\":\"{variant_name}\",\"{content_name}\":null}}` reads, so what \
+                     serde writes for the variant and what serde reads for it have no payload in \
+                     common and no schema can be written for the pair. Declare `{variant_name}` as \
+                     a unit variant: it writes the identical \
+                     `{{\"{tag_name}\":\"{variant_name}\"}}` and reads it back. Or drop the \
+                     attribute so the slot is written and read in its place."
+                ),
+            )
+            .to_compile_error()
+        })
+        .collect()
+}
+
+/// Builds the Zod `z.discriminatedUnion` expression for a discriminated enum from its per-variant
+/// member schemas, beside [`discriminated_main_schema_code`] which answers the same for JSON.
+#[cfg(feature = "zod")]
+fn discriminated_zod_schema_code(tag_name: &str, members: &[(String, Vec<String>)]) -> String {
+    format!(
+        "z.discriminatedUnion(\"{tag_name}\", [{}])",
+        members
+            .iter()
+            .map(|(member, _opts)| format!("z.strictObject({member})"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
+}
+
 /// Processes a discriminated enum (tagged union in TypeScript) and generates its definitions.
 fn process_discriminated_enum(
     mut item_enum: syn::ItemEnum,
@@ -5634,6 +5710,17 @@ fn process_discriminated_enum(
     #[cfg(not(any(feature = "typescript", feature = "zod", feature = "jsonschema")))]
     let enum_module_name_opt = None;
 
+    // Read before the walk, which rewrites the very attributes the collapse is read off, and
+    // returned before it so no held-back attribute is written onto an item the guard refuses.
+    #[cfg(feature = "serde")]
+    if let Some(output) = guard_failure_output(
+        &item_enum,
+        Some(&item_enum.ident),
+        &adjacent_collapsed_slot_guard_errors(&item_enum, tag_name, content_name),
+    ) {
+        return output;
+    }
+
     // Bind both result tuples whole so feature-gated field access marks them used (no per-element
     // guards): `variants` = (variants, validation_fns, guard_errors);
     // `rendered` = (ts, zod, json).
@@ -5651,17 +5738,8 @@ fn process_discriminated_enum(
     #[cfg(feature = "typescript")]
     let type_code = rendered.0.join(" | ");
 
-    // Generate Zod schema conditionally
     #[cfg(feature = "zod")]
-    let schema_code = format!(
-        "z.discriminatedUnion(\"{tag_name}\", [{}])",
-        rendered
-            .1
-            .iter()
-            .map(|(v, _opts)| format!("z.strictObject({}){}", v, ""))
-            .collect::<Vec<_>>()
-            .join(", ")
-    );
+    let schema_code = discriminated_zod_schema_code(tag_name, &rendered.1);
 
     #[cfg(feature = "typescript")]
     let docs = build_jsdoc_body(docs_vec.as_deref(), item_name);
@@ -6633,6 +6711,9 @@ fn render_untagged_variant(
     match (kind, field_defs) {
         (VariantKind::TupleSingle, [fld]) => Ok(render_untagged_tuple_single(fld, self_type_name)),
         (VariantKind::Named, _) => Ok(render_untagged_named(field_defs, self_type_name)),
+        (VariantKind::Unit, _) if lone_slot_off_wire(variant) => {
+            Err(collapsed_untagged_variant_error(variant))
+        }
         (VariantKind::Unit, _) => Err(unsupported_untagged_variant_error(
             variant,
             "a unit variant",
@@ -6644,6 +6725,37 @@ fn render_untagged_variant(
             ))
         }
     }
+}
+
+/// Refuses an untagged variant that reached the unit wire by taking its lone slot off it, spanned on
+/// the variant.
+///
+/// The treatment is the one a declared unit variant takes and the wire is the same: captured,
+/// `#[serde(untagged)] enum E { One(#[serde(skip)] String) }` writes `null` and reads `null` back,
+/// which is what `enum E { One }` writes and reads in the same place. Only the words part. The
+/// standing refusal offers inner types and named fields as the shapes the union supports, and this
+/// declaration has an inner type on its face — an author reading that is told their code is
+/// something it is not. So the collapse is named instead: the slot is off the wire in both
+/// directions, which is how a declaration holding a type comes to be written as the null a unit
+/// writes.
+///
+/// Whether an untagged union should gain a null member — which would admit both spellings, the two
+/// sharing one wire — is a separate decision this refusal does not take.
+#[cfg(feature = "serde")]
+fn collapsed_untagged_variant_error(variant: &syn::Variant) -> syn::Error {
+    let variant_name = &variant.ident;
+    syn::Error::new_spanned(
+        variant,
+        format!(
+            "model_schema: variant `{variant_name}`: the lone slot of `{variant_name}` is off the \
+             wire in both directions, so serde writes and reads the variant as the bare `null` a \
+             unit variant is written as, whatever the slot holds — and an untagged union has no \
+             member spelling for `null`: a member is written as its inner type or as an object of \
+             named fields, and the slot this one would have been written as never reaches the wire. \
+             Keep the slot on the wire so the member has a value to be written as, or remove \
+             `{variant_name}` from the union."
+        ),
+    )
 }
 
 /// Refuses a variant shape the untagged union has no member spelling for, spanned on the variant.

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -6,12 +6,13 @@ use super::{
 
 #[cfg(feature = "serde")]
 use super::{
-    ConstraintLeaf, MemberAccess, ModelSchemaPropMeta, build_field_validation,
-    cfg_attr_guard_error, check_omitted_key_is_readable, check_optional_field_serialization,
-    collect_untagged_members, constrained_shape, enum_cfg_attr_guard_errors,
-    generate_field_validation, generate_numeric_validation_code, generate_string_validation_code,
-    has_serde_default, helper_name_stem, internally_tagged_guard_errors, needs_injected_default,
-    parse_serde_field_attributes, parse_serde_type_attributes, render_untagged_variant,
+    ConstraintLeaf, MemberAccess, ModelSchemaPropMeta, adjacent_collapsed_slot_guard_errors,
+    build_field_validation, cfg_attr_guard_error, check_omitted_key_is_readable,
+    check_optional_field_serialization, collect_untagged_members, constrained_shape,
+    enum_cfg_attr_guard_errors, generate_field_validation, generate_numeric_validation_code,
+    generate_string_validation_code, has_serde_default, helper_name_stem,
+    internally_tagged_guard_errors, needs_injected_default, parse_serde_field_attributes,
+    parse_serde_type_attributes, render_untagged_variant,
 };
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
@@ -7212,6 +7213,89 @@ fn every_other_declared_arity_keeps_the_kind_it_declared() {
     }
 }
 
+/// The adjacent-form refusals a declaration earns, one per variant that earns one, as rendered
+/// `compile_error!` token strings.
+#[cfg(feature = "serde")]
+fn adjacent_refusals(declaration: &str) -> Vec<String> {
+    let item: syn::ItemEnum = syn::parse_str(declaration).unwrap();
+    adjacent_collapsed_slot_guard_errors(&item, "type", "value")
+        .iter()
+        .map(ToString::to_string)
+        .collect()
+}
+
+/// Captured from serde under `#[serde(tag = "type", content = "value")]`: the variant whose lone
+/// slot is off the wire writes `{"type":"One"}` and serde then refuses to read that back (missing
+/// field `value`), while only `{"type":"One","value":null}` reads. The write set and the read set
+/// have no common member, so the declaration is refused rather than described.
+#[cfg(feature = "serde")]
+#[test]
+fn an_adjacent_variant_whose_lone_slot_is_dropped_is_refused() {
+    let refusals = adjacent_refusals("enum Wire { One(#[serde(skip)] String) }");
+    assert_eq!(refusals.len(), 1, "got: {refusals:?}");
+    for needle in [
+        "`One`",
+        "`Wire`",
+        r#"{\"type\":\"One\"}"#,
+        r#"{\"type\":\"One\",\"value\":null}"#,
+        "Declare `One` as a unit variant",
+    ] {
+        assert!(
+            refusals[0].contains(needle),
+            "{needle} missing from: {}",
+            refusals[0]
+        );
+    }
+}
+
+/// Every other declared arity keeps the landed shrink: captured, a two-slot variant with one slot
+/// off the wire writes and reads `{"type":"One","value":[7]}` and with both off writes and reads
+/// `{"type":"One","value":[]}`, so each has a payload to be described by.
+#[cfg(feature = "serde")]
+#[test]
+fn every_other_adjacent_arity_is_left_alone() {
+    for declaration in [
+        "enum Wire { One(#[serde(skip)] String, u32) }",
+        "enum Wire { One(#[serde(skip)] String, #[serde(skip)] u32) }",
+        "enum Wire { One(String) }",
+        "enum Wire { One { #[serde(skip)] a: String } }",
+        "enum Wire { One }",
+        "enum Wire { One() }",
+    ] {
+        let refusals = adjacent_refusals(declaration);
+        assert!(refusals.is_empty(), "{declaration}: {refusals:?}");
+    }
+}
+
+/// The refusal points at the variant it is about, not at the enum's tagging attribute: an enum with
+/// many variants otherwise sends its author to the wrong line.
+#[cfg(feature = "serde")]
+#[test]
+fn the_adjacent_collapse_refusal_points_at_the_variant() {
+    let item: syn::ItemEnum =
+        syn::parse_str("enum Wire { Kept(u8, bool), Lone(#[serde(skip)] String) }").unwrap();
+    let errors = adjacent_collapsed_slot_guard_errors(&item, "type", "value");
+    assert_eq!(errors.len(), 1, "got: {errors:?}");
+    assert_eq!(
+        errors[0].span().source_text().as_deref(),
+        Some("Lone(#[serde(skip)] String)")
+    );
+}
+
+/// The refusal quotes the keys the declaration named, so the payloads it prints are the author's
+/// own rather than serde's defaults.
+#[cfg(feature = "serde")]
+#[test]
+fn the_adjacent_collapse_refusal_quotes_the_declared_keys() {
+    let item: syn::ItemEnum = syn::parse_str("enum Wire { One(#[serde(skip)] String) }").unwrap();
+    let refusal = adjacent_collapsed_slot_guard_errors(&item, "kind", "payload")[0].to_string();
+    assert!(refusal.contains(r#"{\"kind\":\"One\"}"#), "Got: {refusal}");
+    assert!(
+        refusal.contains(r#"{\"kind\":\"One\",\"payload\":null}"#),
+        "Got: {refusal}"
+    );
+}
+
 /// The member spelling an untagged variant is refused with, run over the kind it publishes.
 #[cfg(feature = "serde")]
 fn untagged_refusal(declaration: &str, members: &[super::FieldDef]) -> String {
@@ -7222,12 +7306,61 @@ fn untagged_refusal(declaration: &str, members: &[super::FieldDef]) -> String {
 
 /// Captured from serde: an untagged variant whose lone slot is off the wire writes and reads `null`
 /// — the payload a declared unit variant writes there — so it takes the refusal a unit variant
-/// takes rather than describing the value nothing carries.
+/// takes rather than describing the value nothing carries. The words are the collapse's own: a
+/// declaration holding one inner type must not be told that inner types are what the union supports.
 #[cfg(feature = "serde")]
 #[test]
-fn an_untagged_variant_whose_lone_slot_is_dropped_is_refused_as_a_unit() {
+fn an_untagged_variant_whose_lone_slot_is_dropped_is_refused_for_the_collapse() {
     let refusal = untagged_refusal("enum Wire { One(#[serde(skip)] String) }", &[]);
-    assert!(refusal.contains("is a unit variant"), "Got: {refusal}");
+    for needle in [
+        "`One`",
+        "off the wire in both directions",
+        "`null`",
+        "Keep the slot on the wire",
+        "remove `One` from the union",
+    ] {
+        assert!(refusal.contains(needle), "{needle} missing from: {refusal}");
+    }
+    assert!(
+        !refusal.contains("supports newtype"),
+        "the collapse must not be told what the union supports: {refusal}"
+    );
+}
+
+/// The collapse's refusal points at the variant it is about, the way the shape refusal beside it
+/// does: an author sent to the enum's attribute is sent to the wrong line.
+#[cfg(feature = "serde")]
+#[test]
+fn the_untagged_collapse_refusal_points_at_the_variant() {
+    let variant = declared_variant("enum Wire { One(#[serde(skip)] String) }");
+    let error =
+        render_untagged_variant(&variant_wire_kind(&variant), &variant, &[], "Wire").unwrap_err();
+    assert_eq!(
+        error.span().source_text().as_deref(),
+        Some("One(#[serde(skip)] String)")
+    );
+}
+
+/// The standing refusal is untouched: a variant declared as a unit — and the empty tuple serde
+/// writes the same way — still reads the words the union has always answered them with.
+#[cfg(feature = "serde")]
+#[test]
+fn a_declared_untagged_unit_variant_keeps_its_own_refusal() {
+    // The ellipsis and em dash are spelled by escape so the pin stays byte-exact without writing a
+    // non-ASCII literal into the source.
+    let expected = "model_schema: variant `One`: `#[serde(untagged)]` supports newtype (`V(T)`) \
+                    and struct (`V { \u{2026} }`) variants only \u{2014} `One` is a unit variant, \
+                    which the union has no member spelling for: a member is written as the inner \
+                    type or as an object of named fields, and a variant that is neither has \
+                    nothing to be written as. Give it a single inner type or named fields, or drop \
+                    `#[serde(untagged)]`.";
+    for declaration in ["enum Wire { One }", "enum Wire { One() }"] {
+        assert_eq!(
+            untagged_refusal(declaration, &[]),
+            expected,
+            "{declaration}"
+        );
+    }
 }
 
 /// A refused tuple variant is named by the arity the author declared, not by the slots that reached

--- a/tests/tuple_variant_tests/tests.rs
+++ b/tests/tuple_variant_tests/tests.rs
@@ -226,7 +226,9 @@ pub enum ExternalKeptOnly {
 }
 
 /// The same drops under a content key, where the array is written under `value` rather than under
-/// the variant's own name.
+/// the variant's own name. `Lone` is declared as the unit it would have been written as: under this
+/// tagging alone the collapse has no payload to be described by and is refused, and this is the
+/// remedy that refusal names.
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "type", content = "value")]
@@ -234,7 +236,7 @@ pub enum AdjacentDroppedSlots {
     Every(#[serde(skip)] String, #[serde(skip)] u32),
     Kept(u8, bool),
     Lead(#[serde(skip)] String, u32),
-    Lone(#[serde(skip)] String),
+    Lone,
 }
 
 /// The kept variant on its own, for the same reading in the adjacent form.
@@ -243,6 +245,21 @@ pub enum AdjacentDroppedSlots {
 #[serde(tag = "type", content = "value")]
 pub enum AdjacentKeptOnly {
     Kept(u8, bool),
+}
+
+/// The adjacent lone-slot collapse, declared without a schema because the surfaces refuse it — the
+/// wire captured below is what they refuse it for.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(tag = "type", content = "value")]
+pub enum AdjacentLoneSlotWire {
+    Lone(#[serde(skip)] String),
+}
+
+/// The same variant declared as the unit it is written as, which is the remedy the refusal names.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(tag = "type", content = "value")]
+pub enum AdjacentUnitWire {
+    Lone,
 }
 
 /// A value serde writes as an object, which is the only content a bare tag can carry beside it.
@@ -2022,21 +2039,66 @@ fn test_serde_writes_a_variant_whose_lone_slot_is_dropped_as_its_name_alone() {
     );
 }
 
-/// The same three readings under a content key: the array shrinks under `value`, and the variant
-/// whose lone slot is gone writes the tag with no content key at all.
+/// The same readings under a content key, and the scope the lone slot's refusal stops at: the array
+/// shrinks under `value` at every other declared arity and reads straight back, so each of them has
+/// one payload the surfaces can describe.
 #[test]
 fn test_serde_writes_a_dropped_variant_slot_the_same_way_under_a_content_key() {
+    for (held, written) in [
+        (
+            AdjacentDroppedSlots::Lead("s".to_owned(), 7_u32),
+            serde_json::json!({ "type": "Lead", "value": [7_u32] }),
+        ),
+        (
+            AdjacentDroppedSlots::Every("s".to_owned(), 1_u32),
+            serde_json::json!({ "type": "Every", "value": [] }),
+        ),
+    ] {
+        assert_eq!(serde_json::to_value(held).unwrap(), written);
+        assert!(
+            serde_json::from_value::<AdjacentDroppedSlots>(written.clone()).is_ok(),
+            "must read back: {written}"
+        );
+    }
+}
+
+/// The wire the adjacent form's lone-slot collapse is refused for: serde writes `{"type":"Lone"}`
+/// and then refuses to read that same payload back, asking for the content key it never wrote. Only
+/// the `value: null` spelling reads, so the write set and the read set have no common member.
+#[test]
+fn test_serde_refuses_the_adjacent_payload_it_writes_for_a_dropped_lone_slot() {
     assert_eq!(
-        serde_json::to_value(AdjacentDroppedSlots::Lead("s".to_owned(), 7_u32)).unwrap(),
-        serde_json::json!({ "type": "Lead", "value": [7_u32] })
-    );
-    assert_eq!(
-        serde_json::to_value(AdjacentDroppedSlots::Every("s".to_owned(), 1_u32)).unwrap(),
-        serde_json::json!({ "type": "Every", "value": [] })
-    );
-    assert_eq!(
-        serde_json::to_value(AdjacentDroppedSlots::Lone("s".to_owned())).unwrap(),
+        serde_json::to_value(AdjacentLoneSlotWire::Lone("s".to_owned())).unwrap(),
         serde_json::json!({ "type": "Lone" })
+    );
+    let refused = serde_json::from_str::<AdjacentLoneSlotWire>(r#"{"type":"Lone"}"#).unwrap_err();
+    assert!(
+        refused.to_string().contains("missing field `value`"),
+        "Got: {refused}"
+    );
+    assert_eq!(
+        serde_json::from_str::<AdjacentLoneSlotWire>(r#"{"type":"Lone","value":null}"#).unwrap(),
+        AdjacentLoneSlotWire::Lone(String::new())
+    );
+    assert!(
+        serde_json::from_str::<AdjacentLoneSlotWire>(r#"{"type":"Lone","value":"s"}"#).is_err(),
+        "the slot's own value must not read back"
+    );
+}
+
+/// The control the refusal's remedy names: the variant declared as a unit writes the identical
+/// payload, reads it back, and still accepts the `value: null` spelling the collapse reads.
+#[test]
+fn test_serde_reads_back_the_adjacent_payload_a_declared_unit_variant_writes() {
+    let written = serde_json::to_value(AdjacentUnitWire::Lone).unwrap();
+    assert_eq!(written, serde_json::json!({ "type": "Lone" }));
+    assert_eq!(
+        serde_json::from_value::<AdjacentUnitWire>(written).unwrap(),
+        AdjacentUnitWire::Lone
+    );
+    assert_eq!(
+        serde_json::from_str::<AdjacentUnitWire>(r#"{"type":"Lone","value":null}"#).unwrap(),
+        AdjacentUnitWire::Lone
     );
 }
 
@@ -2134,30 +2196,46 @@ fn test_a_variant_whose_lone_slot_is_dropped_describes_as_a_string_in_json_schem
 }
 
 /// The adjacent form describes the same shrink under its content key, and drops the key entirely
-/// for the variant whose lone slot is gone — which is the object serde writes for it.
+/// for the variant declared as a unit — the member the refused collapse would have been given, now
+/// reached through the declaration the refusal sends its author to.
 #[cfg(feature = "jsonschema")]
 #[test]
 fn test_a_dropped_variant_slot_shrinks_the_content_key_in_json_schema() {
     let schema = AdjacentDroppedSlots::json_schema();
     let members = schema["oneOf"].as_array().unwrap();
-    let lead = members
-        .iter()
-        .find(|member| member["properties"]["type"]["const"] == "Lead")
-        .unwrap();
+    let member = |name: &str| {
+        let found = members
+            .iter()
+            .find(|member| member["properties"]["type"]["const"] == name)
+            .cloned()
+            .unwrap_or(serde_json::Value::Null);
+        assert!(!found.is_null(), "No member `{name}`. Got: {schema}");
+        found
+    };
     assert_eq!(
-        lead["properties"]["value"]["maxItems"], 1_u32,
+        member("Lead")["properties"]["value"]["maxItems"],
+        1_u32,
         "Got: {schema}"
     );
-    let lone = members
-        .iter()
-        .find(|member| member["properties"]["type"]["const"] == "Lone")
-        .unwrap();
+    let lone = member("Lone");
     assert_eq!(
         lone["required"],
         serde_json::json!(["type"]),
         "Got: {schema}"
     );
     assert!(lone["properties"]["value"].is_null(), "Got: {schema}");
+}
+
+/// The remedy is equivalent on the wire, which is what makes it the one the refusal names: the
+/// variant declared as a unit writes the very payload the refused collapse wrote, and reads it back.
+#[test]
+fn test_the_declared_unit_remedy_writes_the_payload_the_refused_collapse_wrote() {
+    let written = serde_json::to_value(AdjacentDroppedSlots::Lone).unwrap();
+    assert_eq!(written, serde_json::json!({ "type": "Lone" }));
+    assert_eq!(
+        serde_json::from_value::<AdjacentDroppedSlots>(written).unwrap(),
+        AdjacentDroppedSlots::Lone
+    );
 }
 
 /// The bare tag carries nothing beside it for a variant whose lone slot is gone, so the value the

--- a/tests/untagged_tests/tests.rs
+++ b/tests/untagged_tests/tests.rs
@@ -251,6 +251,21 @@ enum OidUnion {
     One { one: ObjectId },
 }
 
+/// The untagged lone-slot collapse, declared without a schema because the union refuses it — the
+/// wire captured below is the one that refusal has to fit.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum UntaggedLoneSlotWire {
+    Lone(#[serde(skip)] String),
+}
+
+/// The same variant declared as the unit it is written as, sharing that one wire.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum UntaggedUnitWire {
+    Lone,
+}
+
 #[test]
 fn test_untagged_entry_constructible() {
     let entry = DataElementSampleValueEntry {
@@ -1148,5 +1163,37 @@ fn test_untagged_validate_runs_only_the_held_variants_checks() {
         .validate()
         .is_ok(),
         "the bare member is held to no bound"
+    );
+}
+
+/// The wire the untagged collapse writes and reads: the slot is off the wire in both directions, so
+/// serde writes `null` and reads `null` back, and neither the slot's own value nor an array matches.
+#[test]
+fn test_serde_writes_and_reads_null_for_an_untagged_variant_whose_lone_slot_is_dropped() {
+    let written = serde_json::to_value(UntaggedLoneSlotWire::Lone("s".to_owned())).unwrap();
+    assert_eq!(written, serde_json::Value::Null);
+    assert_eq!(
+        serde_json::from_value::<UntaggedLoneSlotWire>(written).unwrap(),
+        UntaggedLoneSlotWire::Lone(String::new())
+    );
+    assert!(
+        serde_json::from_str::<UntaggedLoneSlotWire>(r#""s""#).is_err(),
+        "the slot's own value must not read back"
+    );
+    assert!(
+        serde_json::from_str::<UntaggedLoneSlotWire>("[]").is_err(),
+        "no array spelling reads back"
+    );
+}
+
+/// The control: a variant declared as a unit writes and reads the same `null`, so the two
+/// declarations share one wire in both directions.
+#[test]
+fn test_serde_writes_and_reads_the_same_null_for_a_declared_untagged_unit_variant() {
+    let written = serde_json::to_value(UntaggedUnitWire::Lone).unwrap();
+    assert_eq!(written, serde_json::Value::Null);
+    assert_eq!(
+        serde_json::from_value::<UntaggedUnitWire>(written).unwrap(),
+        UntaggedUnitWire::Lone
     );
 }


### PR DESCRIPTION
Two refinements to the lone-slot variant collapse.

Under adjacent tagging, a variant declaring one slot and taking it off the wire in both directions writes the tag alone — and serde then refuses to read that very payload back, asking for the content key it never wrote; only the tag-beside-null spelling reads. The write set and the read set share no payload, the same property that already refuses one-directional halves, so the declaration is refused before the walk, spanned on the variant, quoting both payloads under the tag and content keys the declaration named and pointing at the remedy the control proves equivalent: declare the variant as a unit variant, which writes the identical payload and reads it back. The other three taggings keep their round-tripping collapses.

Untagged, the collapse correctly inherits the unit-variant refusal, but the inherited words offered newtype variants as a supported shape — which the refused declaration is on its face. It now gets words naming the collapse: the slot never reaches the wire, so the variant is the bare null a unit writes, which the union has no member spelling for; keep the slot on the wire or remove the variant. The declared unit variant's refusal is pinned byte-identical.