### PR TITLE
annotate a generic brand's default with its real branded class

### DIFF
--- a/README.md
+++ b/README.md
@@ -1053,7 +1053,7 @@ export const UserId$SchemaFactory = <IdType extends ZodType>(
   return schema;
 };
 
-export const UserId$SchemaDefault: ZodType<UserId<string>> = UserId$SchemaFactory(z.string());
+export const UserId$SchemaDefault: $ZodBranded<ZodString, "UserId"> = UserId$SchemaFactory(z.string());
 
 export type CorrelationId = string & $brand<"CorrelationId">;
 const CorrelationId$RawSchema = z.string().brand<"CorrelationId">().meta({
@@ -1370,7 +1370,7 @@ export const DocumentId$SchemaFactory = <IdType extends ZodType>(
   return schema;
 };
 
-export const DocumentId$SchemaDefault: ZodType<DocumentId<string>> = DocumentId$SchemaFactory(z.string());
+export const DocumentId$SchemaDefault: $ZodBranded<ZodString, "DocumentId"> = DocumentId$SchemaFactory(z.string());
 ```
 
 ## Field Validation (`model_schema_prop`)

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -698,10 +698,35 @@ struct BrandedDefaultChecks {
 ///
 /// `constrained` is `None` for every item but a branded newtype's own — see
 /// [`zod_default_block`]'s doc comment for what it names.
+///
+/// `brand` is `None` for every item but a branded newtype's own, exactly like `constrained` —
+/// but unlike `constrained`, it is `Some` whether or not the brand carries any check at all: a
+/// `.brand()` call is in the factory's chain either way, so the annotation question it answers
+/// (see [`branded_default_annotation`]) applies whether or not there is a check to route.
 #[cfg(feature = "zod")]
 struct ZodDefaultInputs<'defaults> {
+    #[cfg(feature = "typescript")]
+    brand: Option<BrandedAnnotation<'defaults>>,
     constrained: Option<(&'defaults str, &'defaults BrandedDefaultChecks)>,
     default_types: &'defaults [(syn::Ident, syn::Type)],
+}
+
+/// What a branded newtype's `$SchemaDefault` is annotated with, read off the shape of the
+/// brand's own inner rather than off any one parameter's filling — see
+/// [`branded_default_annotation`]. Only [`branded_default_annotation`] reads it, and that
+/// function is itself `typescript`-gated (the annotation it writes is a TypeScript-surface
+/// concern), so the enum carries the same gate rather than existing unread in a zod-without-
+/// typescript build.
+#[cfg(all(feature = "zod", feature = "typescript"))]
+enum BrandedAnnotation<'defaults> {
+    /// The inner is exactly one bare type parameter (`pub struct Name<T>(pub T)`) — the erased
+    /// inner itself carries no concrete class to name, so the annotation is read off that one
+    /// parameter's own declared default instead.
+    BareParameter(&'defaults str),
+    /// Every other inner shape — a tuple, an array, a concrete sibling — annotated with the bare
+    /// class [`branded_zod_type_name`] already reads off it for the non-generic const, widened
+    /// the same way regardless of what fills the brand's parameters.
+    Widened(String),
 }
 
 /// What [`default_zod_rendering`] found: a self-contained expression left eager, or a name
@@ -5154,9 +5179,21 @@ fn build_branded_zod_schema_method(
             }
             _ => None,
         };
+        #[cfg(feature = "typescript")]
+        let brand = Some(
+            if let FieldDefType::TypeParam(parameter) = &inner.field_type
+                && !inner.is_array()
+            {
+                BrandedAnnotation::BareParameter(parameter.as_str())
+            } else {
+                BrandedAnnotation::Widened(branded_zod_type_name(inner))
+            },
+        );
         let defaults = ZodDefaultInputs {
-            default_types: &args.default_types,
+            #[cfg(feature = "typescript")]
+            brand,
             constrained: constrained_default,
+            default_types: &args.default_types,
         };
         zod_factory_block(
             item_name,
@@ -12459,41 +12496,98 @@ fn zod_default_block(
         .collect();
     let fold_keys: Vec<String> = fields.iter().map(FieldDef::zod_type).collect();
     record_zod_default_arguments(rust_ident, fold_keys);
-    let arguments: Vec<String> = parameters
-        .iter()
-        .zip(&fields)
-        .map(|(parameter, field)| {
-            let rendering = default_zod_rendering(field);
-            match defaults.constrained {
-                Some((target, checks)) if target == parameter.as_str() => match rendering {
-                    DefaultZodRendering::Eager(schema) => {
-                        format!("{schema}{}", checks.chained)
-                    }
-                    DefaultZodRendering::Deferred(schema) => {
-                        deferred_zod_operand(&format!("{schema}{}", checks.base))
-                    }
-                },
-                _ => rendering.into_argument(),
-            }
-        })
-        .collect();
+    let renderings: Vec<DefaultZodRendering> = fields.iter().map(default_zod_rendering).collect();
 
     #[cfg(feature = "typescript")]
-    let annotation = format!(
-        ": ZodType<{item_name}<{}>>",
-        fields
-            .iter()
-            .map(FieldDef::typescript_typename)
-            .collect::<Vec<_>>()
-            .join(", ")
-    );
+    let annotation =
+        branded_default_annotation(item_name, defaults, parameters, &fields, &renderings);
     #[cfg(not(feature = "typescript"))]
     let annotation = String::new();
+
+    let arguments: Vec<String> = parameters
+        .iter()
+        .zip(renderings)
+        .map(|(parameter, rendering)| match defaults.constrained {
+            Some((target, checks)) if target == parameter.as_str() => match rendering {
+                DefaultZodRendering::Eager(schema) => {
+                    format!("{schema}{}", checks.chained)
+                }
+                DefaultZodRendering::Deferred(schema) => {
+                    deferred_zod_operand(&format!("{schema}{}", checks.base))
+                }
+            },
+            _ => rendering.into_argument(),
+        })
+        .collect();
 
     format!(
         "\n\nexport const {item_name}$SchemaDefault{annotation} = {item_name}$SchemaFactory({});",
         arguments.join(", ")
     )
+}
+
+/// The `$SchemaDefault` annotation [`zod_default_block`] writes: the plain `ZodType<Name<...>>`
+/// spelling for an ordinary generic item, exactly as before this fix — tsc already accepts a
+/// factory's return type there, since nothing in the chain calls `.brand()`, so nothing narrows
+/// the classic `ZodType` interface's own deprecated `_output` field out from under it. A branded
+/// newtype's factory always ends its chain in `.brand()` (see [`branded_zod_expression`]), so its
+/// return type is always some `$ZodBranded<Argument, Name>` — never the plain `Name<...>`
+/// instantiation `ZodType` names — and the annotation has to read the same way, exactly as
+/// [`branded_zod_const_block`] already annotates the non-generic case. See txsch-bpnj.
+#[cfg(all(feature = "zod", feature = "typescript"))]
+fn branded_default_annotation(
+    item_name: &str,
+    defaults: &ZodDefaultInputs<'_>,
+    parameters: &[String],
+    fields: &[FieldDef],
+    renderings: &[DefaultZodRendering],
+) -> String {
+    let plain_annotation = || {
+        format!(
+            ": ZodType<{item_name}<{}>>",
+            fields
+                .iter()
+                .map(FieldDef::typescript_typename)
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    };
+    let Some(brand) = &defaults.brand else {
+        return plain_annotation();
+    };
+    let argument_type = match brand {
+        BrandedAnnotation::Widened(class) => class.clone(),
+        BrandedAnnotation::BareParameter(target) => {
+            // Structurally always found: `target` is read off this same brand's own inner, which
+            // names one of its own declared parameters. Falling back to the plain annotation
+            // rather than panicking if that ever stopped holding costs nothing real — a branded
+            // `$SchemaDefault` is never reached without a parameter list to search.
+            let Some(index) = parameters.iter().position(|parameter| parameter == target) else {
+                return plain_annotation();
+            };
+            branded_default_argument_class(&fields[index], &renderings[index])
+        }
+    };
+    format!(": $ZodBranded<{argument_type}, \"{item_name}\">")
+}
+
+/// The class a bare-parameter brand's own declared-default argument is annotated with, for
+/// [`branded_default_annotation`]: the eager expression's own class from [`branded_zod_type_name`]
+/// bare, or that same class wrapped in `ZodLazy<...>` for a deferred one — `typeof {schema}` when
+/// the deferred target is a plain binding name, which is every deferred shape
+/// [`default_zod_rendering`] folds or defers to a sibling's own `$Schema`/`$SchemaDefault`; the
+/// widened class otherwise, for the one shape it is not — a declared default naming a generic
+/// sibling at some filling other than that sibling's own, whose un-folded reference is a factory
+/// call rather than a name `typeof` can read.
+#[cfg(all(feature = "zod", feature = "typescript"))]
+fn branded_default_argument_class(field: &FieldDef, rendering: &DefaultZodRendering) -> String {
+    match rendering {
+        DefaultZodRendering::Eager(_) => branded_zod_type_name(field),
+        DefaultZodRendering::Deferred(schema) if !schema.contains('(') => {
+            format!("ZodLazy<typeof {schema}>")
+        }
+        DefaultZodRendering::Deferred(_) => format!("ZodLazy<{}>", branded_zod_type_name(field)),
+    }
 }
 
 /// What a generic type's Zod surface is written as: the builder holding the schema its arguments
@@ -12605,8 +12699,10 @@ fn zod_published_binding(
         zod_const_block(item_name, preamble, expression, reexport)
     } else {
         let defaults = ZodDefaultInputs {
-            default_types,
+            #[cfg(feature = "typescript")]
+            brand: None,
             constrained: None,
+            default_types,
         };
         zod_factory_block(
             item_name, rust_ident, parameters, &defaults, preamble, expression, reexport,

--- a/tests/branded_newtype_tests/tests.rs
+++ b/tests/branded_newtype_tests/tests.rs
@@ -53,6 +53,12 @@ mod zod_ts_tests {
     /// the enclosing factory binds for it — so the brand lands on the schema the caller supplied
     /// rather than on a value that admits anything whatever it was filled with. The TypeScript
     /// type beside it keeps `IdType`, its own declaration binding it for real.
+    ///
+    /// The builder itself carries no `$ZodBranded` — its own bound is the plain `IdType extends
+    /// ZodType`, unlike the non-generic const's own base schema, which names it directly. Only
+    /// `$SchemaDefault`, called at the declared default, has a concrete filling to annotate with
+    /// one (txsch-bpnj) — the shape `an_unconstrained_generic_brands_default_is_still_branded`
+    /// below pins.
     #[test]
     fn test_branded_newtype_zod_schema() {
         let zod = RoleId::<String>::zod_schema();
@@ -63,7 +69,25 @@ mod zod_ts_tests {
         assert!(zod.contains("idType.meta({"), "Got: {zod}");
         assert!(zod.contains("}).brand<\"RoleId\">();"), "Got: {zod}");
         assert!(!zod.contains("z.unknown()"), "Got: {zod}");
-        assert!(!zod.contains("$ZodBranded"), "Got: {zod}");
+        let builder_end = zod.find("RoleId$SchemaDefault").unwrap();
+        assert!(!zod[..builder_end].contains("$ZodBranded"), "Got: {zod}");
+    }
+
+    /// Shape (b) from txsch-bpnj's capture: an *unconstrained* generic brand — no
+    /// `minLength`/`maxLength`/`pattern` at all — still has its `$SchemaDefault` annotated
+    /// `$ZodBranded<ZodString, "RoleId">` rather than `ZodType<RoleId<string>>`: the factory's
+    /// chain ends in `.brand()` whether or not there is a check to route, so the same `_output`
+    /// mismatch applies with or without one.
+    #[test]
+    fn an_unconstrained_generic_brands_default_is_still_branded() {
+        let zod = RoleId::<String>::zod_schema();
+        assert!(
+            zod.contains(
+                "export const RoleId$SchemaDefault: $ZodBranded<ZodString, \"RoleId\"> = \
+                 RoleId$SchemaFactory(z.string());"
+            ),
+            "Got:\n{zod}"
+        );
     }
 
     #[test]
@@ -947,12 +971,20 @@ mod constrained_generic_branded_tests {
 
     /// `$SchemaDefault` is the factory called at the declared default argument, with the checks
     /// composed onto that argument — exactly the shape the design settled on.
+    ///
+    /// Annotated `$ZodBranded<ZodString, "StrictDocumentId">` rather than
+    /// `ZodType<StrictDocumentId<string>>`: the factory's own chain always ends in `.brand()`, and
+    /// strict tsc rejects the plain `ZodType<...>` spelling there — the classic interface's
+    /// deprecated `_output` field is computed at the pre-brand type and a brand intersection does
+    /// not refresh it (txsch-bpnj). `$ZodBranded` matches the spelling the non-generic const
+    /// already carries for the identical reason.
     #[test]
     fn the_default_composes_the_factory_with_the_constrained_argument() {
         let zod = StrictDocumentId::<String>::zod_schema();
         assert!(
             zod.contains(
-                "export const StrictDocumentId$SchemaDefault: ZodType<StrictDocumentId<string>> = \
+                "export const StrictDocumentId$SchemaDefault: $ZodBranded<ZodString, \
+                 \"StrictDocumentId\"> = \
                  StrictDocumentId$SchemaFactory(z.string().min(24).max(24).check(z.regex(/^[a-f0-9]{24}$/)));"
             ),
             "Got:\n{zod}"
@@ -994,13 +1026,19 @@ mod constrained_generic_branded_tests {
     /// carry `ZodString`'s own chain methods, only the `.check(...)` every schema exposes. Before
     /// the fix, this same check was appended after the thunk closed, landing on `ZodLazy`, which
     /// has neither.
+    ///
+    /// Annotated `$ZodBranded<ZodLazy<typeof StrictDocumentId$SchemaDefault>, "OuterId">` rather
+    /// than `ZodType<OuterId<StrictDocumentId<string>>>` — the same `.brand()`-vs-`ZodType`
+    /// mismatch `the_default_composes_the_factory_with_the_constrained_argument` documents, with
+    /// the deferred target's own type spelled through `typeof` (txsch-bpnj).
     #[test]
     fn a_constrained_brands_default_naming_another_constrained_brands_default_composes_the_checks_inside_the_thunk()
      {
         let zod = OuterId::<String>::zod_schema();
         assert!(
             zod.contains(
-                "export const OuterId$SchemaDefault: ZodType<OuterId<StrictDocumentId<string>>> = \
+                "export const OuterId$SchemaDefault: $ZodBranded<ZodLazy<typeof \
+                 StrictDocumentId$SchemaDefault>, \"OuterId\"> = \
                  OuterId$SchemaFactory(z.lazy(() => \
                  StrictDocumentId$SchemaDefault.check(z.minLength(10))));"
             ),
@@ -1054,13 +1092,19 @@ mod constrained_default_names_a_sibling_tests {
     /// Before the fix: `OuterBrand$SchemaFactory(z.lazy(() => InnerString$Schema).min(3))` —
     /// `.min` landing on `ZodLazy`, which does not have it. After: the check composes inside the
     /// thunk, over `InnerString$Schema`'s own base `.check(...)` surface.
+    ///
+    /// Annotated `$ZodBranded<ZodLazy<typeof InnerString$Schema>, "OuterBrand">` rather than
+    /// `ZodType<OuterBrand<InnerString>>` — the same `.brand()`-vs-`ZodType` mismatch
+    /// `constrained_generic_branded_tests` documents for the primitive-default case, with the
+    /// deferred target's own type spelled through `typeof` (txsch-bpnj).
     #[test]
     fn a_constrained_brands_default_naming_a_non_generic_sibling_composes_the_check_inside_the_thunk()
      {
         let zod = OuterBrand::<String>::zod_schema();
         assert!(
             zod.contains(
-                "export const OuterBrand$SchemaDefault: ZodType<OuterBrand<InnerString>> = \
+                "export const OuterBrand$SchemaDefault: $ZodBranded<ZodLazy<typeof \
+                 InnerString$Schema>, \"OuterBrand\"> = \
                  OuterBrand$SchemaFactory(z.lazy(() => InnerString$Schema.check(z.minLength(3))));"
             ),
             "Got:\n{zod}"


### PR DESCRIPTION
Every generic branded newtype's `$SchemaDefault` was annotated `: ZodType<Name<...>>`, and strict tsc rejects that assignment for any `.brand()`-returning factory call: Zod v4's brand intersection narrows `_zod.output` but never recomputes the classic interface's deprecated top-level `_output`, which stays the un-branded type and fails structural assignability. Verdicts were captured first (tsc --strict + zod 4.4.3) for four real-emission shapes plus the non-generic control.

- A bare-parameter brand's default is now annotated with the branded class its factory actually returns — `$ZodBranded<ZodString, "Name">` for an eager primitive default, `$ZodBranded<ZodLazy<typeof X>, "Name">` for a deferred sibling binding — mirroring what the non-generic const already does.
- Composite-inner brands widen to the same class the non-generic annotation reads; ordinary non-brand generics keep `ZodType<X<...>>`, whose control capture passes.
- The annotation machinery is cfg-gated so a zod-without-typescript build carries none of it.
- README's two branded-newtype example blocks updated from real output.

Gate: `just lint-all` and `just test` (full feature powerset) green.