### PR TITLE
Close each member of a flattened choice's TypeScript operand against its siblings' keys

### DIFF
--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -841,6 +841,28 @@ impl FieldDef {
         }
     }
 
+    /// The members of the untagged union this field names as an object flattening it spells them,
+    /// as the registry recorded them — and nothing for a field that names no such union, and for one
+    /// whose members carry no exclusion the union's own name does not already describe.
+    ///
+    /// Answered under the same bound [`Self::zod_union_members`] is answered under, and for the same
+    /// reason: what is spliced in the name's place has to be the whole of what the operand
+    /// describes.
+    #[cfg(all(feature = "serde", feature = "typescript"))]
+    pub fn ts_union_members(&self) -> Vec<String> {
+        let wrapped = self
+            .model_schema_prop_meta
+            .as_ref()
+            .is_some_and(|meta| !meta.preprocess.is_empty());
+        if self.array_depth > 0 || wrapped {
+            return Vec::new();
+        }
+        let FieldDefType::SiblingType(name, _) = &self.field_type else {
+            return Vec::new();
+        };
+        lookup_alias_info(name).map_or_else(Vec::new, |info| info.ts_union_members)
+    }
+
     /// Builds the TypeScript type before the outermost optional wrap: the type match plus one
     /// `Array<…>` per array level, each carrying the `| null` of the level it wraps. The outermost
     /// level's wrap lives in `typescript_typename` and `typescript_slot_typename`, which is where

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -118,6 +118,9 @@ use crate::utils::ZodUnionMember;
 #[cfg(all(feature = "serde", any(feature = "zod", feature = "typescript")))]
 use crate::utils::{FlattenVariant, WireLeaf, record_flatten_variants, record_wire_leaves};
 
+#[cfg(all(feature = "serde", feature = "typescript"))]
+use crate::utils::record_ts_union_members;
+
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 use crate::utils::register_alias_info;
 
@@ -219,12 +222,14 @@ type ZodMergeParts = Vec<ZodUnionMember>;
 #[cfg(all(feature = "serde", not(feature = "zod")))]
 type ZodMergeParts = Vec<String>;
 
-/// Per-member data collected from an untagged enum: the TypeScript member types, the Zod member
-/// schemas, what those Zod members contribute to an object that merges the enum, the JSON-schema
-/// value tokens, the `compile_error!` tokens for any field-level guard violations, the per-member
-/// serde validation functions, and the `validate()` match arms those functions are run from.
+/// Per-member data collected from an untagged enum: the TypeScript member types, what those members
+/// are spelled as where an object merges the enum, the Zod member schemas, what those Zod members
+/// contribute to an object that merges the enum, the JSON-schema value tokens, the `compile_error!`
+/// tokens for any field-level guard violations, the per-member serde validation functions, and the
+/// `validate()` match arms those functions are run from.
 #[cfg(feature = "serde")]
 type UntaggedMemberData = (
+    Vec<String>,
     Vec<String>,
     Vec<String>,
     ZodMergeParts,
@@ -1772,34 +1777,42 @@ fn flattened_zod_branches(fld: &FieldDef) -> Vec<String> {
 }
 
 /// What one flattened source is written as where the TypeScript merge names it: the parenthesised
-/// union of the per-variant key sets an externally tagged enum recorded, and the name itself
+/// union of the key sets the choice it names recorded for this position, and the name itself
 /// everywhere else.
 ///
 /// TypeScript distributes an intersection over a union on its own, so a name standing for a choice
-/// every branch of which is an object already describes what the multiplication would write and is
-/// left as the one operand it is. What it cannot distribute over is a branch that is no object: the
-/// bare string a unit variant publishes standing alone intersects the object to `never`, and the
-/// payload serde actually writes for that variant — the variant's name holding `null` — belongs to
-/// no branch of the result. Where the enum's recorded leaves prove such a branch, the operand is
-/// spelled as the key sets serde writes instead of as the union the enum publishes.
+/// of objects reaches every branch the multiplication would write. Two things it does not reach are
+/// what the recorded operands carry. One is a branch that is no object: the bare string a unit
+/// variant publishes standing alone intersects the object to `never`, and the payload serde actually
+/// writes for that variant — the variant's name holding `null` — belongs to no branch of the result.
+/// The other is what each branch says about its siblings: the excess-property check reads the union
+/// of every branch's keys, so a branch that names one of them is still satisfied by a payload
+/// carrying the rest, and the type describes payloads serde writes for no value. The recorded
+/// operands close each branch against the keys the others name, which is a thing only two branches
+/// or more have to say.
 ///
 /// A name the registry proves nothing about, and a source declared below the object, keep the
 /// spelling they always had.
 #[cfg(all(feature = "serde", feature = "typescript"))]
 fn flattened_ts_spelling(fld: &FieldDef) -> String {
     let named = fld.typescript_merged_typename();
-    if named_wire_leaves(fld).is_none() {
-        return named;
-    }
     let variants: Vec<String> = fld
         .flatten_variants()
         .into_iter()
         .map(|variant| variant.typescript)
         .collect();
-    if variants.is_empty() {
+    if !variants.is_empty() {
+        return if variants.len() > 1 || named_wire_leaves(fld).is_some() {
+            format!("({})", variants.join(" | "))
+        } else {
+            named
+        };
+    }
+    let members = fld.ts_union_members();
+    if members.is_empty() {
         named
     } else {
-        format!("({})", variants.join(" | "))
+        format!("({})", members.join(" | "))
     }
 }
 
@@ -6113,27 +6126,47 @@ fn render_external_variant(
 /// of taken from the member, in the shape the same variant would have rendered as had it carried
 /// data. That is what puts the two spellings of one variant at one indent and under one `JSDoc`
 /// block.
+///
+/// The TypeScript operand carries one thing beyond that shape: each variant says outright that it
+/// does not tag the keys its siblings tag. Nothing in the key set alone says it — a payload carrying
+/// two variants' keys at once satisfies either of them structurally, and an object joined to the
+/// choice makes both of those keys known — so what serde writes one variant at a time would be
+/// described two at a time. The Zod operand needs no such thing: a `z.strictObject` recognizes
+/// exactly the keys it names and refuses the second variant's on that alone.
 #[cfg(all(feature = "serde", any(feature = "typescript", feature = "zod")))]
 fn record_external_flatten_operands(
     rust_ident: &str,
     variants: &[DiscriminatedVariant],
     members: &[(String, String, proc_macro2::TokenStream)],
 ) {
+    #[cfg(feature = "typescript")]
+    let exclusions = sibling_key_exclusions(
+        &variants
+            .iter()
+            .map(|variant| Some(vec![variant.discriminator_value.clone()]))
+            .collect::<Vec<_>>(),
+    );
     let operands: Vec<FlattenVariant> = variants
         .iter()
         .zip(members)
-        .map(|(variant, member)| {
+        .enumerate()
+        .map(|(index, (variant, member))| {
             let unit = matches!(variant.kind, VariantKind::Unit);
             let key = &variant.discriminator_value;
             #[cfg(feature = "typescript")]
-            let typescript = if unit {
-                format!(
-                    "{{\n{}\n  \"{key}\": null;\n}}",
-                    member_jsdoc_block(&variant.docs)
-                )
-            } else {
-                member.0.clone()
+            let typescript = {
+                let tagged = if unit {
+                    format!(
+                        "{{\n{}\n  \"{key}\": null;\n}}",
+                        member_jsdoc_block(&variant.docs)
+                    )
+                } else {
+                    member.0.clone()
+                };
+                close_tagged_flatten_member(&tagged, &exclusions[index])
             };
+            #[cfg(not(feature = "typescript"))]
+            let _: usize = index;
             #[cfg(feature = "zod")]
             let zod = if unit {
                 format!("z.strictObject({{\n  \"{key}\": z.null(),\n}})")
@@ -6149,6 +6182,57 @@ fn record_external_flatten_operands(
         })
         .collect();
     record_flatten_variants(rust_ident, &operands);
+}
+
+/// Which of a flattened choice's keys each member has to say it does not carry, one list per member
+/// and in the order the union writes them.
+///
+/// A member is closed against every key its siblings name and it does not. Its own are left off
+/// because it carries them, and the excluded keys are the payloads a merge would otherwise describe
+/// and serde never writes: one branch's keys beside another's.
+///
+/// `None` is a member whose keys nothing here proves — a name the registry classified no further, a
+/// map, a scalar. Such a member is left unclosed, and names no key for its siblings to exclude
+/// either: a key it was told to leave out could be one it carries, and an exclusion is only worth
+/// writing where the declaration proves it.
+#[cfg(all(feature = "serde", feature = "typescript"))]
+fn sibling_key_exclusions(member_keys: &[Option<Vec<String>>]) -> Vec<Vec<String>> {
+    member_keys
+        .iter()
+        .map(|member| {
+            let Some(own) = member.as_ref() else {
+                return Vec::new();
+            };
+            let mut excluded: Vec<String> = Vec::new();
+            for key in member_keys.iter().flatten().flatten() {
+                if !own.contains(key) && !excluded.contains(key) {
+                    excluded.push(key.clone());
+                }
+            }
+            excluded
+        })
+        .collect()
+}
+
+/// One externally tagged variant's flatten operand with its siblings' tags marked absent, written in
+/// the key-per-line shape [`render_external_variant`] already wrote the variant in.
+///
+/// A member that is no object literal keeps its spelling: there is no key list to add a line to, and
+/// the exclusion is best-effort in exactly the way the excess-property posture around it is.
+#[cfg(all(feature = "serde", feature = "typescript"))]
+fn close_tagged_flatten_member(member: &str, excluded: &[String]) -> String {
+    if excluded.is_empty() {
+        return member.to_owned();
+    }
+    let Some(keys) = member.strip_suffix("\n}") else {
+        return member.to_owned();
+    };
+    let mut closed = keys.to_owned();
+    for key in excluded {
+        let _ = write!(closed, "\n  \"{key}\"?: never;");
+    }
+    closed.push_str("\n}");
+    closed
 }
 
 /// Joins an externally tagged enum's rendered members into its three union surfaces: the
@@ -6894,6 +6978,43 @@ fn render_untagged_named(
     (ts, zod, json_val)
 }
 
+/// The keys one untagged member names, and `None` where nothing here proves them.
+///
+/// A `Named` variant writes its own fields and is the whole of what it writes, so its keys are the
+/// ones the member already spells. Every other member is written as the type it names — the merge
+/// reads what that name published for the questions it can ask a registry, and its key list is not
+/// one of them.
+#[cfg(all(feature = "serde", feature = "typescript"))]
+fn untagged_member_keys(kind: &VariantKind, field_defs: &[FieldDef]) -> Option<Vec<String>> {
+    matches!(kind, VariantKind::Named)
+        .then(|| field_defs.iter().map(|fld| fld.name.clone()).collect())
+}
+
+/// One untagged member's flatten operand with its siblings' keys marked absent, written in the
+/// one-line shape [`render_untagged_named`] already wrote the member in.
+///
+/// A member that is no object literal keeps its spelling, which is the same answer
+/// [`untagged_member_keys`] gives it: a name is what it is written as, and nothing here proves what
+/// it would have to be told to leave out.
+#[cfg(all(feature = "serde", feature = "typescript"))]
+fn close_untagged_flatten_member(member: &str, excluded: &[String]) -> String {
+    if excluded.is_empty() {
+        return member.to_owned();
+    }
+    let Some(keys) = member.strip_suffix(" }") else {
+        return member.to_owned();
+    };
+    let mut closed = keys.trim_end().to_owned();
+    for key in excluded {
+        if !closed.ends_with('{') {
+            closed.push(';');
+        }
+        let _ = write!(closed, " {key}?: never");
+    }
+    closed.push_str(" }");
+    closed
+}
+
 /// Builds the `{ type: object, properties, required, additionalProperties: false }` JSON-schema
 /// value token for a `Named` untagged variant.
 #[cfg(all(feature = "serde", feature = "jsonschema"))]
@@ -7268,6 +7389,8 @@ fn collect_untagged_members(
     let enum_type_name = item_enum.ident.to_string();
     let type_parameters = type_parameters_in_scope(&item_enum.generics);
     let mut ts_parts: Vec<String> = Vec::new();
+    #[cfg(feature = "typescript")]
+    let mut ts_member_keys: Vec<Option<Vec<String>>> = Vec::new();
     let mut zod_parts: Vec<String> = Vec::new();
     #[cfg(feature = "zod")]
     let mut zod_merge_parts: ZodMergeParts = Vec::new();
@@ -7309,6 +7432,8 @@ fn collect_untagged_members(
                     &zod,
                     ts_parts.len() + 1,
                 ));
+                #[cfg(feature = "typescript")]
+                ts_member_keys.push(untagged_member_keys(&kind, &field_defs));
                 ts_parts.push(ts);
                 zod_parts.push(zod);
                 json_parts.push(json_val);
@@ -7327,8 +7452,14 @@ fn collect_untagged_members(
         );
     }
 
+    #[cfg(feature = "typescript")]
+    let ts_merge_parts = ts_flatten_operands(&ts_parts, &ts_member_keys);
+    #[cfg(not(feature = "typescript"))]
+    let ts_merge_parts: Vec<String> = Vec::new();
+
     (
         ts_parts,
+        ts_merge_parts,
         zod_parts,
         zod_merge_parts,
         json_parts,
@@ -7336,6 +7467,32 @@ fn collect_untagged_members(
         validation_fns,
         build_member_check_arms(per_variant_checks),
     )
+}
+
+/// What an object flattening an untagged enum spells in the enum's name's place, one operand per
+/// member — and nothing where the name already spells the same payload set.
+///
+/// Standing alone the union describes one member at a time and needs no exclusions. Intersected with
+/// an open object it stops doing so: the excess-property check reads the union of every member's
+/// keys, and each member is satisfied structurally by a payload carrying more keys than it names, so
+/// the type admits a payload carrying two members' keys at once and serde, Zod and the JSON-schema
+/// document all refuse. Closing each member against its siblings' keys is what puts the four
+/// surfaces back on one payload set.
+///
+/// A union no member of which proves a key — one written over names alone — has nothing to close,
+/// and the merge keeps naming the enum rather than writing out what the name already says.
+#[cfg(all(feature = "serde", feature = "typescript"))]
+fn ts_flatten_operands(members: &[String], member_keys: &[Option<Vec<String>>]) -> Vec<String> {
+    let operands: Vec<String> = sibling_key_exclusions(member_keys)
+        .iter()
+        .zip(members)
+        .map(|(excluded, member)| close_untagged_flatten_member(member, excluded))
+        .collect();
+    if operands == members {
+        Vec::new()
+    } else {
+        operands
+    }
 }
 
 /// What one rendered member contributes to an object that merges the enum: the members of the union
@@ -7655,6 +7812,7 @@ fn process_untagged_enum(
     // Render each variant into its union member (TS / Zod / JSON parts).
     let (
         ts_parts,
+        ts_merge_parts,
         zod_parts,
         zod_merge_parts,
         json_parts,
@@ -7674,6 +7832,10 @@ fn process_untagged_enum(
     record_zod_union_members(&name.to_string(), &zod_merge_parts);
     #[cfg(not(feature = "zod"))]
     let _: &_ = &zod_merge_parts;
+    #[cfg(feature = "typescript")]
+    record_ts_union_members(&name.to_string(), &ts_merge_parts);
+    #[cfg(not(feature = "typescript"))]
+    let _: &_ = &ts_merge_parts;
 
     #[cfg(not(any(feature = "typescript", feature = "zod", feature = "jsonschema")))]
     let _: &_ = &(name, item_name, &ts_parts, &zod_parts, &json_parts, args);

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -405,7 +405,7 @@ fn positional_option_field_is_exempt() {
 /// Collects the untagged-path guard failures as rendered `compile_error!` token streams.
 #[cfg(feature = "serde")]
 fn untagged_guard_error_tokens(item: &mut syn::ItemEnum) -> Vec<proc_macro2::TokenStream> {
-    collect_untagged_members(item, UNTAGGED_MODULE).4
+    collect_untagged_members(item, UNTAGGED_MODULE).5
 }
 
 /// Collects the untagged-path guard failures as rendered `compile_error!` token strings.
@@ -585,7 +585,8 @@ fn untagged_member_carries_its_constraint_to_the_surfaces() {
             },
         }
     };
-    let (_, zod_parts, _, _, errors, _, _) = collect_untagged_members(&mut item, UNTAGGED_MODULE);
+    let (_, _, zod_parts, _, _, errors, _, _) =
+        collect_untagged_members(&mut item, UNTAGGED_MODULE);
     assert!(errors.is_empty(), "got: {errors:?}");
     assert!(
         zod_parts[0].contains("z.string().min(2).check(z.regex(/^[a-z]+$/))"),
@@ -607,7 +608,7 @@ fn untagged_member_constraint_generates_the_validator_and_hangs_it_on_the_member
             },
         }
     };
-    let (_, _, _, _, errors, validation_fns, _) =
+    let (_, _, _, _, _, errors, validation_fns, _) =
         collect_untagged_members(&mut item, UNTAGGED_MODULE);
     assert!(errors.is_empty(), "got: {errors:?}");
     assert_eq!(validation_fns.len(), 1, "got: {validation_fns:?}");
@@ -642,7 +643,7 @@ fn untagged_member_constraint_generates_nothing_without_a_schema_module() {
             },
         }
     };
-    let (_, _, _, _, errors, validation_fns, _) = collect_untagged_members(&mut item, None);
+    let (_, _, _, _, _, errors, validation_fns, _) = collect_untagged_members(&mut item, None);
     assert!(errors.is_empty(), "got: {errors:?}");
     assert!(validation_fns.is_empty(), "got: {validation_fns:?}");
     let attrs = &item.variants[0].fields.iter().next().unwrap().attrs;
@@ -809,7 +810,7 @@ fn untagged_member_reaching_an_unwritable_map_key_is_refused() {
 #[cfg(all(feature = "serde", feature = "jsonschema"))]
 fn untagged_member_values(mut item: syn::ItemEnum) -> Vec<String> {
     collect_untagged_members(&mut item, UNTAGGED_MODULE)
-        .3
+        .4
         .iter()
         .map(ToString::to_string)
         .collect()
@@ -1740,7 +1741,7 @@ fn a_refused_map_key_leaves_no_hook_naming_the_dropped_module() {
             },
         }
     };
-    let errors = collect_untagged_members(&mut item, UNTAGGED_MODULE).4;
+    let errors = collect_untagged_members(&mut item, UNTAGGED_MODULE).5;
     assert_eq!(errors.len(), 1, "got: {errors:?}");
     assert!(
         errors[0].to_string().contains("a map key must be a plain"),
@@ -7476,7 +7477,8 @@ fn a_scalar_union_member_is_recorded_as_the_type_serde_writes_it_as() {
             Many(Vec<Holder>),
         }
     };
-    let (_, _, merge_parts, _, errors, _, _) = collect_untagged_members(&mut item, UNTAGGED_MODULE);
+    let (_, _, _, merge_parts, _, errors, _, _) =
+        collect_untagged_members(&mut item, UNTAGGED_MODULE);
     assert!(errors.is_empty(), "got: {errors:?}");
     let recorded: Vec<(String, Option<&str>)> = merge_parts
         .iter()
@@ -7591,7 +7593,8 @@ fn recorded_union_flatten_error(
     mut item: syn::ItemEnum,
     field: &syn::Field,
 ) -> Option<String> {
-    let (_, _, merge_parts, _, errors, _, _) = collect_untagged_members(&mut item, UNTAGGED_MODULE);
+    let (_, _, _, merge_parts, _, errors, _, _) =
+        collect_untagged_members(&mut item, UNTAGGED_MODULE);
     assert!(errors.is_empty(), "got: {errors:?}");
     register_alias_info(
         rust_ident,
@@ -7607,7 +7610,8 @@ fn recorded_union_flatten_error(
 /// write, in declaration order.
 #[cfg(all(feature = "serde", feature = "zod"))]
 fn recorded_member_trails(mut item: syn::ItemEnum) -> Vec<(String, Option<&'static str>)> {
-    let (_, _, merge_parts, _, errors, _, _) = collect_untagged_members(&mut item, UNTAGGED_MODULE);
+    let (_, _, _, merge_parts, _, errors, _, _) =
+        collect_untagged_members(&mut item, UNTAGGED_MODULE);
     assert!(errors.is_empty(), "got: {errors:?}");
     merge_parts
         .iter()

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -267,6 +267,12 @@ pub struct AliasInfo {
     /// [`record_zod_factory`] as the item decides which of the two it publishes.
     #[cfg(feature = "zod")]
     pub publishes_zod_factory: bool,
+    /// What an untagged enum's members are spelled as where an object flattens the enum itself, one
+    /// per member in the order the union writes them — and empty both for every other item and
+    /// wherever spelling the members says nothing the enum's own name does not already say. Filled
+    /// by [`record_ts_union_members`] once that enum's own expansion has rendered them.
+    #[cfg(all(feature = "serde", feature = "typescript"))]
+    pub ts_union_members: Vec<String>,
     /// What the value surface written under this name is, in the vocabulary a constrained brand's
     /// refusal names shapes by — and [`PublishedShape::Flat(None)`] both when that surface is one
     /// string checks land on and when nothing has been recorded at all. Filled by
@@ -654,6 +660,8 @@ pub fn register_alias_info(
                 module_name: module_name.to_owned(),
                 #[cfg(feature = "zod")]
                 publishes_zod_factory: false,
+                #[cfg(all(feature = "serde", feature = "typescript"))]
+                ts_union_members: Vec::new(),
                 value_shape: PublishedShape::Flat(None),
                 #[cfg(all(feature = "serde", any(feature = "zod", feature = "typescript")))]
                 wire: Vec::new(),
@@ -746,6 +754,26 @@ pub fn record_zod_union_members(rust_ident: &str, members: &[ZodUnionMember]) {
     });
 }
 
+/// Records what an untagged enum's members are spelled as where an object flattens the enum itself,
+/// on the entry that enum has already registered.
+///
+/// The two spellings of one union part where an object is joined to it. Standing alone the union
+/// describes one member at a time, and the enum's own name is the whole of what it publishes;
+/// intersected with an open object each member is left satisfied by a payload carrying the other
+/// members' keys as well, which serde writes for no value. The members recorded here carry the
+/// exclusions that close them against one another, so the merge can spell them in the name's place.
+///
+/// Nothing is recorded where those exclusions come to nothing — a union of names proves no key an
+/// object could be told to leave out — and the merge then names the union as it always did.
+#[cfg(all(feature = "serde", feature = "typescript"))]
+pub fn record_ts_union_members(rust_ident: &str, members: &[String]) {
+    ALIAS_INFO.with(|map| {
+        if let Some(info) = map.borrow_mut().get_mut(rust_ident) {
+            info.ts_union_members = members.to_vec();
+        }
+    });
+}
+
 /// Records what an externally tagged enum's variants are spelled as where an object flattens the
 /// enum itself, on the entry that enum has already registered.
 ///
@@ -756,10 +784,11 @@ pub fn record_zod_union_members(rust_ident: &str, members: &[ZodUnionMember]) {
 /// where the union publishes a bare string no object joins. So the flatten-edge spelling is recorded
 /// beside the union's rather than read back off it.
 ///
-/// Recorded for every externally tagged enum, and read by each surface under the bound that
-/// surface's own merge has: Zod joins one operand per variant wherever the enum is flattened
-/// directly, TypeScript only where a variant is proved to be no object, an intersection distributing
-/// over a union of objects on its own.
+/// Recorded for every externally tagged enum, and read by each surface wherever the enum is
+/// flattened directly. A Zod intersection recognizes exactly the keys its operands name, so it takes
+/// one operand per variant; TypeScript distributes over a union of objects on its own and takes the
+/// variants for what the union alone cannot say — the key set serde writes for a unit variant, and
+/// each variant's silence about the keys its siblings tag.
 #[cfg(all(feature = "serde", any(feature = "typescript", feature = "zod")))]
 pub fn record_flatten_variants(rust_ident: &str, variants: &[FlattenVariant]) {
     ALIAS_INFO.with(|map| {

--- a/tests/flatten_tests/tests.rs
+++ b/tests/flatten_tests/tests.rs
@@ -667,17 +667,52 @@ struct FlatOverMemberExtObjUntagged {
     own: String,
 }
 
-/// And that enum flattened directly, where the two merged surfaces part. TypeScript distributes an
-/// intersection over a union on its own and every branch here is an object, so the name is already
-/// the whole answer and stays the one operand it always was. A Zod intersection recognizes exactly
-/// the keys its operands name and a `z.union` names none, so joining the object to the name admits
-/// nothing at all and the object is multiplied over the variants there.
+/// And that enum flattened directly, where the two merged surfaces multiply for different reasons. A
+/// Zod intersection recognizes exactly the keys its operands name and a `z.union` names none, so
+/// joining the object to the name admits nothing at all. TypeScript reaches every branch by
+/// distributing and needs the variants for what no branch says on its own: that it does not carry
+/// the tag its sibling carries.
 #[cfg(any(feature = "jsonschema", feature = "zod", feature = "typescript"))]
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct ExtObjDirectHolder {
     #[serde(flatten)]
     ext: MemberExtObjects,
+    own: String,
+}
+
+/// The same enum reached through an `Option`, where the absence branch reads its keys off the
+/// operand beside it. `keyof` a union is the keys its branches share, which for two variants tagging
+/// different names was none at all — an empty mapped type, and one every object passes through.
+/// Closing each variant against the other is what gives that branch the keys to leave out.
+#[cfg(feature = "typescript")]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct OptExtObjHolder {
+    #[serde(flatten, skip_serializing_if = "Option::is_none", default)]
+    ext: Option<MemberExtObjects>,
+    own: String,
+}
+
+/// An untagged union written over the objects its members are rather than over names, and the struct
+/// that flattens it. serde matches a member on its shape and writes one member's keys at a time, and
+/// the members here are the only ones whose keys the declaration itself spells — a member written as
+/// a name is what it is written as, and the merge is told nothing it could close the others against.
+#[cfg(any(feature = "jsonschema", feature = "zod", feature = "typescript"))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(untagged)]
+enum InlineUntagEither {
+    Left { left: String },
+    Right { right: bool },
+}
+
+#[cfg(any(feature = "jsonschema", feature = "zod", feature = "typescript"))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct InlineUntagDirectHolder {
+    #[serde(flatten)]
+    either: InlineUntagEither,
     own: String,
 }
 
@@ -3149,18 +3184,23 @@ fn test_the_direct_tagged_flatten_schema_multiplies_the_object_over_the_variants
 /// bare string a unit variant publishes standing alone intersects the object to `never`, and the
 /// payload serde writes for that variant belongs to no branch of the result.
 ///
+/// Each key set also says it does not carry the other's tag, which is what keeps the type on the one
+/// variant at a time serde writes. Without it the excess-property check reads the union of both key
+/// sets and either branch is satisfied by a payload carrying both.
+///
 /// Read off tsc 7.0.2 under `--strict`, the emitted declarations compiled as written: this type
 /// accepts `{ own: "o", Bare: null }` and `{ own: "o", Wrapped: { b: true } }`, and rejects
-/// `{ own: "o" }`, `{ own: "o", Bare: "Bare" }` and `{ Bare: null }`. Named as the enum's own union,
-/// the first of those was `TS2353: 'Bare' does not exist in type '{ own: string; } & { Wrapped:
-/// FlatSecond; }'`.
+/// `{ own: "o" }`, `{ own: "o", Bare: "Bare" }`, `{ Bare: null }` and
+/// `{ own: "o", Bare: null, Wrapped: { b: true } }`. Named as the enum's own union, the first of
+/// those was `TS2353: 'Bare' does not exist in type '{ own: string; } & { Wrapped: FlatSecond; }'`;
+/// without the exclusions the last one was accepted.
 #[test]
 #[cfg(feature = "typescript")]
 fn test_the_direct_tagged_flatten_type_spells_the_key_set_serde_writes() {
     let ts = ExtBareDirectHolder::ts_definition();
     assert!(
         ts.contains(
-            "} & ({\n  /**\n   * Bare\n   * \n   */\n  \"Bare\": null;\n} | {\n  /**\n   * Wrapped\n   * \n   */\n  \"Wrapped\": FlatSecond;\n});"
+            "} & ({\n  /**\n   * Bare\n   * \n   */\n  \"Bare\": null;\n  \"Wrapped\"?: never;\n} | {\n  /**\n   * Wrapped\n   * \n   */\n  \"Wrapped\": FlatSecond;\n  \"Bare\"?: never;\n});"
         ),
         "expected one key set per variant, got: {ts}"
     );
@@ -3222,17 +3262,25 @@ fn test_the_all_object_tagged_direct_flatten_schema_multiplies_the_object_over_t
     );
 }
 
-/// TypeScript distributes an intersection over a union of objects on its own, so the same enum stays
-/// the one operand it always was there — byte for byte, and payload for payload what the
-/// multiplication describes.
+/// TypeScript distributes an intersection over a union of objects on its own, so the branches are
+/// ones the enum's own name already reaches. What the name does not reach is what each branch says
+/// about the other: the excess-property check reads the union of both key sets, so a payload
+/// carrying both tags satisfies either branch structurally — a payload serde writes for no value and
+/// the other three surfaces refuse. Spelling the variants is what carries that.
+///
+/// Read off tsc 7.0.2 under `--strict`, the emitted declarations compiled as written: this type
+/// accepts `{ own: "o", One: { a: "x" } }` and `{ own: "o", Two: { b: true } }`, and rejects
+/// `{ own: "o" }`, `{ One: { a: "x" } }` and
+/// `{ own: "o", One: { a: "x" }, Two: { b: true } }`. Named as the enum's own union, that last one
+/// was accepted.
 #[test]
 #[cfg(feature = "typescript")]
-fn test_an_all_object_tagged_direct_flatten_type_is_byte_identical() {
+fn test_an_all_object_tagged_direct_flatten_type_closes_each_variant_against_the_other() {
     let ts = ExtObjDirectHolder::ts_definition();
     let declared = &ts[ts.find("export type").unwrap()..];
     assert_eq!(
         declared,
-        "export type ExtObjDirectHolder = {\n  /**\n   * own\n   * \n   */\n  own: string;\n} & MemberExtObjects;"
+        "export type ExtObjDirectHolder = {\n  /**\n   * own\n   * \n   */\n  own: string;\n} & ({\n  /**\n   * One\n   * \n   */\n  \"One\": FlatFirst;\n  \"Two\"?: never;\n} | {\n  /**\n   * Two\n   * \n   */\n  \"Two\": FlatSecond;\n  \"One\"?: never;\n});"
     );
 }
 
@@ -3242,5 +3290,126 @@ fn test_an_all_object_tagged_direct_flatten_document_is_byte_identical() {
     assert_eq!(
         serde_json::to_string(&ExtObjDirectHolder::json_schema()).unwrap(),
         r#"{"type":"object","oneOf":[{"type":"object","properties":{"own":{"type":"string"},"One":{"type":"object","additionalProperties":false,"properties":{"a":{"type":"string"}},"required":["a"]}},"required":["own","One"],"additionalProperties":false},{"type":"object","properties":{"own":{"type":"string"},"Two":{"type":"object","additionalProperties":false,"properties":{"b":{"type":"boolean"}},"required":["b"]}},"required":["own","Two"],"additionalProperties":false}]}"#
+    );
+}
+
+/// And the absence branch beside the same enum reads the closed variants' keys, where it had none to
+/// read: `keyof` a union is the keys its branches share, so before the exclusions the branch was an
+/// empty mapped type — `{}`, which every object passes through, including one carrying part of a
+/// variant's key set.
+///
+/// Read off tsc 7.0.2 under `--strict`, the emitted declarations compiled as written: this type
+/// accepts `{ own: "o" }`, `{ own: "o", One: { a: "x" } }` and `{ own: "o", Two: { b: true } }`, and
+/// rejects `{ own: "o", One: { a: "x" }, Two: { b: true } }`.
+#[test]
+#[cfg(feature = "typescript")]
+fn test_the_optional_all_object_tagged_flatten_type_names_the_keys_its_absence_leaves_out() {
+    let ts = OptExtObjHolder::ts_definition();
+    let declared = &ts[ts.find("export type").unwrap()..];
+    assert_eq!(
+        declared,
+        "export type OptExtObjHolder = {\n  /**\n   * own\n   * \n   */\n  own: string;\n} & (({\n  /**\n   * One\n   * \n   */\n  \"One\": FlatFirst;\n  \"Two\"?: never;\n} | {\n  /**\n   * Two\n   * \n   */\n  \"Two\": FlatSecond;\n  \"One\"?: never;\n}) | { [K in keyof ({\n  /**\n   * One\n   * \n   */\n  \"One\": FlatFirst;\n  \"Two\"?: never;\n} | {\n  /**\n   * Two\n   * \n   */\n  \"Two\": FlatSecond;\n  \"One\"?: never;\n})]?: never });"
+    );
+}
+
+/// Standing on their own the two tagged enums are written exactly as they were on TypeScript too.
+/// The exclusions answer what an intersection with an open object does to the choice, and a name
+/// publishing the choice alone is joined to nothing: it describes one variant at a time already.
+#[test]
+#[cfg(feature = "typescript")]
+fn test_the_tagged_enums_are_byte_identical_standing_alone_on_typescript() {
+    let bare = MemberExtBare::ts_definition();
+    let objects = MemberExtObjects::ts_definition();
+    assert_eq!(
+        [
+            &bare[bare.find("export type").unwrap()..],
+            &objects[objects.find("export type").unwrap()..],
+        ],
+        [
+            "export type MemberExtBare =   /**\n   * Bare\n   * \n   */\n  \"Bare\" | {\n  /**\n   * Wrapped\n   * \n   */\n  \"Wrapped\": FlatSecond;\n};",
+            "export type MemberExtObjects = {\n  /**\n   * One\n   * \n   */\n  \"One\": FlatFirst;\n} | {\n  /**\n   * Two\n   * \n   */\n  \"Two\": FlatSecond;\n};",
+        ]
+    );
+}
+
+/// The untagged footing answers the same way, on the members whose keys the declaration spells. What
+/// serde writes is one member's keys at a time — it matches a member on its shape — and the merged
+/// type said otherwise for the reason the tagged one did.
+#[test]
+#[cfg(any(feature = "jsonschema", feature = "zod", feature = "typescript"))]
+fn test_a_directly_flattened_inline_untagged_union_round_trips_every_member() {
+    let forms = [
+        (
+            InlineUntagEither::Left {
+                left: "l".to_owned(),
+            },
+            serde_json::json!({ "left": "l", "own": "o" }),
+        ),
+        (
+            InlineUntagEither::Right { right: true },
+            serde_json::json!({ "right": true, "own": "o" }),
+        ),
+    ];
+    for (either, expected) in forms {
+        let holder = InlineUntagDirectHolder {
+            either,
+            own: "o".to_owned(),
+        };
+        let written = serde_json::to_value(&holder).unwrap();
+        assert_eq!(written, expected);
+        let back: InlineUntagDirectHolder = serde_json::from_value(written).unwrap();
+        assert_eq!(back, holder);
+    }
+}
+
+/// So the merged type spells the members in the union's name's place, each closed against the keys
+/// the other names.
+///
+/// Read off tsc 7.0.2 under `--strict`, the emitted declarations compiled as written: this type
+/// accepts `{ own: "o", left: "l" }` and `{ own: "o", right: true }`, and rejects `{ own: "o" }`,
+/// `{ left: "l" }` and `{ own: "o", left: "l", right: true }`. Named as the enum's own union, that
+/// last one was accepted.
+#[test]
+#[cfg(feature = "typescript")]
+fn test_an_inline_untagged_direct_flatten_type_closes_each_member_against_the_other() {
+    let ts = InlineUntagDirectHolder::ts_definition();
+    let declared = &ts[ts.find("export type").unwrap()..];
+    assert_eq!(
+        declared,
+        "export type InlineUntagDirectHolder = {\n  /**\n   * own\n   * \n   */\n  own: string;\n} & ({ left: string; right?: never } | { right: boolean; left?: never });"
+    );
+}
+
+/// And the union standing alone is written exactly as it was, on every surface: the exclusions are
+/// what an intersection with an open object needs, and nothing joins the name here.
+#[test]
+#[cfg(feature = "typescript")]
+fn test_the_inline_untagged_union_is_byte_identical_standing_alone() {
+    let ts = InlineUntagEither::ts_definition();
+    let declared = &ts[ts.find("export type").unwrap()..];
+    assert_eq!(
+        declared,
+        "export type InlineUntagEither = { left: string } | { right: boolean };"
+    );
+}
+
+#[test]
+#[cfg(feature = "zod")]
+fn test_the_inline_untagged_direct_flatten_schema_is_unchanged() {
+    let zod = InlineUntagDirectHolder::zod_schema();
+    assert!(
+        zod.contains(
+            "z.union([\n  InlineUntagDirectHolder$OwnSchema.and(z.lazy(() => z.strictObject({ left: z.string(), }))),\n  InlineUntagDirectHolder$OwnSchema.and(z.lazy(() => z.strictObject({ right: z.boolean(), }))),\n])"
+        ),
+        "expected one operand per member, got: {zod}"
+    );
+}
+
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_the_inline_untagged_direct_flatten_document_is_unchanged() {
+    assert_eq!(
+        serde_json::to_string(&InlineUntagDirectHolder::json_schema()).unwrap(),
+        r#"{"type":"object","anyOf":[{"type":"object","properties":{"own":{"type":"string"},"left":{"type":"string"}},"required":["own","left"],"additionalProperties":false},{"type":"object","properties":{"own":{"type":"string"},"right":{"type":"boolean"}},"required":["own","right"],"additionalProperties":false}]}"#
     );
 }


### PR DESCRIPTION
A flattened union's TypeScript operand admitted a payload carrying two branches' keys at once — which serde never writes, and Zod and the JSON document both refuse — because excess-property checking against a union target reads the union of all members' keys. Every member of a flattened choice's operand now names, for each key its siblings name and it does not, an optional member mapped to never, the spelling tsc verifiably refuses the cross-branch payload with while accepting both single-branch payloads.

Applied only at the flatten edge: the recorded per-variant tagged operands carry the exclusions (spelled per variant whenever the choice has two or more members, which is how the all-object tagged footing gains them), and untagged unions record a member list beside the Zod one, closing struct-variant members against their siblings' named fields while leaving members whose keys nothing proves unclosed — and contributing no keys for others to exclude. A union a name publishes standing alone is untouched, newly pinned as such on TypeScript. The nullable direct flatten's absence branch also gains real keys to leave out, where keyof over the union of differently-tagged variants used to be the empty mapped type that admitted a partial base. The internally tagged footing needed nothing: its literal discriminant already narrows before excess-property checking runs.