### PR TITLE
Let the publisher's registration answer the consult the registry could not

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -586,8 +586,12 @@ export const Document$Schema: ZodType<Document> = Document$RawSchema;
 /// appended to: `#[model_schema(minLength = 3)] struct Outer(pub Blob);` over
 /// `#[serde(transparent)] struct Blob(pub serde_json::Value);` is refused for the same reason the
 /// opaque inner spelled directly is. That answer comes from the named type's own expansion, so a
-/// brand written above the type it names — or over a type this crate never expands — keeps the
-/// emission it has always had rather than being refused for where its inner happens to be written.
+/// brand written above the type it names is not refused where it stands — the type it names has not
+/// been read yet, and at that point a name declared below and a type this crate never expands are
+/// the same silence. The consult is kept instead, and the named type's own expansion answers it:
+/// the refusal arrives there, spanned on that declaration and naming the brand, so the verdict is
+/// the same in either order. A brand over a type this crate never expands keeps the emission it has
+/// always had, its consult never answered.
 ///
 #[proc_macro_attribute]
 pub fn model_schema(args: TokenStream, input: TokenStream) -> TokenStream {

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -50,8 +50,8 @@ use crate::features::object_id::OBJECT_ID_HEX_PATTERN;
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 use crate::utils::{
-    AliasKind, PublishedShape, constraining_pattern, lookup_alias_info, portable_pattern,
-    record_value_shape,
+    AliasKind, PublishedShape, ShapeQuestion, constraining_pattern, lookup_alias_info,
+    portable_pattern, record_shape_question, record_value_shape, shape_questions_for,
 };
 
 #[cfg(feature = "serde")]
@@ -1074,6 +1074,10 @@ pub fn exec_model_schema(args: TokenStream, input: TokenStream) -> TokenStream {
     // impls, which a proc macro cannot answer — so it is asked here, of the compiler, and read off
     // the item before the shapes take it.
     let filling_bound_checks = default_types_bound_checks(&item, &parsed_args);
+    // Held across the dispatch that consumes the item: a constrained brand written above this
+    // declaration left its consult for whichever expansion registers the name, and this is that
+    // expansion.
+    let registering = item_schema_ident(&item).cloned();
     let expanded = if let Item::Struct(item_struct) = item {
         process_struct(item_struct, &parsed_args)
     } else if let Item::Enum(item_enum) = item {
@@ -1085,7 +1089,8 @@ pub fn exec_model_schema(args: TokenStream, input: TokenStream) -> TokenStream {
             .to_compile_error()
             .into()
     };
-    with_filling_bound_checks(expanded, &filling_bound_checks)
+    let answered = with_prefixed_tokens(expanded, &deferred_shape_refusals(registering.as_ref()));
+    with_prefixed_tokens(answered, &filling_bound_checks)
 }
 
 /// Classifies what an alias resolves to, for the registry.
@@ -2348,26 +2353,24 @@ fn reads_any_name(tokens: proc_macro2::TokenStream, names: &[String]) -> bool {
     })
 }
 
-/// Emits the expansion with the checks a `default_types` declaration earned beside it, or the
-/// expansion untouched where it earned none.
+/// Emits the expansion with the tokens it earned beside it standing ahead of it, or the expansion
+/// untouched where it earned none.
 ///
-/// The checks accompany the expansion rather than replacing it: a filling failing a bound is a
-/// statement about the item, not a reason to withhold the item, and everything naming the item
-/// should still resolve so the bound's own diagnostic is the one the author reads.
+/// Both callers hand over statements *about* the item rather than reasons to withhold it — the
+/// checks a `default_types` declaration earned, and the refusals a constrained brand written above
+/// this declaration was owed — so everything naming the item still resolves and those diagnostics
+/// are the ones the author reads, rather than a cascade of unresolved names on top of them.
 ///
 /// They go ahead of it because a doc example is annotated at the same filling, and where the
 /// filling does not hold that annotation fails on the whole attribute. Both diagnostics are the one
 /// disagreement, and the author should meet the one that names the entry first.
-fn with_filling_bound_checks(
-    expanded: TokenStream,
-    checks: &[proc_macro2::TokenStream],
-) -> TokenStream {
-    if checks.is_empty() {
+fn with_prefixed_tokens(expanded: TokenStream, prefix: &[proc_macro2::TokenStream]) -> TokenStream {
+    if prefix.is_empty() {
         return expanded;
     }
     let item_and_surface: proc_macro2::TokenStream = expanded.into();
     quote! {
-        #(#checks)*
+        #(#prefix)*
         #item_and_surface
     }
     .into()
@@ -2539,7 +2542,8 @@ fn branded_option_inner_error(
 /// so a name whose recorded surface carries no such check is the very disagreement spelled one
 /// module out — `Blob$Schema.min(3)` against `const Blob$Schema = z.unknown().brand<"Blob">()` is a
 /// `TypeError` at load, before a payload is read. A name the registry cannot answer for keeps
-/// today's emission; see [`crate::utils::record_value_shape`]. That is also why the constrained
+/// today's emission *here*, and leaves the question for whichever expansion registers it — see
+/// [`deferred_shape_question`] and [`crate::utils::record_value_shape`]. That is also why the constrained
 /// path asserts `Display` separately: the guard bounds the schema surfaces, the assertion bounds
 /// the Rust one. A sequence wrapper is the one `SiblingType` spelling that says its shape outright
 /// without being asked, and is refused as the array it is.
@@ -2598,16 +2602,9 @@ fn branded_constraint_inner_error(
         return Some(syn::Error::new_spanned(inner_field, message).to_compile_error());
     }
     let message = match (&inner.field_type, non_string_inner_shape(&inner)) {
-        (FieldDefType::SiblingType(inner_name, _), Some(shape)) => format!(
-            "model_schema: branded newtype `{name}` applies string constraints (pattern, \
-             minLength, maxLength) to `{inner_name}`, which this crate writes as the {shape} \
-             value the checks are then appended to — and that binding carries no string for them \
-             to measure: Zod either reads `.min`/`.max` as a bound on something else or has no \
-             such check on it at all, JSON Schema ignores `minLength`/`maxLength`/`pattern` \
-             outside `\"type\": \"string\"`, and `validate()` measures the inner's `Display` \
-             rendering — three surfaces, three answers. Brand a string-typed inner, or drop the \
-             constraints."
-        ),
+        (FieldDefType::SiblingType(inner_name, _), Some(shape)) => {
+            named_inner_constraint_message(&name.to_string(), inner_name, shape)
+        }
         (_, Some(shape)) => format!(
             "model_schema: branded newtype `{name}` applies string constraints (pattern, \
              minLength, maxLength) to a {shape} inner type, which cannot carry them: Zod reads \
@@ -2619,6 +2616,125 @@ fn branded_constraint_inner_error(
         (_, None) => return None,
     };
     Some(syn::Error::new_spanned(inner_field, message).to_compile_error())
+}
+
+/// The consult a constrained brand leaves unanswered, for the expansion that registers the name to
+/// answer, or `None` for every brand the registry could answer at its own expansion.
+///
+/// Read after the brand has passed its guards, so that a brand refused outright — over one of its
+/// own parameters, over a pattern that is no regex — leaves nothing behind: it publishes no schema,
+/// and a second diagnostic arriving at another declaration would name a brand the author has
+/// already been told to fix.
+///
+/// The arguments are resolved here rather than kept as tokens because this is the expansion that
+/// holds them, and they are resolved through the very call [`instantiated_value_shape`] fills a
+/// recorded position with — so an answer reached one declaration later is the answer the other
+/// order reaches now.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn deferred_shape_question(
+    item_struct: &syn::ItemStruct,
+    args: &ModelSchemaArgs,
+) -> Option<ShapeQuestion> {
+    if !args.has_string_constraints() {
+        return None;
+    }
+    let inner =
+        branded_inner_value_surface(&item_struct.generics, item_struct.fields.iter().next()?);
+    if inner.is_array() || sequence_wrapper_element(&inner).is_some() {
+        return None;
+    }
+    let FieldDefType::SiblingType(inner_name, arguments) = &inner.field_type else {
+        return None;
+    };
+    if lookup_alias_info(inner_name).is_some() {
+        return None;
+    }
+    Some(ShapeQuestion {
+        argument_shapes: arguments.iter().map(non_string_inner_shape).collect(),
+        brand: item_struct.ident.to_string(),
+        inner: inner_name.clone(),
+    })
+}
+
+/// What a name a brand asked about publishes, once the registration answering it has landed —
+/// `None` where that is a shape a string check lands on, and where the reference wrote no argument
+/// at the position the registration published.
+///
+/// The same filling [`instantiated_value_shape`] performs, over shapes the asking expansion had
+/// already resolved rather than over the argument defs it no longer holds. Both readings are of one
+/// record, so the two orders of a pair cannot come to different verdicts.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn answered_shape(
+    published: PublishedShape,
+    argument_shapes: &[Option<&'static str>],
+) -> Option<&'static str> {
+    match published {
+        PublishedShape::Flat(shape) => shape,
+        PublishedShape::Parameter(position) => *argument_shapes.get(position)?,
+    }
+}
+
+/// The `compile_error!` tokens an item owes the constrained brands that asked about its name before
+/// it existed, spanned on the item's own name — the only tokens this expansion holds.
+///
+/// Read off the registry rather than off the questions alone, so an item its own guards refused
+/// answers nothing: it registered no shape, and a brand over a name that publishes nothing is
+/// already reading a crate that will not compile.
+///
+/// A question the registration proves is a string settles silently, and a question no registration
+/// ever reaches stays unanswered — which is the foreign-type admission, kept exactly as it was.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn deferred_shape_refusals(registering: Option<&Ident>) -> Vec<proc_macro2::TokenStream> {
+    let Some(name) = registering else {
+        return Vec::new();
+    };
+    let rust_ident = name.to_string();
+    let questions = shape_questions_for(&rust_ident);
+    // Asked before the record is read, so the expansion of an item no brand named — which is most
+    // of them — never pays for the lookup.
+    if questions.is_empty() {
+        return Vec::new();
+    }
+    let Some(info) = lookup_alias_info(&rust_ident) else {
+        return Vec::new();
+    };
+    questions
+        .into_iter()
+        .filter_map(|question| {
+            let shape = answered_shape(info.value_shape, &question.argument_shapes)?;
+            let message = named_inner_constraint_message(&question.brand, &rust_ident, shape);
+            Some(syn::Error::new_spanned(name, message).to_compile_error())
+        })
+        .collect()
+}
+
+/// The same, where no surface reads a published shape and so no brand ever asked.
+#[cfg(not(any(feature = "typescript", feature = "zod", feature = "jsonschema")))]
+const fn deferred_shape_refusals(
+    _registering: Option<&syn::Ident>,
+) -> Vec<proc_macro2::TokenStream> {
+    Vec::new()
+}
+
+/// How a constrained brand over a name the registry proves publishes no string is refused, in the
+/// one wording both orders of the two declarations reach it by.
+///
+/// Written once and read from both the brand's own expansion and the named item's, because those
+/// two are the same fact about the same pair and an author moving one declaration past the other
+/// should read the same sentence. Only the span differs: the brand's expansion holds the inner it
+/// wrote, and the named item's holds nothing but itself — which is why the message names the brand
+/// rather than leaving the span to say which one it is.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn named_inner_constraint_message(brand: &str, inner: &str, shape: &str) -> String {
+    format!(
+        "model_schema: branded newtype `{brand}` applies string constraints (pattern, minLength, \
+         maxLength) to `{inner}`, which this crate writes as the {shape} value the checks are then \
+         appended to — and that binding carries no string for them to measure: Zod either reads \
+         `.min`/`.max` as a bound on something else or has no such check on it at all, JSON Schema \
+         ignores `minLength`/`maxLength`/`pattern` outside `\"type\": \"string\"`, and `validate()` \
+         measures the inner's `Display` rendering — three surfaces, three answers. Brand a \
+         string-typed inner, or drop the constraints."
+    )
 }
 
 /// Names the shape an inner type resolves to that has no string for the constraints to measure, or
@@ -2677,11 +2793,15 @@ fn non_string_inner_shape(inner: &FieldDef) -> Option<&'static str> {
 /// registry has no answer for — one declared below the type reading it, or one this crate never
 /// expands at all.
 ///
-/// Those two are the same absence and take the same answer, which is the emission the name has
-/// always had. Refusing on absence would refuse the unresolved user type the guard admits on
-/// purpose, and would make a diagnostic out of declaration order: moving a declaration would turn a
-/// compiling program into a refused one without changing what it means, and an author cannot act on
-/// a guard that fires on where a type is written rather than on what it is.
+/// Those two are the same absence *at this moment* and take the same answer, which is the emission
+/// the name has always had. Refusing on absence would refuse the unresolved user type the guard
+/// admits on purpose, and would make a diagnostic out of declaration order: moving a declaration
+/// would turn a compiling program into a refused one without changing what it means, and an author
+/// cannot act on a guard that fires on where a type is written rather than on what it is.
+///
+/// What tells the two apart is not available here and does arrive later: one of them registers. So
+/// the admission stands and the consult is kept — see [`deferred_shape_question`] — for the
+/// expansion that can answer it. A name nothing registers keeps the admission for good.
 ///
 /// A name that recorded a parameter position publishes a family, and the argument written at that
 /// position is the member of it this reference names — the same argument the emission composes the
@@ -4875,6 +4995,12 @@ fn process_branded_newtype(item_struct: syn::ItemStruct, args: &ModelSchemaArgs)
     let module_ident = Ident::new(&module_name, name.span());
 
     register_branded_newtype(&item_struct, &rust_ident, &item_name, &module_name);
+
+    // Recorded after the registration that reads such questions, so a brand naming itself cannot
+    // answer its own.
+    if let Some(question) = deferred_shape_question(&item_struct, args) {
+        record_shape_question(question);
+    }
 
     // Extract docs and example
     #[cfg(feature = "zod")]

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -5093,6 +5093,21 @@ fn register_branded_newtype(
 }
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+/// Registers the brand, then records the consult question its own registration could not answer —
+/// in that order, so a brand naming itself cannot answer its own.
+fn register_brand_with_questions(
+    item_struct: &syn::ItemStruct,
+    args: &ModelSchemaArgs,
+    rust_ident: &str,
+    item_name: &str,
+    module_name: &str,
+) {
+    register_branded_newtype(item_struct, rust_ident, item_name, module_name);
+    if let Some(question) = deferred_shape_question(item_struct, args) {
+        record_shape_question(question);
+    }
+}
+
 fn process_branded_newtype(item_struct: syn::ItemStruct, args: &ModelSchemaArgs) -> TokenStream {
     if let Some(output) = branded_guard_failure_output(&item_struct, args) {
         return output;
@@ -5104,13 +5119,7 @@ fn process_branded_newtype(item_struct: syn::ItemStruct, args: &ModelSchemaArgs)
     let module_name = ident_schema_module_name(&rust_ident);
     let module_ident = Ident::new(&module_name, name.span());
 
-    register_branded_newtype(&item_struct, &rust_ident, &item_name, &module_name);
-
-    // Recorded after the registration that reads such questions, so a brand naming itself cannot
-    // answer its own.
-    if let Some(question) = deferred_shape_question(&item_struct, args) {
-        record_shape_question(question);
-    }
+    register_brand_with_questions(&item_struct, args, &rust_ident, &item_name, &module_name);
 
     // Extract docs and example
     #[cfg(feature = "zod")]

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -5092,9 +5092,9 @@ fn register_branded_newtype(
     .record(rust_ident);
 }
 
-#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 /// Registers the brand, then records the consult question its own registration could not answer —
 /// in that order, so a brand naming itself cannot answer its own.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn register_brand_with_questions(
     item_struct: &syn::ItemStruct,
     args: &ModelSchemaArgs,
@@ -5108,6 +5108,7 @@ fn register_brand_with_questions(
     }
 }
 
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn process_branded_newtype(item_struct: syn::ItemStruct, args: &ModelSchemaArgs) -> TokenStream {
     if let Some(output) = branded_guard_failure_output(&item_struct, args) {
         return output;

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -17,7 +17,8 @@ use super::{
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 use super::{
     AliasKind, PublishedShape, alias_map_key_guard_error, branded_guard_errors, check_map_key,
-    ident_schema_module_name, record_value_shape, register_alias_info,
+    deferred_shape_question, deferred_shape_refusals, ident_schema_module_name,
+    record_shape_question, record_value_shape, register_alias_info,
 };
 
 #[cfg(all(feature = "serde", feature = "zod"))]
@@ -3263,14 +3264,18 @@ fn string_constraints_over_a_named_inner_the_registry_calls_a_string_pass() {
     assert!(errors.is_empty(), "got: {errors:?}");
 }
 
-/// A name the registry has no answer for keeps the emission it has always had.
+/// A name the registry has no answer for keeps the emission it has always had, at the consult
+/// itself.
 ///
-/// The two names that reach this are the same absence: one written above the item that registers
-/// it, and one this crate never expands at all — an unresolved user type whose schema the author
-/// supplies. Refusing on absence would refuse the second for the sake of the first, and would make
-/// a diagnostic out of declaration order: moving a declaration would turn a compiling program into
-/// a refused one without changing what it means. The `Display` assertion still bounds the Rust
-/// surface either way.
+/// The two names that reach this are the same absence here: one written above the item that
+/// registers it, and one this crate never expands at all — an unresolved user type whose schema the
+/// author supplies. Refusing on absence would refuse the second for the sake of the first, and the
+/// argument alone tells them apart no better, a publisher being free to write a string whatever its
+/// parameter is handed. The `Display` assertion still bounds the Rust surface either way.
+///
+/// What the guard does *not* do is forget the question: the first of the two is answered by the
+/// registration that follows, which is what takes the verdict off declaration order without
+/// touching this admission. See the deferred tests below.
 ///
 /// Both of them name a type the declaration has already fixed, which is what the admission rests
 /// on; a name written over one of the brand's own parameters has not, and is refused below.
@@ -3488,6 +3493,169 @@ fn a_recorded_position_is_read_off_the_arguments_the_reference_writes() {
 
     let unwritten = brand_over_named_inner_errors("PublishesItsSecond<String>");
     assert!(unwritten.is_empty(), "got: {unwritten:?}");
+}
+
+/// The question a constrained brand leaves where the registry has no record, spelled as the brand's
+/// own expansion would leave it.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn ask_about(brand: &syn::ItemStruct) -> bool {
+    deferred_shape_question(brand, &pattern_args()).is_some_and(|question| {
+        record_shape_question(question);
+        true
+    })
+}
+
+/// A brand written over the given inner, under a name that is the same in both declaration orders
+/// so the two refusals can be read against each other.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn brand_over(inner: &str) -> syn::ItemStruct {
+    let ty: syn::Type = syn::parse_str(inner).unwrap();
+    syn::parse_quote! {
+        #[serde(transparent)]
+        struct Branded(pub #ty);
+    }
+}
+
+/// What the expansion registering a name emits for the questions asked about it, as rendered
+/// `compile_error!` token strings.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn deferred_refusals_for(rust_ident: &str) -> Vec<String> {
+    let name = syn::Ident::new(rust_ident, proc_macro2::Span::call_site());
+    deferred_shape_refusals(Some(&name))
+        .iter()
+        .map(ToString::to_string)
+        .collect()
+}
+
+/// A consult the registry could not answer is kept, and the expansion that finally registers the
+/// name answers it — filling the position that registration published with the argument shape the
+/// brand resolved when it asked.
+///
+/// The brand is admitted at its own expansion whatever the argument, because a name declared below
+/// it and a name this crate never expands are one absence there. What closes the half is that the
+/// absence is temporary: the registry is a compile-local recording the later expansion also writes
+/// to, so the answer arrives one declaration later rather than never.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn a_question_left_where_the_registry_was_silent_is_answered_by_the_later_registration() {
+    let brand = brand_over("AnsweredLater<u32>");
+    assert!(
+        branded_errors_with(&brand, &pattern_args()).is_empty(),
+        "the brand's own expansion has nothing to refuse it on"
+    );
+    assert!(ask_about(&brand));
+    assert!(
+        deferred_refusals_for("AnsweredLater").is_empty(),
+        "nothing has registered under the name yet"
+    );
+
+    seed_published_shape("AnsweredLater", PublishedShape::Parameter(0));
+    let errors = deferred_refusals_for("AnsweredLater");
+    assert_eq!(errors.len(), 1, "got: {errors:?}");
+    assert!(errors[0].contains("compile_error"), "got: {}", errors[0]);
+    assert!(errors[0].contains("`Branded`"), "got: {}", errors[0]);
+    assert!(errors[0].contains("`AnsweredLater`"), "got: {}", errors[0]);
+    assert!(errors[0].contains("numeric"), "got: {}", errors[0]);
+}
+
+/// Both orders of the one pair refuse in one wording, so an author moving either declaration past
+/// the other reads the same sentence — only the span moves, to the tokens the answering expansion
+/// holds.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn both_orders_of_the_same_pair_refuse_in_one_wording() {
+    assert!(ask_about(&brand_over("WordingBelow<u32>")));
+    seed_published_shape("WordingBelow", PublishedShape::Parameter(0));
+    let below = deferred_refusals_for("WordingBelow");
+    assert_eq!(below.len(), 1, "got: {below:?}");
+
+    seed_published_shape("WordingAbove", PublishedShape::Parameter(0));
+    let above = brand_over_named_inner_errors("WordingAbove<u32>");
+    assert_eq!(above.len(), 1, "got: {above:?}");
+
+    assert_eq!(
+        below[0].replace("WordingBelow", "Inner"),
+        above[0].replace("WordingAbove", "Inner")
+    );
+}
+
+/// A registration proving the argument is a string settles its question silently, so the pair that
+/// works keeps working — and keeps working in the order the registry could not answer.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn a_question_a_string_argument_answers_settles_silently() {
+    assert!(ask_about(&brand_over("SettlesSilently<String>")));
+    seed_published_shape("SettlesSilently", PublishedShape::Parameter(0));
+    let errors = deferred_refusals_for("SettlesSilently");
+    assert!(errors.is_empty(), "got: {errors:?}");
+}
+
+/// A name nothing ever registers leaves its question unanswered, which is the foreign-type
+/// admission the guard makes on purpose — an unresolved user type whose schema the author supplies.
+///
+/// Read off the registry rather than off the question, so the absence that never ends is told from
+/// the one that does by the registration itself rather than by anything the brand could have known.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn a_question_no_registration_reaches_stays_unanswered() {
+    assert!(ask_about(&brand_over("NeverRegisters<u32>")));
+    let errors = deferred_refusals_for("NeverRegisters");
+    assert!(errors.is_empty(), "got: {errors:?}");
+}
+
+/// A brand the registry could answer leaves no question, so the pair the other order already
+/// refuses is refused once rather than twice.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn a_brand_the_registry_answers_leaves_no_question() {
+    seed_published_shape("AlreadyAnswering", PublishedShape::Parameter(0));
+    for inner in ["AlreadyAnswering<u32>", "AlreadyAnswering<String>"] {
+        assert!(
+            deferred_shape_question(&brand_over(inner), &pattern_args()).is_none(),
+            "for {inner}"
+        );
+    }
+}
+
+/// Nothing is asked where nothing would be appended: a brand carrying no string checks, and an
+/// inner whose own spelling fixes a shape the registry is never consulted about.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn a_brand_with_nothing_to_append_asks_nothing() {
+    assert!(
+        deferred_shape_question(
+            &brand_over("Unasked<u32>"),
+            &super::ModelSchemaArgs::default()
+        )
+        .is_none()
+    );
+    for inner in ["Vec<Unasked>", "BTreeSet<Unasked>", "String", "u32"] {
+        assert!(
+            deferred_shape_question(&brand_over(inner), &pattern_args()).is_none(),
+            "for {inner}"
+        );
+    }
+}
+
+/// A registration publishing a flat shape answers whatever the reference wrote, and one publishing
+/// a position the reference left unwritten answers nothing — the same two readings the consult
+/// itself makes of one record.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn a_deferred_answer_reads_the_record_the_consult_would_have_read() {
+    assert!(ask_about(&brand_over("FlatlyNumeric")));
+    seed_value_shape("FlatlyNumeric", Some("numeric"));
+    let flat = deferred_refusals_for("FlatlyNumeric");
+    assert_eq!(flat.len(), 1, "got: {flat:?}");
+    assert!(flat[0].contains("numeric"), "got: {}", flat[0]);
+
+    assert!(ask_about(&brand_over("FlatlyString")));
+    seed_value_shape("FlatlyString", None);
+    assert!(deferred_refusals_for("FlatlyString").is_empty());
+
+    assert!(ask_about(&brand_over("PublishesUnwritten<String>")));
+    seed_published_shape("PublishesUnwritten", PublishedShape::Parameter(1));
+    assert!(deferred_refusals_for("PublishesUnwritten").is_empty());
 }
 
 /// What a tuple struct records: serde writes one slot as that slot's value alone, so the schema is

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -250,6 +250,31 @@ pub enum PublishedShape {
     Parameter(usize),
 }
 
+/// A constrained brand's consult the registry had no record to answer with, kept until the named
+/// item registers and can answer it.
+///
+/// At the brand's own expansion a name declared below it and a name this crate never expands are
+/// one absence, and the argument the reference wrote proves nothing on its own — a publisher may
+/// write a string whatever its parameter is handed. So the admission stands at that moment, and
+/// what is recorded here is the question rather than a verdict. The registry is a compile-local
+/// recording the later expansion also writes to, so the item that finally registers under the name
+/// reads the questions naming it and answers them in its own output.
+///
+/// The arguments are kept as the shapes they resolve to rather than as the types they were written
+/// as, because the brand's expansion is the only one still holding those tokens.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[derive(Clone)]
+pub struct ShapeQuestion {
+    /// What each argument the reference wrote resolves to, in the order it wrote them — the filling
+    /// a recorded parameter position takes, and `None` where that argument is one a string check
+    /// lands on.
+    pub argument_shapes: Vec<Option<&'static str>>,
+    /// The brand that wrote the checks, named so the refusal says which declaration to fix.
+    pub brand: String,
+    /// The name it asked about, which is the entry an answer arrives on.
+    pub inner: String,
+}
+
 #[derive(Clone)]
 pub struct AliasInfo {
     pub export_name: String,
@@ -631,6 +656,38 @@ impl JsSpelling {
 
 thread_local! {
     static ALIAS_INFO: RefCell<HashMap<String, AliasInfo>> = RefCell::new(HashMap::new());
+}
+
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+thread_local! {
+    static SHAPE_QUESTIONS: RefCell<Vec<ShapeQuestion>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Keeps a constrained brand's unanswered consult for whichever expansion registers the name it
+/// asked about.
+///
+/// Recorded once the brand has passed its own guards, so a brand that publishes nothing leaves no
+/// question behind for a later item to refuse it over.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+pub fn record_shape_question(question: ShapeQuestion) {
+    SHAPE_QUESTIONS.with(|questions| questions.borrow_mut().push(question));
+}
+
+/// Every question asked about a name, in the order the brands asking them expanded.
+///
+/// The questions are left in place rather than taken: a name is registered by one expansion, and
+/// leaving them makes reading them an observation rather than a move — nothing downstream has to
+/// know whether something else read first.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+pub fn shape_questions_for(rust_ident: &str) -> Vec<ShapeQuestion> {
+    SHAPE_QUESTIONS.with(|questions| {
+        questions
+            .borrow()
+            .iter()
+            .filter(|question| question.inner == rust_ident)
+            .cloned()
+            .collect()
+    })
 }
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]

--- a/tests/branded_newtype_tests/tests.rs
+++ b/tests/branded_newtype_tests/tests.rs
@@ -1779,9 +1779,10 @@ mod branded_sibling_inner_tests {
     ///
     /// That absence is the same one an unresolved user type leaves — a type this crate never
     /// expands, whose schema the author supplies — so refusing on it would refuse the second for
-    /// the sake of the first, and would make a diagnostic out of declaration order: moving a
-    /// declaration would turn a compiling program into a refused one without changing what it
-    /// means. The `Display` assertion still bounds the Rust surface either way.
+    /// the sake of the first. The consult is kept for the registration that follows instead, and
+    /// here that registration proves a string and settles it silently: what the author reads is the
+    /// same verdict wherever the two items are written. The `Display` assertion still bounds the
+    /// Rust surface either way.
     #[test]
     fn a_constrained_brand_over_a_forward_declared_sibling_keeps_its_emission() {
         assert_eq!(


### PR DESCRIPTION
A constrained brand over a generic publisher declared below it found no registry record, so a numeric argument stayed admitted — three surfaces, three answers — while the same pair declared the other way refused. The admission at the brand's own expansion is structural: a below-declared name and a foreign name are one absence there, and the argument alone proves nothing.

The brand's unanswerable consult is now recorded as an open question (brand, inner, the written arguments' resolved shapes) after its guards pass and its registration lands, so a refused brand leaves nothing behind and a self-naming brand cannot answer itself. The item that later registers under the questioned name reads the questions naming it and, where its recorded shape filled with the question's argument proves non-string, emits the refusal in its own output — spanned on its declaration, named for the brand, in the one wording both orders now share. A name nothing ever registers leaves its question unanswered and the foreign-name admission stands byte-identical; string arguments settle silently in both orders, byte-identical and verified under tsc and recorded zod.