### PR TITLE
spell brand-annotation classes off the z namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1053,14 +1053,14 @@ export const UserId$SchemaFactory = <IdType extends ZodType>(
   return schema;
 };
 
-export const UserId$SchemaDefault: $ZodBranded<ZodString, "UserId"> = UserId$SchemaFactory(z.string());
+export const UserId$SchemaDefault: z.core.$ZodBranded<z.ZodString, "UserId"> = UserId$SchemaFactory(z.string());
 
 export type CorrelationId = string & $brand<"CorrelationId">;
 const CorrelationId$RawSchema = z.string().brand<"CorrelationId">().meta({
   description: "CorrelationId",
 });
 
-export const CorrelationId$Schema: $ZodBranded<ZodString, "CorrelationId"> = CorrelationId$RawSchema;
+export const CorrelationId$Schema: z.core.$ZodBranded<z.ZodString, "CorrelationId"> = CorrelationId$RawSchema;
 ```
 
 Generated TypeScript (without `zod` feature):
@@ -1225,7 +1225,7 @@ const SlugId$RawSchema = z.string().min(3).max(50).check(z.regex(/^[a-z0-9_]+$/)
   description: "SlugId",
 });
 
-export const SlugId$Schema: $ZodBranded<ZodString, "SlugId"> = SlugId$RawSchema;
+export const SlugId$Schema: z.core.$ZodBranded<z.ZodString, "SlugId"> = SlugId$RawSchema;
 ```
 
 Serde deserialization validates automatically:
@@ -1370,7 +1370,7 @@ export const DocumentId$SchemaFactory = <IdType extends ZodType>(
   return schema;
 };
 
-export const DocumentId$SchemaDefault: $ZodBranded<ZodString, "DocumentId"> = DocumentId$SchemaFactory(z.string());
+export const DocumentId$SchemaDefault: z.core.$ZodBranded<z.ZodString, "DocumentId"> = DocumentId$SchemaFactory(z.string());
 ```
 
 ## Field Validation (`model_schema_prop`)

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -5022,14 +5022,18 @@ fn branded_zod_inner(args: &ModelSchemaArgs, inner: &FieldDef) -> String {
 /// spelled `ObjectId` is not mistaken for the `$oid` object, and so a composite is annotated with
 /// the class its own value rendering produces instead of falling through to `ZodString`.
 ///
-/// Each name is the class bare, as `ZodObject` is: every one of them defaults its type parameters,
-/// so the annotation widens the raw schema rather than restating its element types.
+/// Each name is spelled off the `z` namespace (`z.ZodObject`, ...), never bare: `import { z } from
+/// "zod";` is the entire import surface CLAUDE.md's and README's own generation pattern requires of
+/// a consumer, and none of these classes is a top-level *value* export under that line — only a
+/// top-level *type* export, reachable solely by qualifying it off `z` (txsch-9rcw). Every one of
+/// them defaults its type parameters, so the annotation widens the raw schema rather than restating
+/// its element types.
 ///
 /// A named inner has no class of its own to name — the type it names publishes one, and this
 /// expansion cannot resolve it — so the annotation is the type of the very binding the value is
-/// composed from, read back off that same rendering. A check the brand adds returns the schema it
-/// was called on, so the binding's type is the base schema's type whether or not the brand
-/// constrains it.
+/// composed from, read back off that same rendering (a local `const`/factory name, not a `zod`
+/// export, so it is written bare). A check the brand adds returns the schema it was called on, so
+/// the binding's type is the base schema's type whether or not the brand constrains it.
 ///
 /// A type parameter reaches this off the erased def, as `z.unknown()` — the opaque arm — so the
 /// annotation follows the value rather than naming a binding the value no longer composes from.
@@ -5037,14 +5041,14 @@ fn branded_zod_inner(args: &ModelSchemaArgs, inner: &FieldDef) -> String {
 fn branded_zod_type_name(inner: &FieldDef) -> String {
     #[cfg(feature = "object_id")]
     if branded_inner_is_object_id(inner) {
-        return "ZodObject".to_owned();
+        return "z.ZodObject".to_owned();
     }
     if let Some(composite) = branded_inner_composite(inner) {
         return match composite {
-            BrandedComposite::Array => "ZodArray".to_owned(),
-            BrandedComposite::Map => "ZodRecord".to_owned(),
-            BrandedComposite::Opaque => "ZodUnknown".to_owned(),
-            BrandedComposite::Tuple => "ZodTuple".to_owned(),
+            BrandedComposite::Array => "z.ZodArray".to_owned(),
+            BrandedComposite::Map => "z.ZodRecord".to_owned(),
+            BrandedComposite::Opaque => "z.ZodUnknown".to_owned(),
+            BrandedComposite::Tuple => "z.ZodTuple".to_owned(),
         };
     }
     if let FieldDefType::SiblingType(_, args) = &inner.field_type
@@ -5053,9 +5057,9 @@ fn branded_zod_type_name(inner: &FieldDef) -> String {
         return format!("typeof {}", inner.zod_type());
     }
     match inner.typescript_typename().as_str() {
-        "number" => "ZodNumber".to_owned(),
-        "boolean" => "ZodBoolean".to_owned(),
-        _ => "ZodString".to_owned(),
+        "number" => "z.ZodNumber".to_owned(),
+        "boolean" => "z.ZodBoolean".to_owned(),
+        _ => "z.ZodString".to_owned(),
     }
 }
 
@@ -5225,7 +5229,7 @@ fn branded_zod_const_block(
     {
         format!(
             "const {item_name}$RawSchema = {expression};\n\nexport const {item_name}$Schema: \
-             $ZodBranded<{}, \"{item_name}\"> = {item_name}$RawSchema;{reexport}",
+             z.core.$ZodBranded<{}, \"{item_name}\"> = {item_name}$RawSchema;{reexport}",
             branded_zod_type_name(inner)
         )
     }
@@ -5583,8 +5587,10 @@ fn branded_guard_failure_output(
 /// to name, so the intersection is written against a `unique symbol` declared beside the type, and
 /// those two lines are the whole emission. Zod brands the inner's own schema with
 /// `.brand<"Name">()`, carries the item's description in the `.meta({ description })` every item
-/// carries it in, and annotates the exported binding `$ZodBranded<Class, "Name">` for the `Class`
-/// read off the very inner that rendering was built from.
+/// carries it in, and annotates the exported binding `z.core.$ZodBranded<Class, "Name">` for the
+/// `Class` read off the very inner that rendering was built from — every class name spelled off the
+/// `z` namespace, since none resolves as a bare name under the documented `import { z } from
+/// "zod";` (txsch-9rcw).
 ///
 /// Generic parameters on the struct are preserved in the TypeScript output, whose declaration
 /// binds them. The two validating surfaces read the inner off the erased def instead, so a
@@ -12531,9 +12537,10 @@ fn zod_default_block(
 /// factory's return type there, since nothing in the chain calls `.brand()`, so nothing narrows
 /// the classic `ZodType` interface's own deprecated `_output` field out from under it. A branded
 /// newtype's factory always ends its chain in `.brand()` (see [`branded_zod_expression`]), so its
-/// return type is always some `$ZodBranded<Argument, Name>` — never the plain `Name<...>`
+/// return type is always some `z.core.$ZodBranded<Argument, Name>` — never the plain `Name<...>`
 /// instantiation `ZodType` names — and the annotation has to read the same way, exactly as
-/// [`branded_zod_const_block`] already annotates the non-generic case. See txsch-bpnj.
+/// [`branded_zod_const_block`] already annotates the non-generic case. See txsch-bpnj. The class is
+/// spelled off the `z` namespace throughout, per [`branded_zod_type_name`] (txsch-9rcw).
 #[cfg(all(feature = "zod", feature = "typescript"))]
 fn branded_default_annotation(
     item_name: &str,
@@ -12568,12 +12575,12 @@ fn branded_default_annotation(
             branded_default_argument_class(&fields[index], &renderings[index])
         }
     };
-    format!(": $ZodBranded<{argument_type}, \"{item_name}\">")
+    format!(": z.core.$ZodBranded<{argument_type}, \"{item_name}\">")
 }
 
 /// The class a bare-parameter brand's own declared-default argument is annotated with, for
 /// [`branded_default_annotation`]: the eager expression's own class from [`branded_zod_type_name`]
-/// bare, or that same class wrapped in `ZodLazy<...>` for a deferred one — `typeof {schema}` when
+/// bare, or that same class wrapped in `z.ZodLazy<...>` for a deferred one — `typeof {schema}` when
 /// the deferred target is a plain binding name, which is every deferred shape
 /// [`default_zod_rendering`] folds or defers to a sibling's own `$Schema`/`$SchemaDefault`; the
 /// widened class otherwise, for the one shape it is not — a declared default naming a generic
@@ -12584,9 +12591,9 @@ fn branded_default_argument_class(field: &FieldDef, rendering: &DefaultZodRender
     match rendering {
         DefaultZodRendering::Eager(_) => branded_zod_type_name(field),
         DefaultZodRendering::Deferred(schema) if !schema.contains('(') => {
-            format!("ZodLazy<typeof {schema}>")
+            format!("z.ZodLazy<typeof {schema}>")
         }
-        DefaultZodRendering::Deferred(_) => format!("ZodLazy<{}>", branded_zod_type_name(field)),
+        DefaultZodRendering::Deferred(_) => format!("z.ZodLazy<{}>", branded_zod_type_name(field)),
     }
 }
 

--- a/tests/branded_newtype_tests/tests.rs
+++ b/tests/branded_newtype_tests/tests.rs
@@ -75,15 +75,17 @@ mod zod_ts_tests {
 
     /// Shape (b) from txsch-bpnj's capture: an *unconstrained* generic brand — no
     /// `minLength`/`maxLength`/`pattern` at all — still has its `$SchemaDefault` annotated
-    /// `$ZodBranded<ZodString, "RoleId">` rather than `ZodType<RoleId<string>>`: the factory's
-    /// chain ends in `.brand()` whether or not there is a check to route, so the same `_output`
-    /// mismatch applies with or without one.
+    /// `z.core.$ZodBranded<z.ZodString, "RoleId">` rather than `ZodType<RoleId<string>>`: the
+    /// factory's chain ends in `.brand()` whether or not there is a check to route, so the same
+    /// `_output` mismatch applies with or without one. Every class name is spelled off the `z`
+    /// namespace, since none resolves as a bare name under the documented `import { z } from
+    /// "zod";` (txsch-9rcw).
     #[test]
     fn an_unconstrained_generic_brands_default_is_still_branded() {
         let zod = RoleId::<String>::zod_schema();
         assert!(
             zod.contains(
-                "export const RoleId$SchemaDefault: $ZodBranded<ZodString, \"RoleId\"> = \
+                "export const RoleId$SchemaDefault: z.core.$ZodBranded<z.ZodString, \"RoleId\"> = \
                  RoleId$SchemaFactory(z.string());"
             ),
             "Got:\n{zod}"
@@ -114,7 +116,7 @@ mod zod_ts_tests {
         let zod = CorrelationId::zod_schema();
         assert!(zod.contains("z.string().brand"), "Got: {zod}");
         assert!(
-            zod.contains("$ZodBranded<ZodString, \"CorrelationId\">"),
+            zod.contains("z.core.$ZodBranded<z.ZodString, \"CorrelationId\">"),
             "Got: {zod}"
         );
     }
@@ -129,7 +131,7 @@ mod zod_ts_tests {
         );
         // Should contain the exported typed schema
         assert!(
-            zod.contains("export const CorrelationId$Schema: $ZodBranded<ZodString, \"CorrelationId\"> = CorrelationId$RawSchema"),
+            zod.contains("export const CorrelationId$Schema: z.core.$ZodBranded<z.ZodString, \"CorrelationId\"> = CorrelationId$RawSchema"),
             "Should contain exported schema referencing raw schema. Got: {zod}"
         );
     }
@@ -459,7 +461,9 @@ mod objectid_branded_surface_tests {
             "Got:\n{zod}"
         );
         assert!(
-            zod.contains(r#"PlainObjectId$Schema: $ZodBranded<ZodObject, "PlainObjectId">"#),
+            zod.contains(
+                r#"PlainObjectId$Schema: z.core.$ZodBranded<z.ZodObject, "PlainObjectId">"#
+            ),
             "Got:\n{zod}"
         );
         assert_eq!(
@@ -495,7 +499,7 @@ mod objectid_branded_surface_tests {
             "a string check must never sit on the $oid object. Got:\n{zod}"
         );
         assert!(
-            zod.contains(r#"HexObjectId$Schema: $ZodBranded<ZodObject, "HexObjectId">"#),
+            zod.contains(r#"HexObjectId$Schema: z.core.$ZodBranded<z.ZodObject, "HexObjectId">"#),
             "Got:\n{zod}"
         );
         assert_eq!(
@@ -583,7 +587,7 @@ mod objectid_branded_surface_tests {
             "Got:\n{zod}"
         );
         assert!(
-            zod.contains(r#"ObjectIdList$Schema: $ZodBranded<ZodArray, "ObjectIdList">"#),
+            zod.contains(r#"ObjectIdList$Schema: z.core.$ZodBranded<z.ZodArray, "ObjectIdList">"#),
             "Got:\n{zod}"
         );
         assert_eq!(
@@ -972,18 +976,20 @@ mod constrained_generic_branded_tests {
     /// `$SchemaDefault` is the factory called at the declared default argument, with the checks
     /// composed onto that argument — exactly the shape the design settled on.
     ///
-    /// Annotated `$ZodBranded<ZodString, "StrictDocumentId">` rather than
+    /// Annotated `z.core.$ZodBranded<z.ZodString, "StrictDocumentId">` rather than
     /// `ZodType<StrictDocumentId<string>>`: the factory's own chain always ends in `.brand()`, and
     /// strict tsc rejects the plain `ZodType<...>` spelling there — the classic interface's
     /// deprecated `_output` field is computed at the pre-brand type and a brand intersection does
-    /// not refresh it (txsch-bpnj). `$ZodBranded` matches the spelling the non-generic const
-    /// already carries for the identical reason.
+    /// not refresh it (txsch-bpnj). `z.core.$ZodBranded` matches the spelling the non-generic const
+    /// already carries for the identical reason, and every class name is spelled off the `z`
+    /// namespace, since none resolves as a bare name under the documented `import { z } from
+    /// "zod";` (txsch-9rcw).
     #[test]
     fn the_default_composes_the_factory_with_the_constrained_argument() {
         let zod = StrictDocumentId::<String>::zod_schema();
         assert!(
             zod.contains(
-                "export const StrictDocumentId$SchemaDefault: $ZodBranded<ZodString, \
+                "export const StrictDocumentId$SchemaDefault: z.core.$ZodBranded<z.ZodString, \
                  \"StrictDocumentId\"> = \
                  StrictDocumentId$SchemaFactory(z.string().min(24).max(24).check(z.regex(/^[a-f0-9]{24}$/)));"
             ),
@@ -1027,17 +1033,18 @@ mod constrained_generic_branded_tests {
     /// the fix, this same check was appended after the thunk closed, landing on `ZodLazy`, which
     /// has neither.
     ///
-    /// Annotated `$ZodBranded<ZodLazy<typeof StrictDocumentId$SchemaDefault>, "OuterId">` rather
-    /// than `ZodType<OuterId<StrictDocumentId<string>>>` — the same `.brand()`-vs-`ZodType`
+    /// Annotated `z.core.$ZodBranded<z.ZodLazy<typeof StrictDocumentId$SchemaDefault>, "OuterId">`
+    /// rather than `ZodType<OuterId<StrictDocumentId<string>>>` — the same `.brand()`-vs-`ZodType`
     /// mismatch `the_default_composes_the_factory_with_the_constrained_argument` documents, with
-    /// the deferred target's own type spelled through `typeof` (txsch-bpnj).
+    /// the deferred target's own type spelled through `typeof` (txsch-bpnj), and every class name
+    /// spelled off the `z` namespace (txsch-9rcw).
     #[test]
     fn a_constrained_brands_default_naming_another_constrained_brands_default_composes_the_checks_inside_the_thunk()
      {
         let zod = OuterId::<String>::zod_schema();
         assert!(
             zod.contains(
-                "export const OuterId$SchemaDefault: $ZodBranded<ZodLazy<typeof \
+                "export const OuterId$SchemaDefault: z.core.$ZodBranded<z.ZodLazy<typeof \
                  StrictDocumentId$SchemaDefault>, \"OuterId\"> = \
                  OuterId$SchemaFactory(z.lazy(() => \
                  StrictDocumentId$SchemaDefault.check(z.minLength(10))));"
@@ -1093,17 +1100,18 @@ mod constrained_default_names_a_sibling_tests {
     /// `.min` landing on `ZodLazy`, which does not have it. After: the check composes inside the
     /// thunk, over `InnerString$Schema`'s own base `.check(...)` surface.
     ///
-    /// Annotated `$ZodBranded<ZodLazy<typeof InnerString$Schema>, "OuterBrand">` rather than
-    /// `ZodType<OuterBrand<InnerString>>` — the same `.brand()`-vs-`ZodType` mismatch
+    /// Annotated `z.core.$ZodBranded<z.ZodLazy<typeof InnerString$Schema>, "OuterBrand">` rather
+    /// than `ZodType<OuterBrand<InnerString>>` — the same `.brand()`-vs-`ZodType` mismatch
     /// `constrained_generic_branded_tests` documents for the primitive-default case, with the
-    /// deferred target's own type spelled through `typeof` (txsch-bpnj).
+    /// deferred target's own type spelled through `typeof` (txsch-bpnj), and every class name
+    /// spelled off the `z` namespace (txsch-9rcw).
     #[test]
     fn a_constrained_brands_default_naming_a_non_generic_sibling_composes_the_check_inside_the_thunk()
      {
         let zod = OuterBrand::<String>::zod_schema();
         assert!(
             zod.contains(
-                "export const OuterBrand$SchemaDefault: $ZodBranded<ZodLazy<typeof \
+                "export const OuterBrand$SchemaDefault: z.core.$ZodBranded<z.ZodLazy<typeof \
                  InnerString$Schema>, \"OuterBrand\"> = \
                  OuterBrand$SchemaFactory(z.lazy(() => InnerString$Schema.check(z.minLength(3))));"
             ),
@@ -1365,7 +1373,7 @@ mod branded_composite_inner_tests {
             "Got:\n{zod}"
         );
         assert!(
-            zod.contains(r#"LabelList$Schema: $ZodBranded<ZodArray, "LabelList">"#),
+            zod.contains(r#"LabelList$Schema: z.core.$ZodBranded<z.ZodArray, "LabelList">"#),
             "Got:\n{zod}"
         );
         assert_eq!(
@@ -1388,7 +1396,7 @@ mod branded_composite_inner_tests {
             "Got:\n{zod}"
         );
         assert!(
-            zod.contains(r#"WeightMap$Schema: $ZodBranded<ZodRecord, "WeightMap">"#),
+            zod.contains(r#"WeightMap$Schema: z.core.$ZodBranded<z.ZodRecord, "WeightMap">"#),
             "Got:\n{zod}"
         );
         assert_eq!(
@@ -1411,7 +1419,7 @@ mod branded_composite_inner_tests {
             "Got:\n{zod}"
         );
         assert!(
-            zod.contains(r#"LabelPair$Schema: $ZodBranded<ZodTuple, "LabelPair">"#),
+            zod.contains(r#"LabelPair$Schema: z.core.$ZodBranded<z.ZodTuple, "LabelPair">"#),
             "Got:\n{zod}"
         );
         assert_eq!(
@@ -1436,7 +1444,7 @@ mod branded_composite_inner_tests {
             serde_json::json!({ "type": "array", "items": { "type": "string" } })
         );
         assert!(
-            LabelSet::zod_schema().contains(r#"$ZodBranded<ZodArray, "LabelSet">"#),
+            LabelSet::zod_schema().contains(r#"z.core.$ZodBranded<z.ZodArray, "LabelSet">"#),
             "Got:\n{}",
             LabelSet::zod_schema()
         );
@@ -1450,7 +1458,7 @@ mod branded_composite_inner_tests {
             })
         );
         assert!(
-            ByteQuad::zod_schema().contains(r#"$ZodBranded<ZodArray, "ByteQuad">"#),
+            ByteQuad::zod_schema().contains(r#"z.core.$ZodBranded<z.ZodArray, "ByteQuad">"#),
             "Got:\n{}",
             ByteQuad::zod_schema()
         );
@@ -1470,7 +1478,7 @@ mod branded_composite_inner_tests {
             "Got:\n{zod}"
         );
         assert!(
-            zod.contains(r#"Payload$Schema: $ZodBranded<ZodUnknown, "Payload">"#),
+            zod.contains(r#"Payload$Schema: z.core.$ZodBranded<z.ZodUnknown, "Payload">"#),
             "Got:\n{zod}"
         );
         assert_eq!(Payload::json_schema(), serde_json::json!({}));
@@ -1513,7 +1521,7 @@ mod branded_composite_inner_tests {
             })
         );
         assert!(
-            LabelRow::zod_schema().contains(r#"$ZodBranded<ZodArray, "LabelRow">"#),
+            LabelRow::zod_schema().contains(r#"z.core.$ZodBranded<z.ZodArray, "LabelRow">"#),
             "Got:\n{}",
             LabelRow::zod_schema()
         );
@@ -1997,7 +2005,9 @@ mod branded_sibling_inner_tests {
             "Got:\n{zod}"
         );
         assert!(
-            zod.contains(r#"WrappedPart$Schema: $ZodBranded<typeof Part$Schema, "WrappedPart">"#),
+            zod.contains(
+                r#"WrappedPart$Schema: z.core.$ZodBranded<typeof Part$Schema, "WrappedPart">"#
+            ),
             "Got:\n{zod}"
         );
         assert_eq!(WrappedPart::json_schema(), Part::json_schema());
@@ -2019,8 +2029,9 @@ mod branded_sibling_inner_tests {
     fn a_forward_declared_sibling_brand_carries_the_named_types_schema() {
         assert_eq!(WrappedTail::json_schema(), Tail::json_schema());
         assert!(
-            WrappedTail::zod_schema()
-                .contains(r#"WrappedTail$Schema: $ZodBranded<typeof Tail$Schema, "WrappedTail">"#),
+            WrappedTail::zod_schema().contains(
+                r#"WrappedTail$Schema: z.core.$ZodBranded<typeof Tail$Schema, "WrappedTail">"#
+            ),
             "Got:\n{}",
             WrappedTail::zod_schema()
         );
@@ -2067,7 +2078,9 @@ mod branded_sibling_inner_tests {
             "Got:\n{zod}"
         );
         assert!(
-            zod.contains(r#"ShortSlug$Schema: $ZodBranded<typeof Slug$Schema, "ShortSlug">"#),
+            zod.contains(
+                r#"ShortSlug$Schema: z.core.$ZodBranded<typeof Slug$Schema, "ShortSlug">"#
+            ),
             "Got:\n{zod}"
         );
     }
@@ -2300,7 +2313,7 @@ mod branded_chrono_inner_tests {
             "Got:\n{zod}"
         );
         assert!(
-            zod.contains(r#"Stamp$Schema: $ZodBranded<ZodString, "Stamp">"#),
+            zod.contains(r#"Stamp$Schema: z.core.$ZodBranded<z.ZodString, "Stamp">"#),
             "Got:\n{zod}"
         );
         assert_eq!(


### PR DESCRIPTION
Branded const/default annotations wrote bare `$ZodBranded`/`ZodString`/`ZodLazy`/…, none of which resolve under the `import { z } from "zod";` line the documented generation pattern gives consumers — `$ZodBranded` is not a top-level export at all, and the class interfaces are type exports reachable only by qualifying off `z`. Verdicts captured first (tsc --strict, zod 4.4.3, exactly the documented import): all three shapes pass with the namespaced spelling, and a wrong-class negative control still fails, proving the checks are real.

- `branded_zod_type_name` emits `z.ZodString`/`z.ZodNumber`/`z.ZodObject`/… ; `branded_zod_const_block` and `branded_default_annotation` wrap with `z.core.$ZodBranded<...>`; deferred shapes use `z.ZodLazy<...>`.
- `typeof X` arms stay bare — those name local bindings, not zod exports.
- Pinned test strings and README brand blocks updated from real output.

Gate: `just lint-all` and `just test` (full feature powerset) green.