### PR TITLE
compose constrained-brand checks inside the deferral thunk

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -678,6 +678,20 @@ struct VariantParts {
     type_code: String,
 }
 
+/// The two spellings [`zod_default_block`] has on hand for a constrained bare-parameter brand's
+/// check chain — see [`branded_zod_string_checks`] and [`branded_zod_base_checks`] for what each
+/// renders and why both exist.
+#[cfg(feature = "zod")]
+struct BrandedDefaultChecks {
+    /// Composed inside a deferred argument's `z.lazy(...)` thunk, onto whatever the thunk
+    /// resolves to — a sibling's `$Schema` or the fold's `$SchemaDefault` — neither of which is
+    /// guaranteed to expose `.min`/`.max`, only the base `.check(...)` every schema carries.
+    base: String,
+    /// Chained onto an eager argument — `z.string()` and the like — which the checks' own
+    /// `ZodString` methods always apply to directly.
+    chained: String,
+}
+
 /// What [`zod_default_block`] and [`zod_factory_block`] need beyond the item's own name and
 /// parameter list, bundled into one reference because the two already carry as many positional
 /// parameters as `clippy::too_many_arguments` admits.
@@ -686,8 +700,31 @@ struct VariantParts {
 /// [`zod_default_block`]'s doc comment for what it names.
 #[cfg(feature = "zod")]
 struct ZodDefaultInputs<'defaults> {
-    constrained: Option<(&'defaults str, &'defaults str)>,
+    constrained: Option<(&'defaults str, &'defaults BrandedDefaultChecks)>,
     default_types: &'defaults [(syn::Ident, syn::Type)],
+}
+
+/// What [`default_zod_rendering`] found: a self-contained expression left eager, or a name
+/// [`deferred_zod_operand`] still has to wrap — kept apart from the final string so
+/// [`zod_default_block`] can tell which one it has before deciding where a constrained brand's
+/// checks belong: chained directly onto an eager expression, or composed inside the thunk of a
+/// deferred one, whose own annotation is not guaranteed to carry `ZodString`'s chain methods.
+#[cfg(feature = "zod")]
+enum DefaultZodRendering {
+    Deferred(String),
+    Eager(String),
+}
+
+#[cfg(feature = "zod")]
+impl DefaultZodRendering {
+    /// The plain argument an unconstrained default composes: deferred renderings gain their
+    /// `z.lazy(...)` wrapper here, at the one place both variants converge back to a single string.
+    fn into_argument(self) -> String {
+        match self {
+            Self::Deferred(schema) => deferred_zod_operand(&schema),
+            Self::Eager(schema) => schema,
+        }
+    }
 }
 
 #[cfg(feature = "jsonschema")]
@@ -2987,7 +3024,7 @@ fn branded_option_inner_error(
 /// One of the brand's *own* type parameters is not asked of the registry — nothing is registered
 /// under a parameter's own name — but nor is it refused outright the way it once was. It is asked
 /// of the item's own `default_types` declaration instead, the same declaration
-/// [`default_zod_argument`] reads when it composes `$SchemaDefault`'s arguments: the *factory*'s
+/// [`default_zod_rendering`] reads when it composes `$SchemaDefault`'s arguments: the *factory*'s
 /// parameter still says its shape outright, because a caller supplying `ObjectId$Schema` must not
 /// inherit string bounds meant for `String`, so [`branded_zod_inner`] never appends a check to the
 /// bare parameter it renders inside the builder. What the checks reach instead is the default
@@ -4840,6 +4877,31 @@ fn branded_zod_string_checks(args: &ModelSchemaArgs) -> String {
     checks
 }
 
+/// The same three constraints [`branded_zod_string_checks`] renders, spelled instead as one
+/// `.check(...)` call over the base check functions (`z.minLength`, `z.maxLength`, `z.regex`) —
+/// the surface every Zod schema exposes, unlike `.min`/`.max`, which live on `ZodString` alone and
+/// so are not guaranteed to exist on whatever a deferred or folded default argument is annotated
+/// as. See [`zod_default_block`] for where the two spellings are chosen between.
+#[cfg(feature = "zod")]
+fn branded_zod_base_checks(args: &ModelSchemaArgs) -> String {
+    let mut checks = Vec::new();
+    if let Some(min_len) = args.min_length {
+        checks.push(format!("z.minLength({min_len})"));
+    }
+    if let Some(max_len) = args.max_length {
+        checks.push(format!("z.maxLength({max_len})"));
+    }
+    if let Some(pattern) = &args.pattern {
+        let literal_body = escape_js_regex_literal(pattern);
+        checks.push(format!("z.regex(/{literal_body}/)"));
+    }
+    if checks.is_empty() {
+        String::new()
+    } else {
+        format!(".check({})", checks.join(", "))
+    }
+}
+
 /// Whether a branded newtype's inner is an `ObjectId` written on its own, and so reaches the wire
 /// as the `$oid` object rather than as any string.
 ///
@@ -5082,9 +5144,13 @@ fn build_branded_zod_schema_method(
         branded_zod_const_block(item_name, inner, &expression, &reexport)
     } else {
         let checks = branded_zod_string_checks(args);
-        let constrained_default = match (&inner.field_type, checks.is_empty()) {
+        let branded_checks = BrandedDefaultChecks {
+            base: branded_zod_base_checks(args),
+            chained: checks,
+        };
+        let constrained_default = match (&inner.field_type, branded_checks.chained.is_empty()) {
             (FieldDefType::TypeParam(parameter), false) if !inner.is_array() => {
-                Some((parameter.as_str(), checks.as_str()))
+                Some((parameter.as_str(), &branded_checks))
             }
             _ => None,
         };
@@ -12304,11 +12370,11 @@ fn declared_default_field(parameter: &str, default_types: &[(syn::Ident, syn::Ty
         )
 }
 
-/// The Zod argument one declared default composes: the ordinary rendering [`FieldDef::zod_type`]
-/// gives every field, deferred through [`deferred_zod_operand`] wherever that rendering names
-/// another item's own module-scope binding — its factory, called with fresh arguments exactly as
-/// an ordinary field naming it does, or, where the default names that item at exactly the
-/// arguments it calls its own, that item's `$SchemaDefault` directly (the fold).
+/// The rendering one declared default composes: the ordinary rendering [`FieldDef::zod_type`]
+/// gives every field, deferred wherever that rendering names another item's own module-scope
+/// binding — its factory, called with fresh arguments exactly as an ordinary field naming it does,
+/// or, where the default names that item at exactly the arguments it calls its own, that item's
+/// `$SchemaDefault` directly (the fold).
 ///
 /// Either shape is deferred for the reason [`deferred_zod_operand`]'s own doc comment states for a
 /// flattened base: `{name}$SchemaFactory` and `{name}$SchemaDefault` are each another module-scope
@@ -12336,7 +12402,7 @@ fn declared_default_field(parameter: &str, default_types: &[(syn::Ident, syn::Ty
 /// declared, rather than reconstructing a plain instantiation beside them. See
 /// [`record_zod_default_arguments`].
 #[cfg(feature = "zod")]
-fn default_zod_argument(field: &FieldDef) -> String {
+fn default_zod_rendering(field: &FieldDef) -> DefaultZodRendering {
     if field.array_depth == 0
         && !field.is_optional()
         && let FieldDefType::SiblingType(name, args) = &field.field_type
@@ -12346,12 +12412,15 @@ fn default_zod_argument(field: &FieldDef) -> String {
         {
             let rendered: Vec<String> = args.iter().map(FieldDef::zod_type).collect();
             if zod_default_arguments(name).as_deref() == Some(rendered.as_slice()) {
-                return deferred_zod_operand(&format!("{}$SchemaDefault", info.export_name));
+                return DefaultZodRendering::Deferred(format!(
+                    "{}$SchemaDefault",
+                    info.export_name
+                ));
             }
         }
-        return deferred_zod_operand(&field.zod_type());
+        return DefaultZodRendering::Deferred(field.zod_type());
     }
-    field.zod_type()
+    DefaultZodRendering::Eager(field.zod_type())
 }
 
 /// What a generic item appends after its factory: the factory called with each parameter's
@@ -12366,10 +12435,17 @@ fn default_zod_argument(field: &FieldDef) -> String {
 ///
 /// `defaults.constrained` names the one parameter, if any, a branded newtype's own
 /// `pattern`/`minLength`/`maxLength` land on — the parameter its bare-parameter inner *is* —
-/// together with the check chain [`branded_zod_string_checks`] built for it. Every ordinary
-/// generic struct, tuple struct, enum and alias passes `None`: only a brand carries type-level
-/// string constraints, and [`branded_zod_inner`] already keeps them off the factory's own
-/// parameter, so the one place left for them is the default argument built here.
+/// together with the two check-chain spellings [`BrandedDefaultChecks`] built for it. Every
+/// ordinary generic struct, tuple struct, enum and alias passes `None`: only a brand carries
+/// type-level string constraints, and [`branded_zod_inner`] already keeps them off the factory's
+/// own parameter, so the one place left for them is the default argument built here.
+///
+/// Which spelling applies follows [`default_zod_rendering`]'s own answer for that argument: an
+/// eager rendering (a self-contained expression such as `z.string()`) takes the chained spelling
+/// directly, exactly as before this function had any deferred shape to consider; a deferred one
+/// takes the base spelling *inside* the `z.lazy(...)` thunk `into_argument` would otherwise close
+/// over untouched — appending after the thunk would land the checks on `ZodLazy`, which carries
+/// neither `.min`/`.max` nor any refinement of the schema it resolves to.
 #[cfg(feature = "zod")]
 fn zod_default_block(
     item_name: &str,
@@ -12387,12 +12463,17 @@ fn zod_default_block(
         .iter()
         .zip(&fields)
         .map(|(parameter, field)| {
-            let argument = default_zod_argument(field);
+            let rendering = default_zod_rendering(field);
             match defaults.constrained {
-                Some((target, checks)) if target == parameter.as_str() => {
-                    format!("{argument}{checks}")
-                }
-                _ => argument,
+                Some((target, checks)) if target == parameter.as_str() => match rendering {
+                    DefaultZodRendering::Eager(schema) => {
+                        format!("{schema}{}", checks.chained)
+                    }
+                    DefaultZodRendering::Deferred(schema) => {
+                        deferred_zod_operand(&format!("{schema}{}", checks.base))
+                    }
+                },
+                _ => rendering.into_argument(),
             }
         })
         .collect();

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -2641,7 +2641,7 @@ fn a_string_filling_annotates_the_example_as_no_filling_does() {
 }
 
 /// The three shapes a declared default renders as: a primitive's ordinary Zod expression, another
-/// primitive's, and a reference to a generic sibling read back through [`super::default_zod_argument`]
+/// primitive's, and a reference to a generic sibling read back through [`super::default_zod_rendering`]
 /// rather than reconstructed. The third row is the one that matters — `DocumentId` is registered as
 /// a factory publisher whose own `$SchemaDefault` was recorded at exactly `z.string()`, and
 /// `IdType = DocumentId<String>` names it at that identical argument, so the render folds onto
@@ -2676,7 +2676,7 @@ fn declared_default_renders_each_shape_the_table_describes() {
         )];
         let field = super::declared_default_field(parameter, &default_types);
         assert_eq!(
-            super::default_zod_argument(&field),
+            super::default_zod_rendering(&field).into_argument(),
             expected,
             "for `{parameter} = {filled_at}`"
         );
@@ -2704,7 +2704,7 @@ fn a_default_naming_a_sibling_at_other_than_its_own_default_calls_the_factory() 
     let default_types = vec![(syn::parse_quote!(IdType), ty)];
     let field = super::declared_default_field("IdType", &default_types);
     assert_eq!(
-        super::default_zod_argument(&field),
+        super::default_zod_rendering(&field).into_argument(),
         "z.lazy(() => DocumentId$SchemaFactory(z.number().int()))"
     );
 }
@@ -2716,7 +2716,10 @@ fn a_default_naming_a_sibling_at_other_than_its_own_default_calls_the_factory() 
 #[test]
 fn a_parameter_with_no_declared_default_falls_back_to_string() {
     let field = super::declared_default_field("IdType", &[]);
-    assert_eq!(super::default_zod_argument(&field), "z.string()");
+    assert_eq!(
+        super::default_zod_rendering(&field).into_argument(),
+        "z.string()"
+    );
 }
 
 #[cfg(feature = "jsonschema")]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -900,7 +900,7 @@ pub fn publishes_zod_factory(rust_ident: &str) -> bool {
 /// before deferral and before a constrained brand's `.min`/`.max`/`.check` chain is appended.
 ///
 /// This is a comparison key, not the text `$SchemaDefault` emits: the fold in
-/// [`default_zod_argument`] renders a downstream reference's own arguments the same plain way, so
+/// [`default_zod_rendering`] renders a downstream reference's own arguments the same plain way, so
 /// the two must agree in form for the comparison to ever succeed. Recorded once as the item's
 /// `$SchemaDefault` is built, so a later item whose own declared default names this one at the
 /// identical arguments can read them back and fold onto this binding instead of composing a second

--- a/tests/branded_newtype_tests/tests.rs
+++ b/tests/branded_newtype_tests/tests.rs
@@ -916,6 +916,18 @@ mod constrained_generic_branded_tests {
         pub id: HolderType,
     }
 
+    /// A SECOND constrained generic brand — itself carrying string constraints, unlike
+    /// `StrictDocumentIdHolder` above, which carries none — whose declared default names
+    /// `StrictDocumentId` at exactly its own declared default. The fold (txsch-qobf) resolves
+    /// `default_zod_rendering` to the deferred `z.lazy(() => StrictDocumentId$SchemaDefault)`
+    /// spelling, and `OuterId`'s own checks have to compose *inside* that thunk rather than after
+    /// it — the folded-generic-sibling half of txsch-euxz's bug, the non-generic half being
+    /// `constrained_default_names_a_sibling_tests::OuterBrand` below.
+    #[model_schema(minLength = 10, default_types(WrapType = StrictDocumentId<String>))]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct OuterId<WrapType>(pub WrapType);
+
     /// The builder every call to the factory runs through carries no string check at all: a caller
     /// filling `IdType` with something other than the declared default — an `ObjectId` schema, say
     /// — must not inherit bounds meant for the default.
@@ -971,6 +983,115 @@ mod constrained_generic_branded_tests {
                  StrictDocumentId$SchemaDefault));"
             ),
             "Got:\n{zod}"
+        );
+    }
+
+    /// `OuterId` is itself constrained, and its declared default folds onto `StrictDocumentId`'s
+    /// own `$SchemaDefault` — the deferred, checks-carrying binding, not a plain
+    /// `StrictDocumentId$SchemaFactory(z.string())` reconstruction. `OuterId`'s own `minLength`
+    /// check composes *inside* the `z.lazy(...)` thunk, over `.check(...)`'s base spelling rather
+    /// than `.min(...)`'s chain spelling — the deferred target's annotation is not guaranteed to
+    /// carry `ZodString`'s own chain methods, only the `.check(...)` every schema exposes. Before
+    /// the fix, this same check was appended after the thunk closed, landing on `ZodLazy`, which
+    /// has neither.
+    #[test]
+    fn a_constrained_brands_default_naming_another_constrained_brands_default_composes_the_checks_inside_the_thunk()
+     {
+        let zod = OuterId::<String>::zod_schema();
+        assert!(
+            zod.contains(
+                "export const OuterId$SchemaDefault: ZodType<OuterId<StrictDocumentId<string>>> = \
+                 OuterId$SchemaFactory(z.lazy(() => \
+                 StrictDocumentId$SchemaDefault.check(z.minLength(10))));"
+            ),
+            "Got:\n{zod}"
+        );
+    }
+
+    /// The composed default enforces both bounds: `StrictDocumentId`'s own 24-hex, inherited
+    /// through the fold, and `OuterId`'s own `minLength`.
+    #[test]
+    fn the_folded_default_instantiation_enforces_both_brands_bounds_through_serde() {
+        let valid: OuterId<StrictDocumentId<String>> =
+            serde_json::from_str("\"64de3d95ff45b119e5b53a7e\"").unwrap();
+        valid.validate().unwrap();
+
+        let too_short: Result<OuterId<StrictDocumentId<String>>, _> =
+            serde_json::from_str("\"abc\"");
+        assert!(
+            too_short.is_err(),
+            "Should reject a value StrictDocumentId's own 24-hex bound rejects"
+        );
+    }
+}
+
+/// The non-generic-sibling half of txsch-euxz's bug: a constrained generic brand whose declared
+/// default names an ordinary (non-generic) `#[model_schema]` sibling. Held apart from
+/// `constrained_generic_branded_tests` above (whose fixtures all name a *generic* sibling) so each
+/// module pins one of the two spellings `default_zod_rendering` can defer to — a bare `$Schema`
+/// here, a folded `$SchemaDefault` there.
+#[cfg(all(feature = "zod", feature = "typescript", feature = "serde"))]
+mod constrained_default_names_a_sibling_tests {
+    use super::*;
+
+    /// An unconstrained branded newtype — the sibling a generic brand's own declared default can
+    /// name. Carries no checks of its own, so any composed checks downstream are unambiguously
+    /// `OuterBrand`'s.
+    #[model_schema()]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct InnerString(pub String);
+
+    /// A constrained generic brand whose declared default names `InnerString` — a non-generic
+    /// sibling, so `default_zod_rendering` defers to its bare `$Schema` binding (never a
+    /// `$SchemaDefault`, which only a generic sibling publishes) rather than reconstructing it
+    /// eagerly. This is the exact repro from txsch-euxz's own bug report.
+    #[model_schema(minLength = 3, default_types(T = InnerString))]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct OuterBrand<T>(pub T);
+
+    /// Before the fix: `OuterBrand$SchemaFactory(z.lazy(() => InnerString$Schema).min(3))` —
+    /// `.min` landing on `ZodLazy`, which does not have it. After: the check composes inside the
+    /// thunk, over `InnerString$Schema`'s own base `.check(...)` surface.
+    #[test]
+    fn a_constrained_brands_default_naming_a_non_generic_sibling_composes_the_check_inside_the_thunk()
+     {
+        let zod = OuterBrand::<String>::zod_schema();
+        assert!(
+            zod.contains(
+                "export const OuterBrand$SchemaDefault: ZodType<OuterBrand<InnerString>> = \
+                 OuterBrand$SchemaFactory(z.lazy(() => InnerString$Schema.check(z.minLength(3))));"
+            ),
+            "Got:\n{zod}"
+        );
+    }
+
+    /// The factory's own bare parameter still carries no check — exactly the invariant
+    /// `constrained_generic_branded_tests::the_factorys_own_parameter_carries_no_check` pins for
+    /// the primitive-default case, unaffected by where the default happens to point.
+    #[test]
+    fn the_factorys_own_parameter_carries_no_check() {
+        let zod = OuterBrand::<String>::zod_schema();
+        let builder_end = zod.find("OuterBrand$SchemaFactoryCache").unwrap();
+        let builder = &zod[..builder_end];
+        for check in [".min(", ".max(", ".check("] {
+            assert!(
+                !builder.contains(check),
+                "found {check} in builder:\n{builder}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_default_instantiation_enforces_the_bound_through_serde() {
+        let valid: OuterBrand<InnerString> = serde_json::from_str("\"abc\"").unwrap();
+        valid.validate().unwrap();
+
+        let too_short: Result<OuterBrand<InnerString>, _> = serde_json::from_str("\"ab\"");
+        assert!(
+            too_short.is_err(),
+            "Should reject a too-short value via serde"
         );
     }
 }


### PR DESCRIPTION
A constrained generic brand whose declared default names a sibling type emitted its check chain after the `z.lazy(...)` wrapper — `.min(3)` on `ZodLazy`, which neither type-checks nor enforces. Verdicts for both candidate spellings were captured first against real emitted output (tsc --strict + zod 4.4.3 runtime) in a scratch consumer; checks-inside-the-thunk passed both and was chosen.

- `default_zod_rendering` now returns an eager/deferred distinction instead of a final string, so `zod_default_block` knows where the checks belong before the `z.lazy` wrapper closes.
- Deferred arguments take a new base spelling — `.check(z.minLength(N), z.maxLength(N), z.regex(...))`, the surface every Zod schema exposes — composed inside the thunk over the sibling's binding; eager arguments keep the `ZodString` chain exactly as before.
- Covers both deferred shapes: a non-generic sibling's `$Schema` and a folded generic sibling's `$SchemaDefault`, each pinned red-first with serde-enforcement tests.

Gate: `just lint-all` and `just test` (full feature powerset) green.