### PR TITLE
Consume the values the type-level serde walk has no use for

### DIFF
--- a/src/features/serde.rs
+++ b/src/features/serde.rs
@@ -134,8 +134,8 @@ pub fn parse_serde_key_omission(attrs: &[Attribute]) -> SerdeKeyOmission {
 /// Consumes the value of a `key = value` the walk had no use for.
 ///
 /// An unread value ends the walk on the comma that follows it, taking every attribute written
-/// after it along — so which attributes a field is read by would otherwise depend on the order
-/// someone happened to write them in.
+/// after it along — so which attributes a declaration is read by would otherwise depend on the
+/// order someone happened to write them in.
 fn consume_unread_value(nested: &ParseNestedMeta<'_>) -> syn::Result<()> {
     if nested.input.peek(Token![=]) {
         nested.value()?.parse::<syn::Expr>()?;
@@ -217,6 +217,7 @@ pub fn parse_serde_type_attributes(attrs: &[Attribute]) -> SerdeTypeMeta {
                 } else {
                     // Ignore other serde attributes.
                 }
+                consume_unread_value(&nested)?;
                 Ok(())
             })
             .unwrap_or_else(|e| {

--- a/src/features/serde/tests.rs
+++ b/src/features/serde/tests.rs
@@ -220,3 +220,96 @@ fn test_attributes_after_an_unread_value_are_still_read() {
         "rename is written last of all"
     );
 }
+
+/// The type walk carries the same obligation as the field walk, and a heavier consequence: a tag
+/// left unread describes a discriminated union as something else on every surface at once, while
+/// serde goes on writing the tag.
+#[test]
+fn test_type_attributes_after_an_unread_value_are_still_read() {
+    let item: syn::ItemEnum = syn::parse_quote! {
+        #[serde(expecting = "an action", tag = "kind", content = "payload", rename_all = "camelCase")]
+        enum E {
+            FirstOne(String),
+        }
+    };
+    let meta = parse_serde_type_attributes(&item.attrs);
+    assert_eq!(
+        meta.tag.as_deref(),
+        Some("kind"),
+        "tag is written after an unread value"
+    );
+    assert_eq!(meta.content.as_deref(), Some("payload"));
+    assert_eq!(meta.rename_all.as_deref(), Some("camelCase"));
+}
+
+#[test]
+fn test_untagged_after_an_unread_value_is_still_read() {
+    let item: syn::ItemEnum = syn::parse_quote! {
+        #[serde(bound = "T: Clone", untagged)]
+        enum E<T> {
+            FirstOne(T),
+        }
+    };
+    assert!(parse_serde_type_attributes(&item.attrs).untagged);
+}
+
+/// Every value-carrying key the type walk ignores has to be survivable, not only the one that was
+/// measured — otherwise which of them a type may be written with is a matter of luck.
+#[test]
+fn test_every_ignored_value_carrying_type_key_is_survived() {
+    let expecting: syn::ItemEnum = syn::parse_quote! {
+        #[serde(expecting = "an action", tag = "kind")]
+        enum E { FirstOne(String) }
+    };
+    let bound: syn::ItemEnum = syn::parse_quote! {
+        #[serde(bound = "T: Clone", tag = "kind")]
+        enum E<T> { FirstOne(T) }
+    };
+    let serde_crate: syn::ItemEnum = syn::parse_quote! {
+        #[serde(crate = "serde", tag = "kind")]
+        enum E { FirstOne(String) }
+    };
+    let from: syn::ItemEnum = syn::parse_quote! {
+        #[serde(from = "Other", tag = "kind")]
+        enum E { FirstOne(String) }
+    };
+    let try_from: syn::ItemEnum = syn::parse_quote! {
+        #[serde(try_from = "Other", tag = "kind")]
+        enum E { FirstOne(String) }
+    };
+    let into: syn::ItemEnum = syn::parse_quote! {
+        #[serde(into = "Other", tag = "kind")]
+        enum E { FirstOne(String) }
+    };
+    for (key, item) in [
+        ("expecting", &expecting),
+        ("bound", &bound),
+        ("crate", &serde_crate),
+        ("from", &from),
+        ("try_from", &try_from),
+        ("into", &into),
+    ] {
+        assert_eq!(
+            parse_serde_type_attributes(&item.attrs).tag.as_deref(),
+            Some("kind"),
+            "tag written after `{key} = ...` should still be read"
+        );
+    }
+}
+
+/// A list with nothing to step over is read exactly as it was, key for key.
+#[test]
+fn test_type_attributes_without_unread_values_are_unchanged() {
+    let item: syn::ItemEnum = syn::parse_quote! {
+        #[serde(tag = "type", content = "data", rename_all = "camelCase")]
+        enum E {
+            FirstOne(String),
+        }
+    };
+    let meta = parse_serde_type_attributes(&item.attrs);
+    assert_eq!(meta.tag.as_deref(), Some("type"));
+    assert_eq!(meta.content.as_deref(), Some("data"));
+    assert_eq!(meta.rename_all.as_deref(), Some("camelCase"));
+    assert!(!meta.untagged);
+    assert!(meta.cfg_attr_rejection.is_none());
+}

--- a/tests/enum_tests/tests.rs
+++ b/tests/enum_tests/tests.rs
@@ -21,6 +21,37 @@ use serde_json::Value;
 ))]
 use tixschema::model_schema;
 
+// A tagged enum whose tag is written after a serde key this crate has no use for. Reaching the tag
+// at all means consuming that key's value: left on the parse stream it ends the attribute walk on
+// the comma that follows, and the surfaces then describe a wire serde is not writing.
+#[cfg(all(
+    test,
+    feature = "serde",
+    any(feature = "typescript", feature = "jsonschema", feature = "zod")
+))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(expecting = "an action", tag = "kind", rename_all = "camelCase")]
+enum ActionTaggedAfterIgnoredKey {
+    Generate { value: String },
+    Upload { value: String },
+}
+
+// The same declaration with nothing for the walk to step over, so the two renderings can be held
+// against each other: an attribute the walk ignores may not change a byte of what is generated.
+#[cfg(all(
+    test,
+    feature = "serde",
+    any(feature = "typescript", feature = "jsonschema", feature = "zod")
+))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+enum ActionTaggedWithNothingIgnored {
+    Generate { value: String },
+    Upload { value: String },
+}
+
 // Test single-value enum used as a field in a discriminated union.
 #[cfg(all(test, any(feature = "typescript", feature = "zod", feature = "serde")))]
 #[model_schema()]
@@ -329,6 +360,65 @@ fn test_discriminated_union_ts_definition() {
     // Check Zod discriminated union - now in separate method
     let zod_schema = PaymentMethod::zod_schema();
     assert!(zod_schema.contains("z.discriminatedUnion(\"type\""));
+}
+
+/// The tag is written after a key this crate ignores, so it is reached only if that key's value is
+/// consumed. Each surface has to describe the discriminated wire serde writes, and has to describe
+/// it exactly as it does for the same declaration with nothing to ignore.
+#[test]
+#[cfg(all(feature = "typescript", feature = "serde"))]
+fn test_tag_written_after_an_ignored_key_reaches_the_ts_definition() {
+    let ts = ActionTaggedAfterIgnoredKey::ts_definition();
+    assert!(
+        ts.contains("kind: \"generate\"") && ts.contains("kind: \"upload\""),
+        "TS definition should carry the discriminant. Got:\n{ts}"
+    );
+    assert_eq!(
+        ts.replace("ActionTaggedAfterIgnoredKey", "Action"),
+        ActionTaggedWithNothingIgnored::ts_definition()
+            .replace("ActionTaggedWithNothingIgnored", "Action"),
+        "the ignored key may not change a byte of the TypeScript"
+    );
+}
+
+#[test]
+#[cfg(all(feature = "serde", feature = "zod"))]
+fn test_tag_written_after_an_ignored_key_reaches_the_zod_schema() {
+    let zod = ActionTaggedAfterIgnoredKey::zod_schema();
+    assert!(
+        zod.contains("z.discriminatedUnion(\"kind\""),
+        "Zod schema should be a discriminated union. Got:\n{zod}"
+    );
+    assert_eq!(
+        zod.replace("ActionTaggedAfterIgnoredKey", "Action"),
+        ActionTaggedWithNothingIgnored::zod_schema()
+            .replace("ActionTaggedWithNothingIgnored", "Action"),
+        "the ignored key may not change a byte of the Zod schema"
+    );
+}
+
+#[test]
+#[cfg(all(feature = "jsonschema", feature = "serde"))]
+fn test_tag_written_after_an_ignored_key_reaches_the_json_schema() {
+    let schema = ActionTaggedAfterIgnoredKey::json_schema();
+    for variant in schema["oneOf"].as_array().unwrap() {
+        assert!(
+            variant["properties"]
+                .as_object()
+                .unwrap()
+                .contains_key("kind"),
+            "every variant should carry the discriminant. Got:\n{schema}"
+        );
+    }
+    assert_eq!(
+        schema
+            .to_string()
+            .replace("ActionTaggedAfterIgnoredKey", "Action"),
+        ActionTaggedWithNothingIgnored::json_schema()
+            .to_string()
+            .replace("ActionTaggedWithNothingIgnored", "Action"),
+        "the ignored key may not change a byte of the JSON schema"
+    );
 }
 
 #[test]


### PR DESCRIPTION
The type-level serde walk read tag, content, rename_all and untagged, but an unread key = value left its value on the parse stream, syn failed on the comma after it, the swallowed error ended the walk, and every attribute written afterward went unseen. Measured on serde(expecting = ..., tag = ...): the walk lost the tag and the enum rendered externally tagged on all three surfaces while serde wrote the internal tag — rename_all lost in the same list.

The fix is the one production line the field-side walk already landed: consume the unread value before accepting the key. Pins cover tag, content, and rename_all each read after an unknown key, all six documented value-carrying keys surviving, and byte-identity for lists without unknown keys asserted against a live sibling rather than a remembered baseline. The list-form residual the fix narrows to (an unread key(...) group still ends the walk) is recorded as follow-up work with its own measurements.