### PR TITLE
record fold-comparison keys, not emitted argument text

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -12381,6 +12381,8 @@ fn zod_default_block(
         .iter()
         .map(|parameter| declared_default_field(parameter, defaults.default_types))
         .collect();
+    let fold_keys: Vec<String> = fields.iter().map(FieldDef::zod_type).collect();
+    record_zod_default_arguments(rust_ident, fold_keys);
     let arguments: Vec<String> = parameters
         .iter()
         .zip(&fields)
@@ -12394,7 +12396,6 @@ fn zod_default_block(
             }
         })
         .collect();
-    record_zod_default_arguments(rust_ident, arguments.clone());
 
     #[cfg(feature = "typescript")]
     let annotation = format!(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -662,7 +662,7 @@ thread_local! {
     /// The names whose items publish a Zod factory. Kept out of [`ALIAS_INFO`] so the answer
     /// survives the item's own registration — see [`record_zod_factory`].
     static ZOD_FACTORY_PUBLISHERS: RefCell<HashSet<String>> = RefCell::new(HashSet::new());
-    /// Each generic item's own `$SchemaDefault` argument list, one rendered Zod expression per
+    /// Each generic item's own `$SchemaDefault` fold-comparison keys, one plain rendering per
     /// parameter in declaration order — see [`record_zod_default_arguments`].
     static ZOD_DEFAULT_ARGUMENTS: RefCell<HashMap<String, Vec<String>>> = RefCell::new(HashMap::new());
 }
@@ -895,14 +895,17 @@ pub fn publishes_zod_factory(rust_ident: &str) -> bool {
     ZOD_FACTORY_PUBLISHERS.with(|names| names.borrow().contains(rust_ident))
 }
 
-/// Records the Zod argument list `rust_ident`'s own `$SchemaDefault` calls its factory with, one
-/// rendered expression per parameter in declaration order.
+/// Records `rust_ident`'s own `$SchemaDefault` fold-comparison keys — the plain [`FieldDef::zod_type`]
+/// rendering of each declared-default field, one per parameter in declaration order, computed
+/// before deferral and before a constrained brand's `.min`/`.max`/`.check` chain is appended.
 ///
-/// Recorded once as the item's `$SchemaDefault` is built, so a later item whose own declared
-/// default names this one at the identical arguments can read them back and fold onto this
-/// binding instead of composing a second call the memo cache does not share with it — two
-/// separately written `z.string()` calls are two different objects, and the cache keys on argument
-/// identity, not on what the argument says.
+/// This is a comparison key, not the text `$SchemaDefault` emits: the fold in
+/// [`default_zod_argument`] renders a downstream reference's own arguments the same plain way, so
+/// the two must agree in form for the comparison to ever succeed. Recorded once as the item's
+/// `$SchemaDefault` is built, so a later item whose own declared default names this one at the
+/// identical arguments can read them back and fold onto this binding instead of composing a second
+/// call the memo cache does not share with it — two separately written `z.string()` calls are two
+/// different objects, and the cache keys on argument identity, not on what the argument says.
 #[cfg(feature = "zod")]
 pub fn record_zod_default_arguments(rust_ident: &str, arguments: Vec<String>) {
     ZOD_DEFAULT_ARGUMENTS.with(|map| {

--- a/tests/branded_newtype_tests/tests.rs
+++ b/tests/branded_newtype_tests/tests.rs
@@ -904,6 +904,18 @@ mod constrained_generic_branded_tests {
     #[serde(transparent)]
     pub struct StrictDocumentId<IdType>(pub IdType);
 
+    /// A declared default naming `StrictDocumentId` at exactly its own declared default — the
+    /// `ProDoctivity` `EcmDocument`/`DocumentId` shape the fold feature was motivated by. Before
+    /// the fix, the comparison read `StrictDocumentId$SchemaDefault`'s emitted text — the
+    /// `.min`/`.max`/`.check` chain and all — against the plain rendering this struct's own field
+    /// computes, so the two could never agree and the fold silently composed an unconstrained
+    /// `StrictDocumentId$SchemaFactory(z.string())` in its place.
+    #[model_schema(default_types(HolderType = StrictDocumentId<String>))]
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct StrictDocumentIdHolder<HolderType> {
+        pub id: HolderType,
+    }
+
     /// The builder every call to the factory runs through carries no string check at all: a caller
     /// filling `IdType` with something other than the declared default — an `ObjectId` schema, say
     /// — must not inherit bounds meant for the default.
@@ -945,6 +957,21 @@ mod constrained_generic_branded_tests {
 
         let too_short: Result<StrictDocumentId<String>, _> = serde_json::from_str("\"abc\"");
         assert!(too_short.is_err(), "Should reject a too-short id via serde");
+    }
+
+    /// `$SchemaDefault` folds onto `StrictDocumentId$SchemaDefault` by reference, carrying the
+    /// 24-hex bounds in rather than reconstructing an unconstrained instantiation the memo would
+    /// not share with it.
+    #[test]
+    fn a_default_naming_the_constrained_brands_own_default_folds_onto_its_binding() {
+        let zod = StrictDocumentIdHolder::<String>::zod_schema();
+        assert!(
+            zod.contains(
+                "= StrictDocumentIdHolder$SchemaFactory(z.lazy(() => \
+                 StrictDocumentId$SchemaDefault));"
+            ),
+            "Got:\n{zod}"
+        );
     }
 }
 

--- a/tests/generic_types_tests/tests.rs
+++ b/tests/generic_types_tests/tests.rs
@@ -243,6 +243,8 @@ mod zod {
         OverriddenDefault, Pair, PlainConst, Positional, Quintet, Referrer, Summarised, Tagged,
         Untagged, WireFolder, Wrapper, keyed_alias_schema,
     };
+    #[cfg(all(feature = "typescript", feature = "serde"))]
+    use super::{ConstrainedEchoedDefault, ConstrainedId, DeepEchoedDefault};
 
     /// Two generic items whose declared defaults name each other: `CycleLeader`'s names
     /// `CycleFollower` and `CycleFollower`'s names `CycleLeader` back, at arguments neither can have
@@ -539,6 +541,55 @@ mod zod {
             zod.contains(
                 "= OverriddenDefault$SchemaFactory(z.lazy(() => \
                  Tagged$SchemaFactory(z.number().int())));"
+            ),
+            "Got: {zod}"
+        );
+    }
+
+    /// Nothing else in this crate constructs `ConstrainedId` directly — every other use names it
+    /// only as a bare type argument — so this pins the same bounds-through-serde behavior
+    /// `constrained_generic_branded_tests::StrictDocumentId` in `branded_newtype_tests` covers for
+    /// the identical shape.
+    #[cfg(all(feature = "typescript", feature = "serde"))]
+    #[test]
+    fn a_constrained_ids_declared_default_enforces_the_bounds_through_serde() {
+        let valid: ConstrainedId<String> =
+            serde_json::from_str("\"64de3d95ff45b119e5b53a7e\"").unwrap();
+        valid.validate().unwrap();
+
+        let too_short: Result<ConstrainedId<String>, _> = serde_json::from_str("\"abc\"");
+        assert!(too_short.is_err(), "Should reject a too-short id via serde");
+    }
+
+    /// The fold fires for a *constrained* generic brand exactly as it does for `Tagged`: the
+    /// recorded comparison key is the plain rendering, not the `.min`/`.max`/`.check` chain
+    /// `$SchemaDefault` emits, so the two forms agree and the bounds are carried in by reference
+    /// instead of silently dropped.
+    #[cfg(all(feature = "typescript", feature = "serde"))]
+    #[test]
+    fn a_default_naming_a_constrained_brands_own_default_folds_onto_its_binding() {
+        let zod = ConstrainedEchoedDefault::<String>::zod_schema();
+        assert!(
+            zod.contains(
+                "= ConstrainedEchoedDefault$SchemaFactory(z.lazy(() => \
+                 ConstrainedId$SchemaDefault));"
+            ),
+            "Got: {zod}"
+        );
+    }
+
+    /// A downstream default naming a sibling whose own recorded fold key itself names a further
+    /// sibling at matching arguments — the fold chains two levels deep, reading
+    /// `ConstrainedEchoedDefault`'s comparison key back rather than the deferred, checks-carrying
+    /// text its own `$SchemaDefault` emits.
+    #[cfg(all(feature = "typescript", feature = "serde"))]
+    #[test]
+    fn a_default_naming_a_siblings_default_that_itself_folds_chains_two_levels_deep() {
+        let zod = DeepEchoedDefault::<String>::zod_schema();
+        assert!(
+            zod.contains(
+                "= DeepEchoedDefault$SchemaFactory(z.lazy(() => \
+                 ConstrainedEchoedDefault$SchemaDefault));"
             ),
             "Got: {zod}"
         );
@@ -1653,6 +1704,44 @@ pub struct EchoedDefault<HolderType> {
 #[model_schema(default_types(HolderType = Tagged<u32>))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OverriddenDefault<HolderType> {
+    pub held: HolderType,
+}
+
+/// A generic branded newtype whose inner is a bare type parameter, carrying string constraints —
+/// held here rather than reused from `branded_newtype_tests` because each integration test file
+/// compiles as its own crate. `$SchemaDefault` composes the checks onto the declared-default
+/// argument, exactly as `constrained_generic_branded_tests::StrictDocumentId` does there.
+#[cfg(all(feature = "zod", feature = "typescript", feature = "serde"))]
+#[model_schema(
+    minLength = 24,
+    maxLength = 24,
+    pattern = "^[a-f\\d]{24}$",
+    default_types(IdType = String)
+)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ConstrainedId<IdType>(pub IdType);
+
+/// A declared default naming a *constrained* generic brand at exactly the arguments that brand
+/// calls its own. The emitted `$SchemaDefault` text carries a `.min`/`.max`/`.check` chain the
+/// plain rendering a downstream reference computes never spells, so the fold comparison has to key
+/// on the plain form or a constrained brand can never fold — the checks would be silently dropped
+/// from every reference naming it at its own default.
+#[cfg(all(feature = "zod", feature = "typescript", feature = "serde"))]
+#[model_schema(default_types(HolderType = ConstrainedId<String>))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConstrainedEchoedDefault<HolderType> {
+    pub held: HolderType,
+}
+
+/// A declared default naming a sibling — `ConstrainedEchoedDefault` — whose own recorded fold key
+/// itself names a further sibling (`ConstrainedId`) at matching arguments. The fold has to chain
+/// two levels deep, reading `ConstrainedEchoedDefault`'s comparison key back rather than the
+/// deferred, checks-carrying text its own `$SchemaDefault` emits.
+#[cfg(all(feature = "zod", feature = "typescript", feature = "serde"))]
+#[model_schema(default_types(HolderType = ConstrainedEchoedDefault<ConstrainedId<String>>))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeepEchoedDefault<HolderType> {
     pub held: HolderType,
 }
 


### PR DESCRIPTION
The recorded `$SchemaDefault` argument list is only ever read by the fold comparison, yet it stored the emission spelling — post-deferral (`z.lazy` wrappers) and post-checks (a constrained brand's `.min/.max/.check` chain). The comparison renders a downstream reference's arguments plainly, so the two forms could never agree for a constrained brand and the fold silently composed the unconstrained filling — dropping every id constraint from a document-level default naming a constrained id brand.

- `zod_default_block` now records the plain `FieldDef::zod_type` rendering, computed before deferral and before the check append; emission is unchanged.
- Red-first fixtures pin the single-level fold (`z.lazy(() => ConstrainedId$SchemaDefault)`), the same shape in the branded-newtype suite, and a two-level chained fold.
- Existing fold/non-fold/cycle tests untouched and byte-identical.

Gate: `just lint-all` and `just test` (full feature powerset) green.