### PR TITLE
Quote every member key serde writes that is not an identifier; backtick the product name the stricter toolchain flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -1292,7 +1292,7 @@ Branded newtypes support doc comments (for Zod `.meta({ description })`) and com
 /// Generic document identifier.
 ///
 /// - `DocumentId<String>` for API/HTTP layer
-/// - `DocumentId<ObjectId>` for MongoDB layer
+/// - `DocumentId<ObjectId>` for `MongoDB` layer
 ///
 /// ```rust example
 /// DocumentId("64de3d95ff45b119e5b53a7e".to_string())
@@ -1310,7 +1310,7 @@ const buildDocumentId$Schema = <IdType extends ZodType>(
   idType: IdType,
 ) =>
   idType.meta({
-  description: "Generic document identifier.\n- `DocumentId<String>` for API/HTTP layer\n- `DocumentId<ObjectId>` for MongoDB layer",
+  description: "Generic document identifier.\n- `DocumentId<String>` for API/HTTP layer\n- `DocumentId<ObjectId>` for `MongoDB` layer",
   example: "64de3d95ff45b119e5b53a7e",
 }).brand<"DocumentId">();
 

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -5789,6 +5789,30 @@ fn member_jsdoc_block(body: &str) -> String {
     jsdoc_block(body, MEMBER_INDENT)
 }
 
+/// The spelling a member key is written as on the text surfaces.
+///
+/// A key serde writes is a wire name rather than an identifier: `#[serde(rename = "reply-to")]`
+/// spells one no JavaScript identifier can hold, and written bare it ends the object the member
+/// sits in — every member after it reads as something else. Quoting is what the wire name always
+/// needed, and a key that already reads as an identifier is left exactly as it was, so no spelling
+/// that parsed before is rewritten.
+///
+/// Identifier is read as the ASCII spelling alone, which is the same span [`name_arg_value`] admits
+/// for a name the macro is given. A key outside it is quoted rather than refused: it is legal as a
+/// string, and it is serde's to name.
+fn ts_member_key(key: &str) -> String {
+    let mut chars = key.chars();
+    let heads_an_identifier = chars
+        .next()
+        .is_some_and(|first| first.is_ascii_alphabetic() || first == '_' || first == '$');
+    if heads_an_identifier
+        && chars.all(|char| char.is_ascii_alphanumeric() || char == '_' || char == '$')
+    {
+        return key.to_owned();
+    }
+    format!("\"{}\"", key.replace('\\', "\\\\").replace('"', "\\\""))
+}
+
 /// The one-line description a set of lines is published as, escaped for the `description: "…"` it
 /// is spliced into.
 ///
@@ -7608,7 +7632,7 @@ fn render_untagged_named(
         .map(|fld| {
             format!(
                 "{}{}: {}",
-                fld.name,
+                ts_member_key(&fld.name),
                 fld.optional_key_marker(),
                 fld.typescript_typename()
             )
@@ -7623,14 +7647,11 @@ fn render_untagged_named(
         let mut body = String::from("z.strictObject({ ");
         for fld in field_defs {
             let zod_field_type = fld.zod_type();
+            let key = ts_member_key(&fld.name);
             if fld.contains_type_reference(self_type_name) {
-                let _ = write!(
-                    body,
-                    "get {}() {{ return {}; }}, ",
-                    fld.name, zod_field_type
-                );
+                let _ = write!(body, "get {key}() {{ return {zod_field_type}; }}, ");
             } else {
-                let _ = write!(body, "{}: {}, ", fld.name, zod_field_type);
+                let _ = write!(body, "{key}: {zod_field_type}, ");
             }
         }
         body.push_str("})");
@@ -7681,7 +7702,7 @@ fn close_untagged_flatten_member(member: &str, excluded: &[String]) -> String {
         if !closed.ends_with('{') {
             closed.push(';');
         }
-        let _ = write!(closed, " {key}?: never");
+        let _ = write!(closed, " {}?: never", ts_member_key(key));
     }
     closed.push_str(" }");
     closed
@@ -8592,12 +8613,13 @@ fn tagged_variant_parts(
     discriminator_value: &str,
     discriminator_docs: &str,
 ) -> VariantParts {
+    let tag_key = ts_member_key(tag_name);
     VariantParts {
         json_fields: Vec::new(),
         optional_fields: Vec::new(),
-        schema_code: format!("{{\n  {tag_name}: z.literal(\"{discriminator_value}\"),\n"),
+        schema_code: format!("{{\n  {tag_key}: z.literal(\"{discriminator_value}\"),\n"),
         type_code: format!(
-            "{{\n{}\n  {tag_name}: \"{discriminator_value}\";\n",
+            "{{\n{}\n  {tag_key}: \"{discriminator_value}\";\n",
             member_jsdoc_block(discriminator_docs)
         ),
     }
@@ -8728,12 +8750,14 @@ fn write_named_variant_fields(
     let optional_fields = &mut parts.optional_fields;
     let json_schema_variant_fields = &mut parts.json_fields;
     for fld in field_defs {
+        let key = ts_member_key(&fld.name);
+
         // Add TypeScript type definition
         let _ = writeln!(
             variant_type_code,
             "{}\n  {}{}: {};",
             member_jsdoc_block(&fld.docs),
-            fld.name,
+            key,
             fld.optional_key_marker(),
             fld.typescript_typename()
         );
@@ -8748,11 +8772,10 @@ fn write_named_variant_fields(
                 // Use getter syntax to defer the reference
                 let _ = writeln!(
                     variant_schema_code,
-                    "  get {}() {{ return {}; }},",
-                    fld.name, zod_field_type
+                    "  get {key}() {{ return {zod_field_type}; }},"
                 );
             } else {
-                let _ = writeln!(variant_schema_code, "  {}: {},", fld.name, zod_field_type);
+                let _ = writeln!(variant_schema_code, "  {key}: {zod_field_type},");
             }
         }
 
@@ -8817,11 +8840,13 @@ fn write_tuple_single_variant_fields(
         );
         return;
     };
+    let content_key = ts_member_key(content_name);
+
     // Add TypeScript type definition with JSDoc comment
     let _ = writeln!(
         variant_type_code,
         "  /** Tuple value */\n  {}: {};",
-        content_name,
+        content_key,
         fld.typescript_slot_typename()
     );
 
@@ -8835,10 +8860,10 @@ fn write_tuple_single_variant_fields(
             // Use getter syntax to defer the reference
             let _ = writeln!(
                 variant_schema_code,
-                "  get {content_name}() {{ return {zod_field_type}; }},"
+                "  get {content_key}() {{ return {zod_field_type}; }},"
             );
         } else {
-            let _ = writeln!(variant_schema_code, "  {content_name}: {zod_field_type},");
+            let _ = writeln!(variant_schema_code, "  {content_key}: {zod_field_type},");
         }
     }
 
@@ -8883,11 +8908,12 @@ fn write_tuple_multiple_variant_fields(
         .enumerate()
         .map(|(i, _)| format!("element {i}"))
         .collect();
+    let content_key = ts_member_key(content_name);
     let _ = writeln!(
         variant_type_code,
         "  /** Tuple: [{}] */\n  {}: {};",
         tuple_desc.join(", "),
-        content_name,
+        content_key,
         ts_tuple
     );
 
@@ -8909,10 +8935,10 @@ fn write_tuple_multiple_variant_fields(
             // Use getter syntax to defer the reference
             let _ = writeln!(
                 variant_schema_code,
-                "  get {content_name}() {{ return {zod_tuple}; }},"
+                "  get {content_key}() {{ return {zod_tuple}; }},"
             );
         } else {
-            let _ = writeln!(variant_schema_code, "  {content_name}: {zod_tuple},");
+            let _ = writeln!(variant_schema_code, "  {content_key}: {zod_tuple},");
         }
     }
 
@@ -10348,12 +10374,14 @@ fn write_field_type_and_schema(
     fld: &FieldDef,
     self_type_name: Option<&str>,
 ) -> String {
+    let key = ts_member_key(&fld.name);
+
     // Always write TypeScript type
     let _ = writeln!(
         type_code,
         "{}\n  {}{}: {};",
         member_jsdoc_block(&fld.docs),
-        fld.name,
+        key,
         fld.optional_key_marker(),
         fld.typescript_typename()
     );
@@ -10372,10 +10400,10 @@ fn write_field_type_and_schema(
 
         if defer {
             // Use getter syntax to defer the reference
-            format!("  get {}() {{ return {}; }},\n", fld.name, zod_type)
+            format!("  get {key}() {{ return {zod_type}; }},\n")
         } else {
             // Normal property syntax
-            format!("  {}: {},\n", fld.name, zod_type)
+            format!("  {key}: {zod_type},\n")
         }
     }
 
@@ -10383,6 +10411,7 @@ fn write_field_type_and_schema(
     {
         // When zod feature is disabled, there is no schema fragment to emit
         let _: &_ = &self_type_name; // Suppress unused variable warning
+        let _: &str = &key;
         String::new()
     }
 }

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -9135,3 +9135,52 @@ fn a_flatten_source_with_no_name_of_its_own_keeps_the_placeholder() {
         "serde_json :: json ! ({ \"type\" : \"object\" })"
     );
 }
+
+/// A key an identifier can hold is written bare, which is every key the emission wrote before the
+/// rule existed.
+#[test]
+fn an_identifier_member_key_is_written_bare() {
+    for key in ["id", "userId", "_private", "$ref", "a1", "A", "_", "$"] {
+        assert_eq!(
+            super::ts_member_key(key),
+            key,
+            "expected `{key}` written bare"
+        );
+    }
+}
+
+/// A wire name no identifier can hold is written as the string it is, so the object it sits in still
+/// closes after it.
+#[test]
+fn a_non_identifier_member_key_is_written_as_a_string() {
+    assert_eq!(super::ts_member_key("reply-to"), "\"reply-to\"");
+    assert_eq!(super::ts_member_key("content-type"), "\"content-type\"");
+    assert_eq!(super::ts_member_key("2fa"), "\"2fa\"");
+    assert_eq!(super::ts_member_key(""), "\"\"");
+    assert_eq!(super::ts_member_key("a b"), "\"a b\"");
+    assert_eq!(super::ts_member_key("caf\u{e9}"), "\"caf\u{e9}\"");
+}
+
+/// A key carrying the two characters the string form itself is written with is escaped, so quoting
+/// cannot be what ends the string early.
+#[test]
+fn a_member_key_carrying_a_quote_or_a_backslash_is_escaped() {
+    assert_eq!(super::ts_member_key("a\"b"), "\"a\\\"b\"");
+    assert_eq!(super::ts_member_key("a\\b"), "\"a\\\\b\"");
+}
+
+/// The untagged member's sibling exclusions are keys the same rule applies to: one an identifier
+/// cannot hold is denied under the string serde writes it as.
+#[cfg(all(feature = "serde", feature = "typescript"))]
+#[test]
+fn an_untagged_sibling_exclusion_writes_a_non_identifier_key_as_a_string() {
+    let closed = super::close_untagged_flatten_member(
+        "{ subject: string }",
+        &["reply-to".to_owned(), "sent_at".to_owned()],
+    );
+
+    assert_eq!(
+        closed,
+        "{ subject: string; \"reply-to\"?: never; sent_at?: never }"
+    );
+}

--- a/tests/readme_example_tests/tests.rs
+++ b/tests/readme_example_tests/tests.rs
@@ -442,7 +442,7 @@ fn test_the_documented_branded_newtype_example_is_declarable_and_shows_what_it_e
     /// Generic document identifier.
     ///
     /// - `DocumentId<String>` for API/HTTP layer
-    /// - `DocumentId<ObjectId>` for MongoDB layer
+    /// - `DocumentId<ObjectId>` for `MongoDB` layer
     ///
     /// ```rust example
     /// DocumentId("64de3d95ff45b119e5b53a7e".to_string())

--- a/tests/serde_tests/tests.rs
+++ b/tests/serde_tests/tests.rs
@@ -105,6 +105,54 @@ struct UserWithSerde {
     user_id: String,
 }
 
+// ========================================================================
+// Wire Names That No Identifier Can Hold
+// ========================================================================
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(untagged)]
+enum Body {
+    Fresh { subject: String },
+    Reply { reply_to: String },
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(tag = "kind")]
+enum Delivery {
+    Sent {
+        #[serde(rename = "sent-at")]
+        sent_at: String,
+    },
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct Envelope {
+    #[serde(flatten)]
+    body: Body,
+    id: String,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct Message {
+    id: String,
+    #[serde(rename = "reply-to", default, skip_serializing_if = "Option::is_none")]
+    reply_to: Option<String>,
+}
+
+/// A key an identifier can hold is written as it always was, on both text surfaces.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+struct PlainKeys {
+    #[serde(rename = "$ref")]
+    reference: String,
+    #[serde(rename = "user_id2")]
+    user_id: String,
+}
+
 #[test]
 fn test_serde_types_constructible() {
     let color = Color::Red;
@@ -135,6 +183,27 @@ fn test_serde_types_constructible() {
         user_id: String::new(),
     };
     assert!(user.user_id.is_empty());
+    let message = Message {
+        id: String::new(),
+        reply_to: None,
+    };
+    assert!(message.reply_to.is_none());
+    let delivery = Delivery::Sent {
+        sent_at: String::new(),
+    };
+    assert!(matches!(delivery, Delivery::Sent { .. }));
+    let envelope = Envelope {
+        body: Body::Reply {
+            reply_to: String::new(),
+        },
+        id: String::new(),
+    };
+    assert!(matches!(envelope.body, Body::Reply { .. }));
+    let plain = PlainKeys {
+        reference: String::new(),
+        user_id: String::new(),
+    };
+    assert!(plain.reference.is_empty());
 }
 
 #[test]
@@ -354,5 +423,92 @@ fn test_compliant_optionals_serialize_absent_and_parse_absent() {
     assert_eq!(
         serde_json::to_string(&some).unwrap(),
         r#"{"name":"n","note":"here"}"#
+    );
+}
+
+/// The struct-field seam: a renamed key is the string serde writes, which is what the object needs
+/// to still close after it.
+#[test]
+#[cfg(feature = "typescript")]
+fn test_a_hyphenated_field_key_is_written_as_a_string() {
+    let ts = Message::ts_definition();
+
+    assert!(
+        ts.lines().any(|line| line == r#"  "reply-to"?: string;"#),
+        "expected the key as a string member:\n{ts}"
+    );
+    assert!(
+        ts.lines().any(|line| line == "  id: string;"),
+        "an identifier-legal key stays bare:\n{ts}"
+    );
+}
+
+/// The same key on the Zod surface, which is object-literal syntax and refuses a bare hyphen for
+/// the same reason the type does.
+#[test]
+#[cfg(feature = "zod")]
+fn test_a_hyphenated_field_key_is_written_as_a_string_in_zod() {
+    let zod = Message::zod_schema();
+
+    assert!(
+        zod.contains(r#"  "reply-to": "#),
+        "expected the key as a string member:\n{zod}"
+    );
+    assert!(
+        zod.contains("  id: z.string(),"),
+        "an identifier-legal key stays bare:\n{zod}"
+    );
+}
+
+/// The struct-variant seam: a variant's own fields are members of the variant's object and are
+/// written by their own seam, which needs the same rule.
+#[test]
+#[cfg(feature = "typescript")]
+fn test_a_hyphenated_variant_field_key_is_written_as_a_string() {
+    let ts = Delivery::ts_definition();
+
+    assert!(
+        ts.lines().any(|line| line == r#"  "sent-at": string;"#),
+        "expected the key as a string member:\n{ts}"
+    );
+    assert!(
+        ts.lines().any(|line| line == r#"  kind: "Sent";"#),
+        "an identifier-legal tag stays bare:\n{ts}"
+    );
+}
+
+/// The flatten-operand seam and the sibling exclusion beside it, both written from keys an
+/// identifier can hold: the whole intersection is spelled as it always was.
+///
+/// The quoted half of this seam is held in the unit tests, against the closer directly. It cannot be
+/// reached from here: a key on this path is the field's own name whatever serde was told to rename
+/// it to, so no rename spells one an identifier cannot hold.
+#[test]
+#[cfg(feature = "typescript")]
+fn test_a_flatten_operand_and_its_sibling_exclusions_stay_bare_for_identifier_keys() {
+    let ts = Envelope::ts_definition();
+
+    assert!(
+        ts.contains(
+            "} & ({ subject: string; reply_to?: never } | { reply_to: string; subject?: never });"
+        ),
+        "expected the intersection unchanged:\n{ts}"
+    );
+}
+
+/// The rule reads the key, not the rename: `$` and a trailing digit are identifier-legal and are
+/// left exactly as they were written.
+#[test]
+#[cfg(feature = "typescript")]
+fn test_identifier_legal_renamed_keys_stay_bare() {
+    let ts = PlainKeys::ts_definition();
+
+    assert!(
+        ts.lines().any(|line| line == "  $ref: string;"),
+        "expected a bare `$ref`:\n{ts}"
+    );
+    assert!(
+        ts.lines().any(|line| line == "  user_id2: string;"),
+        "expected a bare `user_id2`:\n{ts}"
     );
 }


### PR DESCRIPTION
Two consumer blockers.

A field serde-renamed to a spelling that is not a TypeScript identifier — reply-to was the live case — was written bare on both text surfaces, and a bare hyphen ends the object literal: a consumer's generated file failed to parse from that member on, with the Zod object breaking identically. The capture showed this was longstanding at both the old and new consumer pins, not a rework regression, and that only the externally tagged enum seam already quoted. A shared helper now writes any member key that is not an ASCII identifier as the quoted, escaped string at every member-writing seam — struct fields, struct and tuple variants, untagged members, the tagged twin of the untagged closer, and the tag/content keys — erring toward quoting since a declined key is still legal as a string. Identifier-legal keys stay bare byte-identical, and the quoted module type-checks with the Zod and type surfaces proven to agree on the key set.

The pinned documented-brand example spelled MongoDB unbackticked in rustdoc; the CI toolchain's clippy denies doc_markdown on it while the local beta accepts it, which is exactly why CI on master has been red behind a green local powerset. The name is backticked in the three coupled spellings the pins hold together — the fixture doc, the README declaration, and the emitted description — matching the convention the crate's own test docs already use.