### PR TITLE
Bind the declared documents where the recursion state lives, so a filling can name a sibling item

### DIFF
--- a/src/features/jsonschema.rs
+++ b/src/features/jsonschema.rs
@@ -80,6 +80,14 @@ fn defs_pointer(def_name: &str) -> String {
 /// take the fillings positionally, in the order the item declares its parameters, and the two
 /// argumentless forms are those same two applied to what the item declared for itself. An item
 /// declaring none publishes the pair alone: there is no slot to fill, and nothing to pass.
+///
+/// Which of the argumentless forms evaluates that declared filling is not free to choose. A
+/// filling may name another item, and such a document is written by asking that item's own
+/// `within` — which reads the names in flight and the definitions being hoisted. Only
+/// `json_schema_within` holds those, so it is the one that evaluates the declared documents, and
+/// `json_schema` reaches its own filling the same way every other rooted document is reached: by
+/// running `within` against a fresh document. An item declaring parameters is rooted exactly as
+/// one declaring none is.
 pub fn json_schema_methods(
     def_name: &str,
     body: &proc_macro2::TokenStream,
@@ -104,24 +112,27 @@ pub fn json_schema_methods(
         };
     }
     let rooted = rooted_document(
+        &quote::quote! { Self::json_schema_within(&mut in_flight, &mut hoisted_defs) },
+    );
+    let rooted_at_arguments = rooted_document(
         &quote::quote! { Self::json_schema_within_with(&mut in_flight, &mut hoisted_defs, args) },
     );
-    let declared = declared_arguments(parameters);
+    let declared = declared_delegation(parameters);
     let bindings = argument_bindings(parameters);
     quote::quote! {
         pub fn json_schema() -> serde_json::Value {
-            Self::json_schema_with(#declared)
+            #rooted
         }
 
         pub fn json_schema_with(args: &[serde_json::Value]) -> serde_json::Value {
-            #rooted
+            #rooted_at_arguments
         }
 
         pub fn json_schema_within(
             in_flight: &mut Vec<&'static str>,
             hoisted_defs: &mut serde_json::Map<String, serde_json::Value>,
         ) -> serde_json::Value {
-            Self::json_schema_within_with(in_flight, hoisted_defs, #declared)
+            #declared
         }
 
         pub fn json_schema_within_with(
@@ -182,10 +193,23 @@ fn rooted_document(described: &proc_macro2::TokenStream) -> proc_macro2::TokenSt
     }
 }
 
-/// The filling an item declared for itself, as the argument list its argumentless forms pass on.
-fn declared_arguments(parameters: &[SchemaParameter]) -> proc_macro2::TokenStream {
+/// The filling an item declared for itself, handed on to the form that takes fillings — the body
+/// of the argumentless `within`, which is the one frame that owns the recursion state.
+///
+/// The documents are bound to a local before the delegation rather than written into the call. A
+/// filling naming another item describes through that item's own `within`, which reads the run's
+/// two values; a borrow taken for the delegation would still be live while the filling asked for
+/// its own, and neither value exists at all in a frame that does not receive them. Bound here,
+/// each filling runs to completion in turn and the borrows are handed on only once the array
+/// holds them all — the remedy a reference site carrying a nested generic argument already uses.
+///
+/// Declaration order, which is the order the fillings are read back off the argument list in.
+fn declared_delegation(parameters: &[SchemaParameter]) -> proc_macro2::TokenStream {
     let declared = parameters.iter().map(|parameter| &parameter.default);
-    quote::quote! { &[#(#declared),*] }
+    quote::quote! {
+        let arguments = [#(#declared),*];
+        Self::json_schema_within_with(in_flight, hoisted_defs, &arguments)
+    }
 }
 
 /// The locals the body reads its parameters through, bound off the argument list positionally.

--- a/tests/generic_types_tests/tests.rs
+++ b/tests/generic_types_tests/tests.rs
@@ -766,8 +766,8 @@ mod jsonschema {
     #[cfg(all(feature = "chrono", feature = "object_id"))]
     use super::StoredFolder;
     use super::{
-        CountedFolder, EcmDocument, KeyedByParameter, Pair, Tagged, WireFolder, Wrapper,
-        ecm_document_schema,
+        Branch, CountedFolder, EcmDocument, Envelope, Grove, KeyedByParameter, Pair, Perch, Roost,
+        Sealed, Tagged, WireFolder, Wrapper, ecm_document_schema,
     };
 
     /// A key every instantiation writes as a string leaves the value side describable, so the
@@ -968,6 +968,59 @@ mod jsonschema {
         );
         assert_eq!(
             properties["nested"]["properties"]["held"]["properties"]["value"],
+            serde_json::json!({ "type": "string" })
+        );
+    }
+
+    /// A filling naming another item is not a literal document but a request made of that item,
+    /// and only the frame carrying the run's two values can make it. Made there, the standalone
+    /// document holds at the parameter position exactly what the named item publishes — the same
+    /// document a reference site supplying that type as an argument would have embedded.
+    #[test]
+    fn a_filling_naming_another_item_embeds_the_document_that_item_publishes() {
+        let schema = Sealed::<Envelope>::json_schema();
+        assert_eq!(schema["properties"]["body"], Envelope::json_schema());
+        assert_eq!(
+            schema["properties"]["seal"],
+            serde_json::json!({ "type": "string" })
+        );
+    }
+
+    /// A name is one name however it was reached. Reached once as a declared filling and once as a
+    /// plain field, it is still the single definition the root carries, and both arrivals are
+    /// pointers into it rather than two copies of a body.
+    #[test]
+    fn a_name_reached_as_a_filling_and_as_a_field_is_defined_once() {
+        let schema = Grove::<Branch>::json_schema();
+        let pointer = serde_json::json!({ "$ref": "#/$defs/Branch" });
+        assert_eq!(schema["properties"]["filled"], pointer);
+        assert_eq!(schema["properties"]["named"], pointer);
+
+        let defs = schema["$defs"].as_object().unwrap().clone();
+        assert_eq!(defs.len(), 1, "Got: {defs:?}");
+        assert_eq!(
+            defs["Branch"]["properties"]["children"],
+            serde_json::json!({ "type": "array", "items": pointer })
+        );
+    }
+
+    /// A cycle closing through a declared filling is the cycle every other edge closes: the name is
+    /// recognized while its own description is still running, so the filling describes as the
+    /// pointer and the frame that put the name in flight hoists the body that pointer resolves
+    /// against.
+    #[test]
+    fn a_cycle_closing_through_a_declared_filling_defers_the_same_way() {
+        let schema = Roost::<Perch>::json_schema();
+        assert_eq!(
+            schema["properties"]["host"],
+            serde_json::json!({ "$ref": "#/$defs/Perch" })
+        );
+        assert_eq!(
+            schema["$defs"]["Perch"]["properties"]["roosts"]["items"]["properties"]["host"],
+            serde_json::json!({ "$ref": "#/$defs/Perch" })
+        );
+        assert_eq!(
+            schema["$defs"]["Perch"]["properties"]["tag"],
             serde_json::json!({ "type": "string" })
         );
     }
@@ -1281,6 +1334,58 @@ pub struct MixedArguments {
 pub struct Referrer {
     pub boxed: Boxed<u32>,
     pub tagged: Tagged<String>,
+}
+
+/// A declared filling that names another item rather than a primitive. Such a filling is not a
+/// literal document: it is written by asking the named item for its own, which reads the names in
+/// flight and the definitions being hoisted — so which frame the argumentless forms evaluate the
+/// filling in is the whole of what makes this fixture expand. Read by the JSON surface alone,
+/// which is the only one that fills a parameter with a document.
+#[cfg(feature = "jsonschema")]
+#[model_schema(default_types(BodyType = Envelope))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Sealed<BodyType> {
+    pub body: BodyType,
+    pub seal: String,
+}
+
+/// A self-referential item: what puts a name in `$defs` at all.
+#[cfg(feature = "jsonschema")]
+#[model_schema()]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Branch {
+    pub children: Vec<Self>,
+    pub name: String,
+}
+
+/// The same name reached twice over, once as a declared filling and once as a plain field — the two
+/// arrivals a single hoisted definition has to answer for both of.
+#[cfg(feature = "jsonschema")]
+#[model_schema(default_types(BranchType = Branch))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Grove<BranchType> {
+    pub filled: BranchType,
+    pub named: Branch,
+}
+
+/// A cycle that closes through a declared filling: the item the filling names holds the generic
+/// item back, reaching it without arguments — which is writable only because the parameter carries
+/// a Rust-level default too. That is the one shape reaching this cycle. A cycle running through two
+/// declared fillings is a cycle in the parameter defaults themselves, which rustc refuses while
+/// computing them, before the attribute is read at all.
+#[cfg(feature = "jsonschema")]
+#[model_schema(default_types(HostType = Perch))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Roost<HostType = Perch> {
+    pub host: HostType,
+}
+
+#[cfg(feature = "jsonschema")]
+#[model_schema()]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Perch {
+    pub roosts: Vec<Roost>,
+    pub tag: String,
 }
 
 /// The same two, named from a field that forwards the referrer's own parameter into each. Read by


### PR DESCRIPTION
A default_types filling naming another model_schema item did not compile: the declared filling renders as a sibling call reading the in-flight recursion state, and both argumentless forms hosted it where that state was absent or already borrowed — two E0425s in json_schema and an E0499 in json_schema_within, the compiler's own help naming the remedy.

The argumentless json_schema is now the rooted wrapper over json_schema_within, the shape a non-generic item already had, so it never hosts the declared expressions; json_schema_within binds the declared documents to a local array first — each sibling filling's call runs to completion there, one at a time — and hands both borrows on only once the array holds them all, the same bind-before-the-call ordering the reference-site seam already records. A sibling reached both as a filling and as a plain field still hoists one definition with both arrivals pointing into it; a cycle closing through a declared filling defers exactly as any other edge; a mutually recursive pair of declared defaults is refused by rustc itself before the attribute is read, captured rather than assumed. The flattened-parameter merge now pins its declared-default half too — an object-writing sibling named as the default multiplies its members into the standalone document — closing the criterion that was uncompilable until both landings met.