### PR TITLE
route a generic brand's string constraints onto its declared default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -463,6 +463,33 @@ untouched — that is the one position it renders in, as an unbounded array.
 There is no fallback filling. A guessed one produces a document that silently rejects valid
 payloads, which is what the declaration exists to prevent.
 
+### String Constraints on a Generic Brand's Declared Default
+
+A branded newtype's own `pattern`/`minLength`/`maxLength` normally have no inner to measure when
+the inner is one of the brand's own bare type parameters — a parameter is the opaque value on
+every surface, and `z.unknown()` carries no `.min`/`.max`. `branded_constraint_inner_error` reads
+the declared default for that parameter instead of refusing outright: `declared_default_field`
+resolves the same `default_types` entry `zod_default_block` reads, and `non_string_inner_shape`
+asks of it the same question asked of a concrete argument — string-shaped, the checks compose onto
+the default; not string-shaped, the refusal names the default rather than the parameter, through
+`declared_default_constraint_message`. An entry the declaration left out falls back to `String`,
+the same fallback `schema_example_value_type` uses for the identical gap, so the guard alone
+requires nothing; only `jsonschema`'s own separate requirement (above) forces every parameter to
+declare one.
+
+The checks never reach the factory's own parameter — `branded_zod_inner` renders a bare-parameter
+inner with no check appended regardless of genericness, since a caller filling the parameter with
+something other than the default (an `ObjectId` schema, say) must not inherit bounds meant for it.
+They land once, on `$SchemaDefault`'s argument for that one parameter: `zod_default_block` and
+`zod_factory_block` both take a `ZodDefaultInputs` bundling `default_types` with the optional
+`(parameter, checks)` pair a branded newtype's own expansion supplies — `None` for every ordinary
+generic struct, tuple struct, enum and alias, which carry no type-level string constraint of their
+own. The JSON surface needs no separate change: a bare parameter's document is already the runtime
+argument bound to the parameter's declared filling (`json_argument_value`, defaulting through
+`declared_filling_json_schema_value`), which `branded_layered_over` narrows with the brand's own
+bounds through the same `allOf` a named inner is narrowed through — never the inert `{}` a
+parameter with no default at all would describe as.
+
 ### Adding Examples to Types
 
 To add examples to your types for inclusion in Zod schemas:

--- a/README.md
+++ b/README.md
@@ -987,7 +987,7 @@ const buildWrapperType$Schema = <T extends ZodType>(
 
 Only the item's *own* parameters are read this way. A name the expansion cannot resolve because the type lives elsewhere keeps its `Name$Schema` reference, since that type publishes the binding.
 
-One consequence is worth stating outright: a parameter is a value only where a factory binds one for it, and a JSON document is written at one filling rather than for the type as declared — so no `model_schema_prop` bound may be spelled against a type parameter. A branded newtype cannot apply `pattern`, `minLength`, or `maxLength` to one of its own — see [Branded Newtype Validation Constraints](#branded-newtype-validation-constraints) — and a *field* typed with one is refused for the same reason, at every depth the parameter is reached through:
+One consequence is worth stating outright: a parameter is a value only where a factory binds one for it, and a JSON document is written at one filling rather than for the type as declared — so no `model_schema_prop` bound may be spelled against a type parameter, and a *field* typed with one is refused for the same reason, at every depth the parameter is reached through. A branded newtype's own `pattern`/`minLength`/`maxLength` are the one exception: applied directly to a bare-parameter inner, they read the parameter's *declared default* rather than the parameter itself — see [Branded Newtype Validation Constraints](#branded-newtype-validation-constraints).
 
 ```rust
 #[model_schema(default_types(IdType = String))]
@@ -1148,21 +1148,38 @@ You can add `pattern`, `minLength`, and `maxLength` constraints directly on the 
 
 That answer comes from the type's own expansion, so it is only available once that expansion has run: a brand written **above** the type it names, or over a type this crate never expands at all, is admitted with the emission it has always had. Declaration order is not a diagnostic — moving a declaration must not turn a compiling program into a rejected one — so keep a constrained brand below the type it constrains if you want the check.
 
-An opaque inner is `serde_json::Value` **or one of the brand's own type parameters**, which both validating surfaces read as the opaque value (see [Type Parameters](#type-parameters)). There is nothing there for the checks to attach to: Zod 4's `z.unknown()` carries no `.min`/`.max` at all, and `.brand()` hands back that same schema rather than a wrapper that could. Constrain a string-typed inner instead, or brand at the instantiation:
+An opaque inner is `serde_json::Value`, which both validating surfaces read as the opaque value (see [Type Parameters](#type-parameters)) and which the checks are refused against outright — there is nothing there for them to attach to.
+
+**One of the brand's own type parameters is different: it reads its declared default instead of being refused.** A bare parameter is not itself a type the checks could measure, but `#[model_schema]` already requires (for `jsonschema`) or defaults (elsewhere) a concrete filling for every parameter — see [Declaring the default type](#declaring-the-default-type) — and that filling is exactly as concrete as a named type's own schema. So the guard asks the same question of the declared default it asks of a named inner: a string-shaped default carries the checks, a non-string one is refused in its place. The checks land once, on `$SchemaDefault`'s argument for that parameter; the factory itself stays unconstrained, so a caller filling the parameter with something else — an `ObjectId` schema, say — is never held to bounds meant for the default:
 
 ```rust
-// Rejected: the checks would have to measure a value no surface has a shape for.
-#[model_schema(minLength = 3, default_types(T = String))]
+// Accepted: `IdType`'s declared default is `String`, so the checks land there.
+#[model_schema(minLength = 24, maxLength = 24, pattern = "^[a-f0-9]{24}$", default_types(IdType = String))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct GenericSlug<T>(pub T);
+pub struct DocumentId<IdType>(pub IdType);
 
-// Accepted: the inner is a string, and the brand says so.
-#[model_schema(minLength = 3)]
+// Rejected: `IdType`'s declared default is `u32`, which cannot carry them.
+#[model_schema(minLength = 3, default_types(IdType = u32))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct Slug(pub String);
+pub struct GenericCount<IdType>(pub IdType);
 ```
+
+```typescript
+const buildDocumentId$Schema = <IdType extends ZodType>(idType: IdType) =>
+  idType.brand<"DocumentId">();
+
+// The factory itself carries no check — a non-default filling is not held to it.
+export const DocumentId$SchemaFactory = <IdType extends ZodType>(idType: IdType) => { /* ... */ };
+
+// $SchemaDefault composes the factory with the constrained default argument.
+export const DocumentId$SchemaDefault = DocumentId$SchemaFactory(
+  z.string().min(24).max(24).check(z.regex(/^[a-f0-9]{24}$/)),
+);
+```
+
+An entry `default_types` leaves out falls back to `String`, the same fallback a parameter with no declared filling gets everywhere else the declaration is read — so a constrained bare-parameter brand with no `default_types` at all still compiles. Only the `jsonschema` feature actually requires a declared entry for every parameter, through the unrelated requirement in the table above.
 
 **A name written over one of those parameters is rejected too**, whether or not the named type has expanded yet. `Tagged<T>` is not a type the declaration fixed — the instantiation fixes it — so the checks land on whatever the caller supplies: Zod appends them to a schema the call site decides the shape of, the one JSON document written for every instantiation still holds the `{}` a parameter describes as, and `validate()` measures the inner's `Display` rendering, which rejects `TaggedSlug(Tagged(7))` for having one decimal digit rather than for its value. This is the one place the registry's silence is not read as consent, and it is what keeps declaration order out of the diagnostic: the same two declarations written in the other order are rejected through the registry, so admitting this order would decide one program two ways.
 

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -678,6 +678,18 @@ struct VariantParts {
     type_code: String,
 }
 
+/// What [`zod_default_block`] and [`zod_factory_block`] need beyond the item's own name and
+/// parameter list, bundled into one reference because the two already carry as many positional
+/// parameters as `clippy::too_many_arguments` admits.
+///
+/// `constrained` is `None` for every item but a branded newtype's own — see
+/// [`zod_default_block`]'s doc comment for what it names.
+#[cfg(feature = "zod")]
+struct ZodDefaultInputs<'defaults> {
+    constrained: Option<(&'defaults str, &'defaults str)>,
+    default_types: &'defaults [(syn::Ident, syn::Type)],
+}
+
 #[cfg(feature = "jsonschema")]
 impl MapMemberItem {
     /// The item wrapped for its slot, kept in the form it arrived in.
@@ -2972,13 +2984,23 @@ fn branded_option_inner_error(
 /// the Rust one. A sequence wrapper is the one `SiblingType` spelling that says its shape outright
 /// without being asked, and is refused as the array it is.
 ///
-/// One of the brand's *own* type parameters is not such a name: it says its shape outright too,
-/// because both validating surfaces have already settled that it has none. Reading the inner off
-/// [`surface_field_def`] puts it in front of the opaque arm, where it belongs — Zod 4's
-/// `z.unknown()` carries no `.min`/`.max` at all, and `.brand()` returns the same instance rather
-/// than a wrapper that could, so there is nothing for the checks to attach to; JSON Schema's
-/// string keywords go inert beside the `{}` a parameter describes as; and `validate()` still
-/// measures `Display`. Three surfaces, three answers — the disagreement this guard exists to stop.
+/// One of the brand's *own* type parameters is not asked of the registry — nothing is registered
+/// under a parameter's own name — but nor is it refused outright the way it once was. It is asked
+/// of the item's own `default_types` declaration instead, the same declaration
+/// [`default_zod_argument`] reads when it composes `$SchemaDefault`'s arguments: the *factory*'s
+/// parameter still says its shape outright, because a caller supplying `ObjectId$Schema` must not
+/// inherit string bounds meant for `String`, so [`branded_zod_inner`] never appends a check to the
+/// bare parameter it renders inside the builder. What the checks reach instead is the default
+/// argument the factory is called with to produce `$SchemaDefault` — and a declared default is a
+/// concrete filling, which is exactly the case the next paragraph already admits for a *named*
+/// argument. So this guard resolves the same declaration [`declared_default_field`] resolves and
+/// asks [`non_string_inner_shape`] the same question of it: string-shaped, the checks compose onto
+/// that default and the declaration compiles; not string-shaped, the refusal below names the
+/// default rather than the parameter, because the default is what the author has to change. An
+/// entry the declaration left out is not asked here at all — a build generating JSON documents
+/// already refuses that under `jsonschema`, and a build that does not falls back to the same
+/// `String` every other reader of an absent entry falls back to, which carries the checks same as
+/// a written one would.
 ///
 /// A name written *over* one of those parameters is the same answer reached one module out, and is
 /// refused ahead of the registry entirely. `Later<T>` names a type whose schema the brand composes
@@ -3025,6 +3047,19 @@ fn branded_constraint_inner_error(
         );
         return Some(syn::Error::new_spanned(inner_field, message).to_compile_error());
     }
+    if !inner.is_array()
+        && let FieldDefType::TypeParam(parameter) = &inner.field_type
+    {
+        let default = declared_default_field(parameter, &args.default_types);
+        // `None` here means string-shaped — including the `String` fallback for an entry the
+        // declaration left out — so the bare parameter is admitted exactly where a concrete
+        // argument of the same shape would be.
+        return non_string_inner_shape(&default).map(|_| {
+            let default_ty = declared_default_type_name(parameter, &args.default_types);
+            let message = declared_default_constraint_message(name, parameter, &default_ty);
+            syn::Error::new_spanned(inner_field, message).to_compile_error()
+        });
+    }
     let message = match (&inner.field_type, non_string_inner_shape(&inner)) {
         (FieldDefType::SiblingType(inner_name, _), Some(shape)) => {
             named_inner_constraint_message(&name.to_string(), inner_name, shape)
@@ -3040,6 +3075,37 @@ fn branded_constraint_inner_error(
         (_, None) => return None,
     };
     Some(syn::Error::new_spanned(inner_field, message).to_compile_error())
+}
+
+/// The Rust spelling of `parameter`'s declared default, for the refusal that names it — `String`
+/// for an entry the declaration left out, the same fallback [`declared_default_field`] resolves to
+/// a `FieldDef` from. Only reached once that fallback has already proven *not* string-shaped, so
+/// the fallback branch here is unreachable in practice; it is total anyway because a refusal
+/// message is not the place to let a lookup miss go unspelled.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn declared_default_type_name(
+    parameter: &str,
+    default_types: &[(syn::Ident, syn::Type)],
+) -> String {
+    default_types
+        .iter()
+        .find(|(declared, _)| declared == parameter)
+        .map_or_else(|| "String".to_owned(), |(_, ty)| quote! { #ty }.to_string())
+}
+
+/// Why a constrained brand's bare-parameter inner is refused when its *declared default* — not the
+/// parameter — turns out not to be string-shaped: the default is what `$SchemaDefault` composes
+/// the checks onto, so a default the checks cannot measure is refused in its place.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn declared_default_constraint_message(name: &Ident, parameter: &str, default_ty: &str) -> String {
+    format!(
+        "model_schema: branded newtype `{name}` applies string constraints (pattern, minLength, \
+         maxLength), but its declared default for `{parameter}` is `{default_ty}`, which cannot \
+         carry them: Zod reads `.min`/`.max` as bounds on the value itself and has no regex check \
+         for a non-string schema, JSON Schema ignores `minLength`/`maxLength`/`pattern` outside \
+         `\"type\": \"string\"`, and `validate()` measures the inner's `Display` rendering. \
+         Declare a string-typed default, or drop the constraints."
+    )
 }
 
 /// The consult a constrained brand leaves unanswered, for the expansion that registers the name to
@@ -4843,11 +4909,17 @@ fn branded_inner_composite(inner: &FieldDef) -> Option<BrandedComposite> {
 /// its `Display` is the `$oid` member and the checks land there.
 ///
 /// The inner is the def [`surface_field_def`] has already erased the brand's own type
-/// parameters out of, so a parameter composes into the value as `z.unknown()` rather than as a
-/// binding nothing declares. The checks never land on one: an opaque inner carries no string for
-/// them to measure and is refused by [`branded_constraint_inner_error`] before this.
+/// parameters out of, so a parameter composes into the value as the argument the factory binds
+/// for it rather than as a binding nothing declares. A bare parameter carries no checks here even
+/// when the brand declares them: the factory's argument is whatever a caller supplies, and a
+/// caller supplying `ObjectId$Schema` must not inherit string bounds meant for the declared
+/// default. Those checks are appended once, to the default argument `$SchemaDefault` composes the
+/// factory with — see [`zod_default_block`] — never to the parameter this function renders.
 #[cfg(feature = "zod")]
 fn branded_zod_inner(args: &ModelSchemaArgs, inner: &FieldDef) -> String {
+    if !inner.is_array() && matches!(inner.field_type, FieldDefType::TypeParam(_)) {
+        return inner.zod_type();
+    }
     let checks = branded_zod_string_checks(args);
     #[cfg(feature = "object_id")]
     if branded_inner_is_object_id(inner) {
@@ -4990,6 +5062,11 @@ fn branded_zod_expression(
 /// class read off its inner, rather than with the `ZodType<Name>` every other `const` carries: the
 /// brand is what the annotation has to state, and only the value it wraps says which class it is.
 /// A factory needs no such annotation — its return type is read back off the builder.
+///
+/// When the brand carries string constraints over a bare-parameter inner — the case
+/// [`branded_constraint_inner_error`] admits rather than refuses — the checks are routed onto
+/// `$SchemaDefault`'s argument for that parameter, never onto the factory's own. See
+/// [`zod_default_block`].
 #[cfg(feature = "zod")]
 fn build_branded_zod_schema_method(
     args: &ModelSchemaArgs,
@@ -5004,11 +5081,22 @@ fn build_branded_zod_schema_method(
     let body = if parameters.is_empty() {
         branded_zod_const_block(item_name, inner, &expression, &reexport)
     } else {
+        let checks = branded_zod_string_checks(args);
+        let constrained_default = match (&inner.field_type, checks.is_empty()) {
+            (FieldDefType::TypeParam(parameter), false) if !inner.is_array() => {
+                Some((parameter.as_str(), checks.as_str()))
+            }
+            _ => None,
+        };
+        let defaults = ZodDefaultInputs {
+            default_types: &args.default_types,
+            constrained: constrained_default,
+        };
         zod_factory_block(
             item_name,
             rust_ident,
             parameters,
-            &args.default_types,
+            &defaults,
             "",
             &expression,
             &reexport,
@@ -12200,10 +12288,12 @@ fn zod_factory_memoized_binding(item_name: &str, parameters: &[String]) -> Strin
 }
 
 /// The `FieldDef` one `default_types` entry parses as: the declared filling for `parameter`, or —
-/// absent one — `String`, [`schema_example_value_type`]'s own fallback for the identical gap.
-/// Reached only in a build without `jsonschema`, the one feature that requires every parameter to
-/// declare one.
-#[cfg(feature = "zod")]
+/// absent one — `String`, [`schema_example_value_type`]'s own fallback for the identical gap. The
+/// fallback is only ever the *answer* in a build without `jsonschema`, the one feature that
+/// requires every parameter to declare one — but the constrained-brand guard,
+/// [`branded_constraint_inner_error`], reads this in every build, string constraints being a
+/// question the Zod and Rust surfaces answer regardless of `jsonschema`.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn declared_default_field(parameter: &str, default_types: &[(syn::Ident, syn::Type)]) -> FieldDef {
     default_types
         .iter()
@@ -12273,18 +12363,37 @@ fn default_zod_argument(field: &FieldDef) -> String {
 /// returns, so an item declared below this one can read it back through [`default_zod_argument`]
 /// and fold onto this very binding where its own declared default names this item at the same
 /// arguments.
+///
+/// `defaults.constrained` names the one parameter, if any, a branded newtype's own
+/// `pattern`/`minLength`/`maxLength` land on — the parameter its bare-parameter inner *is* —
+/// together with the check chain [`branded_zod_string_checks`] built for it. Every ordinary
+/// generic struct, tuple struct, enum and alias passes `None`: only a brand carries type-level
+/// string constraints, and [`branded_zod_inner`] already keeps them off the factory's own
+/// parameter, so the one place left for them is the default argument built here.
 #[cfg(feature = "zod")]
 fn zod_default_block(
     item_name: &str,
     rust_ident: &str,
     parameters: &[String],
-    default_types: &[(syn::Ident, syn::Type)],
+    defaults: &ZodDefaultInputs<'_>,
 ) -> String {
     let fields: Vec<FieldDef> = parameters
         .iter()
-        .map(|parameter| declared_default_field(parameter, default_types))
+        .map(|parameter| declared_default_field(parameter, defaults.default_types))
         .collect();
-    let arguments: Vec<String> = fields.iter().map(default_zod_argument).collect();
+    let arguments: Vec<String> = parameters
+        .iter()
+        .zip(&fields)
+        .map(|(parameter, field)| {
+            let argument = default_zod_argument(field);
+            match defaults.constrained {
+                Some((target, checks)) if target == parameter.as_str() => {
+                    format!("{argument}{checks}")
+                }
+                _ => argument,
+            }
+        })
+        .collect();
     record_zod_default_arguments(rust_ident, arguments.clone());
 
     #[cfg(feature = "typescript")]
@@ -12316,12 +12425,14 @@ fn zod_default_block(
 /// Beside the factory, this also publishes `$SchemaDefault` — see [`zod_default_block`] — the
 /// factory called at the item's own declared defaults, so a consumer who wants the ordinary
 /// filling never has to construct the argument list by hand.
+///
+/// `defaults` is passed straight through to [`zod_default_block`].
 #[cfg(feature = "zod")]
 fn zod_factory_block(
     item_name: &str,
     rust_ident: &str,
     parameters: &[String],
-    default_types: &[(syn::Ident, syn::Type)],
+    defaults: &ZodDefaultInputs<'_>,
     preamble: &str,
     expression: &str,
     reexport: &str,
@@ -12362,7 +12473,7 @@ fn zod_factory_block(
     #[cfg(not(feature = "typescript"))]
     let returns = String::new();
 
-    let default_block = zod_default_block(item_name, rust_ident, parameters, default_types);
+    let default_block = zod_default_block(item_name, rust_ident, parameters, defaults);
 
     format!(
         "{built}\n\n{declarations}export const {item_name}$SchemaFactory = \
@@ -12395,7 +12506,9 @@ fn zod_const_block(item_name: &str, preamble: &str, expression: &str, reexport: 
 ///
 /// The one seam every item takes that decision at, so a struct, a tuple struct, an enum and an
 /// alias cannot come to answer it differently. A branded newtype takes the same decision beside
-/// this one, because only its `const` half differs — see [`branded_zod_const_block`].
+/// this one, because only its `const` half differs — see [`branded_zod_const_block`]. None of
+/// these items carries type-level string constraints — that is a brand's alone — so the factory is
+/// always built with no constrained parameter to route checks onto.
 #[cfg(feature = "zod")]
 fn zod_published_binding(
     item_name: &str,
@@ -12409,14 +12522,12 @@ fn zod_published_binding(
     if parameters.is_empty() {
         zod_const_block(item_name, preamble, expression, reexport)
     } else {
-        zod_factory_block(
-            item_name,
-            rust_ident,
-            parameters,
+        let defaults = ZodDefaultInputs {
             default_types,
-            preamble,
-            expression,
-            reexport,
+            constrained: None,
+        };
+        zod_factory_block(
+            item_name, rust_ident, parameters, &defaults, preamble, expression, reexport,
         )
     }
 }

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -3800,17 +3800,17 @@ fn a_tuple_struct_records_the_value_surface_its_slots_publish() {
     }
 }
 
-/// A brand constraining one of its own type parameters has nothing to hang the checks on.
-///
-/// Both validating surfaces read a parameter as the opaque value, and an opaque value takes no
-/// string checks: Zod 4's `z.unknown()` carries no `.min`/`.max`, and `.brand()` hands back that
-/// same instance rather than a wrapper that could; JSON Schema's string keywords go inert beside
-/// the `{}` a parameter describes as; and `validate()` still measures `Display`. So the parameter
-/// reaches the same refusal `serde_json::Value` reaches, through the same opaque arm — the erasure
-/// is what puts it there, and is why the guard does not have to name parameters itself.
+/// A brand constraining one of its own type parameters no longer has nothing to hang the checks
+/// on: it consults the parameter's *declared default* instead of the parameter itself, the same
+/// way a concrete argument is consulted through the registry. A `String` default carries the
+/// checks fine, and an entry the declaration left out falls back to `String` —
+/// [`super::declared_default_field`]'s own fallback, [`super::schema_example_value_type`]'s for the
+/// identical gap — so `pattern_args()`, which declares no `default_types` at all, is admitted here
+/// too: this guard alone requires nothing, and `jsonschema` is what actually requires an entry,
+/// through the unrelated `default_types_guard_errors`.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
-fn string_constraints_over_the_brands_own_type_parameter_are_rejected() {
+fn string_constraints_over_the_brands_own_type_parameter_consult_the_declared_default() {
     for inner in ["T", "U"] {
         let ty: syn::Type = syn::parse_str(inner).unwrap();
         let errors = branded_errors_with(
@@ -3820,11 +3820,54 @@ fn string_constraints_over_the_brands_own_type_parameter_are_rejected() {
             },
             &pattern_args(),
         );
-        assert_eq!(errors.len(), 1, "for {inner}, got: {errors:?}");
-        assert!(errors[0].contains("`Branded`"), "got: {}", errors[0]);
+        assert!(errors.is_empty(), "for {inner}, got: {errors:?}");
+    }
+}
+
+/// A bare-parameter inner with an *explicitly* declared string-shaped default is admitted the same
+/// way the fallback is — `String` is not special-cased, it is simply the shape a `String` default
+/// resolves to like any other.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn string_constraints_over_the_brands_own_type_parameter_with_a_string_default_pass() {
+    let errors = branded_errors_with(
+        &syn::parse_quote! {
+            #[serde(transparent)]
+            struct Branded<T>(pub T);
+        },
+        &super::parse_model_schema_args(quote::quote! {
+            pattern = "^[a-z]+$", default_types(T = String)
+        }),
+    );
+    assert!(errors.is_empty(), "got: {errors:?}");
+}
+
+/// A bare-parameter inner whose declared default is not string-shaped is refused exactly where a
+/// concrete non-string argument is refused, except the message names the *default* rather than the
+/// parameter — that is what the author has to change, since the parameter itself is never asked.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn string_constraints_over_the_brands_own_type_parameter_with_a_non_string_default_are_rejected() {
+    let errors = branded_errors_with(
+        &syn::parse_quote! {
+            #[serde(transparent)]
+            struct Branded<T>(pub T);
+        },
+        &super::parse_model_schema_args(quote::quote! {
+            pattern = "^[a-z]+$", default_types(T = u32)
+        }),
+    );
+    assert_eq!(errors.len(), 1, "got: {errors:?}");
+    for needle in [
+        "compile_error",
+        "`Branded`",
+        "`T`",
+        "`u32`",
+        "declared default",
+    ] {
         assert!(
-            errors[0].contains("opaque"),
-            "for {inner}, got: {}",
+            errors[0].contains(needle),
+            "{needle} missing: {}",
             errors[0]
         );
     }
@@ -4258,9 +4301,11 @@ fn distinct_entries_are_read_unchanged() {
 }
 
 /// The argument shares the list with the string constraints and the name override, and reading it
-/// costs none of them. This is the only place the coexistence can be asked: a type-level string
-/// constraint is a brand's alone, and a brand over a type parameter is already refused at its
-/// inner field, so no one item reaches an emitter carrying both.
+/// costs none of them. This is the one place their coexistence at the *parser* can be asked
+/// without also asking what the guard makes of it — see
+/// `string_constraints_over_the_brands_own_type_parameter_consult_the_declared_default` for that,
+/// now that a brand's bare-parameter inner reads its declared default rather than being refused
+/// outright.
 #[test]
 fn default_types_coexists_with_every_other_argument() {
     let args = super::parse_model_schema_args(quote::quote! {

--- a/tests/branded_newtype_tests/tests.rs
+++ b/tests/branded_newtype_tests/tests.rs
@@ -828,6 +828,37 @@ mod branded_constrained_json_schema_tests {
     #[serde(transparent)]
     pub struct ShortId(pub String);
 
+    /// A generic brand's bare-parameter inner has no type of its own to describe, so its document
+    /// is the declared default's — `{"type": "string"}` for `default_types(IdType = String)` —
+    /// narrowed by the brand's own bounds through the same `allOf` a named inner is narrowed
+    /// through. Not the inert `{}` a parameter with no default at all would describe as.
+    #[model_schema(
+        minLength = 24,
+        maxLength = 24,
+        pattern = "^[a-f\\d]{24}$",
+        default_types(IdType = String)
+    )]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct GenericConstrainedId<IdType>(pub IdType);
+
+    #[test]
+    fn test_constrained_generic_branded_json_schema_carries_the_defaults_document() {
+        assert_eq!(
+            GenericConstrainedId::<String>::json_schema(),
+            serde_json::json!({
+                "allOf": [
+                    { "type": "string" },
+                    {
+                        "minLength": 24_u32,
+                        "maxLength": 24_u32,
+                        "pattern": "^[a-f0-9]{24}$"
+                    }
+                ]
+            })
+        );
+    }
+
     #[test]
     fn test_constrained_branded_json_schema() {
         // The `\d` the brand is declared with reaches the schema as the members it stands for: a
@@ -852,6 +883,68 @@ mod branded_constrained_json_schema_tests {
         assert_eq!(schema["maxLength"], 50_i64, "Got: {schema}");
         // No pattern constraint — should not be present
         assert!(schema.get("pattern").is_none(), "Got: {schema}");
+    }
+}
+
+/// A generic branded newtype whose inner is a bare type parameter, carrying string constraints.
+/// The constraints have nowhere to land on the parameter itself, so they land on the parameter's
+/// *declared default* instead: `StrictDocumentId$SchemaDefault` enforces the 24-hex bounds,
+/// `StrictDocumentId$SchemaFactory` stays unconstrained for every other filling.
+#[cfg(all(feature = "zod", feature = "typescript", feature = "serde"))]
+mod constrained_generic_branded_tests {
+    use super::*;
+
+    #[model_schema(
+        minLength = 24,
+        maxLength = 24,
+        pattern = "^[a-f\\d]{24}$",
+        default_types(IdType = String)
+    )]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct StrictDocumentId<IdType>(pub IdType);
+
+    /// The builder every call to the factory runs through carries no string check at all: a caller
+    /// filling `IdType` with something other than the declared default — an `ObjectId` schema, say
+    /// — must not inherit bounds meant for the default.
+    #[test]
+    fn the_factorys_own_parameter_carries_no_check() {
+        let zod = StrictDocumentId::<String>::zod_schema();
+        let builder_end = zod.find("StrictDocumentId$SchemaFactoryCache").unwrap();
+        let builder = &zod[..builder_end];
+        for check in [".min(", ".max(", ".check("] {
+            assert!(
+                !builder.contains(check),
+                "found {check} in builder:\n{builder}"
+            );
+        }
+        assert!(builder.contains("idType.meta({"), "Got:\n{builder}");
+    }
+
+    /// `$SchemaDefault` is the factory called at the declared default argument, with the checks
+    /// composed onto that argument — exactly the shape the design settled on.
+    #[test]
+    fn the_default_composes_the_factory_with_the_constrained_argument() {
+        let zod = StrictDocumentId::<String>::zod_schema();
+        assert!(
+            zod.contains(
+                "export const StrictDocumentId$SchemaDefault: ZodType<StrictDocumentId<string>> = \
+                 StrictDocumentId$SchemaFactory(z.string().min(24).max(24).check(z.regex(/^[a-f0-9]{24}$/)));"
+            ),
+            "Got:\n{zod}"
+        );
+    }
+
+    /// A value at the declared default validates against the 24-hex bounds through Rust's own
+    /// `validate()`/serde path, which reads the same constraints the Zod surface enforces.
+    #[test]
+    fn the_default_instantiation_enforces_the_bounds_through_serde() {
+        let valid: StrictDocumentId<String> =
+            serde_json::from_str("\"64de3d95ff45b119e5b53a7e\"").unwrap();
+        valid.validate().unwrap();
+
+        let too_short: Result<StrictDocumentId<String>, _> = serde_json::from_str("\"abc\"");
+        assert!(too_short.is_err(), "Should reject a too-short id via serde");
     }
 }
 


### PR DESCRIPTION
A branded newtype whose inner is a bare type parameter can now carry `pattern`/`minLength`/`maxLength`. The checks belong to the declared default argument — which is concrete — never to the factory's own parameter.

- `branded_constraint_inner_error` resolves the parameter's `default_types` entry and admits a string-shaped default (including the `String` fallback in non-jsonschema builds); a non-string default is refused with a spanned message naming the default, since that is what the author has to change.
- `branded_zod_inner` never appends checks to a bare parameter, so `X$SchemaFactory(ObjectId$Schema)` inherits nothing meant for `String`.
- `zod_default_block` appends the check chain to that one parameter's default argument when composing `X$SchemaDefault`.
- The JSON surface already narrowed the default's document through `allOf` — pinned by a new test, no code change.
- Docs updated in README and CLAUDE.md.

Gate: `just lint-all` and `just test` (full feature powerset) green.