### PR TITLE
publish a default beside every generic factory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -375,6 +375,15 @@ a function taking one required schema argument per parameter — while a type th
 parameter keeps exporting `X$Schema` exactly as before. `zod_binding_suffix` is the one seam that
 decides which, and `zod_published_binding` the one seam that writes either.
 
+Beside the factory, a generic type also exports `X$SchemaDefault` — the factory called at the
+type's own declared `default_types`, so a consumer who wants the ordinary filling shares the memo
+rather than building a second schema for it. `zod_default_block` builds the const, through
+`default_zod_argument`, the same `get_field_def` path every field renders through; where a
+declared default names another generic item at exactly the arguments that item calls its own,
+the rendered argument folds onto that item's `$SchemaDefault` instead of reconstructing a factory
+call the memo would not share with it — see `record_zod_default_arguments`. `zod_binding_reexport`
+covers both bindings wherever a renamed item re-exports its factory.
+
 Each factory memoizes on the identity of its arguments, one cache level per parameter, so two
 calls with the same argument objects return the identical schema and no two argument lists
 collide. The levels are written out to the exact depth the type declares rather than looped over:

--- a/README.md
+++ b/README.md
@@ -798,7 +798,7 @@ A struct, a tuple struct, an enum, an alias and a branded newtype can each name 
 
 **JSON Schema writes the document of whatever fills the parameter.** JSON Schema has no type parameters at all, so a document exists only at one filling: the type `default_types` declares where the document stands on its own, and the reference site's arguments where a field embeds it. The shape around the parameter -- an array, a map's keys, a tuple's arity -- is described either way.
 
-**Zod publishes a factory rather than a schema.** A Zod schema is a runtime value and TypeScript generics do not exist at runtime, so there is no one value a generic type could publish: the caller has to say what fills each parameter before anything can validate. A generic type therefore exports `X$SchemaFactory`, a function taking one required schema argument per parameter, and a field written with a parameter composes the argument bound for it.
+**Zod publishes a factory rather than a schema -- and a default beside it.** A Zod schema is a runtime value and TypeScript generics do not exist at runtime, so there is no one value a generic type could publish: the caller has to say what fills each parameter before anything can validate. A generic type therefore exports `X$SchemaFactory`, a function taking one required schema argument per parameter, and a field written with a parameter composes the argument bound for it. It also exports `X$SchemaDefault`: the factory called at the type's own declared `default_types`, memoized like any other call, so a consumer who wants the ordinary filling never constructs the argument list by hand.
 
 **With the `jsonschema` feature on, every type parameter needs a declared default type.** JSON Schema has no type parameters, so its document has to be built from one concrete filling, and `default_types` is where that filling is named — see [Declaring the default type](#declaring-the-default-type) below.
 
@@ -848,6 +848,8 @@ export const Wrapper$SchemaFactory = <IdType extends ZodType>(
   Wrapper$SchemaFactoryCache.set(idType, schema);
   return schema;
 };
+
+export const Wrapper$SchemaDefault: ZodType<Wrapper<string>> = Wrapper$SchemaFactory(z.string());
 ```
 
 Every parameter is a real TypeScript type parameter, never a bare `ZodType` annotation: `ZodType` defaults its own parameters, so an argument annotated with it would infer every field it validates as `unknown` and the caller would learn nothing from the schema handed back. Arguments are required -- a default would let a call site say nothing about a filling and still be handed a schema, which is exactly the silent mis-validation the factory exists to prevent.
@@ -860,6 +862,8 @@ const storedDocument = EcmDocument$SchemaFactory(objectIdSchema, z.date());
 
 EcmDocument$SchemaFactory(z.string(), z.number()) === wireDocument;  // false -- fresh arguments, new key
 ```
+
+That is why `$SchemaDefault` is written as a call through the factory rather than composed inline: a declared default that itself names another generic item -- `default_types(IdType = DocumentId<String>)` -- reads back `DocumentId`'s own `$SchemaDefault` rather than reconstructing `DocumentId$SchemaFactory(z.string())` from scratch. The two calls would key different cache entries even though they mean the same filling, so reading the sibling's binding back is what keeps `EcmDocument$SchemaDefault` sharing the one `DocumentId` schema everything else that asks for the ordinary filling shares too.
 
 A generic type that also flattens keeps the deferred read of its base, so declaration order stays irrelevant: `.and(z.lazy(() => Envelope$Schema))` composes inside the factory unchanged.
 
@@ -924,6 +928,8 @@ let stored = ecm_document_schema::Schema::json_schema_with(&[
 ```
 
 A field naming a generic type reaches that same entry point with the arguments written at the field, so what it embeds is the document its own filling describes -- a `StoredFolder` holding `EcmDocument<ObjectId, DateTime<Utc>>` embeds the `$oid` object and a date-time string, where a `WireFolder` holding `EcmDocument<String, f64>` embeds a string and a number. A parameter forwarded into such a reference carries whatever filled the item forwarding it.
+
+Zod reads the same declaration for `EcmDocument$SchemaDefault` -- see [Type Parameters](#type-parameters) above -- so the JSON document a standalone type describes and the Zod schema its ordinary filling validates against are built from the one statement of what that filling is, never two.
 
 The declaration is read in both directions, and each refusal points at what earned it:
 
@@ -1037,6 +1043,8 @@ export const UserId$SchemaFactory = <IdType extends ZodType>(
   UserId$SchemaFactoryCache.set(idType, schema);
   return schema;
 };
+
+export const UserId$SchemaDefault: ZodType<UserId<string>> = UserId$SchemaFactory(z.string());
 
 export type CorrelationId = string & $brand<"CorrelationId">;
 const CorrelationId$RawSchema = z.string().brand<"CorrelationId">().meta({
@@ -1335,6 +1343,8 @@ export const DocumentId$SchemaFactory = <IdType extends ZodType>(
   DocumentId$SchemaFactoryCache.set(idType, schema);
   return schema;
 };
+
+export const DocumentId$SchemaDefault: ZodType<DocumentId<string>> = DocumentId$SchemaFactory(z.string());
 ```
 
 ## Field Validation (`model_schema_prop`)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -765,9 +765,11 @@ pub fn model_schema_prop(_args: TokenStream, input: TokenStream) -> TokenStream 
 /// ```
 ///
 /// A generic type publishes `X$SchemaFactory` rather than `X$Schema`, because a Zod schema is a
-/// runtime value and one value cannot stand for every filling of a parameter. Each factory
-/// memoizes on the identity of the arguments it was handed, and `createSchemaCache` is the helper
-/// they all build those caches with:
+/// runtime value and one value cannot stand for every filling of a parameter. It also publishes
+/// `X$SchemaDefault`, the factory called at the type's own declared `default_types` — the ordinary
+/// filling, memoized like any other call so a consumer of the common case never has to construct
+/// the argument list by hand. Each factory memoizes on the identity of the arguments it was
+/// handed, and `createSchemaCache` is the helper they all build those caches with:
 ///
 #[cfg_attr(
     feature = "typescript",

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -39,7 +39,8 @@ use core::iter::once;
 
 #[cfg(feature = "zod")]
 use crate::utils::{
-    escape_js_regex_literal, extract_example_from_docs, record_zod_factory, zod_factory_argument,
+    escape_js_regex_literal, extract_example_from_docs, publishes_zod_factory,
+    record_zod_default_arguments, record_zod_factory, zod_default_arguments, zod_factory_argument,
 };
 
 #[cfg(all(feature = "zod", feature = "object_id"))]
@@ -1238,8 +1239,13 @@ fn process_type_alias(item_type: ItemType, args: &ModelSchemaArgs) -> TokenStrea
     let ts_method = generate_alias_ts_definition_method(&alias, &export_name, &alias_field_def);
     let json_schema_method =
         generate_alias_json_schema_method(&alias, &export_name, &alias_field_def, args);
-    let zod_method =
-        generate_alias_zod_method(&alias, &export_name, &rust_ident_str, &alias_field_def);
+    let zod_method = generate_alias_zod_method(
+        &alias,
+        &export_name,
+        &rust_ident_str,
+        &alias_field_def,
+        &args.default_types,
+    );
 
     let output = quote! {
         #alias
@@ -1446,11 +1452,7 @@ fn build_struct_delegate_items(
     #[cfg(feature = "zod")]
     let has_example = schema_example_method.is_some();
     #[cfg(feature = "zod")]
-    let reexport = ident_reexport_zod(
-        rust_ident,
-        item_name,
-        zod_binding_suffix(rust_ident, parameters),
-    );
+    let reexport = zod_binding_reexport(rust_ident, item_name, parameters);
     #[cfg(not(feature = "zod"))]
     let _: &_ = &(item_name, rust_ident, parameters);
     #[cfg(not(feature = "zod"))]
@@ -1904,6 +1906,7 @@ fn struct_schema_impl_items(
             item_name,
             rust_ident,
             &type_parameters,
+            &args.default_types,
             &bodies.1,
             "",
             &flatten.1,
@@ -4215,14 +4218,19 @@ fn build_tuple_struct_zod_schema_method(
     item_name: &str,
     rust_ident: &str,
     parameters: &[String],
+    default_types: &[(syn::Ident, syn::Type)],
     zod_body: &str,
 ) -> proc_macro2::TokenStream {
-    let reexport = ident_reexport_zod(
-        rust_ident,
+    let reexport = zod_binding_reexport(rust_ident, item_name, parameters);
+    let schema_str = zod_published_binding(
         item_name,
-        zod_binding_suffix(rust_ident, parameters),
+        rust_ident,
+        parameters,
+        default_types,
+        "",
+        zod_body,
+        &reexport,
     );
-    let schema_str = zod_published_binding(item_name, parameters, "", zod_body, &reexport);
     quote! {
         pub fn zod_schema() -> String {
             #schema_str.to_owned()
@@ -4305,6 +4313,7 @@ fn process_tuple_struct(
             &item_name,
             &name.to_string(),
             &type_parameters_in_scope(&item_struct.generics),
+            &args.default_types,
             &tuple_struct_zod_body(&shape),
         ),
     ];
@@ -4991,15 +5000,19 @@ fn build_branded_zod_schema_method(
     plain_description: &str,
 ) -> proc_macro2::TokenStream {
     let expression = branded_zod_expression(args, item_name, parameters, inner, plain_description);
-    let reexport = ident_reexport_zod(
-        rust_ident,
-        item_name,
-        zod_binding_suffix(rust_ident, parameters),
-    );
+    let reexport = zod_binding_reexport(rust_ident, item_name, parameters);
     let body = if parameters.is_empty() {
         branded_zod_const_block(item_name, inner, &expression, &reexport)
     } else {
-        zod_factory_block(item_name, parameters, "", &expression, &reexport)
+        zod_factory_block(
+            item_name,
+            rust_ident,
+            parameters,
+            &args.default_types,
+            "",
+            &expression,
+            &reexport,
+        )
     };
     quote! {
         pub fn zod_schema() -> String {
@@ -6496,6 +6509,7 @@ fn process_discriminated_enum(
         item_name,
         &name.to_string(),
         &type_parameters_in_scope(&item_enum.generics),
+        &args.default_types,
         &schema_code,
     );
 
@@ -7033,6 +7047,7 @@ fn process_externally_tagged_enum(
         item_name,
         &name.to_string(),
         &type_parameters_in_scope(&item_enum.generics),
+        &args.default_types,
         &schema_code,
     );
 
@@ -7447,6 +7462,7 @@ fn process_internally_tagged_enum(
         item_name,
         &name.to_string(),
         &type_parameters_in_scope(&item_enum.generics),
+        &args.default_types,
         &schema_code,
     );
 
@@ -8467,6 +8483,7 @@ fn build_untagged_schema_impl_items(
         item_name,
         &item_enum.ident.to_string(),
         &type_parameters_in_scope(&item_enum.generics),
+        &args.default_types,
         &schema_code,
     );
 
@@ -12010,6 +12027,28 @@ fn zod_binding_suffix(rust_ident: &str, parameters: &[String]) -> &'static str {
     }
 }
 
+/// The zod re-export text an item's module ends with — the factory's own alongside the default's,
+/// so a renamed generic item's alias answers to both names exactly as its own declaration does.
+///
+/// [`ident_reexport_zod`] writes one binding at a time; a type with no parameter has only one to
+/// write, and a generic type has two — its factory and the default this task adds beside it.
+#[cfg(feature = "zod")]
+fn zod_binding_reexport(rust_ident: &str, export_name: &str, parameters: &[String]) -> String {
+    let mut reexport = ident_reexport_zod(
+        rust_ident,
+        export_name,
+        zod_binding_suffix(rust_ident, parameters),
+    );
+    if !parameters.is_empty() {
+        reexport.push_str(&ident_reexport_zod(
+            rust_ident,
+            export_name,
+            "$SchemaDefault",
+        ));
+    }
+    reexport
+}
+
 /// The identifier holding the expression a factory's arguments compose into. Bound beside the
 /// factory rather than inlined in it, so the factory's return type can be read back off it and
 /// neither can drift from the other.
@@ -12160,6 +12199,91 @@ fn zod_factory_memoized_binding(item_name: &str, parameters: &[String]) -> Strin
     )
 }
 
+/// The `FieldDef` one `default_types` entry parses as: the declared filling for `parameter`, or —
+/// absent one — `String`, [`schema_example_value_type`]'s own fallback for the identical gap.
+/// Reached only in a build without `jsonschema`, the one feature that requires every parameter to
+/// declare one.
+#[cfg(feature = "zod")]
+fn declared_default_field(parameter: &str, default_types: &[(syn::Ident, syn::Type)]) -> FieldDef {
+    default_types
+        .iter()
+        .find(|(declared, _)| declared == parameter)
+        .map_or_else(
+            || get_field_def(parameter, &syn::parse_quote!(String), ""),
+            |(_, ty)| get_field_def(parameter, ty, ""),
+        )
+}
+
+/// The Zod argument one declared default composes: the ordinary rendering [`FieldDef::zod_type`]
+/// gives every field, or — where the default names another generic item at exactly the arguments
+/// that item calls its own — that item's own `$SchemaDefault`.
+///
+/// The fold matters beyond spelling: the factory's memo keys on argument identity, so two
+/// `z.string()` literals written at two call sites are two different objects and share nothing,
+/// while reading the sibling's own binding back reuses the very object its `$SchemaDefault` is
+/// pinned to — which is also what carries in whatever checks and brand the sibling's own default
+/// declared, rather than reconstructing a plain instantiation beside them. See
+/// [`record_zod_default_arguments`].
+///
+/// Left alone otherwise: a default written with different arguments still validates through the
+/// sibling's factory, exactly as a struct field of the same type does.
+#[cfg(feature = "zod")]
+fn default_zod_argument(field: &FieldDef) -> String {
+    if field.array_depth == 0
+        && !field.is_optional()
+        && let FieldDefType::SiblingType(name, args) = &field.field_type
+        && publishes_zod_factory(name)
+        && let Some(info) = lookup_alias_info(name)
+    {
+        let rendered: Vec<String> = args.iter().map(FieldDef::zod_type).collect();
+        if zod_default_arguments(name).as_deref() == Some(rendered.as_slice()) {
+            return format!("{}$SchemaDefault", info.export_name);
+        }
+    }
+    field.zod_type()
+}
+
+/// What a generic item appends after its factory: the factory called with each parameter's
+/// declared default, so `X$SchemaDefault === X$SchemaFactory(<the same arguments>)` by
+/// construction — through the very factory a hand-written call would go through, never the
+/// builder, which skips the memo and would build a second schema for the same filling.
+///
+/// Its own argument list is recorded through [`record_zod_default_arguments`] before this
+/// returns, so an item declared below this one can read it back through [`default_zod_argument`]
+/// and fold onto this very binding where its own declared default names this item at the same
+/// arguments.
+#[cfg(feature = "zod")]
+fn zod_default_block(
+    item_name: &str,
+    rust_ident: &str,
+    parameters: &[String],
+    default_types: &[(syn::Ident, syn::Type)],
+) -> String {
+    let fields: Vec<FieldDef> = parameters
+        .iter()
+        .map(|parameter| declared_default_field(parameter, default_types))
+        .collect();
+    let arguments: Vec<String> = fields.iter().map(default_zod_argument).collect();
+    record_zod_default_arguments(rust_ident, arguments.clone());
+
+    #[cfg(feature = "typescript")]
+    let annotation = format!(
+        ": ZodType<{item_name}<{}>>",
+        fields
+            .iter()
+            .map(FieldDef::typescript_typename)
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+    #[cfg(not(feature = "typescript"))]
+    let annotation = String::new();
+
+    format!(
+        "\n\nexport const {item_name}$SchemaDefault{annotation} = {item_name}$SchemaFactory({});",
+        arguments.join(", ")
+    )
+}
+
 /// What a generic type's Zod surface is written as: the builder holding the schema its arguments
 /// compose into, the return type read back off it, the cache interfaces, and the exported factory.
 ///
@@ -12167,10 +12291,16 @@ fn zod_factory_memoized_binding(item_name: &str, parameters: &[String]) -> Strin
 /// type has no one schema to publish — the caller has to say what fills each parameter before
 /// anything can validate. What it publishes instead is the function that answers that, and the
 /// cache is what keeps a filling asked for twice from becoming two schemas.
+///
+/// Beside the factory, this also publishes `$SchemaDefault` — see [`zod_default_block`] — the
+/// factory called at the item's own declared defaults, so a consumer who wants the ordinary
+/// filling never has to construct the argument list by hand.
 #[cfg(feature = "zod")]
 fn zod_factory_block(
     item_name: &str,
+    rust_ident: &str,
     parameters: &[String],
+    default_types: &[(syn::Ident, syn::Type)],
     preamble: &str,
     expression: &str,
     reexport: &str,
@@ -12211,9 +12341,11 @@ fn zod_factory_block(
     #[cfg(not(feature = "typescript"))]
     let returns = String::new();
 
+    let default_block = zod_default_block(item_name, rust_ident, parameters, default_types);
+
     format!(
         "{built}\n\n{declarations}export const {item_name}$SchemaFactory = \
-         {bounds}({arguments}\n){returns} => {{\n{body}\n}};{reexport}"
+         {bounds}({arguments}\n){returns} => {{\n{body}\n}};{default_block}{reexport}"
     )
 }
 
@@ -12246,7 +12378,9 @@ fn zod_const_block(item_name: &str, preamble: &str, expression: &str, reexport: 
 #[cfg(feature = "zod")]
 fn zod_published_binding(
     item_name: &str,
+    rust_ident: &str,
     parameters: &[String],
+    default_types: &[(syn::Ident, syn::Type)],
     preamble: &str,
     expression: &str,
     reexport: &str,
@@ -12254,7 +12388,15 @@ fn zod_published_binding(
     if parameters.is_empty() {
         zod_const_block(item_name, preamble, expression, reexport)
     } else {
-        zod_factory_block(item_name, parameters, preamble, expression, reexport)
+        zod_factory_block(
+            item_name,
+            rust_ident,
+            parameters,
+            default_types,
+            preamble,
+            expression,
+            reexport,
+        )
     }
 }
 
@@ -12385,21 +12527,26 @@ fn generate_zod_schema_method(
     item_name: &str,
     rust_ident: &str,
     parameters: &[String],
+    default_types: &[(syn::Ident, syn::Type)],
     schema_code: &str,
     show_opts: &str,
     flatten_schemas: &[MergedOperand],
 ) -> proc_macro2::TokenStream {
     #[cfg(feature = "zod")]
     {
-        let reexport = ident_reexport_zod(
-            rust_ident,
-            item_name,
-            zod_binding_suffix(rust_ident, parameters),
-        );
+        let reexport = zod_binding_reexport(rust_ident, item_name, parameters);
         let own = format!("z.strictObject({{\n{schema_code}}}){show_opts}");
         let (preamble, expression) = zod_merged_statements(item_name, &own, flatten_schemas);
         // Note: Example injection is handled by the delegating method on the type itself.
-        let body = zod_published_binding(item_name, parameters, &preamble, &expression, &reexport);
+        let body = zod_published_binding(
+            item_name,
+            rust_ident,
+            parameters,
+            default_types,
+            &preamble,
+            &expression,
+            &reexport,
+        );
 
         quote::quote! {
             pub fn zod_schema() -> String {
@@ -12414,6 +12561,7 @@ fn generate_zod_schema_method(
             item_name,
             rust_ident,
             parameters,
+            default_types,
             schema_code,
             show_opts,
             flatten_schemas,
@@ -12621,16 +12769,21 @@ fn generate_discriminated_enum_zod_schema_method(
     item_name: &str,
     rust_ident: &str,
     parameters: &[String],
+    default_types: &[(syn::Ident, syn::Type)],
     schema_code: &str,
 ) -> proc_macro2::TokenStream {
     #[cfg(feature = "zod")]
     {
-        let reexport = ident_reexport_zod(
-            rust_ident,
+        let reexport = zod_binding_reexport(rust_ident, item_name, parameters);
+        let schema_str = zod_published_binding(
             item_name,
-            zod_binding_suffix(rust_ident, parameters),
+            rust_ident,
+            parameters,
+            default_types,
+            "",
+            schema_code,
+            &reexport,
         );
-        let schema_str = zod_published_binding(item_name, parameters, "", schema_code, &reexport);
         quote::quote! {
             pub fn zod_schema() -> String {
                 #schema_str.to_owned()
@@ -12640,7 +12793,13 @@ fn generate_discriminated_enum_zod_schema_method(
 
     #[cfg(not(feature = "zod"))]
     {
-        let _: &_ = &(item_name, rust_ident, parameters, schema_code);
+        let _: &_ = &(
+            item_name,
+            rust_ident,
+            parameters,
+            default_types,
+            schema_code,
+        );
         quote::quote! {
             // Zod schema method not available - zod feature disabled
             // To enable: add "zod" to your features
@@ -12780,6 +12939,7 @@ fn generate_alias_zod_method(
     export_name: &str,
     rust_ident: &str,
     field_def: &FieldDef,
+    default_types: &[(syn::Ident, syn::Type)],
 ) -> proc_macro2::TokenStream {
     #[cfg(feature = "zod")]
     {
@@ -12788,12 +12948,16 @@ fn generate_alias_zod_method(
         // yields `Name$Schema`).
         let schema_code = surface_field_def(&alias.generics, field_def).zod_type();
         let parameters = type_parameters_in_scope(&alias.generics);
-        let reexport = ident_reexport_zod(
-            rust_ident,
+        let reexport = zod_binding_reexport(rust_ident, export_name, &parameters);
+        let body = zod_published_binding(
             export_name,
-            zod_binding_suffix(rust_ident, &parameters),
+            rust_ident,
+            &parameters,
+            default_types,
+            "",
+            &schema_code,
+            &reexport,
         );
-        let body = zod_published_binding(export_name, &parameters, "", &schema_code, &reexport);
         quote! {
             pub fn zod_schema() -> String {
                 #body.to_owned()
@@ -12804,7 +12968,7 @@ fn generate_alias_zod_method(
     {
         // Without the `zod` feature, `FieldDef::zod_type` does not exist; nothing in
         // this build has zod enabled, so the schema method would be cfg'd out anyway.
-        let _: &_ = &(alias, export_name, rust_ident, field_def);
+        let _: &_ = &(alias, export_name, rust_ident, field_def, default_types);
         quote! {}
     }
 }

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -2640,6 +2640,82 @@ fn a_string_filling_annotates_the_example_as_no_filling_does() {
     assert_eq!(render(&filled), render(&super::ModelSchemaArgs::default()));
 }
 
+/// The three shapes a declared default renders as: a primitive's ordinary Zod expression, another
+/// primitive's, and a reference to a generic sibling read back through [`super::default_zod_argument`]
+/// rather than reconstructed. The third row is the one that matters — `DocumentId` is registered as
+/// a factory publisher whose own `$SchemaDefault` was recorded at exactly `z.string()`, and
+/// `IdType = DocumentId<String>` names it at that identical argument, so the render folds onto
+/// `DocumentId$SchemaDefault` instead of composing `DocumentId$SchemaFactory(z.string())` a second
+/// time.
+#[cfg(feature = "zod")]
+#[test]
+fn declared_default_renders_each_shape_the_table_describes() {
+    register_alias_info(
+        "DocumentId",
+        "DocumentId",
+        "document_id_schema",
+        AliasKind::NoEnumMembers,
+    );
+    super::record_zod_factory("DocumentId", true);
+    super::record_zod_default_arguments("DocumentId", vec!["z.string()".to_owned()]);
+
+    for (parameter, filled_at, expected) in [
+        ("IdType", quote::quote! { String }, "z.string()"),
+        ("DateType", quote::quote! { f64 }, "z.number()"),
+        (
+            "IdType",
+            quote::quote! { DocumentId<String> },
+            "DocumentId$SchemaDefault",
+        ),
+    ] {
+        let ty: syn::Type = syn::parse2(filled_at.clone()).unwrap();
+        let default_types = vec![(
+            syn::Ident::new(parameter, proc_macro2::Span::call_site()),
+            ty,
+        )];
+        let field = super::declared_default_field(parameter, &default_types);
+        assert_eq!(
+            super::default_zod_argument(&field),
+            expected,
+            "for `{parameter} = {filled_at}`"
+        );
+    }
+}
+
+/// The fold only fires where the written arguments match the sibling's own recorded default; a
+/// reference to the same generic sibling at a *different* argument still calls its factory, exactly
+/// as an ordinary field naming it does.
+#[cfg(feature = "zod")]
+#[test]
+fn a_default_naming_a_sibling_at_other_than_its_own_default_calls_the_factory() {
+    register_alias_info(
+        "DocumentId",
+        "DocumentId",
+        "document_id_schema",
+        AliasKind::NoEnumMembers,
+    );
+    super::record_zod_factory("DocumentId", true);
+    super::record_zod_default_arguments("DocumentId", vec!["z.string()".to_owned()]);
+
+    let ty: syn::Type = syn::parse_quote!(DocumentId<u32>);
+    let default_types = vec![(syn::parse_quote!(IdType), ty)];
+    let field = super::declared_default_field("IdType", &default_types);
+    assert_eq!(
+        super::default_zod_argument(&field),
+        "DocumentId$SchemaFactory(z.number().int())"
+    );
+}
+
+/// A parameter with no `default_types` entry falls back to `String`, exactly as
+/// [`super::schema_example_value_type`] falls back for the identical absence — reached only in a
+/// build without `jsonschema`, the one feature that requires every parameter to declare one.
+#[cfg(feature = "zod")]
+#[test]
+fn a_parameter_with_no_declared_default_falls_back_to_string() {
+    let field = super::declared_default_field("IdType", &[]);
+    assert_eq!(super::default_zod_argument(&field), "z.string()");
+}
+
 #[cfg(feature = "jsonschema")]
 #[test]
 fn branded_json_schema_method_carries_no_cfg_attribute() {
@@ -2868,8 +2944,9 @@ fn an_alias_type_parameter_is_erased_at_every_depth_on_the_value_surface() {
     ] {
         let alias: syn::ItemType = syn::parse_str(alias_source).unwrap();
         let field_def = super::get_field_def("HolderType", &alias.ty, "");
-        let tokens = super::generate_alias_zod_method(&alias, "HolderType", "Holder", &field_def)
-            .to_string();
+        let tokens =
+            super::generate_alias_zod_method(&alias, "HolderType", "Holder", &field_def, &[])
+                .to_string();
         assert!(
             !tokens.contains("V$Schema"),
             "for {alias_source}, got: {tokens}"
@@ -2905,7 +2982,7 @@ fn alias_zod_method_carries_no_cfg_attribute() {
     );
     let ty: syn::Type = syn::parse_quote!(String);
     let field_def = super::get_field_def("AliasType", &ty, "");
-    let tokens = super::generate_alias_zod_method(&alias, "AliasType", "Alias", &field_def);
+    let tokens = super::generate_alias_zod_method(&alias, "AliasType", "Alias", &field_def, &[]);
     assert_no_cfg_attribute(&tokens, "generate_alias_zod_method");
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -662,6 +662,9 @@ thread_local! {
     /// The names whose items publish a Zod factory. Kept out of [`ALIAS_INFO`] so the answer
     /// survives the item's own registration — see [`record_zod_factory`].
     static ZOD_FACTORY_PUBLISHERS: RefCell<HashSet<String>> = RefCell::new(HashSet::new());
+    /// Each generic item's own `$SchemaDefault` argument list, one rendered Zod expression per
+    /// parameter in declaration order — see [`record_zod_default_arguments`].
+    static ZOD_DEFAULT_ARGUMENTS: RefCell<HashMap<String, Vec<String>>> = RefCell::new(HashMap::new());
 }
 
 thread_local! {
@@ -890,6 +893,29 @@ pub fn record_zod_factory(rust_ident: &str, publishes: bool) {
 #[cfg(feature = "zod")]
 pub fn publishes_zod_factory(rust_ident: &str) -> bool {
     ZOD_FACTORY_PUBLISHERS.with(|names| names.borrow().contains(rust_ident))
+}
+
+/// Records the Zod argument list `rust_ident`'s own `$SchemaDefault` calls its factory with, one
+/// rendered expression per parameter in declaration order.
+///
+/// Recorded once as the item's `$SchemaDefault` is built, so a later item whose own declared
+/// default names this one at the identical arguments can read them back and fold onto this
+/// binding instead of composing a second call the memo cache does not share with it — two
+/// separately written `z.string()` calls are two different objects, and the cache keys on argument
+/// identity, not on what the argument says.
+#[cfg(feature = "zod")]
+pub fn record_zod_default_arguments(rust_ident: &str, arguments: Vec<String>) {
+    ZOD_DEFAULT_ARGUMENTS.with(|map| {
+        map.borrow_mut().insert(rust_ident.to_owned(), arguments);
+    });
+}
+
+/// The argument list [`record_zod_default_arguments`] recorded for `rust_ident`, or `None` where
+/// nothing was — the item declares no parameter, has not registered yet, or this build never
+/// reads defaults at all.
+#[cfg(feature = "zod")]
+pub fn zod_default_arguments(rust_ident: &str) -> Option<Vec<String>> {
+    ZOD_DEFAULT_ARGUMENTS.with(|map| map.borrow().get(rust_ident).cloned())
 }
 
 /// The characters a `\d`, `\w` or `\s` covers in *both* engines, written out as a class body.

--- a/tests/generic_types_tests/tests.rs
+++ b/tests/generic_types_tests/tests.rs
@@ -238,9 +238,10 @@ mod zod {
     #[cfg(all(feature = "chrono", feature = "object_id"))]
     use super::MixedArguments;
     use super::{
-        Adjacent, Carried, Envelope, External, FolderTree, Holder, Internal, KeyedByParameter,
-        LifetimeStruct, Pair, PlainConst, Positional, Quintet, Referrer, Summarised, Tagged,
-        Untagged, WireFolder, Wrapper, keyed_alias_schema,
+        Adjacent, Carried, EchoedDefault, EcmDocument, Envelope, External, FolderTree, Holder,
+        Internal, KeyedByParameter, LifetimeStruct, OverriddenDefault, Pair, PlainConst,
+        Positional, Quintet, Referrer, Summarised, Tagged, Untagged, WireFolder, Wrapper,
+        keyed_alias_schema,
     };
 
     /// A record key has to produce string keys, and serde says every instantiation this map has
@@ -395,7 +396,8 @@ mod zod {
     }
 
     /// A const parameter and a lifetime name no type, so neither reaches a schema and there is
-    /// nothing for a factory to bind — the item publishes the one schema it has.
+    /// nothing for a factory to bind — the item publishes the one schema it has, and no default
+    /// beside it: a `$SchemaDefault` calls a factory, and there is none to call.
     #[test]
     fn an_item_binding_no_type_parameter_still_publishes_a_schema() {
         for (name, zod) in [
@@ -404,6 +406,7 @@ mod zod {
         ] {
             assert!(publishes_a_schema_const(&zod, name), "Got: {zod}");
             assert!(!zod.contains("$SchemaFactory"), "Got: {zod}");
+            assert!(!zod.contains("$SchemaDefault"), "Got: {zod}");
         }
     }
 
@@ -417,6 +420,91 @@ mod zod {
             "Got: {zod}"
         );
         assert!(!publishes_a_schema_const(&zod, "Holder"), "Got: {zod}");
+    }
+
+    /// The re-export covers both bindings a generic item publishes, not only the factory it always
+    /// had — a renamed item's alias answers to `$SchemaDefault` exactly as it answers to
+    /// `$SchemaFactory`.
+    #[test]
+    fn the_default_is_reexported_alongside_the_factory() {
+        let zod = Holder::<String>::zod_schema();
+        assert!(
+            zod.contains("export const Holder$SchemaDefault = RenamedHolder$SchemaDefault;"),
+            "Got: {zod}"
+        );
+    }
+
+    /// A generic item's `$SchemaDefault` is the factory called with each parameter's declared
+    /// default — the ordinary case a consumer no longer has to construct by hand.
+    #[test]
+    fn a_generic_type_publishes_a_default_through_its_own_factory() {
+        let zod = Wrapper::<String>::zod_schema();
+        assert!(
+            zod.contains("export const Wrapper$SchemaDefault"),
+            "Got: {zod}"
+        );
+        assert!(
+            zod.contains("= Wrapper$SchemaFactory(z.string());"),
+            "Got: {zod}"
+        );
+    }
+
+    /// Under `typescript`, the default carries an annotation naming the instantiation it validates
+    /// — the one place a `TypeScript` type is spelled for a binding a factory otherwise reads its
+    /// return type back off.
+    #[cfg(feature = "typescript")]
+    #[test]
+    fn the_default_is_annotated_with_the_instantiation_it_validates() {
+        let zod = Wrapper::<String>::zod_schema();
+        assert!(
+            zod.contains(
+                "export const Wrapper$SchemaDefault: ZodType<Wrapper<string>> = \
+                 Wrapper$SchemaFactory(z.string());"
+            ),
+            "Got: {zod}"
+        );
+    }
+
+    /// Two parameters fill two arguments, each read off its own `default_types` entry and written
+    /// in declaration order.
+    #[test]
+    fn a_two_parameter_default_fills_each_argument_in_declaration_order() {
+        let zod = EcmDocument::<String, f64>::zod_schema();
+        assert!(
+            zod.contains("export const EcmDocument$SchemaDefault"),
+            "Got: {zod}"
+        );
+        assert!(
+            zod.contains("= EcmDocument$SchemaFactory(z.string(), z.number());"),
+            "Got: {zod}"
+        );
+    }
+
+    /// A declared default naming another generic item at exactly the arguments that item calls its
+    /// own default folds the argument onto that item's own `$SchemaDefault`, so the checks and
+    /// brand it declared are carried in by reference instead of rebuilt under a `z.string()` the
+    /// memo would not share with it.
+    #[test]
+    fn a_default_naming_a_siblings_own_default_folds_onto_its_binding() {
+        let zod = EchoedDefault::<String>::zod_schema();
+        assert!(
+            zod.contains("= EchoedDefault$SchemaFactory(Tagged$SchemaDefault);"),
+            "Got: {zod}"
+        );
+    }
+
+    /// The same shape at a filling that names the sibling at an argument other than its own
+    /// default — the fold does not fire, and the reference still calls the sibling's factory
+    /// exactly as an ordinary field naming it does.
+    #[test]
+    fn a_default_naming_a_sibling_at_another_filling_still_calls_its_factory() {
+        let zod = OverriddenDefault::<String>::zod_schema();
+        assert!(
+            zod.contains(
+                "= OverriddenDefault$SchemaFactory(Tagged$SchemaFactory(z.number().int()));"
+            ),
+            "Got: {zod}"
+        );
     }
 
     /// A base is read when the intersection is used rather than while the value holding it is
@@ -1507,6 +1595,28 @@ pub struct Perch {
 pub struct Summarised<ValueType> {
     pub boxed: Boxed<ValueType>,
     pub tagged: Tagged<ValueType>,
+}
+
+/// A `default_types` entry naming another generic item at exactly the arguments that item calls
+/// its own default — the fold that lets the argument read `Tagged$SchemaDefault` rather than
+/// reconstruct `Tagged$SchemaFactory(z.string())` beside it, a call the memo would not share with
+/// `Tagged`'s own binding. Read by the Zod surface alone, which is the only one that renders a
+/// declared default as an argument.
+#[cfg(feature = "zod")]
+#[model_schema(default_types(HolderType = Tagged<String>))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EchoedDefault<HolderType> {
+    pub held: HolderType,
+}
+
+/// The same shape at a filling that names `Tagged` at an argument other than its own declared
+/// default — the whole of the evidence that the fold is conditioned on the arguments matching
+/// rather than firing for any reference to a generic sibling.
+#[cfg(feature = "zod")]
+#[model_schema(default_types(HolderType = Tagged<u32>))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OverriddenDefault<HolderType> {
+    pub held: HolderType,
 }
 
 /// A generic type that names itself, at the filling it was entered at — the cycle a document


### PR DESCRIPTION
A generic type now exports `X$SchemaDefault` alongside `X$SchemaFactory`: the factory called at the type's own declared `default_types`, so a consumer wanting the ordinary filling shares the memo instead of constructing the argument list by hand.

- Each declared default renders through the same `get_field_def` path every field uses (`String` → `z.string()`, `f64` → `z.number()`).
- A default naming another generic item at exactly the arguments that item calls its own default folds onto that item's `$SchemaDefault`, keeping one schema per filling in the memo and carrying the sibling's checks and brand in by reference.
- Under `typescript` the const is annotated with the instantiation it validates (`ZodType<X<...>>`).
- Renamed items re-export `$SchemaDefault` beside `$SchemaFactory`; non-generic types are untouched.
- Docs updated in README, CLAUDE.md, and the `typescript_preamble!` doc comment.

Gate: `just lint-all` and `just test` (full feature powerset) green.