### PR TITLE
Close the generic story: recursion composes, the unrenderable shapes refuse, and whole types pin end to end

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,6 +228,7 @@ pub struct BadConfig {
 - `NaiveTime` → `string` (Zod `z.iso.time()` wrapped in an inline preprocessor that also accepts millis-since-start-of-day)
 - `#[serde(flatten)]` field → TypeScript intersection (`A & B`), Zod `.and(...)`
 - `#[serde(untagged)]` enum → TypeScript union (`A | B`), Zod `z.union([...])`, JSON Schema `anyOf`
+- Type parameter → TypeScript parameter (`X<IdType>`), Zod `X$SchemaFactory(idType)` (memoized, one cache level per parameter), JSON Schema the document of whatever fills it — `default_types(...)` where the type stands alone, the reference site's arguments where a field embeds it. A lifetime is dropped on every surface, a borrowed value writing what its owned form writes; a const renders as an array length only, and is refused where it is handed to a written type as an argument
 
 ### 5. Zod v4 Requirements
 
@@ -389,6 +390,22 @@ every generated module carries once above its per-type definitions. It holds the
 anywhere in the output: a cache's value type depends on its key type, which TypeScript can declare
 but cannot construct.
 
+A generic type may reach itself, directly or through a second type reaching back. JSON Schema
+hoists it into `$defs` once and points a `$ref` at that definition; TypeScript writes the name
+inside itself with its arguments; Zod calls the factory again with the argument the outer call was
+handed, the memo cache being what ends the recursion — the schema is cached before the recursive
+call is made. Which of the item's two bindings a self-reference names is read off the store
+`record_zod_factory` writes, and that is written at `exec_model_schema` ahead of every shape rather
+than where the binding is finally spelled: the fields are rendered before then, so an answer stored
+on the item's own registry entry would be read before the item had put one there.
+
+`write_field_type_and_schema` defers a member whose type reaches the item being defined, and one
+that reaches a type declared *below* it — `reaches_a_type_declared_later`. The second is what ends
+a cycle spanning two types: every cycle contains at least one reference pointing forward, since
+declaration positions cannot strictly decrease all the way round one, and what is left once those
+are deferred cannot cycle. The deferral is a getter rather than `z.lazy`, which at an operand
+position collapses the factory's inferred return type to `any`.
+
 ### Declaring a Default Type per Parameter
 
 JSON Schema has no type parameters, so a generic item's document is built from one concrete
@@ -406,7 +423,20 @@ them is split off. It refuses in both directions:
 - a type parameter with no entry — refused only under `#[cfg(feature = "jsonschema")]`, spanned on
   the parameter, because nothing else reads the default;
 - `default_types` on an item with no type parameter, and an empty `default_types()`, both being a
-  declaration with nothing to declare.
+  declaration with nothing to declare;
+- an entry filled at a type the field-definition dispatch has no arm for — refused only under
+  `#[cfg(feature = "jsonschema")]`, spanned on the filling. That dispatch takes a name it does not
+  recognise for another `#[model_schema]` item, which is right for a sibling declared below and
+  gibberish for `char`: the emission names a `char_schema` module nothing publishes. Tokens cannot
+  separate the two, so `is_undescribable_primitive` refuses only what provably cannot become a
+  sibling — the primitive names the language reserves that the dispatch answers for nowhere
+  (`char`, `i128`, `u128`, `f16`, `f128`).
+
+A const parameter earns its own refusal, from `const_parameter_argument_errors` at the same seam
+and gated on `typescript`/`jsonschema`: a const handed to a written type as an *argument* stands
+where a type is read, so the JSON side would call into a module named after it and the TypeScript
+side would write a name its declaration binds nothing for. A const written as an array length is
+untouched — that is the one position it renders in, as an unbounded array.
 
 There is no fallback filling. A guessed one produces a document that silently rejects valid
 payloads, which is what the declaration exists to prevent.

--- a/README.md
+++ b/README.md
@@ -863,6 +863,36 @@ EcmDocument$SchemaFactory(z.string(), z.number()) === wireDocument;  // false --
 
 A generic type that also flattens keeps the deferred read of its base, so declaration order stays irrelevant: `.and(z.lazy(() => Envelope$Schema))` composes inside the factory unchanged.
 
+#### A generic type may reach itself
+
+A generic type that holds itself -- directly, or through a second type that holds it back -- is described on every surface. JSON Schema hoists it into `$defs` once and points a `$ref` back at that one definition, which stands because every reference around the cycle carries the same filling. TypeScript writes the name inside itself, arguments and all. Zod calls the factory again with the argument the outer call was handed, and the memo cache is what makes that terminate: the schema is in the cache before the recursive call is made, so it comes back rather than being rebuilt.
+
+```rust
+#[model_schema(default_types(IdType = String))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Node<IdType> {
+    pub children: Vec<Self>,
+    pub id: IdType,
+}
+```
+
+```typescript
+export type Node<IdType> = {
+  children: Array<Node<IdType>>;
+  id: IdType;
+};
+
+const buildNode$Schema = <IdType extends ZodType>(
+  idType: IdType,
+) =>
+  z.strictObject({
+  get children() { return z.array(Node$SchemaFactory(idType)); },
+  id: idType,
+});
+```
+
+The member is written as a getter so that the call is made after the factory has reached its cache rather than while its object is still being built. Where a cycle spans two types, the reference the getter is written on is the one pointing *forward* -- at a type declared below -- because that is the reference no cycle can be built without: if every reference in a cycle named something already declared, declaration positions would have to decrease all the way round. Deferring those leaves nothing that can cycle, and every reference pointing back at a type already declared is written as it stands.
+
 #### Declaring the default type
 
 JSON Schema has no type parameters. A generic type's document has to be built from one concrete filling, and nothing in the declaration says which — so `default_types` says it, one `Parameter = Type` pair per type parameter:
@@ -878,6 +908,8 @@ pub struct EcmDocument<IdType, DateType> {
 ```
 
 The pairs may be written in any order, and the argument sits beside every other item-level argument -- `name`, `pattern`, `minLength`, `maxLength`, `no_display` -- changing none of them. A lifetime and a const parameter name no type, so neither takes an entry.
+
+A lifetime is dropped from every emitted surface, neither TypeScript nor JSON Schema having one and a borrowed value writing exactly what its owned form writes. A const renders in one position only -- an array length, which [describes as an unbounded array](#collections-and-maps) -- so a const handed to a written type as an *argument* is refused, spanned on the argument: an argument list is read as a list of types, and the const standing in one would have the JSON document call into a module named after it and the TypeScript declaration write a name it binds nothing for. A const no written type carries is untouched.
 
 The declared filling is what `json_schema()` writes the document at. Beside it, a generic type's schema module publishes `json_schema_with`, which takes one document per parameter, positionally, in the order the item declares them:
 
@@ -900,6 +932,7 @@ The declaration is read in both directions, and each refusal points at what earn
 | An entry naming something the item does not declare | Refused in **every** feature configuration, spanned on the entry. A misspelled parameter fills nothing, and the parameter it was meant for would be left with no default at all. |
 | A type parameter with no entry | Refused only where `jsonschema` is on, spanned on the parameter. Nothing else reads the default, so the same item compiles untouched without that feature. |
 | `default_types` on an item declaring no type parameter | Refused, there being nothing for a filling to fill. |
+| An entry filled at a type the macro cannot describe -- `char`, `i128`, `u128`, `f16`, `f128` | Refused only where `jsonschema` is on, spanned on the filling. A name the type dispatch has no arm for is read as another `#[model_schema]` item, which is right for a sibling declared below and gibberish for a primitive: the emission would name a `char_schema` module nothing publishes. Only the primitive names the language reserves are refused, so a forward-referenced sibling keeps compiling. |
 
 There is deliberately no fallback. Guessing a filling produces a document that silently rejects valid payloads, which is the failure the declaration exists to prevent.
 

--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -12,7 +12,9 @@ use crate::features::model_schema_prop::ModelSchemaPropMeta;
 use crate::utils::{lookup_alias_info, safe_type_name, written_type};
 
 #[cfg(feature = "zod")]
-use crate::utils::{ZodUnionMember, escape_js_regex_literal, zod_factory_argument};
+use crate::utils::{
+    ZodUnionMember, escape_js_regex_literal, publishes_zod_factory, zod_factory_argument,
+};
 
 #[cfg(all(feature = "serde", any(feature = "typescript", feature = "zod")))]
 use crate::utils::FlattenVariant;
@@ -785,33 +787,113 @@ impl FieldDef {
         }
     }
 
-    /// Rewrites any `Self` type reference to the concrete enclosing type name.
+    /// Whether this field reaches a generic type the registry does not hold yet — a
+    /// `#[model_schema]` item declared below the one being expanded.
     ///
-    /// A recursive type may refer to itself with the `Self` keyword
-    /// (e.g. `Array(Vec<Self>)`). The macro detects recursion and renders
-    /// references by comparing type names, so `Self` must be resolved to the
-    /// actual type name before that logic runs; afterwards `Vec<Self>` is
-    /// treated exactly like `Vec<EnclosingType>`.
+    /// Such a reference is written as a call to the factory that item goes on to publish, which is
+    /// the only binding that can take the arguments written here. Spliced in as it stands, the call
+    /// runs while the containing builder's own body is being evaluated — and where the item below
+    /// points back at this one, that call re-enters this factory before it has reached its cache,
+    /// and the pair recurses until the stack ends.
     ///
-    /// Recurses through `SiblingType` generics, `Map` keys/values, and `Tuple`
-    /// elements.
-    pub fn resolve_self_references(&mut self, type_name: &str) {
+    /// Deferring exactly these references is enough to end that, and it needs no cycle to be found.
+    /// Every cycle contains at least one of them: if every reference in a cycle named something
+    /// already registered, declaration positions would strictly decrease all the way round, which
+    /// no cycle can do. What is left once they are deferred is a graph whose every remaining
+    /// reference names something declared earlier, so it cannot cycle and every chain of eager
+    /// calls ends.
+    ///
+    /// The same partial-answer regime the export name and the map-key registry already run under:
+    /// a name the registry does not hold is a name expanded later, and one it does hold was
+    /// expanded before.
+    #[cfg(feature = "zod")]
+    pub fn reaches_a_type_declared_later(&self) -> bool {
+        match &self.field_type {
+            FieldDefType::SiblingType(name, generics) => {
+                (!generics.is_empty()
+                    && !is_sequence_wrapper(name)
+                    && lookup_alias_info(name).is_none())
+                    || generics.iter().any(Self::reaches_a_type_declared_later)
+            }
+            FieldDefType::Map(key, value) => {
+                key.reaches_a_type_declared_later() || value.reaches_a_type_declared_later()
+            }
+            FieldDefType::Tuple(elements) => {
+                elements.iter().any(Self::reaches_a_type_declared_later)
+            }
+            FieldDefType::TypeParam(_)
+            | FieldDefType::Unknown
+            | FieldDefType::StringLiteral(_)
+            | FieldDefType::Boolean
+            | FieldDefType::String
+            | FieldDefType::U8
+            | FieldDefType::U16
+            | FieldDefType::U32
+            | FieldDefType::U64
+            | FieldDefType::I8
+            | FieldDefType::I16
+            | FieldDefType::I32
+            | FieldDefType::I64
+            | FieldDefType::Usize
+            | FieldDefType::Isize
+            | FieldDefType::F32
+            | FieldDefType::F64 => false,
+            #[cfg(feature = "object_id")]
+            FieldDefType::ObjectId => false,
+            #[cfg(feature = "chrono")]
+            FieldDefType::NaiveDate
+            | FieldDefType::NaiveTime
+            | FieldDefType::NaiveDateTime
+            | FieldDefType::DateTime => false,
+        }
+    }
+
+    /// Rewrites any `Self` type reference to the concrete enclosing type name, at the parameters
+    /// the enclosing item declares.
+    ///
+    /// A recursive type may refer to itself with the `Self` keyword (e.g. `Array(Vec<Self>)`). The
+    /// macro detects recursion and renders references by comparing type names, so `Self` must be
+    /// resolved to the actual type name before that logic runs; afterwards `Vec<Self>` is treated
+    /// exactly like `Vec<EnclosingType>`.
+    ///
+    /// `Self` on a *generic* item names that item at its own parameters — it is the one spelling
+    /// whose arguments are implied rather than written — so the parameters are restored here, where
+    /// the name is. Left off, the reference reads as a name with no arguments at all: the Zod
+    /// surface calls the item's factory with none of the arguments it requires, and the TypeScript
+    /// one writes a bare name beside a declaration that binds parameters. `Self` cannot be written
+    /// with arguments of its own, so there is nothing here to overwrite.
+    ///
+    /// Recurses through `SiblingType` generics, `Map` keys/values, and `Tuple` elements.
+    pub fn resolve_self_references(&mut self, type_name: &str, parameters: &[String]) {
         match &mut self.field_type {
             FieldDefType::SiblingType(name, generics) => {
                 if name == "Self" {
                     type_name.clone_into(name);
+                    generics.extend(parameters.iter().map(|parameter| Self {
+                        name: parameter.clone(),
+                        field_type: FieldDefType::TypeParam(parameter.clone()),
+                        array_depth: 0,
+                        array_lengths: Vec::new(),
+                        docs: String::new(),
+                        model_schema_prop_meta: None,
+                        nullable_levels: Vec::new(),
+                        absent_from_wire: false,
+                        omits_value: false,
+                        #[cfg(feature = "jsonschema")]
+                        type_span: Span::call_site(),
+                    }));
                 }
                 for generic in generics.iter_mut() {
-                    generic.resolve_self_references(type_name);
+                    generic.resolve_self_references(type_name, parameters);
                 }
             }
             FieldDefType::Map(key, value) => {
-                key.resolve_self_references(type_name);
-                value.resolve_self_references(type_name);
+                key.resolve_self_references(type_name, parameters);
+                value.resolve_self_references(type_name, parameters);
             }
             FieldDefType::Tuple(elements) => {
                 for element in elements.iter_mut() {
-                    element.resolve_self_references(type_name);
+                    element.resolve_self_references(type_name, parameters);
                 }
             }
             // Leaf types cannot contain nested references.
@@ -1082,7 +1164,7 @@ impl FieldDef {
                     // type declares parameters, and the one schema it has where it declares none.
                     // Read off the registry rather than off the arguments written here, because a
                     // name carrying arguments says nothing about which of the two it published.
-                    if info.publishes_zod_factory {
+                    if publishes_zod_factory(name) {
                         zod_factory_call(&info.export_name, lst)
                     } else {
                         format!("{}$Schema", info.export_name)
@@ -1778,6 +1860,27 @@ fn get_field_def_type_or_sibling(t_name: &str) -> FieldDefType {
         }
         type_name => FieldDefType::SiblingType(type_name.to_owned(), vec![]),
     }
+}
+
+/// Whether a name is one the language reserves for a primitive type that
+/// [`get_field_def_type_or_sibling`] has no arm for.
+///
+/// The dispatch above is total by construction: a name it does not recognise is taken for a sibling
+/// — another `model_schema` item, named before or after this one — and rendered as a reference to
+/// the module that item publishes. That is the right reading of `Foo`, which may well be declared
+/// below, and it is gibberish for `char`: no module named `char_schema` will ever exist, so the
+/// reference resolves to nothing and the author reads an `E0433` about a module they never wrote.
+///
+/// The two cannot be told apart by tokens, so only what is *provably* not a sibling is named here:
+/// the primitive names the language reserves, minus the ones the dispatch does answer for. A
+/// caller refusing on this answer refuses exactly the spellings that cannot become siblings later.
+///
+/// `f16` and `f128` are listed with `char`, `i128` and `u128` although the language does not yet
+/// stabilise them: they are reserved primitive names either way, and a build that gains them
+/// should reach a refusal naming the limitation rather than the phantom module.
+#[cfg(feature = "jsonschema")]
+pub fn is_undescribable_primitive(name: &str) -> bool {
+    matches!(name, "char" | "i128" | "u128" | "f16" | "f128")
 }
 
 /// Parses serde attributes from struct/enum attributes (requires "serde" feature).

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -25,6 +25,9 @@ use crate::{
     utils::{get_field_docs, get_variant_docs, strip_examples_from_docs},
 };
 
+#[cfg(feature = "jsonschema")]
+use crate::field_type::is_undescribable_primitive;
+
 #[cfg(feature = "typescript")]
 use crate::utils::ts_generic_params;
 use crate::utils::type_parameters_in_scope;
@@ -1072,6 +1075,21 @@ pub fn exec_model_schema(args: TokenStream, input: TokenStream) -> TokenStream {
     ) {
         return output;
     }
+    // A const handed to a written type as an argument stands where a type belongs, and no surface
+    // that renders an argument list can spell it — refused here, beside the example refusal, and
+    // ahead of every shape.
+    if let Some(output) = guard_failure_output(
+        &item,
+        item_schema_ident(&item),
+        &const_parameter_argument_errors(&item),
+    ) {
+        return output;
+    }
+    // Which Zod binding this item publishes turns on whether it declares type parameters, and a
+    // field written at the item's own name reads that answer back the way any other reference
+    // does. Recorded here, ahead of every shape, because a self-reference is rendered while the
+    // item's own expansion is still running and would otherwise read an answer nobody had given.
+    record_own_zod_binding(&item);
     // Whether a filling satisfies the bounds its parameter declares is a question about trait
     // impls, which a proc macro cannot answer — so it is asked here, of the compiler, and read off
     // the item before the shapes take it.
@@ -2085,6 +2103,33 @@ const fn item_schema_ident(item: &Item) -> Option<&syn::Ident> {
     }
 }
 
+/// Records which of the two Zod bindings an item publishes, ahead of the shape it is dispatched to.
+///
+/// The decision is whether the item declares type parameters: one publishes a factory, taking one
+/// argument per parameter, and one that declares none publishes the single schema it has. Taken
+/// here rather than where the binding is finally spelled — which is after the item's own fields
+/// have been rendered — because a field written at the item's own name is a reference like any
+/// other and reads the answer off the store while those fields are being rendered.
+///
+/// An item shape this attribute does not expand declares nothing and publishes nothing.
+#[cfg(feature = "zod")]
+fn record_own_zod_binding(item: &Item) {
+    let Some(generics) = item_generics(item) else {
+        return;
+    };
+    let Some(name) = item_schema_ident(item) else {
+        return;
+    };
+    record_zod_factory(
+        &name.to_string(),
+        !type_parameters_in_scope(generics).is_empty(),
+    );
+}
+
+/// Nothing, in a build that publishes no Zod binding at all.
+#[cfg(not(feature = "zod"))]
+const fn record_own_zod_binding(_item: &Item) {}
+
 /// The parameters an item declares — the three shapes `model_schema` expands each bind their own;
 /// anything else binds none this expansion can read.
 const fn item_generics(item: &Item) -> Option<&syn::Generics> {
@@ -2133,6 +2178,8 @@ fn default_types_guard_errors(
     let rejections = entries_naming_no_parameter(args, &declared);
     #[cfg(feature = "jsonschema")]
     rejections.extend(parameters_left_without_a_default(args, &declared));
+    #[cfg(feature = "jsonschema")]
+    rejections.extend(fillings_no_document_can_be_built_from(args));
 
     rejections
         .iter()
@@ -2211,6 +2258,72 @@ fn missing_default_message(name: &syn::Ident, declared: &[&syn::Ident]) -> Strin
          because the `jsonschema` feature is enabled. Declare one for every parameter of this item, \
          each with the type its document should be generated from: \
          `#[model_schema(default_types({sample}))]`."
+    )
+}
+
+/// The refusal every `default_types` entry earns whose filling names a value no document can be
+/// built from, spanned on the filling as written.
+///
+/// A filling is rendered through the same dispatch a field's type is, and that dispatch takes a
+/// name it does not recognise for a sibling — another `model_schema` item, whose schema module the
+/// emission then names. For `Foo` that is right even when `Foo` is declared below. For `char` it is
+/// gibberish: the emission names `char_schema`, no such module is ever published, and the author
+/// reads an `E0433` about a module they never wrote plus two `E0425`s about bindings that belong to
+/// the generated body — three diagnostics, none of which mentions `char`.
+///
+/// The guard cannot separate the two by tokens, so it refuses only what is provably not a sibling:
+/// see [`is_undescribable_primitive`]. A forward-referenced sibling keeps compiling exactly as it
+/// does today.
+///
+/// Gated, on the same footing as the missing-entry direction: the filling is read to build a
+/// document and nowhere else, so a build that generates none is not short of anything. The same
+/// fixture compiles and passes under `serde,typescript,zod`.
+#[cfg(feature = "jsonschema")]
+fn fillings_no_document_can_be_built_from(args: &ModelSchemaArgs) -> Vec<syn::Error> {
+    args.default_types
+        .iter()
+        .filter_map(|(name, filling)| {
+            let written = bare_type_name(filling)?;
+            is_undescribable_primitive(&written).then(|| {
+                syn::Error::new_spanned(filling, undescribable_filling_message(name, &written))
+            })
+        })
+        .collect()
+}
+
+/// The name a type is written as when it is written as a bare name and nothing else — no
+/// qualifier, no path, no arguments — or `None` for every other spelling.
+///
+/// Only that shape can be checked against a list of reserved names: `some::path::char` names
+/// whatever that path resolves to, and a name carrying arguments is not a primitive at all.
+#[cfg(feature = "jsonschema")]
+fn bare_type_name(filling: &syn::Type) -> Option<String> {
+    let syn::Type::Path(type_path) = filling else {
+        return None;
+    };
+    if type_path.qself.is_some() {
+        return None;
+    }
+    let [segment] = type_path.path.segments.iter().collect::<Vec<_>>()[..] else {
+        return None;
+    };
+    matches!(segment.arguments, syn::PathArguments::None).then(|| segment.ident.to_string())
+}
+
+/// Why a filling the dispatch has no arm for is refused: what the filling is read for, what the
+/// emission would otherwise name, what the feature has to do with it, and the way out.
+#[cfg(feature = "jsonschema")]
+fn undescribable_filling_message(name: &syn::Ident, written: &str) -> String {
+    format!(
+        "`default_types` entry `{name}` is filled at `{written}`, which `#[model_schema]` cannot \
+         build a JSON-schema document from. The filling is what the parameter's document is \
+         generated from, and it is rendered through the same dispatch a field's type is — a \
+         dispatch that has no arm for `{written}` and so takes it for another `#[model_schema]` \
+         item, emitting a call into a `{written}_schema` module that nothing publishes. This is \
+         refused because the `jsonschema` feature is enabled, the document being the only thing \
+         the filling is read for. Fill the parameter at a type the macro describes — a primitive it \
+         maps, or a `#[model_schema]` item — or model `{written}` as a newtype over one that \
+         carries what the wire holds."
     )
 }
 
@@ -2556,6 +2669,197 @@ fn const_parameter_example_message(consts: &[&syn::Ident]) -> String {
          enabled, `zod` being the only surface that reads an example. Remove the ` ```rust example \
          ` block, or the const parameter, whichever this item can do without."
     )
+}
+
+/// The `compile_error!` tokens an item earns for handing one of its own const parameters to a
+/// generic type it writes, or none where no type written on it does that.
+///
+/// A const parameter reaches the emitted surfaces in two ways, and only one of them is renderable.
+/// As an array length — `[u8; N]` — it describes as an unbounded array, which README.md states
+/// outright as the reading of every length the expansion cannot read, alongside a `const` item and
+/// any computed expression. As an *argument* to another type it is renderable nowhere: the argument
+/// list of a written type is read as a list of types, so `ConstLeaf<N>` puts `N` where a type
+/// belongs and every surface takes it for one. The JSON side emits a call into an `n_schema` module
+/// nothing publishes; the TypeScript side writes `ConstLeaf<N>` into a declaration that binds no
+/// `N` and beside a `ConstLeaf` that binds no parameter, a const being dropped from the declaration
+/// it was written on. Neither is a document the author can act on, and neither names the const.
+///
+/// Answered at the one seam every expanded shape is dispatched from, beside the example refusal a
+/// const already earns, so a struct, an enum and an alias cannot come to answer differently.
+///
+/// Gated on the two surfaces that render the argument. Zod names the schema the *item* publishes
+/// and a const-declaring item publishes the one schema it has, so a build with neither of those two
+/// on renders this correctly and is owed nothing. An item whose const reaches no argument — a const
+/// no type is written around, which is what `PlainConst` and `Padded` carry — earns nothing in any
+/// build.
+#[cfg(any(feature = "typescript", feature = "jsonschema"))]
+fn const_parameter_argument_errors(item: &Item) -> Vec<proc_macro2::TokenStream> {
+    let Some(generics) = item_generics(item) else {
+        return Vec::new();
+    };
+    let consts: Vec<String> = generics
+        .params
+        .iter()
+        .filter_map(|param| match param {
+            syn::GenericParam::Const(const_param) => Some(const_param.ident.to_string()),
+            syn::GenericParam::Type(_) | syn::GenericParam::Lifetime(_) => None,
+        })
+        .collect();
+    if consts.is_empty() {
+        return Vec::new();
+    }
+    let mut found: Vec<syn::Ident> = Vec::new();
+    for written in item_written_types(item) {
+        collect_const_arguments(written, &consts, &mut found);
+    }
+    found
+        .iter()
+        .map(|argument| {
+            attr_guard_error(
+                &syn::Error::new_spanned(
+                    argument,
+                    const_parameter_argument_message(&argument.to_string()),
+                ),
+                &item_label(item),
+            )
+        })
+        .collect()
+}
+
+/// Every type an item writes out: a struct's field types, an enum's variant field types, an alias's
+/// target. The types whose spelling reaches a surface, which is where an argument is written.
+#[cfg(any(feature = "typescript", feature = "jsonschema"))]
+fn item_written_types(item: &Item) -> Vec<&syn::Type> {
+    if let Item::Struct(item_struct) = item {
+        item_struct.fields.iter().map(|field| &field.ty).collect()
+    } else if let Item::Enum(item_enum) = item {
+        item_enum
+            .variants
+            .iter()
+            .flat_map(|variant| variant.fields.iter().map(|field| &field.ty))
+            .collect()
+    } else if let Item::Type(item_type) = item {
+        vec![item_type.ty.as_ref()]
+    } else {
+        Vec::new()
+    }
+}
+
+/// Every place one of `consts` is handed to a written type as an argument, collected as the ident
+/// it was written at so the refusal points there.
+///
+/// An array length is walked *through* rather than read: `[ConstLeaf<N>; 4]` holds an argument and
+/// `[u8; N]` holds a length, and only the first is what this collects. A bare ident inside angle
+/// brackets can reach here as either a type or a const argument depending on what `syn` could
+/// decide from the tokens alone, so both spellings are read.
+#[cfg(any(feature = "typescript", feature = "jsonschema"))]
+fn collect_const_arguments(written: &syn::Type, consts: &[String], found: &mut Vec<syn::Ident>) {
+    match written {
+        syn::Type::Path(type_path) => {
+            for segment in &type_path.path.segments {
+                let syn::PathArguments::AngleBracketed(angled) = &segment.arguments else {
+                    continue;
+                };
+                for argument in &angled.args {
+                    match argument {
+                        syn::GenericArgument::Type(inner) => {
+                            if let Some(ident) = bare_ident(inner)
+                                && consts.contains(&ident.to_string())
+                            {
+                                found.push(ident);
+                            } else {
+                                collect_const_arguments(inner, consts, found);
+                            }
+                        }
+                        syn::GenericArgument::Const(syn::Expr::Path(path)) => {
+                            if let Some(ident) = path.path.get_ident()
+                                && consts.contains(&ident.to_string())
+                            {
+                                found.push(ident.clone());
+                            }
+                        }
+                        // A const written as anything but a bare name is an expression, not one of
+                        // the item's parameters standing alone; a lifetime and an associated
+                        // binding name no const at all.
+                        syn::GenericArgument::Const(_)
+                        | syn::GenericArgument::Lifetime(_)
+                        | syn::GenericArgument::AssocType(_)
+                        | syn::GenericArgument::AssocConst(_)
+                        | syn::GenericArgument::Constraint(_)
+                        | _ => {}
+                    }
+                }
+            }
+        }
+        syn::Type::Array(array) => collect_const_arguments(&array.elem, consts, found),
+        syn::Type::Slice(slice) => collect_const_arguments(&slice.elem, consts, found),
+        syn::Type::Reference(reference) => collect_const_arguments(&reference.elem, consts, found),
+        syn::Type::Paren(paren) => collect_const_arguments(&paren.elem, consts, found),
+        syn::Type::Group(group) => collect_const_arguments(&group.elem, consts, found),
+        syn::Type::Tuple(tuple) => {
+            for element in &tuple.elems {
+                collect_const_arguments(element, consts, found);
+            }
+        }
+        // None of these writes an argument list a const could stand in: a function pointer, an
+        // `impl Trait`, an inferred or never type, a trait object, a raw pointer, and the two
+        // spellings `syn` hands back unparsed.
+        syn::Type::FnPtr(_)
+        | syn::Type::ImplTrait(_)
+        | syn::Type::Infer(_)
+        | syn::Type::Macro(_)
+        | syn::Type::Never(_)
+        | syn::Type::Ptr(_)
+        | syn::Type::TraitObject(_)
+        | syn::Type::Verbatim(_)
+        | _ => {}
+    }
+}
+
+/// The ident a type is written as when it is written as a bare name and nothing else, or `None`.
+#[cfg(any(feature = "typescript", feature = "jsonschema"))]
+fn bare_ident(written: &syn::Type) -> Option<syn::Ident> {
+    let syn::Type::Path(type_path) = written else {
+        return None;
+    };
+    if type_path.qself.is_some() {
+        return None;
+    }
+    type_path.path.get_ident().cloned()
+}
+
+/// Why a const handed to a written type as an argument is refused: where the const does render,
+/// where this one stands instead, what each surface would emit, what the features have to do with
+/// it, and the way out.
+#[cfg(any(feature = "typescript", feature = "jsonschema"))]
+fn const_parameter_argument_message(name: &str) -> String {
+    let surfaces = if cfg!(feature = "typescript") && cfg!(feature = "jsonschema") {
+        "the `typescript` and `jsonschema` features are enabled, the two surfaces that render an \
+         argument list"
+    } else if cfg!(feature = "typescript") {
+        "the `typescript` feature is enabled, a surface that renders an argument list"
+    } else {
+        "the `jsonschema` feature is enabled, a surface that renders an argument list"
+    };
+    format!(
+        "`#[model_schema]` cannot render the const parameter `{name}` as a type argument. An \
+         argument list is read as a list of types — that is what every surface writes one from — so \
+         `{name}` standing in one is taken for a type, and no surface can spell it: the JSON \
+         document would call into a `{}_schema` module nothing publishes, and the TypeScript \
+         declaration would write `{name}` where nothing binds it, a const being dropped from the \
+         declaration it was written on. This is refused because {surfaces}. A const does render as \
+         an array length — `[T; {name}]`, which describes as an unbounded array — so hold the value \
+         that way, or fill the argument with a type.",
+        name.to_lowercase()
+    )
+}
+
+/// Nothing, in a build that renders no argument list: Zod names the schema the *item* published and
+/// a const-declaring item publishes the one schema it has, so the const never stands where a type
+/// is read.
+#[cfg(not(any(feature = "typescript", feature = "jsonschema")))]
+const fn const_parameter_argument_errors(_item: &Item) -> Vec<proc_macro2::TokenStream> {
+    Vec::new()
 }
 
 /// The `compile_error!` tokens for every `cfg_attr`-wrapped serde attribute an enum carries: on the
@@ -7377,7 +7681,7 @@ fn untagged_member_field_def(
         &prop_meta,
         serde_guard_errors,
     );
-    field_def.resolve_self_references(ctx.type_name);
+    field_def.resolve_self_references(ctx.type_name, ctx.type_parameters);
     apply_model_schema_prop_meta(&mut field_def, prop_meta, field_name);
     (field_def, member_guard_errors)
 }
@@ -9758,10 +10062,14 @@ fn write_field_type_and_schema(
     {
         let zod_type = fld.zod_type();
 
-        // Check if this field contains a recursive reference to self
-        let is_recursive = self_type_name.is_some_and(|name| fld.contains_type_reference(name));
+        // A reference back to the item being defined, and a reference forward to one declared
+        // below it, are the two a value cannot be read for while this object literal is being
+        // built — see `reaches_a_type_declared_later` for why deferring the second ends every
+        // cycle a set of generic types can form.
+        let defer = self_type_name.is_some_and(|name| fld.contains_type_reference(name))
+            || fld.reaches_a_type_declared_later();
 
-        if is_recursive {
+        if defer {
             // Use getter syntax to defer the reference
             format!("  get {}() {{ return {}; }},\n", fld.name, zod_type)
         } else {
@@ -10910,7 +11218,7 @@ fn process_field(
     // Resolve `Self` references to the concrete type name so recursive fields
     // (e.g. `Vec<Self>`) are treated exactly like `Vec<EnclosingType>`. Resolved before the guards
     // read the field so each one asks its question of the type the surfaces will render.
-    field_def.resolve_self_references(ctx.type_name);
+    field_def.resolve_self_references(ctx.type_name, ctx.type_parameters);
 
     // The field as the author spelled it, kept for the one guard that reads a written *name*: an
     // `as = Type` may name one of the item's own parameters, and the target it is compared against

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -4147,6 +4147,79 @@ fn a_default_types_refusal_is_spanned_on_what_earned_it() {
     }
 }
 
+/// A filling is rendered through the dispatch a field's type is, and that dispatch takes a name it
+/// has no arm for to be another `#[model_schema]` item — right for `Foo`, gibberish for `char`,
+/// which emitted a call into a `char_schema` module nothing publishes and left the author reading
+/// an `E0433` about a module they never wrote plus two `E0425`s about the generated body's own
+/// bindings. Refused at the entry instead, in words that name the type and the limitation.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_filling_no_document_can_be_built_from_is_refused_at_the_entry() {
+    for written in ["char", "i128", "u128", "f16", "f128"] {
+        let messages = default_types_messages(
+            "pub struct Probe<ValueType> { pub held: ValueType }",
+            &format!("default_types(ValueType = {written})"),
+        );
+        assert_eq!(messages.len(), 1, "for {written}: {messages:?}");
+        for needle in [
+            "compile_error",
+            written,
+            "ValueType",
+            &format!("{}_schema", written.to_lowercase()),
+            "`jsonschema` feature",
+            "type `Probe`",
+        ] {
+            assert!(
+                messages[0].contains(needle),
+                "{needle} missing for {written}: {}",
+                messages[0]
+            );
+        }
+    }
+}
+
+/// The refusal points at the filling as written — the token the author can change — rather than at
+/// the parameter it fills or the whole attribute.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn an_undescribable_filling_refusal_is_spanned_on_the_filling() {
+    let refusals = default_types_refusals(
+        "pub struct Probe<WideType, NarrowType> { pub wide: WideType, pub narrow: NarrowType }",
+        "default_types(WideType = String, NarrowType = char)",
+    );
+    assert_eq!(refusals.len(), 1, "got: {refusals:?}");
+    assert_eq!(refusals[0].span().source_text().as_deref(), Some("char"));
+}
+
+/// Only what is provably not a sibling is refused. A bare `Foo` is a legitimate forward reference
+/// to an item declared below, every primitive the dispatch has an arm for describes as it always
+/// did, and a name carrying arguments or a path qualifier is not a primitive at all.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_renderable_or_sibling_named_filling_is_left_alone() {
+    for written in [
+        "Foo",
+        "String",
+        "bool",
+        "u8",
+        "u64",
+        "i64",
+        "usize",
+        "isize",
+        "f32",
+        "f64",
+        "PathBuf",
+        "Vec<char>",
+        "some::path::char",
+    ] {
+        let messages = default_types_messages(
+            "pub struct Probe<ValueType> { pub held: ValueType }",
+            &format!("default_types(ValueType = {written})"),
+        );
+        assert!(messages.is_empty(), "for {written}: {messages:?}");
+    }
+}
+
 /// The JSON document is built from the declared default, so a parameter left without one is
 /// refused wherever that document is written — and the refusal says what the default is for, that
 /// the feature is what requires it, and the attribute to write for this item's own parameters.
@@ -4683,6 +4756,105 @@ fn a_const_declaring_alias_is_left_alone() {
     let source = format!("{EXAMPLE_DOC_BLOCK}pub type Probe<const WIDTH: usize> = [u8; WIDTH];");
     let messages = const_example_messages(&source);
     assert!(messages.is_empty(), "got: {messages:?}");
+}
+
+/// The `compile_error!` tokens `source` earns for handing one of its own consts to a written type.
+/// Parsed from text so the tokens carry file locations and each refusal's span can be read back as
+/// the source it points at.
+#[cfg(any(feature = "typescript", feature = "jsonschema"))]
+fn const_argument_refusals(source: &str) -> Vec<proc_macro2::TokenStream> {
+    super::const_parameter_argument_errors(&syn::parse_str(source).unwrap())
+}
+
+/// The refusals `source` earns, rendered.
+#[cfg(any(feature = "typescript", feature = "jsonschema"))]
+fn const_argument_messages(source: &str) -> Vec<String> {
+    const_argument_refusals(source)
+        .iter()
+        .map(ToString::to_string)
+        .collect()
+}
+
+/// An argument list is read as a list of types, so a const standing in one is taken for a type and
+/// no surface that renders the list can spell it — the JSON side names a module nothing publishes,
+/// the TypeScript side writes a name its declaration does not bind. Refused wherever a type is
+/// written, in every shape the attribute expands.
+#[cfg(any(feature = "typescript", feature = "jsonschema"))]
+#[test]
+fn a_const_handed_to_a_written_type_as_an_argument_is_refused() {
+    for (source, label) in [
+        (
+            "pub struct Probe<const WIDTH: usize> { pub held: Leaf<WIDTH> }",
+            "type `Probe`",
+        ),
+        (
+            "pub enum Probe<const WIDTH: usize> { Held { held: Leaf<WIDTH> } }",
+            "type `Probe`",
+        ),
+        (
+            "pub type Probe<const WIDTH: usize> = Leaf<WIDTH>;",
+            "type `Probe`",
+        ),
+    ] {
+        let messages = const_argument_messages(source);
+        assert_eq!(messages.len(), 1, "for {source}: {messages:?}");
+        for needle in ["compile_error", "WIDTH", "const parameter", label] {
+            assert!(
+                messages[0].contains(needle),
+                "{needle} missing for {source}: {}",
+                messages[0]
+            );
+        }
+    }
+}
+
+/// The refusal points at the argument as written, which is the one token the author can act on —
+/// not at the parameter's declaration, and not at the whole field.
+#[cfg(any(feature = "typescript", feature = "jsonschema"))]
+#[test]
+fn a_const_argument_refusal_is_spanned_on_the_argument() {
+    let refusals =
+        const_argument_refusals("pub struct Probe<const WIDTH: usize> { pub held: Leaf<WIDTH> }");
+    assert_eq!(refusals.len(), 1, "got: {refusals:?}");
+    assert_eq!(refusals[0].span().source_text().as_deref(), Some("WIDTH"));
+}
+
+/// An argument nested under whatever the author wrapped it in is the same argument: the walk
+/// reaches through collections, references and tuples, and reads a const under a second type's
+/// argument list too.
+#[cfg(any(feature = "typescript", feature = "jsonschema"))]
+#[test]
+fn a_const_argument_is_found_under_every_wrapper_it_can_be_written_beneath() {
+    for source in [
+        "pub struct Probe<const WIDTH: usize> { pub held: Vec<Leaf<WIDTH>> }",
+        "pub struct Probe<const WIDTH: usize> { pub held: Option<Box<Leaf<WIDTH>>> }",
+        "pub struct Probe<const WIDTH: usize> { pub held: [Leaf<WIDTH>; 4] }",
+        "pub struct Probe<const WIDTH: usize> { pub held: (String, Leaf<WIDTH>) }",
+        "pub struct Probe<const WIDTH: usize> { pub held: HashMap<String, Leaf<WIDTH>> }",
+    ] {
+        let messages = const_argument_messages(source);
+        assert_eq!(messages.len(), 1, "for {source}: {messages:?}");
+    }
+}
+
+/// The one place a const does render is an array *length*, which `README.md` states describes as an
+/// unbounded array — so a length is walked through rather than read, and a const no written type
+/// carries at all earns nothing. Neither does a type parameter standing where a type belongs.
+#[cfg(any(feature = "typescript", feature = "jsonschema"))]
+#[test]
+fn a_const_that_reaches_no_argument_list_earns_no_refusal() {
+    for source in [
+        "pub struct Probe<const WIDTH: usize> { pub held: [u8; WIDTH] }",
+        "pub struct Probe<const WIDTH: usize> { pub held: Vec<[u8; WIDTH]> }",
+        "pub struct Probe<const WIDTH: usize> { pub held: String }",
+        "pub enum Probe<const WIDTH: usize> { Held }",
+        "pub struct Probe<ValueType> { pub held: Leaf<ValueType> }",
+        "pub struct Probe<'label> { pub held: Leaf<'label> }",
+        "pub struct Probe { pub held: Leaf<String> }",
+    ] {
+        let messages = const_argument_messages(source);
+        assert!(messages.is_empty(), "for {source}: {messages:?}");
+    }
 }
 
 /// Builds the `Display` assertion for the sole field of `source`, parsed from text so its spans

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -10,6 +10,8 @@ use regex_syntax::ast::{
 };
 use regex_syntax::hir;
 use std::collections::HashMap;
+#[cfg(feature = "zod")]
+use std::collections::HashSet;
 use syn::{Attribute, Expr, Field, GenericParam, Generics, Lit, LitStr, Meta, Type, Variant};
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
@@ -262,11 +264,6 @@ pub struct AliasInfo {
     pub kind: AliasKind,
     #[cfg(feature = "jsonschema")]
     pub module_name: String,
-    /// Whether the Zod binding published under this name is a factory rather than a `const`, which
-    /// is what a reference to the name has to know to write itself. Filled by
-    /// [`record_zod_factory`] as the item decides which of the two it publishes.
-    #[cfg(feature = "zod")]
-    pub publishes_zod_factory: bool,
     /// What the value surface written under this name is, in the vocabulary a constrained brand's
     /// refusal names shapes by — and [`PublishedShape::Flat(None)`] both when that surface is one
     /// string checks land on and when nothing has been recorded at all. Filled by
@@ -629,6 +626,13 @@ impl JsSpelling {
     }
 }
 
+#[cfg(feature = "zod")]
+thread_local! {
+    /// The names whose items publish a Zod factory. Kept out of [`ALIAS_INFO`] so the answer
+    /// survives the item's own registration — see [`record_zod_factory`].
+    static ZOD_FACTORY_PUBLISHERS: RefCell<HashSet<String>> = RefCell::new(HashSet::new());
+}
+
 thread_local! {
     static ALIAS_INFO: RefCell<HashMap<String, AliasInfo>> = RefCell::new(HashMap::new());
 }
@@ -652,8 +656,6 @@ pub fn register_alias_info(
                 kind,
                 #[cfg(feature = "jsonschema")]
                 module_name: module_name.to_owned(),
-                #[cfg(feature = "zod")]
-                publishes_zod_factory: false,
                 value_shape: PublishedShape::Flat(None),
                 #[cfg(all(feature = "serde", any(feature = "zod", feature = "typescript")))]
                 wire: Vec::new(),
@@ -769,23 +771,39 @@ pub fn record_flatten_variants(rust_ident: &str, variants: &[FlattenVariant]) {
     });
 }
 
-/// Records which of the two Zod bindings a name publishes, on the entry that name has already
-/// registered.
+/// Records which of the two Zod bindings a name publishes.
 ///
 /// A reference reads this back rather than deciding for itself. The decision belongs to the named
-/// item and is taken in one place as it expands — see
-/// [`crate::model_schema::zod_binding_suffix`] — so the binding an item publishes and every
-/// reference written to it move together, whatever the reference was spelled with.
+/// item — it turns on whether that item declares type parameters, nothing a reference can see — and
+/// is taken in one place, before the item is dispatched to its shape, so the binding an item
+/// publishes and every reference written to it move together whatever the reference was spelled
+/// with.
 ///
-/// A name not registered before the reference reading it leaves no answer at all, which is the same
-/// regime the export name already runs under — see [`ident_schema_module_name`].
+/// Held apart from the item's registry entry rather than on it, because a *self*-reference is
+/// written while the item's own expansion is still running: the entry is created as the item
+/// registers and its fields are rendered from it, so an answer stored on the entry would be read
+/// before the item that owns it had put one there — and the `false` a fresh entry carries reads as
+/// "publishes a `const`", which for a generic item names a binding nothing declares. Recorded here
+/// the answer stands from before the first field is rendered until after the last.
+///
+/// A name never recorded answers `false`, which is the right reading for every item that declares
+/// no parameters and for every name this expansion has not seen.
 #[cfg(feature = "zod")]
 pub fn record_zod_factory(rust_ident: &str, publishes: bool) {
-    ALIAS_INFO.with(|map| {
-        if let Some(info) = map.borrow_mut().get_mut(rust_ident) {
-            info.publishes_zod_factory = publishes;
+    ZOD_FACTORY_PUBLISHERS.with(|names| {
+        if publishes {
+            names.borrow_mut().insert(rust_ident.to_owned());
+        } else {
+            names.borrow_mut().remove(rust_ident);
         }
     });
+}
+
+/// Whether the Zod binding published under `rust_ident` is a factory rather than a `const` — what a
+/// reference to the name has to know to write itself. See [`record_zod_factory`].
+#[cfg(feature = "zod")]
+pub fn publishes_zod_factory(rust_ident: &str) -> bool {
+    ZOD_FACTORY_PUBLISHERS.with(|names| names.borrow().contains(rust_ident))
 }
 
 /// The characters a `\d`, `\w` or `\s` covers in *both* engines, written out as a class body.

--- a/tests/generic_types_tests.rs
+++ b/tests/generic_types_tests.rs
@@ -9,3 +9,7 @@ extern crate alloc;
 #[cfg(test)]
 #[path = "generic_types_tests/tests.rs"]
 mod tests;
+
+#[cfg(test)]
+#[path = "generic_types_tests/whole_type_tests.rs"]
+mod whole_type_tests;

--- a/tests/generic_types_tests/whole_type_tests.rs
+++ b/tests/generic_types_tests/whole_type_tests.rs
@@ -1,0 +1,643 @@
+//! Whole generic types, read on every surface at once.
+//!
+//! The fixtures beside this one each hold a single question still — what one parameter position
+//! renders as, what one cache level looks like, what one reference site supplies. A type an author
+//! actually writes holds all of them at the same time, and a suite that only ever asks one at a
+//! time passes while the answers disagree with each other: a member the TypeScript declaration
+//! binds a parameter for, whose Zod factory takes an argument the JSON document has no filling for.
+//!
+//! So each fixture here is read three times over — the TypeScript declaration, the Zod factory, the
+//! JSON document — and, where serde compiles, against the wire the value actually writes. What is
+//! asserted is that the three agree about one type, not that each is separately plausible.
+//!
+//! The recursive pair at the end is the shape none of the single-question fixtures can hold: a type
+//! that reaches itself while it is still being described. The two surfaces answer it differently
+//! and both answers are pinned — JSON writes one definition and points a `$ref` back at it, and Zod
+//! defers the read so that the factory reaches its own memo before the reference is followed. What
+//! the deferral is worth is that the emitted module loads and validates at depth; the pins below
+//! are the emitted spelling, and the depth was read off the real output under `tsc` and `zod`.
+
+/// serde's `rename_all` is what turns the declared members into the keys every surface here spells,
+/// so these read the emitted declaration only where the attribute is parsed at all.
+#[cfg(all(feature = "typescript", feature = "serde"))]
+mod typescript {
+    use super::{
+        ArchiveBranch, ArchiveEntry, ArchiveEvent, ArchiveNode, ArchiveTrunk, ArchiveWire,
+    };
+    // The brand's intersection is read only where the value surface that writes its marker
+    // compiles — see the test below.
+    #[cfg(feature = "zod")]
+    use super::{ArchiveId, ArchiveStamp};
+
+    /// Every parameter the item declares is bound by the declaration, in declaration order, and
+    /// each member is written at whatever the parameter was written under: bare, wrapped in a
+    /// collection, made optional by serde, or handed to a sibling.
+    #[test]
+    fn a_whole_type_binds_every_parameter_its_members_are_written_under() {
+        let ts = ArchiveEntry::<String, f64, String, u32, String>::ts_definition();
+        assert!(
+            ts.contains(
+                "export type ArchiveEntry<IdType, DateType, TagType, SizeType, OwnerType> = {"
+            ),
+            "Got: {ts}"
+        );
+        assert!(ts.contains("  stamp: ArchiveStamp<IdType>;"), "Got: {ts}");
+        assert!(ts.contains("  createdAt: DateType;"), "Got: {ts}");
+        assert!(ts.contains("  tags: Array<TagType>;"), "Got: {ts}");
+        assert!(ts.contains("  byteSize?: SizeType;"), "Got: {ts}");
+        assert!(
+            ts.contains("  ownersByRole: Partial<Record<string, OwnerType>>;"),
+            "Got: {ts}"
+        );
+    }
+
+    /// A brand is a type parameter's own spelling intersected with the marker, so a generic brand
+    /// binds its parameter and spends it in the intersection — and the type holding one names the
+    /// brand with the argument it forwards, two levels from where the parameter was declared.
+    ///
+    /// Which marker is written is the value surface's business — `$brand<"Name">` is Zod's — so the
+    /// intersection is read where that surface compiles.
+    #[cfg(feature = "zod")]
+    #[test]
+    fn a_generic_brand_is_named_with_the_argument_forwarded_to_it() {
+        let brand = ArchiveId::<String>::ts_definition();
+        assert!(
+            brand.contains("export type ArchiveId<IdType> = IdType & $brand<\"ArchiveId\">;"),
+            "Got: {brand}"
+        );
+        let holder = ArchiveStamp::<String>::ts_definition();
+        assert!(
+            holder.contains("export type ArchiveStamp<IdType> = {"),
+            "Got: {holder}"
+        );
+        assert!(
+            holder.contains("  archiveId: ArchiveId<IdType>;"),
+            "Got: {holder}"
+        );
+    }
+
+    /// A discriminated enum's members are its variants, each written as the object the tag joins,
+    /// and the parameter is bound by the union's own declaration rather than by any one member.
+    #[test]
+    fn a_discriminated_generic_enum_binds_its_parameter_across_every_variant() {
+        let ts = ArchiveEvent::<String>::ts_definition();
+        assert!(
+            ts.contains("export type ArchiveEvent<IdType> ="),
+            "Got: {ts}"
+        );
+        assert!(ts.contains("kind: \"created\""), "Got: {ts}");
+        assert!(ts.contains("id: ArchiveId<IdType>"), "Got: {ts}");
+        assert!(ts.contains("kind: \"purged\""), "Got: {ts}");
+        assert!(ts.contains("reason: string"), "Got: {ts}");
+    }
+
+    /// An untagged enum is the bare union of what its variants write, and the parameter reaches it
+    /// through the one variant that names it.
+    #[test]
+    fn an_untagged_generic_enum_is_a_union_of_what_its_variants_write() {
+        let ts = ArchiveWire::<String>::ts_definition();
+        assert!(
+            ts.contains("export type ArchiveWire<IdType> ="),
+            "Got: {ts}"
+        );
+        assert!(ts.contains("id: IdType"), "Got: {ts}");
+        assert!(ts.contains("count: number"), "Got: {ts}");
+    }
+
+    /// TypeScript names a recursive type by writing its own name inside itself, arguments and all —
+    /// the declaration binds the parameter and the member spends it again at the same filling.
+    #[test]
+    fn a_recursive_generic_names_itself_with_the_arguments_it_was_declared_under() {
+        let node = ArchiveNode::<String>::ts_definition();
+        assert!(
+            node.contains("export type ArchiveNode<IdType> = {"),
+            "Got: {node}"
+        );
+        assert!(
+            node.contains("  children: Array<ArchiveNode<IdType>>;"),
+            "Got: {node}"
+        );
+
+        let branch = ArchiveBranch::<String>::ts_definition();
+        assert!(
+            branch.contains("  entries: Array<ArchiveTrunk<IdType>>;"),
+            "Got: {branch}"
+        );
+        let trunk = ArchiveTrunk::<String>::ts_definition();
+        assert!(
+            trunk.contains("  branches: Array<ArchiveBranch<IdType>>;"),
+            "Got: {trunk}"
+        );
+    }
+}
+
+/// The factory's parameter list, its cache interfaces and its argument annotations are TypeScript,
+/// so a build without that surface writes the same schemas with none of them — and the member keys
+/// are serde's. Read where all three compile.
+#[cfg(all(feature = "zod", feature = "typescript", feature = "serde"))]
+mod zod {
+    use super::{
+        ArchiveBranch, ArchiveEntry, ArchiveEvent, ArchiveId, ArchiveNode, ArchiveStamp,
+        ArchiveTrunk, ArchiveWire,
+    };
+
+    /// A generic type publishes a factory, and every member is written from whatever fills its own
+    /// parameter: the argument the factory bound, a collection of one, the optional wrap serde's
+    /// attribute earns, and a sibling factory called with the argument forwarded to it.
+    #[test]
+    fn a_whole_type_writes_each_member_from_the_argument_that_fills_it() {
+        let zod = ArchiveEntry::<String, f64, String, u32, String>::zod_schema();
+        assert!(
+            zod.contains("  stamp: ArchiveStamp$SchemaFactory(idType),"),
+            "Got: {zod}"
+        );
+        assert!(zod.contains("  createdAt: dateType,"), "Got: {zod}");
+        assert!(zod.contains("  tags: z.array(tagType),"), "Got: {zod}");
+        assert!(
+            zod.contains("  byteSize: z.union([sizeType, z.undefined()]).prefault(undefined),"),
+            "Got: {zod}"
+        );
+        assert!(
+            zod.contains("  ownersByRole: z.record(z.string(), ownerType),"),
+            "Got: {zod}"
+        );
+        assert!(
+            zod.contains("export const ArchiveEntry$SchemaFactory ="),
+            "Got: {zod}"
+        );
+        assert!(!zod.contains("ArchiveEntry$Schema:"), "Got: {zod}");
+    }
+
+    /// Five parameters means five levels of memo, each keyed on one argument and holding the map
+    /// the next is looked up in, so the schema is reached only through all five in order.
+    #[test]
+    fn a_five_parameter_factory_memoizes_one_level_per_argument() {
+        let zod = ArchiveEntry::<String, f64, String, u32, String>::zod_schema();
+        for level in 1_u8..=4_u8 {
+            assert!(
+                zod.contains(&format!(
+                    "interface ArchiveEntry$SchemaFactoryCacheL{level}<"
+                )),
+                "level {level} missing: {zod}"
+            );
+        }
+        assert!(
+            zod.contains("ArchiveEntry$SchemaFactoryCacheL4<IdType, DateType, TagType, SizeType>"),
+            "Got: {zod}"
+        );
+    }
+
+    /// A generic brand is a factory too: the brand is appended to whatever schema the argument
+    /// carries, and the type holding one calls that factory rather than naming a schema.
+    #[test]
+    fn a_generic_brand_is_a_factory_the_holder_calls() {
+        let brand = ArchiveId::<String>::zod_schema();
+        assert!(brand.contains(".brand<\"ArchiveId\">()"), "Got: {brand}");
+        assert!(
+            brand.contains("export const ArchiveId$SchemaFactory ="),
+            "Got: {brand}"
+        );
+        let holder = ArchiveStamp::<String>::zod_schema();
+        assert!(
+            holder.contains("  archiveId: ArchiveId$SchemaFactory(idType),"),
+            "Got: {holder}"
+        );
+    }
+
+    /// Both enum shapes are built inside the factory, so a variant naming a parameter reads the
+    /// argument the factory bound: a tagged one through `discriminatedUnion`, an untagged one
+    /// through the bare union its variants write.
+    #[test]
+    fn both_generic_enum_shapes_are_built_from_the_bound_argument() {
+        let tagged = ArchiveEvent::<String>::zod_schema();
+        assert!(
+            tagged.contains("z.discriminatedUnion(\"kind\", ["),
+            "Got: {tagged}"
+        );
+        assert!(
+            tagged.contains("  id: ArchiveId$SchemaFactory(idType),"),
+            "Got: {tagged}"
+        );
+        assert!(
+            tagged.contains("export const ArchiveEvent$SchemaFactory ="),
+            "Got: {tagged}"
+        );
+
+        let untagged = ArchiveWire::<String>::zod_schema();
+        assert!(untagged.contains("z.union(["), "Got: {untagged}");
+        assert!(untagged.contains("id: idType,"), "Got: {untagged}");
+        assert!(
+            untagged.contains("export const ArchiveWire$SchemaFactory ="),
+            "Got: {untagged}"
+        );
+    }
+
+    /// A value is a value: one Zod schema cannot stand for every filling, so a recursive generic
+    /// reaches itself by calling its own factory with the argument it was handed — never by naming
+    /// a `$Schema` binding, which a generic type does not publish at all.
+    ///
+    /// The member is written as a getter so the call is made after the factory has reached its own
+    /// memo, which is what ends the recursion instead of running it to the bottom of the stack.
+    #[test]
+    fn a_self_recursive_generic_calls_its_own_factory_behind_a_deferred_read() {
+        let zod = ArchiveNode::<String>::zod_schema();
+        assert!(
+            zod.contains(
+                "  get children() { return z.array(ArchiveNode$SchemaFactory(idType)); },"
+            ),
+            "Got: {zod}"
+        );
+        assert!(!zod.contains("ArchiveNode$Schema)"), "Got: {zod}");
+    }
+
+    /// A cycle between two generic types is ended at the reference written *forward* — the one
+    /// naming a type declared below, which is the reference a cycle cannot be built without. That
+    /// one is deferred; the reference back at a type already declared is read as it stands, because
+    /// what is left once the forward ones are deferred cannot cycle.
+    #[test]
+    fn a_generic_cycle_is_deferred_at_the_reference_written_forward() {
+        let branch = ArchiveBranch::<String>::zod_schema();
+        assert!(
+            branch.contains(
+                "  get entries() { return z.array(ArchiveTrunk$SchemaFactory(idType)); },"
+            ),
+            "Got: {branch}"
+        );
+
+        let trunk = ArchiveTrunk::<String>::zod_schema();
+        assert!(
+            trunk.contains("  branches: z.array(ArchiveBranch$SchemaFactory(idType)),"),
+            "Got: {trunk}"
+        );
+        assert!(!trunk.contains("get branches()"), "Got: {trunk}");
+    }
+}
+
+/// The documents are pinned byte for byte, and every key in them is the one serde writes.
+#[cfg(all(feature = "jsonschema", feature = "serde"))]
+mod json_schema {
+    use super::{
+        ArchiveBranch, ArchiveEntry, ArchiveEvent, ArchiveId, ArchiveNode, ArchiveStamp,
+        ArchiveTrunk, ArchiveWire,
+    };
+
+    /// JSON Schema has no type parameters, so the document exists at one filling: the declared one.
+    /// Every member is described as whatever that filling describes as, through the same dispatch a
+    /// field written at that type would take, and serde's key rules reach the document unchanged.
+    #[test]
+    fn a_whole_type_describes_every_member_at_its_declared_filling() {
+        assert_eq!(
+            serde_json::to_string(&ArchiveEntry::<String, f64, String, u32, String>::json_schema())
+                .unwrap(),
+            "{\"type\":\"object\",\"additionalProperties\":false,\"properties\":{\"byteSize\":{\"ty\
+             pe\":\"integer\"},\"createdAt\":{\"type\":\"number\"},\"ownersByRole\":{\"type\":\"obj\
+             ect\",\"additionalProperties\":{\"type\":\"string\"}},\"stamp\":{\"type\":\"object\",\
+             \"additionalProperties\":false,\"properties\":{\"archiveId\":{\"type\":\"string\"}},\"\
+             required\":[\"archiveId\"]},\"tags\":{\"type\":\"array\",\"items\":{\"type\":\"string\
+             \"}}},\"required\":[\"createdAt\",\"ownersByRole\",\"stamp\",\"tags\"]}"
+        );
+    }
+
+    /// A brand describes as what it wraps — the document has no marker to carry — so a generic
+    /// brand describes as its declared filling, and the type holding it embeds that.
+    #[test]
+    fn a_generic_brand_describes_as_the_filling_it_wraps() {
+        assert_eq!(
+            serde_json::to_string(&ArchiveId::<String>::json_schema()).unwrap(),
+            "{\"type\":\"string\"}"
+        );
+
+        assert_eq!(
+            serde_json::to_string(&ArchiveStamp::<String>::json_schema()).unwrap(),
+            "{\"type\":\"object\",\"additionalProperties\":false,\"properties\":{\"archiveId\":{\"t\
+             ype\":\"string\"}},\"required\":[\"archiveId\"]}"
+        );
+    }
+
+    /// A tagged enum is the `oneOf` of the objects its tag joins; an untagged one is the `anyOf` of
+    /// what its variants write. The parameter is described at its declared filling in each.
+    #[test]
+    fn both_generic_enum_shapes_describe_at_the_declared_filling() {
+        assert_eq!(
+            serde_json::to_string(&ArchiveEvent::<String>::json_schema()).unwrap(),
+            "{\"type\":\"object\",\"oneOf\":[{\"additionalProperties\":false,\"properties\":{\"kind\
+             \":{\"type\":\"string\",\"const\":\"created\"},\"id\":{\"type\":\"string\"}},\"require\
+             d\":[\"kind\",\"id\"]},{\"additionalProperties\":false,\"properties\":{\"kind\":{\"typ\
+             e\":\"string\",\"const\":\"purged\"},\"reason\":{\"type\":\"string\"}},\"required\":[\
+             \"kind\",\"reason\"]}]}"
+        );
+
+        assert_eq!(
+            serde_json::to_string(&ArchiveWire::<String>::json_schema()).unwrap(),
+            "{\"anyOf\":[{\"type\":\"object\",\"properties\":{\"count\":{\"type\":\"integer\"}},\"r\
+             equired\":[\"count\"],\"additionalProperties\":false},{\"type\":\"object\",\"propertie\
+             s\":{\"id\":{\"type\":\"string\"}},\"required\":[\"id\"],\"additionalProperties\":fals\
+             e}]}"
+        );
+    }
+
+    /// A document cannot be written to the bottom of a recursion, so the type is hoisted into
+    /// `$defs` once and the recursive member points a `$ref` back at it. One definition per name,
+    /// which holds because every reference around this cycle carries the same filling.
+    #[test]
+    fn a_recursive_generic_is_hoisted_once_and_pointed_back_at() {
+        assert_eq!(
+            serde_json::to_string(&ArchiveNode::<String>::json_schema()).unwrap(),
+            "{\"$defs\":{\"ArchiveNode\":{\"type\":\"object\",\"additionalProperties\":false,\"prop\
+             erties\":{\"children\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/$defs/ArchiveNode\"\
+             }},\"id\":{\"type\":\"string\"}},\"required\":[\"children\",\"id\"]}},\"$ref\":\"#/$de\
+             fs/ArchiveNode\"}"
+        );
+    }
+
+    /// A cycle spanning two types is hoisted at whichever of them the document is built from, the
+    /// other written out inline underneath it — so each of the pair is a document in its own right
+    /// and the `$ref` closes back on the one that was asked for.
+    #[test]
+    fn a_generic_cycle_is_hoisted_at_whichever_type_the_document_is_built_from() {
+        assert_eq!(
+            serde_json::to_string(&ArchiveBranch::<String>::json_schema()).unwrap(),
+            "{\"$defs\":{\"ArchiveBranch\":{\"type\":\"object\",\"additionalProperties\":false,\"pr\
+             operties\":{\"entries\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"additiona\
+             lProperties\":false,\"properties\":{\"branches\":{\"type\":\"array\",\"items\":{\"$ref\
+             \":\"#/$defs/ArchiveBranch\"}},\"id\":{\"type\":\"string\"}},\"required\":[\"branches\
+             \",\"id\"]}},\"label\":{\"type\":\"string\"}},\"required\":[\"entries\",\"label\"]}},\
+             \"$ref\":\"#/$defs/ArchiveBranch\"}"
+        );
+
+        assert_eq!(
+            serde_json::to_string(&ArchiveTrunk::<String>::json_schema()).unwrap(),
+            "{\"$defs\":{\"ArchiveTrunk\":{\"type\":\"object\",\"additionalProperties\":false,\"pro\
+             perties\":{\"branches\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"additiona\
+             lProperties\":false,\"properties\":{\"entries\":{\"type\":\"array\",\"items\":{\"$ref\
+             \":\"#/$defs/ArchiveTrunk\"}},\"label\":{\"type\":\"string\"}},\"required\":[\"entries\
+             \",\"label\"]}},\"id\":{\"type\":\"string\"}},\"required\":[\"branches\",\"id\"]}},\"$\
+             ref\":\"#/$defs/ArchiveTrunk\"}"
+        );
+    }
+}
+
+/// The README's recursive-generic example, held to the two things a pasted example has to be: the
+/// README still declares it exactly as declared here, and the emission shown beside it is what the
+/// generator answers with. Drift on either side fails here rather than in someone's editor.
+#[cfg(all(feature = "typescript", feature = "zod"))]
+mod readme {
+    use super::Node;
+
+    fn readme() -> &'static str {
+        include_str!("../../README.md")
+    }
+
+    /// The README declares this, and the generator writes that. Each line is matched whole on both
+    /// sides, so a spelling that is merely a prefix of the emitted one cannot pass for it.
+    fn assert_readme_declares_and_shows(declaration: &str, emission: &str, lines: &[&str]) {
+        assert!(
+            readme().contains(declaration),
+            "the README no longer declares this verbatim:\n{declaration}"
+        );
+        for line in lines {
+            assert!(
+                emission.lines().any(|written| written == *line),
+                "the generator no longer writes this line: {line}\nGot: {emission}"
+            );
+            assert!(
+                readme().lines().any(|shown| shown == *line),
+                "the README no longer shows this line verbatim: {line}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_readme_recursive_example_is_declared_and_shown_as_the_generator_writes_it() {
+        assert_readme_declares_and_shows(
+            "pub struct Node<IdType> {\n    pub children: Vec<Self>,\n    pub id: IdType,\n}",
+            &Node::<String>::ts_definition(),
+            &[
+                "export type Node<IdType> = {",
+                "  children: Array<Node<IdType>>;",
+                "  id: IdType;",
+            ],
+        );
+        assert_readme_declares_and_shows(
+            "pub struct Node<IdType> {",
+            &Node::<String>::zod_schema(),
+            &[
+                "const buildNode$Schema = <IdType extends ZodType>(",
+                "  idType: IdType,",
+                ") =>",
+                "  z.strictObject({",
+                "  get children() { return z.array(Node$SchemaFactory(idType)); },",
+                "  id: idType,",
+                "});",
+            ],
+        );
+    }
+}
+
+/// The wire the surfaces above describe, read off the value itself. A schema that agrees with the
+/// other two and disagrees with serde describes nothing anyone sends.
+#[cfg(feature = "serde")]
+mod wire {
+    use super::{ArchiveEntry, ArchiveEvent, ArchiveId, ArchiveNode, ArchiveStamp, ArchiveWire};
+    use std::collections::HashMap;
+
+    #[test]
+    fn the_whole_type_writes_the_keys_its_schemas_describe() {
+        let entry = ArchiveEntry::<String, f64, String, u32, String> {
+            stamp: ArchiveStamp {
+                archive_id: ArchiveId("doc-1".to_owned()),
+            },
+            created_at: 1.5_f64,
+            tags: vec!["a".to_owned()],
+            byte_size: None,
+            owners_by_role: HashMap::from([("editor".to_owned(), "ana".to_owned())]),
+        };
+        let written = serde_json::to_value(&entry).unwrap();
+        assert_eq!(
+            written,
+            serde_json::json!({
+                "stamp": { "archiveId": "doc-1" },
+                "createdAt": 1.5_f64,
+                "tags": ["a"],
+                "ownersByRole": { "editor": "ana" },
+            })
+        );
+        // The absent key is the one the schema left out of `required` and TypeScript marked `?`.
+        assert!(written.get("byteSize").is_none());
+    }
+
+    #[test]
+    fn the_generic_enums_write_the_shapes_their_schemas_describe() {
+        assert_eq!(
+            serde_json::to_value(ArchiveEvent::Created {
+                id: ArchiveId::<String>("doc-1".to_owned()),
+            })
+            .unwrap(),
+            serde_json::json!({ "kind": "created", "id": "doc-1" })
+        );
+        assert_eq!(
+            serde_json::to_value(ArchiveWire::<String>::Counted { count: 2_u32 }).unwrap(),
+            serde_json::json!({ "count": 2_u32 })
+        );
+    }
+
+    #[test]
+    fn a_recursive_generic_writes_itself_all_the_way_down() {
+        let node = ArchiveNode::<String> {
+            id: "root".to_owned(),
+            children: vec![ArchiveNode {
+                id: "leaf".to_owned(),
+                children: Vec::new(),
+            }],
+        };
+        assert_eq!(
+            serde_json::to_value(&node).unwrap(),
+            serde_json::json!({
+                "id": "root",
+                "children": [{ "id": "leaf", "children": [] }],
+            })
+        );
+    }
+}
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use tixschema::model_schema;
+
+/// A brand over a parameter: the one item shape whose parameter is spent on a single written target
+/// rather than on a list of members, held here so the type below can forward an argument into it.
+#[model_schema(default_types(IdType = String))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ArchiveId<IdType>(pub IdType);
+
+/// The level between the brand and the whole type, so the argument the entry supplies is forwarded
+/// twice before it reaches the brand that spends it.
+#[model_schema(default_types(IdType = String))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchiveStamp<IdType> {
+    pub archive_id: ArchiveId<IdType>,
+}
+
+/// Five parameters, each written under a different shape: made optional by serde, held bare, put in
+/// a map's value position, handed to a sibling, and wrapped in a collection.
+#[model_schema(default_types(
+    IdType = String,
+    DateType = f64,
+    TagType = String,
+    SizeType = u32,
+    OwnerType = String
+))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchiveEntry<IdType, DateType, TagType, SizeType, OwnerType> {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub byte_size: Option<SizeType>,
+    pub created_at: DateType,
+    pub owners_by_role: HashMap<String, OwnerType>,
+    pub stamp: ArchiveStamp<IdType>,
+    pub tags: Vec<TagType>,
+}
+
+/// A tagged generic enum, whose parameter reaches only one of its variants.
+#[model_schema(default_types(IdType = String))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum ArchiveEvent<IdType> {
+    Created { id: ArchiveId<IdType> },
+    Purged { reason: String },
+}
+
+/// The same question for the shape with no tag to join the variants: a bare union, whose members
+/// are told apart by their keys alone.
+#[model_schema(default_types(IdType = String))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ArchiveWire<IdType> {
+    Counted { count: u32 },
+    Identified { id: IdType },
+}
+
+/// A generic type that reaches itself. Every reference around the cycle carries the same filling,
+/// which is what lets one definition stand for the whole of it.
+#[model_schema(default_types(IdType = String))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchiveNode<IdType> {
+    pub children: Vec<Self>,
+    pub id: IdType,
+}
+
+/// The README's own recursive example, declared here exactly as the README declares it so the two
+/// cannot drift.
+#[model_schema(default_types(IdType = String))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Node<IdType> {
+    pub children: Vec<Self>,
+    pub id: IdType,
+}
+
+/// The same, spanning two types rather than one — and declared *above* the type it names, so the
+/// reference that closes the cycle is written forward.
+#[model_schema(default_types(IdType = String))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchiveBranch<IdType> {
+    pub entries: Vec<ArchiveTrunk<IdType>>,
+    pub label: String,
+}
+
+#[model_schema(default_types(IdType = String))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArchiveTrunk<IdType> {
+    pub branches: Vec<ArchiveBranch<IdType>>,
+    pub id: IdType,
+}
+
+/// The declaration itself is the assertion in a build that reads no surface: an item that does not
+/// expand is a compile error, whatever is switched on. Every fixture is built here, so each one is
+/// held to expanding under every combination rather than only under the ones that read it.
+#[test]
+fn every_fixture_expands_in_this_build() {
+    let stamp = ArchiveStamp {
+        archive_id: ArchiveId::<String>("doc-1".to_owned()),
+    };
+    let entry = ArchiveEntry::<String, f64, String, u32, String> {
+        byte_size: None,
+        created_at: 1.5_f64,
+        owners_by_role: HashMap::new(),
+        stamp,
+        tags: Vec::new(),
+    };
+    assert!(entry.tags.is_empty());
+
+    let event = ArchiveEvent::Purged {
+        reason: "expired".to_owned(),
+    };
+    assert!(matches!(event, ArchiveEvent::<String>::Purged { .. }));
+    let wire = ArchiveWire::<String>::Counted { count: 2_u32 };
+    assert!(matches!(wire, ArchiveWire::Counted { count: 2_u32 }));
+
+    let node = ArchiveNode::<String> {
+        children: Vec::new(),
+        id: "root".to_owned(),
+    };
+    assert!(node.children.is_empty());
+    let readme_node = Node::<String> {
+        children: Vec::new(),
+        id: "root".to_owned(),
+    };
+    assert!(readme_node.children.is_empty());
+    let trunk = ArchiveTrunk::<String> {
+        branches: Vec::new(),
+        id: "root".to_owned(),
+    };
+    let branch = ArchiveBranch::<String> {
+        entries: vec![trunk],
+        label: "root".to_owned(),
+    };
+    assert_eq!(branch.label, "root");
+}


### PR DESCRIPTION
The closing piece of generic support.

Recursive generics are supported rather than refused — the deciding captures overturned the refusal plan. Self-recursion used to emit a binding a generic item never publishes, and the mutual pair's eager factory calls overflowed the stack at the first call; tsc accepts the inferred return alias for both shapes with the type staying precise, so no nominal annotation is owed and the factories keep their shape/extend/pick. Cycles are identified through the existing machinery with no new marker: deferring forward references suffices, since every cycle contains one, and the deferral is the getter rather than z.lazy, which collapses the factory's return type. The factory decision moved to a store that outlives registration; Self in a generic item restores the item's own parameters. Verified on the real emitted module: tsc clean over all nine suite types, self-recursion parsing 500 levels deep and the mutual pair 250 from either entry, wrong fillings refused at every depth.

The refusal set came from capture, not from a blanket rule: lifetimes render correctly everywhere and const array lengths are documented behavior, so neither is refused; a const handed to a written type as an argument — a phantom module on one surface and an unbound name on another — is refused, spanned. A default_types filling naming a primitive the machinery has no arm for (char, i128, u128, f16, f128) is refused at the entry in one spanned diagnostic naming the type, the module it would have named, and the feature, replacing the phantom-module error triple.

A whole-type suite pins Rust in, TypeScript, Zod, and JSON Schema out across the combinations no single landing owned, and the type-mapping documentation gains its generics row.