### PR TITLE
Declare the cross-parameter fixture at a filling the document machinery renders

### DIFF
--- a/tests/generic_types_tests/tests.rs
+++ b/tests/generic_types_tests/tests.rs
@@ -1100,7 +1100,7 @@ where
 /// filled too — a joint statement the per-filling check does not make, and one whose name
 /// reproduced beside a single filling would resolve to nothing. The fixture compiling is the whole
 /// of the assertion that such a bound is left to the item's own use sites.
-#[model_schema(default_types(WideType = String, NarrowType = char))]
+#[model_schema(default_types(WideType = String, NarrowType = String))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Widened<WideType: From<NarrowType>, NarrowType: Clone> {
     pub narrow: NarrowType,


### PR DESCRIPTION
The cross-parameter bound fixture declared its narrow filling at char, which predated declared fillings rendering as documents: the machinery has no arm for char, so the emitted delegation named a module that never existed and the suite failed with an unspanned E0433 and two E0425s. The filling moves to String — the fixture's bound still holds through the reflexive From impl, the Rust use site is unchanged, and the document renders. The unrenderable-filling seam itself is recorded as the entry-position slice of the unrenderable-shape guard work.