### PR TITLE
Check cross-parameter bounds jointly; stop enforcing the bounds Rust leaves inert on aliases

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -2173,8 +2173,9 @@ fn missing_default_message(name: &syn::Ident, declared: &[&syn::Ident]) -> Strin
     )
 }
 
-/// The compile-time check every `default_types` filling earns against the bounds its parameter
-/// declares — one per bounded parameter, emitted beside the expansion rather than in place of it.
+/// The compile-time checks a `default_types` declaration earns against the bounds its parameters
+/// declare — one per bounded parameter, and one more carrying jointly whatever bound reads a
+/// neighbour — emitted beside the expansion rather than in place of it.
 ///
 /// A filling is the author's statement of what the item holds; a parameter's bounds are the item's
 /// statement of what it can hold. The two can disagree, and nothing here can tell them apart: a
@@ -2189,46 +2190,142 @@ fn missing_default_message(name: &syn::Ident, declared: &[&syn::Ident]) -> Strin
 /// value of the parameter can take describes an item that is uninhabitable at it, which is as true
 /// in a build that generates no document as in one that does.
 ///
-/// Two declarations earn nothing. A parameter with no bounds admits every filling, so the expansion
-/// is left exactly as it was. And a bound naming another parameter of the item holds only where
-/// that one is filled too — a joint statement this per-filling check does not make, and one whose
-/// name reproduced here would resolve to nothing — so it is left to the item's own use sites.
+/// A parameter with no bounds earns nothing: it admits every filling, so the expansion is left
+/// exactly as it was. A bound naming another parameter of the item earns nothing *here* — the
+/// neighbour's name reproduced beside a single filling would resolve to nothing — and is carried
+/// instead by [`joint_bound_check`], which declares the whole parameter list at once so every name
+/// the bound reads stands at the filling declared for it.
+///
+/// An alias earns nothing at all. Rust does not enforce a bound written on a type alias's
+/// parameter — `type_alias_bounds` exists to say the bound is inert and to offer its deletion — so
+/// a filling that fails one still names a type every use site of the alias accepts, and a refusal
+/// here would refuse a program the language admits. Saying an alias's bound is empty is that lint's
+/// job, not this attribute's.
 fn default_types_bound_checks(
     item: &Item,
     args: &ModelSchemaArgs,
 ) -> Vec<proc_macro2::TokenStream> {
+    if matches!(item, Item::Type(_)) {
+        return Vec::new();
+    }
     let Some(generics) = item_generics(item) else {
         return Vec::new();
     };
-    args.default_types
+    let mut checks: Vec<proc_macro2::TokenStream> = args
+        .default_types
         .iter()
         .filter_map(|(name, filling)| filling_bound_check(generics, name, filling))
-        .collect()
+        .collect();
+    checks.extend(joint_bound_check(generics, args));
+    checks
 }
 
-/// The check one filling earns, or `None` where its parameter declares nothing to check it against.
+/// The check one filling earns against the bounds its parameter declares alone, or `None` where it
+/// declares none such.
 ///
 /// The parameter keeps the ident the author declared it under, so a bound written in terms of the
 /// parameter itself still reads, and the bounds keep the spans they were written at, so the
 /// compiler's `required by this bound` note points at the declaration rather than at anything
 /// emitted here.
+///
+/// A bound reading a neighbour is left out of this function rather than taking the whole parameter
+/// out of it: the two kinds partition the parameter's bounds, so a parameter bounded both ways is
+/// checked against each half exactly once — the neighbour-free half here, the rest in
+/// [`joint_bound_check`].
 fn filling_bound_check(
     generics: &syn::Generics,
     name: &syn::Ident,
     filling: &syn::Type,
 ) -> Option<proc_macro2::TokenStream> {
-    let bounds = declared_bounds(generics, name);
-    if bounds.is_empty()
-        || bounds
-            .iter()
-            .any(|bound| mentions_another_parameter(bound, generics, name))
-    {
+    let bounds: Vec<&syn::TypeParamBound> = declared_bounds(generics, name)
+        .into_iter()
+        .filter(|bound| !mentions_another_parameter(bound, generics, name))
+        .collect();
+    if bounds.is_empty() {
         return None;
     }
     Some(quote! {
         const _: fn() = || {
             fn default_type_filling<#name: #(#bounds)+*>() {}
             default_type_filling::<#filling>();
+        };
+    })
+}
+
+/// The one check carrying every bound the per-filling pass left behind for reading a neighbour, or
+/// `None` where it left none behind or where the item cannot be spelled jointly.
+///
+/// A bound like `WideType: From<NarrowType>` is a statement about two fillings at once, so it is
+/// asked of both at once: one function declaring the item's whole parameter list, carrying in its
+/// `where` clause exactly the bounds the per-filling functions could not, called at every declared
+/// filling in declaration order. Every name such a bound reads is then in scope, and the failure
+/// arrives as an `E0277` on the argument that fails — the entry the author wrote — with the
+/// `required by this bound` note on the bound as written.
+///
+/// Lifetimes are declared as written, bounds and all, and left out of the call, where they elide.
+/// Consts are declared nowhere: a const takes no filling from a convention that names types, so a
+/// joint function declaring one could not be called at all (`E0107` with the const omitted,
+/// `E0284` with it inferred). A bound reading a const is therefore still left to the item's own use
+/// sites, as every bound reading a neighbour was before.
+///
+/// The whole check is withheld unless every type parameter has a filling to stand at. A parameter
+/// left without one is only possible where no JSON document is built, and a bound joining it to its
+/// neighbours states nothing about fillings the author declared — inventing one to complete the
+/// call would ask the compiler a question nobody asked.
+fn joint_bound_check(
+    generics: &syn::Generics,
+    args: &ModelSchemaArgs,
+) -> Option<proc_macro2::TokenStream> {
+    let consts: Vec<String> = generics
+        .params
+        .iter()
+        .filter_map(|param| match param {
+            syn::GenericParam::Const(const_param) => Some(const_param.ident.to_string()),
+            syn::GenericParam::Type(_) | syn::GenericParam::Lifetime(_) => None,
+        })
+        .collect();
+    let mut predicates: Vec<proc_macro2::TokenStream> = Vec::new();
+    let mut declared: Vec<proc_macro2::TokenStream> = Vec::new();
+    let mut fillings: Vec<&syn::Type> = Vec::new();
+    for param in &generics.params {
+        match param {
+            syn::GenericParam::Lifetime(lifetime_param) => {
+                declared.push(quote! { #lifetime_param });
+            }
+            syn::GenericParam::Const(_) => {}
+            syn::GenericParam::Type(type_param) => {
+                let name = &type_param.ident;
+                let filling = args
+                    .default_types
+                    .iter()
+                    .find(|(declared_name, _)| declared_name == name)
+                    .map(|(_, filling)| filling)?;
+                declared.push(quote! { #name });
+                fillings.push(filling);
+                let joint: Vec<&syn::TypeParamBound> = declared_bounds(generics, name)
+                    .into_iter()
+                    .filter(|bound| {
+                        mentions_another_parameter(bound, generics, name)
+                            && !reads_any_name(quote::ToTokens::to_token_stream(bound), &consts)
+                    })
+                    .collect();
+                if !joint.is_empty() {
+                    predicates.push(quote! { #name: #(#joint)+* });
+                }
+            }
+        }
+    }
+    if predicates.is_empty() {
+        return None;
+    }
+    Some(quote! {
+        const _: fn() = || {
+            fn default_type_fillings<#(#declared),*>()
+            where
+                #(#predicates),*
+            {
+            }
+            default_type_fillings::<#(#fillings),*>();
         };
     })
 }

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -4312,28 +4312,204 @@ fn an_unbounded_parameter_earns_no_check() {
 }
 
 /// A bound naming another parameter of the item holds only where that one is filled too, which is a
-/// joint statement this per-filling check does not make — and the neighbour's name reproduced
-/// beside a single filling would resolve to nothing. So the bound is left to the item's own use
-/// sites, whether it names a type parameter, a lifetime or a const.
+/// joint statement no per-filling check makes — and the neighbour's name reproduced beside a single
+/// filling would resolve to nothing. So it earns no check of its own, and is carried instead by the
+/// one check that declares the whole parameter list.
 #[test]
-fn a_bound_naming_another_parameter_of_the_item_earns_no_check() {
+fn a_bound_naming_another_parameter_of_the_item_earns_no_check_of_its_own() {
+    let checks = filling_bound_check_text(
+        "pub struct Pair<AType: From<BType>, BType> { pub a: AType, pub b: BType }",
+        "default_types(AType = String, BType = char)",
+    );
+    assert_eq!(checks.len(), 1, "got: {checks:?}");
+    assert!(
+        !checks[0].contains("fn default_type_filling <"),
+        "the bound reads a neighbour, so no per-filling check carries it: {}",
+        checks[0]
+    );
+}
+
+/// The joint check declares every type parameter the item declares, carries the bounds that read a
+/// neighbour, and is called at every declared filling in the order they were declared — so each
+/// name such a bound reads stands at the filling the author declared for it.
+#[test]
+fn a_bound_naming_another_parameter_is_checked_at_the_whole_parameter_list_at_once() {
+    let checks = filling_bound_check_text(
+        "pub struct Pair<AType: From<BType>, BType> { pub a: AType, pub b: BType }",
+        "default_types(AType = String, BType = char)",
+    );
+    assert_eq!(checks.len(), 1, "got: {checks:?}");
+    for needle in [
+        "fn default_type_fillings < AType , BType > ()",
+        "where AType : From < BType >",
+        "default_type_fillings :: < String , char > ()",
+    ] {
+        assert!(
+            checks[0].contains(needle),
+            "{needle} missing: {}",
+            checks[0]
+        );
+    }
+}
+
+/// The joint call follows the parameter list, not the order the entries were written in: the
+/// arguments stand at positions, and an entry written out of order still fills its own.
+#[test]
+fn the_joint_check_is_called_in_the_order_the_parameters_were_declared() {
+    let checks = filling_bound_check_text(
+        "pub struct Pair<AType: From<BType>, BType> { pub a: AType, pub b: BType }",
+        "default_types(BType = char, AType = String)",
+    );
+    assert_eq!(checks.len(), 1, "got: {checks:?}");
+    assert!(
+        checks[0].contains("default_type_fillings :: < String , char > ()"),
+        "got: {}",
+        checks[0]
+    );
+}
+
+/// A parameter no bound reads is still declared and still filled, so the argument list lines up
+/// with the parameter list however few of them a bound actually joins.
+#[test]
+fn the_joint_check_declares_and_fills_the_parameters_no_bound_reads() {
+    let checks = filling_bound_check_text(
+        "pub struct Trio<AType: From<BType>, BType, CType> { pub a: AType, pub b: BType, pub c: CType }",
+        "default_types(AType = String, BType = char, CType = u8)",
+    );
+    assert_eq!(checks.len(), 1, "got: {checks:?}");
+    assert!(
+        checks[0].contains("fn default_type_fillings < AType , BType , CType > ()")
+            && checks[0].contains("default_type_fillings :: < String , char , u8 > ()"),
+        "got: {}",
+        checks[0]
+    );
+}
+
+/// A lifetime a bound reads is declared as it was written and left out of the call, where it
+/// elides — so a bound joining a parameter to a lifetime is reached like any other.
+#[test]
+fn a_lifetime_a_bound_reads_is_declared_as_written_and_left_out_of_the_call() {
+    let checks = filling_bound_check_text(
+        "pub struct Held<'label, ValueType: Into<&'label str>> { pub held: ValueType }",
+        "default_types(ValueType = String)",
+    );
+    assert_eq!(checks.len(), 1, "got: {checks:?}");
+    for needle in [
+        "fn default_type_fillings < 'label , ValueType > ()",
+        "where ValueType : Into < & 'label str >",
+        "default_type_fillings :: < String > ()",
+    ] {
+        assert!(
+            checks[0].contains(needle),
+            "{needle} missing: {}",
+            checks[0]
+        );
+    }
+}
+
+/// A const takes no filling from a convention that names types, so a joint function declaring one
+/// could not be called at all. A bound reading a const is left to the item's own use sites, as
+/// every bound reading a neighbour was before.
+#[test]
+fn a_bound_reading_a_const_parameter_earns_no_check() {
+    let checks = filling_bound_check_text(
+        "pub struct Bounded<ValueType: Fits<WIDTH>, const WIDTH: usize> { pub held: ValueType }",
+        "default_types(ValueType = String)",
+    );
+    assert!(checks.is_empty(), "got: {checks:?}");
+}
+
+/// A const beside a bound that does not read it costs the joint check nothing: it is declared
+/// nowhere and the call still lines up with the type parameters.
+#[test]
+fn a_const_no_bound_reads_leaves_the_joint_check_standing() {
+    let checks = filling_bound_check_text(
+        "pub struct Sized<AType: From<BType>, BType, const WIDTH: usize> { pub a: AType, pub b: BType }",
+        "default_types(AType = String, BType = char)",
+    );
+    assert_eq!(checks.len(), 1, "got: {checks:?}");
+    assert!(
+        checks[0].contains("fn default_type_fillings < AType , BType > ()")
+            && !checks[0].contains("WIDTH"),
+        "got: {}",
+        checks[0]
+    );
+}
+
+/// A parameter left without a filling — which only a build generating no JSON document allows —
+/// leaves nothing for the joint call to stand at, and a filling nobody declared would ask the
+/// compiler a question nobody asked. So the whole check is withheld.
+#[test]
+fn a_parameter_left_without_a_filling_withholds_the_joint_check() {
+    let checks = filling_bound_check_text(
+        "pub struct Pair<AType: From<BType>, BType> { pub a: AType, pub b: BType }",
+        "default_types(AType = String)",
+    );
+    assert!(checks.is_empty(), "got: {checks:?}");
+}
+
+/// The two kinds of bound partition a parameter's own: the half that reads no neighbour is checked
+/// at the filling alone, the half that does is checked jointly, and neither is checked twice.
+#[test]
+fn a_parameter_bounded_both_ways_is_checked_once_against_each_half() {
+    let checks = filling_bound_check_text(
+        "pub struct Pair<AType: Copy + From<BType>, BType> { pub a: AType, pub b: BType }",
+        "default_types(AType = u8, BType = char)",
+    );
+    assert_eq!(checks.len(), 2, "got: {checks:?}");
+    assert!(
+        checks[0].contains("fn default_type_filling < AType : Copy > ()")
+            && !checks[0].contains("From"),
+        "the per-filling check keeps only the neighbour-free half: {}",
+        checks[0]
+    );
+    assert!(
+        checks[1].contains("where AType : From < BType >") && !checks[1].contains("Copy"),
+        "the joint check holds exactly the complement: {}",
+        checks[1]
+    );
+}
+
+/// A declaration no bound joins earns no joint check, so an item that had none before is left
+/// exactly as it was.
+#[test]
+fn a_declaration_with_no_cross_parameter_bound_earns_no_joint_check() {
     for (source, args) in [
         (
-            "pub struct Pair<AType: From<BType>, BType> { pub a: AType, pub b: BType }",
-            "default_types(AType = String, BType = char)",
+            "pub struct Counted<CountType: Copy> { pub count: CountType }",
+            "default_types(CountType = String)",
         ),
         (
-            "pub struct Held<'label, ValueType: Into<&'label str>> { pub held: ValueType }",
-            "default_types(ValueType = String)",
-        ),
-        (
-            "pub struct Bounded<ValueType: Fits<WIDTH>, const WIDTH: usize> { pub held: ValueType }",
-            "default_types(ValueType = String)",
+            "pub struct Both<IdType, DateType> { pub id: IdType, pub at: DateType }",
+            "default_types(IdType = String, DateType = f64)",
         ),
     ] {
         let checks = filling_bound_check_text(source, args);
-        assert!(checks.is_empty(), "for {source}: {checks:?}");
+        assert!(
+            checks.iter().all(|check| !check.contains("fillings")),
+            "for {source}: {checks:?}"
+        );
     }
+}
+
+/// Rust does not enforce a bound written on a type alias's parameter, so a filling that fails one
+/// still names a type every use site of the alias accepts. Refusing it would refuse a program the
+/// language admits, so the alias earns no check of either kind.
+#[test]
+fn an_alias_earns_no_check_for_a_bound_rust_leaves_unenforced() {
+    for args in [
+        "default_types(ValueType = String)",
+        "default_types(ValueType = u32)",
+    ] {
+        let checks =
+            filling_bound_check_text("pub type Boxed<ValueType: Copy> = Vec<ValueType>;", args);
+        assert!(checks.is_empty(), "for {args}: {checks:?}");
+    }
+    let joint = filling_bound_check_text(
+        "pub type Paired<AType: From<BType>, BType> = (AType, BType);",
+        "default_types(AType = String, BType = char)",
+    );
+    assert!(joint.is_empty(), "got: {joint:?}");
 }
 
 /// A bound written in terms of the parameter it bounds names no neighbour, so it is checked like
@@ -4373,25 +4549,23 @@ fn every_bounded_filling_earns_its_own_check() {
     );
 }
 
-/// The three shapes the attribute expands answer alike: the check is read off the item's own
-/// parameters, which every one of them binds the same way.
+/// The two shapes whose parameters Rust binds answer alike: the check is read off the item's own
+/// parameters, which a struct and an enum bind the same way. The third — an alias, whose parameters
+/// bind nothing Rust checks — is left out entirely.
 #[test]
-fn every_expanded_shape_checks_its_fillings_alike() {
+fn every_expanded_shape_whose_bounds_rust_enforces_checks_its_fillings_alike() {
     let expected = filling_bound_check_text(
         "pub struct Held<ValueType: Copy> { pub held: ValueType }",
         "default_types(ValueType = String)",
     );
     assert_eq!(expected.len(), 1, "got: {expected:?}");
-    for source in [
-        "pub enum Held<ValueType: Copy> { Named { held: ValueType } }",
-        "pub type Held<ValueType: Copy> = Vec<ValueType>;",
-    ] {
-        assert_eq!(
-            filling_bound_check_text(source, "default_types(ValueType = String)"),
-            expected,
-            "for {source}"
-        );
-    }
+    assert_eq!(
+        filling_bound_check_text(
+            "pub enum Held<ValueType: Copy> { Named { held: ValueType } }",
+            "default_types(ValueType = String)",
+        ),
+        expected
+    );
 }
 
 /// The `compile_error!` tokens `source` earns for the example it carries against the parameters it

--- a/tests/generic_types_tests/tests.rs
+++ b/tests/generic_types_tests/tests.rs
@@ -968,12 +968,33 @@ where
 }
 
 /// A parameter whose bound names the item's other parameter, which holds only where that one is
-/// filled too — a joint statement the per-filling check does not make, and one whose name
-/// reproduced beside a single filling would resolve to nothing. The fixture compiling is the whole
-/// of the assertion that such a bound is left to the item's own use sites.
+/// filled too. Both fillings are declared, so the bound is checked at both at once — `String` does
+/// implement `From<char>` — and the fixture compiling is the whole of the assertion that a
+/// satisfying joint filling is let through.
 #[model_schema(default_types(WideType = String, NarrowType = char))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Widened<WideType: From<NarrowType>, NarrowType: Clone> {
+    pub narrow: NarrowType,
+    pub wide: WideType,
+}
+
+/// A parameter bounded both ways at once: `Clone` reads no neighbour and is checked at the filling
+/// alone, `Into<Cow<'label, str>>` reads the item's lifetime and is checked at the whole parameter
+/// list. Both hold at the declared filling, so the fixture compiling asserts the two halves are
+/// each checked and neither is checked twice.
+#[model_schema(default_types(LabelType = String))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Annotated<'label, LabelType: Clone + Into<Cow<'label, str>>> {
+    pub label: LabelType,
+    pub source: Cow<'label, str>,
+}
+
+/// A const beside a bound that reads only type parameters. A const takes no filling, so it is
+/// declared nowhere in the joint check and left out of its call; the fixture compiling asserts its
+/// presence leaves that check standing.
+#[model_schema(default_types(WideType = String, NarrowType = char))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Padded<WideType: From<NarrowType>, NarrowType: Clone, const WIDTH: usize> {
     pub narrow: NarrowType,
     pub wide: WideType,
 }
@@ -1129,9 +1150,10 @@ fn a_parameter_with_no_default_still_expands_where_no_json_document_is_built() {
     assert_eq!(Undefaulted { id: 1_u32 }.id, 1);
 }
 
-/// A declared filling is checked against the bounds its parameter carries, and the two fixtures a
-/// bound can reach — one satisfied, one naming a neighbour and so left alone — both still expand
-/// and still hold what the author wrote into them.
+/// A declared filling is checked against the bounds its parameter carries, and every shape a bound
+/// can reach — satisfied at the filling alone, satisfied jointly with a neighbour, both at once,
+/// and beside a const that takes no filling — still expands and still holds what the author wrote
+/// into it.
 #[test]
 fn a_bounded_parameter_filled_at_a_type_its_bound_admits_still_expands() {
     assert_eq!(
@@ -1147,6 +1169,20 @@ fn a_bounded_parameter_filled_at_a_type_its_bound_admits_still_expands() {
     };
     assert_eq!(widened.narrow, 'x');
     assert_eq!(widened.wide, "x");
+
+    let annotated = Annotated {
+        label: "two".to_owned(),
+        source: Cow::Borrowed("three"),
+    };
+    assert_eq!(annotated.label, "two");
+    assert_eq!(annotated.source, "three");
+
+    let padded: Padded<String, char, 4> = Padded {
+        narrow: 'y',
+        wide: String::from('y'),
+    };
+    assert_eq!(padded.narrow, 'y');
+    assert_eq!(padded.wide, "y");
 }
 
 /// Each alias named by a value, the way every other declaration shape here is: an alias that binds

--- a/tests/generic_types_tests/tests.rs
+++ b/tests/generic_types_tests/tests.rs
@@ -1121,7 +1121,7 @@ pub struct Annotated<'label, LabelType: Clone + Into<Cow<'label, str>>> {
 /// A const beside a bound that reads only type parameters. A const takes no filling, so it is
 /// declared nowhere in the joint check and left out of its call; the fixture compiling asserts its
 /// presence leaves that check standing.
-#[model_schema(default_types(WideType = String, NarrowType = char))]
+#[model_schema(default_types(WideType = String, NarrowType = String))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Padded<WideType: From<NarrowType>, NarrowType: Clone, const WIDTH: usize> {
     pub narrow: NarrowType,


### PR DESCRIPTION
Two follow-ons to the per-filling bound check.

Bounds naming another parameter of the item were conservatively skipped, so a filling failing one compiled silently. The per-filling pass now keeps only the bounds reading no neighbour, and one joint check carries the complement: a generated function declaring the item's whole type-parameter list, the skipped bounds in its where clause at their written spans, called at every declared filling in declaration order — so the E0277 lands on the entry that fails with the required-by note on the author's own bound, and no bound is checked twice. Two capture-driven limits: const parameters cannot be carried in the call (E0107/E0284 both verified), so a bound reading a const stays skipped; and a parameter can lack a filling in builds that don't require default_types to be total, so the joint check withholds itself unless every declared type parameter has one.

The check also stopped enforcing a type alias's parameter bounds, which Rust itself leaves inert and warns to delete: refusing a filling every use site accepts was a false positive. Item::Type returns before generics are read; struct and enum keep the check, pinned at the unit seam since the deny-warnings gate makes a bounded-alias fixture unhostable.