### PR TITLE
Carry the filling beside each in-flight name; merge a flattened parameter at its filling's document

### DIFF
--- a/src/features/jsonschema.rs
+++ b/src/features/jsonschema.rs
@@ -74,6 +74,11 @@ fn defs_pointer(def_name: &str) -> String {
 /// while still in flight describes as a `$ref` into `$defs`, and the frame that put it in flight
 /// hoists its body to the root that pointer resolves against.
 ///
+/// What travels beside each name is the filling its body is being written at, because a pointer
+/// resolves to that body and nothing else. A name re-entered at the same filling is the cycle the
+/// `$ref` describes; one re-entered at another is a body the document has no second place to hold,
+/// and is refused rather than pointed at the wrong one.
+///
 /// An item declaring type parameters publishes each of those two at a filling as well: JSON Schema
 /// has no parameters, so a document exists only once each of them names a type, and which types
 /// those are is the reference site's to say. So `json_schema_with` and `json_schema_within_with`
@@ -85,8 +90,9 @@ pub fn json_schema_methods(
     body: &proc_macro2::TokenStream,
     parameters: &[SchemaParameter],
 ) -> proc_macro2::TokenStream {
-    let described = guarded_description(def_name, body);
+    let in_flight_type = in_flight_type();
     if parameters.is_empty() {
+        let described = guarded_description(def_name, body, &quote::quote! { Vec::new() });
         let rooted = rooted_document(
             &quote::quote! { Self::json_schema_within(&mut in_flight, &mut hoisted_defs) },
         );
@@ -96,13 +102,14 @@ pub fn json_schema_methods(
             }
 
             pub fn json_schema_within(
-                in_flight: &mut Vec<&'static str>,
+                in_flight: &mut #in_flight_type,
                 hoisted_defs: &mut serde_json::Map<String, serde_json::Value>,
             ) -> serde_json::Value {
                 #described
             }
         };
     }
+    let described = guarded_description(def_name, body, &bound_filling(parameters));
     let rooted = rooted_document(
         &quote::quote! { Self::json_schema_within_with(&mut in_flight, &mut hoisted_defs, args) },
     );
@@ -118,14 +125,14 @@ pub fn json_schema_methods(
         }
 
         pub fn json_schema_within(
-            in_flight: &mut Vec<&'static str>,
+            in_flight: &mut #in_flight_type,
             hoisted_defs: &mut serde_json::Map<String, serde_json::Value>,
         ) -> serde_json::Value {
             Self::json_schema_within_with(in_flight, hoisted_defs, #declared)
         }
 
         pub fn json_schema_within_with(
-            in_flight: &mut Vec<&'static str>,
+            in_flight: &mut #in_flight_type,
             hoisted_defs: &mut serde_json::Map<String, serde_json::Value>,
             args: &[serde_json::Value],
         ) -> serde_json::Value {
@@ -135,21 +142,49 @@ pub fn json_schema_methods(
     }
 }
 
+/// The names whose descriptions are still being written, as the type every `within` form carries
+/// them in.
+///
+/// Each name travels with the documents its parameters were filled with, that being what says
+/// which body the definition the name is deferred to will hold. A name declaring no parameter
+/// carries an empty list, and compares equal to itself the way it always did.
+pub fn in_flight_type() -> proc_macro2::TokenStream {
+    quote::quote! { Vec<(&'static str, Vec<serde_json::Value>)> }
+}
+
+/// The filling this frame is writing its body at, read back off the locals the arguments were
+/// bound to — so what is compared is one document per declared parameter, whatever the caller
+/// passed and however short its list was.
+fn bound_filling(parameters: &[SchemaParameter]) -> proc_macro2::TokenStream {
+    let bound = parameters.iter().map(|parameter| &parameter.binding);
+    quote::quote! { vec![#(#bound.clone()),*] }
+}
+
 /// The description guarded against re-entering a name still being written, as the tokens the
 /// `within` form's body is.
+///
+/// `filling` is the documents this frame's parameters were filled with, which is what the guard
+/// reads the re-entry against: the same filling is the cycle the pointer describes, a different one
+/// the body the document cannot hold.
 fn guarded_description(
     def_name: &str,
     body: &proc_macro2::TokenStream,
+    filling: &proc_macro2::TokenStream,
 ) -> proc_macro2::TokenStream {
     let pointer = defs_pointer(def_name);
+    let refusal = refilled_cycle_refusal(def_name);
     quote::quote! {
-        if in_flight.contains(&#def_name) {
+        let filling: Vec<serde_json::Value> = #filling;
+        if let Some((_, in_flight_filling)) =
+            in_flight.iter().find(|(named, _)| *named == #def_name)
+        {
+            #refusal
             // Reserved rather than written: the frame that put this name in flight is still
             // writing the body, and fills the entry in once it has one.
             hoisted_defs.entry(#def_name).or_insert(serde_json::Value::Null);
             return serde_json::json!({ "$ref": #pointer });
         }
-        in_flight.push(#def_name);
+        in_flight.push((#def_name, filling));
         let described = #body;
         in_flight.pop();
         if hoisted_defs.contains_key(#def_name) {
@@ -160,11 +195,40 @@ fn guarded_description(
     }
 }
 
+/// How a reference coming back around to a name at another filling refuses, as the tokens the
+/// guard raises it with.
+///
+/// A pointer resolves to one body, and the document holds one definition per name — so the
+/// reference has nowhere to put the body its own arguments describe, and writing the pointer anyway
+/// would stand the other filling's members where this one's belong. Both fillings are named because
+/// which of them is the mistake is the author's to say, and the way past is named beside them: write
+/// the reference at the filling already being written, or give each filling a definition of its own
+/// by keying `$defs` by name and filling rather than by name.
+fn refilled_cycle_refusal(def_name: &str) -> proc_macro2::TokenStream {
+    let message = format!(
+        "`{def_name}`: a reference closes a cycle at a filling the document is not being written \
+         at — in flight at {{}}, and this reference names {{}}; a document holds one definition per \
+         name, so a cycle cannot change filling partway through it; write the reference at the \
+         filling already in flight, or key the definitions by name and filling so each filling gets \
+         a definition of its own."
+    );
+    quote::quote! {
+        if *in_flight_filling != filling {
+            panic!(
+                #message,
+                serde_json::Value::Array(in_flight_filling.clone()),
+                serde_json::Value::Array(filling),
+            );
+        }
+    }
+}
+
 /// A document standing on its own: `within` run against a fresh document, with whatever it hoisted
 /// joined to the root.
 fn rooted_document(described: &proc_macro2::TokenStream) -> proc_macro2::TokenStream {
+    let in_flight_type = in_flight_type();
     quote::quote! {
-        let mut in_flight: Vec<&'static str> = Vec::new();
+        let mut in_flight: #in_flight_type = Vec::new();
         let mut hoisted_defs = serde_json::Map::new();
         let described = #described;
         if hoisted_defs.is_empty() {

--- a/src/features/jsonschema/tests.rs
+++ b/src/features/jsonschema/tests.rs
@@ -205,3 +205,54 @@ fn test_plain_enum_publishes_the_guarded_method_too() {
         "{method}"
     );
 }
+
+/// A pointer resolves to one body, so the name a frame puts in flight travels with the filling
+/// that body is being written at — which is what a re-entry has to read to tell the cycle a
+/// reference describes from the one it cannot.
+#[test]
+fn test_the_in_flight_recording_carries_the_filling_beside_the_name() {
+    let parameters = vec![SchemaParameter {
+        binding: proc_macro2::Ident::new("_arg_value_type", proc_macro2::Span::call_site()),
+        default: quote::quote! { serde_json::json!({ "type": "string" }) },
+    }];
+    let methods = json_schema_methods("Node", &quote::quote! { body }, &parameters).to_string();
+
+    assert!(
+        methods.contains("in_flight : & mut Vec < (& 'static str , Vec < serde_json :: Value >) >"),
+        "{methods}"
+    );
+    assert!(
+        methods.contains(
+            "let filling : Vec < serde_json :: Value > = vec ! [_arg_value_type . clone ()]"
+        ),
+        "{methods}"
+    );
+    assert!(
+        methods.contains("in_flight . push ((\"Node\" , filling))"),
+        "{methods}"
+    );
+}
+
+/// The two ends a re-entered name can take: the same filling is the cycle the pointer describes,
+/// and any other is a body the document has no second place to hold.
+#[test]
+fn test_a_re_entered_name_is_read_against_the_filling_in_flight() {
+    let methods = json_schema_methods("Node", &quote::quote! { body }, &[]).to_string();
+
+    assert!(
+        methods.contains("in_flight . iter () . find (| (named , _) | * named == \"Node\")"),
+        "{methods}"
+    );
+    assert!(
+        methods.contains("if * in_flight_filling != filling"),
+        "{methods}"
+    );
+    assert!(
+        methods.contains("a document holds one definition per name"),
+        "the refusal does not state the limitation: {methods}"
+    );
+    assert!(
+        methods.contains("key the definitions by name and filling"),
+        "the refusal does not state the way past it: {methods}"
+    );
+}

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -84,7 +84,7 @@ use crate::features::model_schema_prop::{ModelSchemaPropMeta, parse_model_schema
 use crate::features::jsonschema::{
     MergedSource, SchemaParameter,
     generate_plain_enum_json_schema_method as generate_plain_enum_json_schema_method_impl,
-    generate_struct_json_schema_method as generate_struct_json_schema_method_impl,
+    generate_struct_json_schema_method as generate_struct_json_schema_method_impl, in_flight_type,
     json_schema_methods,
 };
 #[cfg(feature = "jsonschema")]
@@ -1921,16 +1921,19 @@ fn refused_item_schema_module(ident: &syn::Ident) -> proc_macro2::TokenStream {
     let refusal = format!("`{ident}`: refused by `#[model_schema()]`, so it describes nothing");
 
     #[cfg(feature = "jsonschema")]
-    let json_schema_methods = quote! {
-        pub fn json_schema() -> serde_json::Value {
-            panic!(#refusal)
-        }
+    let json_schema_methods = {
+        let in_flight_type = in_flight_type();
+        quote! {
+            pub fn json_schema() -> serde_json::Value {
+                panic!(#refusal)
+            }
 
-        pub fn json_schema_within(
-            _in_flight: &mut Vec<&'static str>,
-            _hoisted_defs: &mut serde_json::Map<String, serde_json::Value>,
-        ) -> serde_json::Value {
-            panic!(#refusal)
+            pub fn json_schema_within(
+                _in_flight: &mut #in_flight_type,
+                _hoisted_defs: &mut serde_json::Map<String, serde_json::Value>,
+            ) -> serde_json::Value {
+                panic!(#refusal)
+            }
         }
     };
     #[cfg(not(feature = "jsonschema"))]
@@ -11119,20 +11122,31 @@ fn flatten_merged_sources(flattened_fields: &[FieldDef]) -> Vec<MergedSource> {
 /// An `Option` around it travels too. What it wraps says which members the value contributes, and
 /// the `Option` says whether it contributes them at all — the merge owes the object both answers,
 /// and nothing below this point can still see the wrapper.
+///
+/// A parameter contributes the document its filling describes as, read through the one binding
+/// every other position holding that parameter reads it through — the merge expands whatever it is
+/// handed, so an object filling's members join the base exactly as a named source's do. Whether a
+/// filling is an object at all is the merge's to answer and not the declaration's: which type fills
+/// a parameter is the reference site's to name, so the declaration cannot know it, and the merge is
+/// where it finally is known.
 #[cfg(feature = "jsonschema")]
 fn flatten_merged_source(fld: &FieldDef) -> MergedSource {
     if let FieldDefType::SiblingType(name, arguments) = &fld.field_type {
-        MergedSource {
+        return MergedSource {
             label: name.clone(),
             optional: fld.is_optional(),
             value: sibling_json_schema_value(name, arguments, fld.type_span),
-        }
+        };
+    }
+    let value = if let FieldDefType::TypeParam(parameter) = &fld.field_type {
+        json_argument_value(parameter)
     } else {
-        MergedSource {
-            label: fld.name.clone(),
-            optional: fld.is_optional(),
-            value: quote! { serde_json::json!({ "type": "object" }) },
-        }
+        quote! { serde_json::json!({ "type": "object" }) }
+    };
+    MergedSource {
+        label: fld.name.clone(),
+        optional: fld.is_optional(),
+        value,
     }
 }
 

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -8579,3 +8579,41 @@ fn a_word_boundary_pattern_keeps_its_regex() {
          return Err (format ! (\"'{}' does not match pattern '{}'\" , \"field\" , \"\\\\b\")) ; } } Ok (()) } "
     );
 }
+
+/// A flattened source that is one of the item's own parameters contributes the document its
+/// filling describes as, read through the one binding every other position holding that parameter
+/// reads it through — not the placeholder that stands for a value the expansion cannot name, which
+/// carries no member and multiplies nothing into the object being written.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_flattened_type_parameter_is_merged_at_the_document_its_filling_binds() {
+    let ty: syn::Type = syn::parse_str("HeldType").unwrap();
+    let mut held = super::get_field_def("held", &ty, "");
+    held.erase_type_parameters(&["HeldType".to_owned()]);
+
+    let source = super::flatten_merged_source(&held);
+
+    assert_eq!(source.label, "held");
+    assert_eq!(
+        source.value.to_string(),
+        "_arg_held_type . clone ()",
+        "the placeholder still stands where the filling belongs"
+    );
+}
+
+/// A flatten source the expansion can name neither as a sibling nor as a parameter has no document
+/// to reach for, and keeps the placeholder it has always contributed.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_flatten_source_with_no_name_of_its_own_keeps_the_placeholder() {
+    let ty: syn::Type = syn::parse_str("serde_json::Value").unwrap();
+    let held = super::get_field_def("held", &ty, "");
+
+    let source = super::flatten_merged_source(&held);
+
+    assert_eq!(source.label, "held");
+    assert_eq!(
+        source.value.to_string(),
+        "serde_json :: json ! ({ \"type\" : \"object\" })"
+    );
+}

--- a/tests/generic_types_tests/tests.rs
+++ b/tests/generic_types_tests/tests.rs
@@ -971,6 +971,99 @@ mod jsonschema {
             serde_json::json!({ "type": "string" })
         );
     }
+
+    /// A cycle written at the filling it was entered at is the one a document holding a single
+    /// definition per name can describe, and it describes exactly as it always has: the definition
+    /// at that filling, and a reference into it wherever the name comes back around.
+    #[test]
+    fn a_cycle_that_keeps_its_filling_defers_through_the_one_definition() {
+        assert_eq!(
+            serde_json::to_string(&super::Recurring::<String>::json_schema()).unwrap(),
+            "{\"$defs\":{\"Recurring\":{\"type\":\"object\",\"additionalProperties\":false,\
+             \"properties\":{\"next\":{\"$ref\":\"#/$defs/Recurring\"},\
+             \"value\":{\"type\":\"string\"}},\"required\":[\"value\"]}},\
+             \"$ref\":\"#/$defs/Recurring\"}"
+        );
+    }
+
+    /// A reference that comes back around to a name at a filling the document is not being written
+    /// at has nowhere to put its own definition, and the pointer it would write resolves to the
+    /// other filling's body. Both fillings are named, because which one is wrong is the author's to
+    /// decide.
+    #[test]
+    #[should_panic(
+        expected = "`Refilled`: a reference closes a cycle at a filling the document is \
+                    not being written at — in flight at [{\"type\":\"string\"}], and \
+                    this reference names [{\"type\":\"boolean\"}]"
+    )]
+    fn a_cycle_that_changes_filling_is_refused_naming_both_fillings() {
+        let _ = super::Refilled::<String>::json_schema();
+    }
+
+    /// The refusal states what stands in the way and what would move it, so an author meeting it
+    /// reads why one definition cannot hold two fillings and what would let it.
+    #[test]
+    #[should_panic(
+        expected = "a document holds one definition per name, so a cycle cannot change \
+                    filling partway through it; write the reference at the filling \
+                    already in flight, or key the definitions by name and filling so \
+                    each filling gets a definition of its own"
+    )]
+    fn the_refused_cycle_states_the_limitation_and_the_way_past_it() {
+        let _ = super::Refilled::<String>::json_schema();
+    }
+
+    /// `#[serde(flatten)]` is read only where `serde` is, so the merge these pin is only written
+    /// there.
+    #[cfg(feature = "serde")]
+    mod flattened_parameter {
+        use super::super::{Carried, FlatCarrier, FlatReferrer};
+
+        /// A flattened parameter is a flattened value like any other: the object its filling
+        /// describes contributes its members to the one being written, beside the ones that object
+        /// writes itself. The filling reaches the merge through the one binding every other
+        /// position reads the parameter through, so the merge never sees which end filled it.
+        #[test]
+        fn a_flattened_parameter_merges_the_members_the_reference_site_filled_it_with() {
+            assert_eq!(
+                FlatReferrer::json_schema()["properties"]["held"],
+                serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "tag": { "type": "string" },
+                        "value": { "type": "integer" }
+                    },
+                    "required": ["tag", "value"],
+                    "additionalProperties": false
+                })
+            );
+        }
+
+        /// A filling that is not an object has no members to merge, and what serde writes for it
+        /// never joins the object being written. The declaration cannot say so — which type fills
+        /// the parameter is the reference site's to name — so the merge answers where the filling
+        /// is finally known, in the words it answers for every other source in.
+        #[test]
+        #[should_panic(
+            expected = "`FlatCarrier`: `#[serde(flatten)]` of `held` is not written as \
+                        an object — its schema describes a `string`, which has no \
+                        members to merge"
+        )]
+        fn a_flattened_parameter_filled_by_a_scalar_is_refused_where_the_filling_is_known() {
+            let _ = FlatCarrier::<String>::json_schema();
+        }
+
+        /// A flatten source naming a type rather than a parameter is untouched by any of this.
+        #[test]
+        fn a_named_flatten_source_beside_a_parameter_describes_as_it_always_has() {
+            assert_eq!(
+                serde_json::to_string(&Carried::<String>::json_schema()).unwrap(),
+                "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"},\
+                 \"trace\":{\"type\":\"string\"}},\"required\":[\"id\",\"trace\"],\
+                 \"additionalProperties\":false}"
+            );
+        }
+    }
 }
 
 use alloc::borrow::Cow;
@@ -1271,6 +1364,54 @@ pub struct Referrer {
 pub struct Summarised<ValueType> {
     pub boxed: Boxed<ValueType>,
     pub tagged: Tagged<ValueType>,
+}
+
+/// A generic type that names itself, at the filling it was entered at — the cycle a document
+/// holding one definition per name describes as a definition and a reference into it. Read only
+/// where a JSON document is built.
+#[cfg(feature = "jsonschema")]
+#[model_schema(default_types(ValueType = String))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Recurring<ValueType> {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next: Option<Box<Recurring<ValueType>>>,
+    pub value: ValueType,
+}
+
+/// The same cycle, closed at a filling the outer frame was not written at: the position holds a
+/// `bool` where the document is being written at a `String`, and one definition cannot describe
+/// both.
+#[cfg(feature = "jsonschema")]
+#[model_schema(default_types(ValueType = String))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Refilled<ValueType> {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub next: Option<Box<Refilled<bool>>>,
+    pub value: ValueType,
+}
+
+/// A struct whose flattened source is one of its own type parameters. `#[serde(flatten)]` is read
+/// only where `serde` is, and the document is built only where `jsonschema` is, so the fixture
+/// exists where both do.
+///
+/// The declared filling is a scalar, which is the filling the merge has to answer for; the object
+/// filling reaches it from the reference site below.
+#[cfg(all(feature = "serde", feature = "jsonschema"))]
+#[model_schema(default_types(HeldType = String))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FlatCarrier<HeldType> {
+    #[serde(flatten)]
+    pub held: HeldType,
+    pub tag: String,
+}
+
+/// The same struct reached from a field that fills its parameter with an object, which is the
+/// other end a filling can arrive from.
+#[cfg(all(feature = "serde", feature = "jsonschema"))]
+#[model_schema()]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FlatReferrer {
+    pub held: FlatCarrier<Inner<u32>>,
 }
 
 #[cfg(not(feature = "jsonschema"))]

--- a/tests/generic_types_tests/tests.rs
+++ b/tests/generic_types_tests/tests.rs
@@ -770,6 +770,58 @@ mod jsonschema {
         ecm_document_schema,
     };
 
+    /// `#[serde(flatten)]` is read only where `serde` is, so the merge these pin is only written
+    /// there.
+    #[cfg(feature = "serde")]
+    mod flattened_parameter {
+        use super::super::{Carried, FlatCarrier, FlatReferrer};
+
+        /// A flattened parameter is a flattened value like any other: the object its filling
+        /// describes contributes its members to the one being written, beside the ones that object
+        /// writes itself. The filling reaches the merge through the one binding every other
+        /// position reads the parameter through, so the merge never sees which end filled it.
+        #[test]
+        fn a_flattened_parameter_merges_the_members_the_reference_site_filled_it_with() {
+            assert_eq!(
+                FlatReferrer::json_schema()["properties"]["held"],
+                serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "tag": { "type": "string" },
+                        "value": { "type": "integer" }
+                    },
+                    "required": ["tag", "value"],
+                    "additionalProperties": false
+                })
+            );
+        }
+
+        /// A filling that is not an object has no members to merge, and what serde writes for it
+        /// never joins the object being written. The declaration cannot say so — which type fills
+        /// the parameter is the reference site's to name — so the merge answers where the filling
+        /// is finally known, in the words it answers for every other source in.
+        #[test]
+        #[should_panic(
+            expected = "`FlatCarrier`: `#[serde(flatten)]` of `held` is not written as \
+                        an object — its schema describes a `string`, which has no \
+                        members to merge"
+        )]
+        fn a_flattened_parameter_filled_by_a_scalar_is_refused_where_the_filling_is_known() {
+            let _: serde_json::Value = FlatCarrier::<String>::json_schema();
+        }
+
+        /// A flatten source naming a type rather than a parameter is untouched by any of this.
+        #[test]
+        fn a_named_flatten_source_beside_a_parameter_describes_as_it_always_has() {
+            assert_eq!(
+                serde_json::to_string(&Carried::<String>::json_schema()).unwrap(),
+                "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"},\
+                 \"trace\":{\"type\":\"string\"}},\"required\":[\"id\",\"trace\"],\
+                 \"additionalProperties\":false}"
+            );
+        }
+    }
+
     /// A key every instantiation writes as a string leaves the value side describable, so the
     /// object says what it holds instead of opening entirely — the answer the concrete
     /// `String`-keyed member beside it already gave.
@@ -997,7 +1049,7 @@ mod jsonschema {
                     this reference names [{\"type\":\"boolean\"}]"
     )]
     fn a_cycle_that_changes_filling_is_refused_naming_both_fillings() {
-        let _ = super::Refilled::<String>::json_schema();
+        let _: serde_json::Value = super::Refilled::<String>::json_schema();
     }
 
     /// The refusal states what stands in the way and what would move it, so an author meeting it
@@ -1010,59 +1062,7 @@ mod jsonschema {
                     each filling gets a definition of its own"
     )]
     fn the_refused_cycle_states_the_limitation_and_the_way_past_it() {
-        let _ = super::Refilled::<String>::json_schema();
-    }
-
-    /// `#[serde(flatten)]` is read only where `serde` is, so the merge these pin is only written
-    /// there.
-    #[cfg(feature = "serde")]
-    mod flattened_parameter {
-        use super::super::{Carried, FlatCarrier, FlatReferrer};
-
-        /// A flattened parameter is a flattened value like any other: the object its filling
-        /// describes contributes its members to the one being written, beside the ones that object
-        /// writes itself. The filling reaches the merge through the one binding every other
-        /// position reads the parameter through, so the merge never sees which end filled it.
-        #[test]
-        fn a_flattened_parameter_merges_the_members_the_reference_site_filled_it_with() {
-            assert_eq!(
-                FlatReferrer::json_schema()["properties"]["held"],
-                serde_json::json!({
-                    "type": "object",
-                    "properties": {
-                        "tag": { "type": "string" },
-                        "value": { "type": "integer" }
-                    },
-                    "required": ["tag", "value"],
-                    "additionalProperties": false
-                })
-            );
-        }
-
-        /// A filling that is not an object has no members to merge, and what serde writes for it
-        /// never joins the object being written. The declaration cannot say so — which type fills
-        /// the parameter is the reference site's to name — so the merge answers where the filling
-        /// is finally known, in the words it answers for every other source in.
-        #[test]
-        #[should_panic(
-            expected = "`FlatCarrier`: `#[serde(flatten)]` of `held` is not written as \
-                        an object — its schema describes a `string`, which has no \
-                        members to merge"
-        )]
-        fn a_flattened_parameter_filled_by_a_scalar_is_refused_where_the_filling_is_known() {
-            let _ = FlatCarrier::<String>::json_schema();
-        }
-
-        /// A flatten source naming a type rather than a parameter is untouched by any of this.
-        #[test]
-        fn a_named_flatten_source_beside_a_parameter_describes_as_it_always_has() {
-            assert_eq!(
-                serde_json::to_string(&Carried::<String>::json_schema()).unwrap(),
-                "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\"},\
-                 \"trace\":{\"type\":\"string\"}},\"required\":[\"id\",\"trace\"],\
-                 \"additionalProperties\":false}"
-            );
-        }
+        let _: serde_json::Value = super::Refilled::<String>::json_schema();
     }
 }
 
@@ -1395,7 +1395,7 @@ pub struct Summarised<ValueType> {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Recurring<ValueType> {
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub next: Option<Box<Recurring<ValueType>>>,
+    pub next: Option<Box<Self>>,
     pub value: ValueType,
 }
 

--- a/tests/generic_types_tests/tests.rs
+++ b/tests/generic_types_tests/tests.rs
@@ -763,13 +763,6 @@ mod zod {
 
 #[cfg(feature = "jsonschema")]
 mod jsonschema {
-    #[cfg(all(feature = "chrono", feature = "object_id"))]
-    use super::StoredFolder;
-    use super::{
-        CountedFolder, EcmDocument, KeyedByParameter, Pair, Tagged, WireFolder, Wrapper,
-        ecm_document_schema,
-    };
-
     /// `#[serde(flatten)]` is read only where `serde` is, so the merge these pin is only written
     /// there.
     #[cfg(feature = "serde")]
@@ -821,6 +814,13 @@ mod jsonschema {
             );
         }
     }
+
+    #[cfg(all(feature = "chrono", feature = "object_id"))]
+    use super::StoredFolder;
+    use super::{
+        CountedFolder, EcmDocument, KeyedByParameter, Pair, Tagged, WireFolder, Wrapper,
+        ecm_document_schema,
+    };
 
     /// A key every instantiation writes as a string leaves the value side describable, so the
     /// object says what it holds instead of opening entirely — the answer the concrete


### PR DESCRIPTION
Two follow-ons to the reference-site JSON arguments landing.

Each name in flight now travels with the documents its parameters were filled with. A reference closing a cycle at the same filling takes the $ref path byte-identically; one that changes filling — previously a silent $ref into the other filling's definition, accepting values the type rejects and rejecting the ones it writes — is refused at document build, naming the item, both fillings, the one-definition-per-name limitation, and the keying growth path.

A #[serde(flatten)] field typed as one of the item's own parameters used to contribute the placeholder object, so the merge multiplied nothing and the closed result rejected every payload the flattened value writes. It now renders the bound argument document — the same binding every other parameter position reads — so an object filling's members multiply into the base at the reference site, and a scalar filling is refused where the filling is finally known, in the merge's own branch-naming words. Non-parameter flatten sources are byte-identical.