### PR TITLE
defer sibling references in default-schema arguments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -384,6 +384,19 @@ the rendered argument folds onto that item's `$SchemaDefault` instead of reconst
 call the memo would not share with it — see `record_zod_default_arguments`. `zod_binding_reexport`
 covers both bindings wherever a renamed item re-exports its factory.
 
+`X$SchemaDefault` is a module-scope `const`, and any argument `default_zod_argument` renders as a
+reference to another item — the fold above, or an ordinary (non-folding) call to that item's own
+`X$SchemaFactory` — names one more module-scope `const`. One macro invocation sees one type, so
+nothing here can know whether that `const` is written above this one in the generated module or
+below it; `default_zod_argument` defers every such reference through `deferred_zod_operand`, the
+same `z.lazy(() => …)` wrap `.and(...)` already relies on for a flattened base. A self-contained
+expression like `z.string()` names no sibling `const` and is left eager. The deferral is also what
+ends a cycle between two declared defaults — `CycleLeader`'s naming `CycleFollower` and
+`CycleFollower`'s naming `CycleLeader` back: neither can have registered the other's arguments yet
+when it expands, so neither side folds, and both calls read the other's factory behind `z.lazy`
+rather than at the top of a `const` initializer — the module loads regardless of which of the two
+names the consuming project's entity list writes first.
+
 Each factory memoizes on the identity of its arguments, one cache level per parameter, so two
 calls with the same argument objects return the identical schema and no two argument lists
 collide. The levels are written out to the exact depth the type declares rather than looped over:

--- a/README.md
+++ b/README.md
@@ -865,6 +865,15 @@ EcmDocument$SchemaFactory(z.string(), z.number()) === wireDocument;  // false --
 
 That is why `$SchemaDefault` is written as a call through the factory rather than composed inline: a declared default that itself names another generic item -- `default_types(IdType = DocumentId<String>)` -- reads back `DocumentId`'s own `$SchemaDefault` rather than reconstructing `DocumentId$SchemaFactory(z.string())` from scratch. The two calls would key different cache entries even though they mean the same filling, so reading the sibling's binding back is what keeps `EcmDocument$SchemaDefault` sharing the one `DocumentId` schema everything else that asks for the ordinary filling shares too.
 
+That reference is deferred, exactly like a flattened base's is: `DocumentId$SchemaDefault` is a module-scope `const`, a generated module concatenates one type's output after another in whatever order the consuming project's entity list produces, and one macro invocation sees one type -- so nothing here can know whether `DocumentId`'s `const` is written above `EcmDocument`'s in the emitted module or below it.
+
+```typescript
+export const EcmDocument$SchemaDefault: ZodType<EcmDocument<DocumentId<string>, number>> =
+  EcmDocument$SchemaFactory(z.lazy(() => DocumentId$SchemaDefault), z.number());
+```
+
+The same deferral covers an argument that does not fold -- a declared default naming a sibling at arguments other than that sibling's own default still calls its factory, behind the identical `z.lazy(() => …)` -- which is what keeps a cycle between two declared defaults from throwing at import: neither side can have registered the other's arguments yet when it is expanded, so neither folds, and both read the other's factory lazily rather than at the top of a `const` initializer.
+
 A generic type that also flattens keeps the deferred read of its base, so declaration order stays irrelevant: `.and(z.lazy(() => Envelope$Schema))` composes inside the factory unchanged.
 
 #### A generic type may reach itself

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -12215,8 +12215,29 @@ fn declared_default_field(parameter: &str, default_types: &[(syn::Ident, syn::Ty
 }
 
 /// The Zod argument one declared default composes: the ordinary rendering [`FieldDef::zod_type`]
-/// gives every field, or — where the default names another generic item at exactly the arguments
-/// that item calls its own — that item's own `$SchemaDefault`.
+/// gives every field, deferred through [`deferred_zod_operand`] wherever that rendering names
+/// another item's own module-scope binding — its factory, called with fresh arguments exactly as
+/// an ordinary field naming it does, or, where the default names that item at exactly the
+/// arguments it calls its own, that item's `$SchemaDefault` directly (the fold).
+///
+/// Either shape is deferred for the reason [`deferred_zod_operand`]'s own doc comment states for a
+/// flattened base: `{name}$SchemaFactory` and `{name}$SchemaDefault` are each another module-scope
+/// `const`, one macro invocation sees one type, and a generated module concatenates one string per
+/// type in whatever order the consuming project's entity list produces — so nothing here can know
+/// whether that `const` is written above this one or below it. `X$SchemaDefault` still goes
+/// through `X$SchemaFactory` either way — the deferral only wraps the argument, never bypasses the
+/// call — so the identity guarantee that composes never turns on which of the two names the
+/// argument; only the moment the name is read moves, from the instant this `const`'s initializer
+/// runs to the first time something asks the resulting schema to validate. A self-contained
+/// expression like `z.string()` names no sibling `const` at all, so it is left eager.
+///
+/// Deferring both shapes — not only the fold — is also what ends a cycle between two declared
+/// defaults without a diagnostic refusing either side: two generic items whose defaults name each
+/// other compile fine (Rust resolves types in a module regardless of declaration order), but
+/// neither can have registered the other's `$SchemaDefault` arguments yet when it is itself
+/// expanded, so neither side folds and both would otherwise call the other's factory eagerly, at
+/// the top of a `const` initializer, with nothing to say which of the two names the module either
+/// side ends up written into declares first.
 ///
 /// The fold matters beyond spelling: the factory's memo keys on argument identity, so two
 /// `z.string()` literals written at two call sites are two different objects and share nothing,
@@ -12224,21 +12245,21 @@ fn declared_default_field(parameter: &str, default_types: &[(syn::Ident, syn::Ty
 /// pinned to — which is also what carries in whatever checks and brand the sibling's own default
 /// declared, rather than reconstructing a plain instantiation beside them. See
 /// [`record_zod_default_arguments`].
-///
-/// Left alone otherwise: a default written with different arguments still validates through the
-/// sibling's factory, exactly as a struct field of the same type does.
 #[cfg(feature = "zod")]
 fn default_zod_argument(field: &FieldDef) -> String {
     if field.array_depth == 0
         && !field.is_optional()
         && let FieldDefType::SiblingType(name, args) = &field.field_type
-        && publishes_zod_factory(name)
-        && let Some(info) = lookup_alias_info(name)
     {
-        let rendered: Vec<String> = args.iter().map(FieldDef::zod_type).collect();
-        if zod_default_arguments(name).as_deref() == Some(rendered.as_slice()) {
-            return format!("{}$SchemaDefault", info.export_name);
+        if publishes_zod_factory(name)
+            && let Some(info) = lookup_alias_info(name)
+        {
+            let rendered: Vec<String> = args.iter().map(FieldDef::zod_type).collect();
+            if zod_default_arguments(name).as_deref() == Some(rendered.as_slice()) {
+                return deferred_zod_operand(&format!("{}$SchemaDefault", info.export_name));
+            }
         }
+        return deferred_zod_operand(&field.zod_type());
     }
     field.zod_type()
 }

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -2646,7 +2646,8 @@ fn a_string_filling_annotates_the_example_as_no_filling_does() {
 /// a factory publisher whose own `$SchemaDefault` was recorded at exactly `z.string()`, and
 /// `IdType = DocumentId<String>` names it at that identical argument, so the render folds onto
 /// `DocumentId$SchemaDefault` instead of composing `DocumentId$SchemaFactory(z.string())` a second
-/// time.
+/// time — deferred, since `DocumentId$SchemaDefault` is a module-scope `const` this one's own
+/// `const` cannot be known to be written above or below.
 #[cfg(feature = "zod")]
 #[test]
 fn declared_default_renders_each_shape_the_table_describes() {
@@ -2665,7 +2666,7 @@ fn declared_default_renders_each_shape_the_table_describes() {
         (
             "IdType",
             quote::quote! { DocumentId<String> },
-            "DocumentId$SchemaDefault",
+            "z.lazy(() => DocumentId$SchemaDefault)",
         ),
     ] {
         let ty: syn::Type = syn::parse2(filled_at.clone()).unwrap();
@@ -2684,7 +2685,9 @@ fn declared_default_renders_each_shape_the_table_describes() {
 
 /// The fold only fires where the written arguments match the sibling's own recorded default; a
 /// reference to the same generic sibling at a *different* argument still calls its factory, exactly
-/// as an ordinary field naming it does.
+/// as an ordinary field naming it does — and that call is deferred exactly as the fold's own
+/// reference is, since `DocumentId$SchemaFactory` is one more module-scope `const` this one cannot
+/// know is declared above it or below.
 #[cfg(feature = "zod")]
 #[test]
 fn a_default_naming_a_sibling_at_other_than_its_own_default_calls_the_factory() {
@@ -2702,7 +2705,7 @@ fn a_default_naming_a_sibling_at_other_than_its_own_default_calls_the_factory() 
     let field = super::declared_default_field("IdType", &default_types);
     assert_eq!(
         super::default_zod_argument(&field),
-        "DocumentId$SchemaFactory(z.number().int())"
+        "z.lazy(() => DocumentId$SchemaFactory(z.number().int()))"
     );
 }
 

--- a/tests/generic_types_tests/tests.rs
+++ b/tests/generic_types_tests/tests.rs
@@ -238,11 +238,40 @@ mod zod {
     #[cfg(all(feature = "chrono", feature = "object_id"))]
     use super::MixedArguments;
     use super::{
-        Adjacent, Carried, EchoedDefault, EcmDocument, Envelope, External, FolderTree, Holder,
-        Internal, KeyedByParameter, LifetimeStruct, OverriddenDefault, Pair, PlainConst,
-        Positional, Quintet, Referrer, Summarised, Tagged, Untagged, WireFolder, Wrapper,
-        keyed_alias_schema,
+        Adjacent, Carried, CycleFollower, CycleLeader, EchoedDefault, EcmDocument, Envelope,
+        External, FolderTree, Holder, Internal, KeyedByParameter, LifetimeStruct,
+        OverriddenDefault, Pair, PlainConst, Positional, Quintet, Referrer, Summarised, Tagged,
+        Untagged, WireFolder, Wrapper, keyed_alias_schema,
     };
+
+    /// Two generic items whose declared defaults name each other: `CycleLeader`'s names
+    /// `CycleFollower` and `CycleFollower`'s names `CycleLeader` back, at arguments neither can have
+    /// registered yet when the other is expanded — one macro invocation sees one type, so neither
+    /// side can know at expansion time that the other's declared default will turn out to name it
+    /// back. Nothing folds, both sides call the other's factory, and both calls are deferred exactly
+    /// as an unfolded reference to any other sibling's factory already is: the module loads and
+    /// resolves each side's read only once something asks the resulting schema to validate, so
+    /// which of the two names is written first in the generated module is never asked.
+    #[test]
+    fn a_cycle_between_two_defaults_is_deferred_on_both_sides() {
+        let leader = CycleLeader::<u32>::zod_schema();
+        assert!(
+            leader.contains(
+                "= CycleLeader$SchemaFactory(z.lazy(() => \
+                 CycleFollower$SchemaFactory(z.number().int())));"
+            ),
+            "Got: {leader}"
+        );
+
+        let follower = CycleFollower::<u32>::zod_schema();
+        assert!(
+            follower.contains(
+                "= CycleFollower$SchemaFactory(z.lazy(() => \
+                 CycleLeader$SchemaFactory(z.number().int())));"
+            ),
+            "Got: {follower}"
+        );
+    }
 
     /// A record key has to produce string keys, and serde says every instantiation this map has
     /// does: it writes a JSON object key as a string or refuses the map outright at serialization.
@@ -484,24 +513,32 @@ mod zod {
     /// own default folds the argument onto that item's own `$SchemaDefault`, so the checks and
     /// brand it declared are carried in by reference instead of rebuilt under a `z.string()` the
     /// memo would not share with it.
+    ///
+    /// The folded reference is deferred through `z.lazy` — `Tagged$SchemaDefault` is a module-scope
+    /// `const` like `EchoedDefault$SchemaDefault` itself, and a generated module concatenates one
+    /// string per type in whatever order the consuming project's entity list produces, so nothing
+    /// here can know whether `Tagged`'s `const` is written above this one or below it.
     #[test]
     fn a_default_naming_a_siblings_own_default_folds_onto_its_binding() {
         let zod = EchoedDefault::<String>::zod_schema();
         assert!(
-            zod.contains("= EchoedDefault$SchemaFactory(Tagged$SchemaDefault);"),
+            zod.contains("= EchoedDefault$SchemaFactory(z.lazy(() => Tagged$SchemaDefault));"),
             "Got: {zod}"
         );
     }
 
     /// The same shape at a filling that names the sibling at an argument other than its own
     /// default — the fold does not fire, and the reference still calls the sibling's factory
-    /// exactly as an ordinary field naming it does.
+    /// exactly as an ordinary field naming it does, deferred exactly as the fold's own reference
+    /// is: `Tagged$SchemaFactory` is a module-scope `const` this one's own `const` cannot know is
+    /// declared above it or below.
     #[test]
     fn a_default_naming_a_sibling_at_another_filling_still_calls_its_factory() {
         let zod = OverriddenDefault::<String>::zod_schema();
         assert!(
             zod.contains(
-                "= OverriddenDefault$SchemaFactory(Tagged$SchemaFactory(z.number().int()));"
+                "= OverriddenDefault$SchemaFactory(z.lazy(() => \
+                 Tagged$SchemaFactory(z.number().int())));"
             ),
             "Got: {zod}"
         );
@@ -1617,6 +1654,20 @@ pub struct EchoedDefault<HolderType> {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OverriddenDefault<HolderType> {
     pub held: HolderType,
+}
+
+#[cfg(feature = "zod")]
+#[model_schema(default_types(ValueType = CycleFollower<u32>))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CycleLeader<ValueType> {
+    pub value: ValueType,
+}
+
+#[cfg(feature = "zod")]
+#[model_schema(default_types(ValueType = CycleLeader<u32>))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CycleFollower<ValueType> {
+    pub value: ValueType,
 }
 
 /// A generic type that names itself, at the filling it was entered at — the cycle a document


### PR DESCRIPTION
`X$SchemaDefault` is a module-scope const whose arguments may name other types' module-scope bindings, and the consuming project's entity list decides emission order — so an eager reference could hit a temporal-dead-zone error at import.

- `default_zod_argument` now wraps every argument that references another item's binding in `z.lazy(() => …)` (`deferred_zod_operand`, the same mechanism flattened bases already use): both the fold onto a sibling's `$SchemaDefault` and a non-folding call to its `$SchemaFactory`.
- Deferring the non-fold path is also what ends a cycle between two declared defaults — neither side can have registered the other's arguments at expansion time, so neither folds, and both must read the other lazily (new `CycleLeader`/`CycleFollower` fixtures pin this).
- Self-contained expressions (`z.string()`, `z.number()`, …) stay eager; the const still goes through the factory, so the memo identity is untouched.
- Docs updated in README and CLAUDE.md.

Gate: `just lint-all` and `just test` (full feature powerset) green.