### PR TITLE
qualify emitted ZodType off the z namespace

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -351,7 +351,7 @@ With `zod` + `typescript` features:
 ```typescript
 export type UserId<ID_TYPE> = ID_TYPE & z.$brand<"UserId">;
 const UserId$RawSchema = z.string().brand<"UserId">();
-export const UserId$Schema: ZodType<UserId<string>> = UserId$RawSchema;
+export const UserId$Schema: z.ZodType<UserId<string>> = UserId$RawSchema;
 ```
 
 With `typescript` only (no `zod`):
@@ -403,8 +403,8 @@ collide. The levels are written out to the exact depth the type declares rather 
 a loop needs a key type it cannot name and a value it cannot type, which means `unknown` and a
 cast at every level, while the written-out form comes back already typed.
 
-Every parameter is a real TypeScript type parameter (`<IdType extends ZodType>`), never a bare
-`ZodType` annotation — `ZodType` defaults its own parameters, so an argument annotated with it
+Every parameter is a real TypeScript type parameter (`<IdType extends z.ZodType>`), never a bare
+`z.ZodType` annotation — `z.ZodType` defaults its own parameters, so an argument annotated with it
 infers every field as `unknown`.
 
 `typescript_preamble!()` returns the one helper the factories share, `createSchemaCache`, which

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ export type User = {
   is_active: boolean;
 };
 
-export const User$Schema: ZodType<User> = z.strictObject({
+export const User$Schema: z.ZodType<User> = z.strictObject({
   id: z.string(),
   name: z.string(),
   email: z.string(),
@@ -340,7 +340,7 @@ export type FixedValue = {
 Generated Zod:
 
 ```typescript
-export const FixedValue$Schema: ZodType<FixedValue> = z.discriminatedUnion("type", [
+export const FixedValue$Schema: z.ZodType<FixedValue> = z.discriminatedUnion("type", [
   z.strictObject({
     type: z.literal("Empty"),
   }),
@@ -416,7 +416,7 @@ export type External = "Bare" | {
 Generated Zod:
 
 ```typescript
-export const External$Schema: ZodType<External> = z.union([
+export const External$Schema: z.ZodType<External> = z.union([
   z.literal("Bare"),
   z.strictObject({
     "Fields": z.strictObject({ a: z.string(), b: z.boolean() }),
@@ -479,7 +479,7 @@ export type Internal = {
 Generated Zod -- a flattened member is an intersection, which has no shape of its own to read the discriminator out of, so a union holding one is a plain `z.union` rather than a `z.discriminatedUnion`:
 
 ```typescript
-export const Internal$Schema: ZodType<Internal> = z.union([
+export const Internal$Schema: z.ZodType<Internal> = z.union([
   z.strictObject({ type: z.literal("Bare") }),
   z.strictObject({ type: z.literal("Fields"), a: z.string(), b: z.boolean() }),
   z.strictObject({ type: z.literal("Wrapped") }).and(z.lazy(() => TagPayload$Schema)),
@@ -532,7 +532,7 @@ export type DataElementSampleValueEntry = {
 Generated Zod:
 
 ```typescript
-export const DataElementSampleValueEntry$Schema: ZodType<DataElementSampleValueEntry> =
+export const DataElementSampleValueEntry$Schema: z.ZodType<DataElementSampleValueEntry> =
   z.strictObject({
     dataElementId: z.string(),
   }).and(z.lazy(() => DataElementSampleValueVariant$Schema));
@@ -581,7 +581,7 @@ Generated Zod:
 
 ```typescript
 const DateValue$RawSchema = z.union([z.number().int(), DateString$Schema]);
-export const DateValue$Schema: ZodType<DateValue> = DateValue$RawSchema;
+export const DateValue$Schema: z.ZodType<DateValue> = DateValue$RawSchema;
 ```
 
 Generated JSON Schema:
@@ -699,7 +699,7 @@ const TreeNode$RawSchema = z.strictObject({
   get children() { return z.array(TreeNode$Schema); },
 });
 
-export const TreeNode$Schema: ZodType<TreeNode> = TreeNode$RawSchema;
+export const TreeNode$Schema: z.ZodType<TreeNode> = TreeNode$RawSchema;
 ```
 
 Recursive enums are also supported. Only the variants that contain a self-reference use getter syntax; non-recursive variants use normal property syntax:
@@ -723,7 +723,7 @@ pub enum DynamicValue {
 Generated Zod:
 
 ```typescript
-export const DynamicValue$Schema: ZodType<DynamicValue> = z.discriminatedUnion("type", [
+export const DynamicValue$Schema: z.ZodType<DynamicValue> = z.discriminatedUnion("type", [
   z.strictObject({
     type: z.literal("string"),
     value: z.string(),
@@ -818,7 +818,7 @@ export type Wrapper<IdType> = {
   name: string;
 };
 
-const buildWrapper$Schema = <IdType extends ZodType>(
+const buildWrapper$Schema = <IdType extends z.ZodType>(
   idType: IdType,
 ) =>
   z.strictObject({
@@ -827,18 +827,18 @@ const buildWrapper$Schema = <IdType extends ZodType>(
   name: z.string(),
 });
 
-type Wrapper$SchemaOf<IdType extends ZodType> = ReturnType<
+type Wrapper$SchemaOf<IdType extends z.ZodType> = ReturnType<
   typeof buildWrapper$Schema<IdType>
 >;
 
 interface Wrapper$SchemaFactoryCache {
-  get<IdType extends ZodType>(key: IdType): Wrapper$SchemaOf<IdType> | undefined;
-  set<IdType extends ZodType>(key: IdType, value: Wrapper$SchemaOf<IdType>): this;
+  get<IdType extends z.ZodType>(key: IdType): Wrapper$SchemaOf<IdType> | undefined;
+  set<IdType extends z.ZodType>(key: IdType, value: Wrapper$SchemaOf<IdType>): this;
 }
 
 const Wrapper$SchemaFactoryCache = createSchemaCache<Wrapper$SchemaFactoryCache>();
 
-export const Wrapper$SchemaFactory = <IdType extends ZodType>(
+export const Wrapper$SchemaFactory = <IdType extends z.ZodType>(
   idType: IdType,
 ): Wrapper$SchemaOf<IdType> => {
   const hit = Wrapper$SchemaFactoryCache.get(idType);
@@ -849,10 +849,10 @@ export const Wrapper$SchemaFactory = <IdType extends ZodType>(
   return schema;
 };
 
-export const Wrapper$SchemaDefault: ZodType<Wrapper<string>> = Wrapper$SchemaFactory(z.string());
+export const Wrapper$SchemaDefault: z.ZodType<Wrapper<string>> = Wrapper$SchemaFactory(z.string());
 ```
 
-Every parameter is a real TypeScript type parameter, never a bare `ZodType` annotation: `ZodType` defaults its own parameters, so an argument annotated with it would infer every field it validates as `unknown` and the caller would learn nothing from the schema handed back. Arguments are required -- a default would let a call site say nothing about a filling and still be handed a schema, which is exactly the silent mis-validation the factory exists to prevent.
+Every parameter is a real TypeScript type parameter, never a bare `z.ZodType` annotation: `z.ZodType` defaults its own parameters, so an argument annotated with it would infer every field it validates as `unknown` and the caller would learn nothing from the schema handed back. Arguments are required -- a default would let a call site say nothing about a filling and still be handed a schema, which is exactly the silent mis-validation the factory exists to prevent.
 
 Each factory memoizes on the *identity* of the arguments it was handed, one cache level per parameter. Two calls with the same argument objects return the identical schema, and no two argument lists collide -- a change in the first argument and a change in the last each key a different level:
 
@@ -868,7 +868,7 @@ That is why `$SchemaDefault` is written as a call through the factory rather tha
 That reference is deferred, exactly like a flattened base's is: `DocumentId$SchemaDefault` is a module-scope `const`, a generated module concatenates one type's output after another in whatever order the consuming project's entity list produces, and one macro invocation sees one type -- so nothing here can know whether `DocumentId`'s `const` is written above `EcmDocument`'s in the emitted module or below it.
 
 ```typescript
-export const EcmDocument$SchemaDefault: ZodType<EcmDocument<DocumentId<string>, number>> =
+export const EcmDocument$SchemaDefault: z.ZodType<EcmDocument<DocumentId<string>, number>> =
   EcmDocument$SchemaFactory(z.lazy(() => DocumentId$SchemaDefault), z.number());
 ```
 
@@ -895,7 +895,7 @@ export type Node<IdType> = {
   id: IdType;
 };
 
-const buildNode$Schema = <IdType extends ZodType>(
+const buildNode$Schema = <IdType extends z.ZodType>(
   idType: IdType,
 ) =>
   z.strictObject({
@@ -979,7 +979,7 @@ pub type Wrapper<T> = Vec<T>;
 ```typescript
 export type WrapperType<T> = Array<T>;
 
-const buildWrapperType$Schema = <T extends ZodType>(
+const buildWrapperType$Schema = <T extends z.ZodType>(
   t: T,
 ) =>
   z.array(t);
@@ -1024,25 +1024,25 @@ Generated TypeScript (with `zod` feature):
 
 ```typescript
 export type UserId<IdType> = IdType & $brand<"UserId">;
-const buildUserId$Schema = <IdType extends ZodType>(
+const buildUserId$Schema = <IdType extends z.ZodType>(
   idType: IdType,
 ) =>
   idType.meta({
   description: "UserId",
 }).brand<"UserId">();
 
-type UserId$SchemaOf<IdType extends ZodType> = ReturnType<
+type UserId$SchemaOf<IdType extends z.ZodType> = ReturnType<
   typeof buildUserId$Schema<IdType>
 >;
 
 interface UserId$SchemaFactoryCache {
-  get<IdType extends ZodType>(key: IdType): UserId$SchemaOf<IdType> | undefined;
-  set<IdType extends ZodType>(key: IdType, value: UserId$SchemaOf<IdType>): this;
+  get<IdType extends z.ZodType>(key: IdType): UserId$SchemaOf<IdType> | undefined;
+  set<IdType extends z.ZodType>(key: IdType, value: UserId$SchemaOf<IdType>): this;
 }
 
 const UserId$SchemaFactoryCache = createSchemaCache<UserId$SchemaFactoryCache>();
 
-export const UserId$SchemaFactory = <IdType extends ZodType>(
+export const UserId$SchemaFactory = <IdType extends z.ZodType>(
   idType: IdType,
 ): UserId$SchemaOf<IdType> => {
   const hit = UserId$SchemaFactoryCache.get(idType);
@@ -1167,11 +1167,11 @@ pub struct GenericCount<IdType>(pub IdType);
 ```
 
 ```typescript
-const buildDocumentId$Schema = <IdType extends ZodType>(idType: IdType) =>
+const buildDocumentId$Schema = <IdType extends z.ZodType>(idType: IdType) =>
   idType.brand<"DocumentId">();
 
 // The factory itself carries no check — a non-default filling is not held to it.
-export const DocumentId$SchemaFactory = <IdType extends ZodType>(idType: IdType) => { /* ... */ };
+export const DocumentId$SchemaFactory = <IdType extends z.ZodType>(idType: IdType) => { /* ... */ };
 
 // $SchemaDefault composes the factory with the constrained default argument.
 export const DocumentId$SchemaDefault = DocumentId$SchemaFactory(
@@ -1340,7 +1340,7 @@ pub struct DocumentId<IdType>(pub IdType);
 Generated Zod:
 
 ```typescript
-const buildDocumentId$Schema = <IdType extends ZodType>(
+const buildDocumentId$Schema = <IdType extends z.ZodType>(
   idType: IdType,
 ) =>
   idType.meta({
@@ -1348,18 +1348,18 @@ const buildDocumentId$Schema = <IdType extends ZodType>(
   example: "64de3d95ff45b119e5b53a7e",
 }).brand<"DocumentId">();
 
-type DocumentId$SchemaOf<IdType extends ZodType> = ReturnType<
+type DocumentId$SchemaOf<IdType extends z.ZodType> = ReturnType<
   typeof buildDocumentId$Schema<IdType>
 >;
 
 interface DocumentId$SchemaFactoryCache {
-  get<IdType extends ZodType>(key: IdType): DocumentId$SchemaOf<IdType> | undefined;
-  set<IdType extends ZodType>(key: IdType, value: DocumentId$SchemaOf<IdType>): this;
+  get<IdType extends z.ZodType>(key: IdType): DocumentId$SchemaOf<IdType> | undefined;
+  set<IdType extends z.ZodType>(key: IdType, value: DocumentId$SchemaOf<IdType>): this;
 }
 
 const DocumentId$SchemaFactoryCache = createSchemaCache<DocumentId$SchemaFactoryCache>();
 
-export const DocumentId$SchemaFactory = <IdType extends ZodType>(
+export const DocumentId$SchemaFactory = <IdType extends z.ZodType>(
   idType: IdType,
 ): DocumentId$SchemaOf<IdType> => {
   const hit = DocumentId$SchemaFactoryCache.get(idType);
@@ -1725,7 +1725,7 @@ pub struct User {
 Generated Zod:
 
 ```typescript
-export const User$Schema: ZodType<User> = z.strictObject({
+export const User$Schema: z.ZodType<User> = z.strictObject({
   name: z.string(),
   email: z.string(),
   age: z.number().int(),
@@ -1912,7 +1912,7 @@ export type Event = {
 Generated Zod:
 
 ```typescript
-export const Event$Schema: ZodType<Event> = z.strictObject({
+export const Event$Schema: z.ZodType<Event> = z.strictObject({
   name: z.string(),
   date: z.iso.date(),
   time: z.preprocess((arg) => { if (typeof arg === "number") { const s = Math.floor(arg / 1000); const hh = String(Math.floor(s / 3600)).padStart(2, "0"); const mm = String(Math.floor((s % 3600) / 60)).padStart(2, "0"); const ss = String(s % 60).padStart(2, "0"); return `${hh}:${mm}:${ss}`; } return arg; }, z.iso.time()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,7 @@ const User$RawSchema = z.strictObject({
   roles: z.array(z.string()),
 });
 
-export const User$Schema: ZodType<User> = User$RawSchema;
+export const User$Schema: z.ZodType<User> = User$RawSchema;
 ```"]
 ///
 /// ## Enum Support
@@ -176,7 +176,7 @@ const Status$RawSchema = z.enum(["active", "inactive", "pending"]).meta({
   description: "Status",
 });
 
-export const Status$Schema: ZodType<Status> = Status$RawSchema;
+export const Status$Schema: z.ZodType<Status> = Status$RawSchema;
 ```"#]
 ///
 /// ## Tagged Unions (Discriminated Unions)
@@ -302,7 +302,7 @@ const Event$RawSchema = z.discriminatedUnion("type", [z.strictObject({
   userId: z.string(),
 })]);
 
-export const Event$Schema: ZodType<Event> = Event$RawSchema;
+export const Event$Schema: z.ZodType<Event> = Event$RawSchema;
 ```"#]
 ///
 /// ## `MongoDB` `ObjectId` Support
@@ -475,7 +475,7 @@ const Document$RawSchema = z.strictObject({
   title: z.string(),
 });
 
-export const Document$Schema: ZodType<Document> = Document$RawSchema;
+export const Document$Schema: z.ZodType<Document> = Document$RawSchema;
 ```
 "#
 )]

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -5150,7 +5150,7 @@ fn branded_zod_expression(
 /// it landed on a value pinned to whatever the first instantiation happened to be.
 ///
 /// The `const` a brand that declares no parameter still publishes is annotated with the branded
-/// class read off its inner, rather than with the `ZodType<Name>` every other `const` carries: the
+/// class read off its inner, rather than with the `z.ZodType<Name>` every other `const` carries: the
 /// brand is what the annotation has to state, and only the value it wraps says which class it is.
 /// A factory needs no such annotation — its return type is read back off the builder.
 ///
@@ -12255,7 +12255,7 @@ fn zod_factory_builder_name(item_name: &str) -> String {
 }
 
 /// The `TypeScript` parameter list a factory and everything written around it are declared under —
-/// `<IdType extends ZodType, DateType extends ZodType>`.
+/// `<IdType extends z.ZodType, DateType extends z.ZodType>`.
 ///
 /// Every parameter is a parameter of the function for real. A bare `ZodType` annotation compiles
 /// and infers nothing: `ZodType` defaults its own parameters, so a field validated by such an
@@ -12266,7 +12266,7 @@ fn zod_factory_bounds(parameters: &[String]) -> String {
         "<{}>",
         parameters
             .iter()
-            .map(|parameter| format!("{parameter} extends ZodType"))
+            .map(|parameter| format!("{parameter} extends z.ZodType"))
             .collect::<Vec<_>>()
             .join(", ")
     )
@@ -12332,8 +12332,8 @@ fn zod_cache_interfaces(item_name: &str, parameters: &[String]) -> String {
         };
         let _ = write!(
             written,
-            "interface {}{held} {{\n  get<{key} extends ZodType>(key: {key}): {value} | \
-             undefined;\n  set<{key} extends ZodType>(key: {key}, value: {value}): this;\n}}\n\n",
+            "interface {}{held} {{\n  get<{key} extends z.ZodType>(key: {key}): {value} | \
+             undefined;\n  set<{key} extends z.ZodType>(key: {key}, value: {value}): this;\n}}\n\n",
             zod_cache_level_name(item_name, depth)
         );
     }
@@ -12532,15 +12532,16 @@ fn zod_default_block(
     )
 }
 
-/// The `$SchemaDefault` annotation [`zod_default_block`] writes: the plain `ZodType<Name<...>>`
-/// spelling for an ordinary generic item, exactly as before this fix — tsc already accepts a
-/// factory's return type there, since nothing in the chain calls `.brand()`, so nothing narrows
-/// the classic `ZodType` interface's own deprecated `_output` field out from under it. A branded
-/// newtype's factory always ends its chain in `.brand()` (see [`branded_zod_expression`]), so its
-/// return type is always some `z.core.$ZodBranded<Argument, Name>` — never the plain `Name<...>`
-/// instantiation `ZodType` names — and the annotation has to read the same way, exactly as
-/// [`branded_zod_const_block`] already annotates the non-generic case. See txsch-bpnj. The class is
-/// spelled off the `z` namespace throughout, per [`branded_zod_type_name`] (txsch-9rcw).
+/// The `$SchemaDefault` annotation [`zod_default_block`] writes: the plain `z.ZodType<Name<...>>`
+/// spelling for an ordinary generic item — tsc already accepts a factory's return type there, since
+/// nothing in the chain calls `.brand()`, so nothing narrows the classic `ZodType` interface's own
+/// deprecated `_output` field out from under it. A branded newtype's factory always ends its chain
+/// in `.brand()` (see [`branded_zod_expression`]), so its return type is always some
+/// `z.core.$ZodBranded<Argument, Name>` — never the plain `Name<...>` instantiation `z.ZodType`
+/// names — and the annotation has to read the same way, exactly as [`branded_zod_const_block`]
+/// already annotates the non-generic case. See txsch-bpnj. The class is spelled off the `z`
+/// namespace throughout, per [`branded_zod_type_name`] (txsch-9rcw) and, since txsch-vyax, every
+/// other emission site as well.
 #[cfg(all(feature = "zod", feature = "typescript"))]
 fn branded_default_annotation(
     item_name: &str,
@@ -12551,7 +12552,7 @@ fn branded_default_annotation(
 ) -> String {
     let plain_annotation = || {
         format!(
-            ": ZodType<{item_name}<{}>>",
+            ": z.ZodType<{item_name}<{}>>",
             fields
                 .iter()
                 .map(FieldDef::typescript_typename)
@@ -12675,7 +12676,7 @@ fn zod_const_block(item_name: &str, preamble: &str, expression: &str, reexport: 
     {
         format!(
             "{preamble}const {item_name}$RawSchema = {expression};\n\nexport const \
-             {item_name}$Schema: ZodType<{item_name}> = {item_name}$RawSchema;{reexport}"
+             {item_name}$Schema: z.ZodType<{item_name}> = {item_name}$RawSchema;{reexport}"
         )
     }
     #[cfg(not(feature = "typescript"))]
@@ -13004,7 +13005,7 @@ fn generate_plain_enum_zod_schema_method(
         {
             quote::quote! {
                 pub fn zod_schema() -> String {
-                    format!("const {}$RawSchema = z.enum([{}]).meta({{\n  description: \"{}\",\n}});\n\nexport const {}$Schema: ZodType<{}> = {}$RawSchema;{}", #item_name, #schema_code, #description, #item_name, #item_name, #item_name, #reexport)
+                    format!("const {}$RawSchema = z.enum([{}]).meta({{\n  description: \"{}\",\n}});\n\nexport const {}$Schema: z.ZodType<{}> = {}$RawSchema;{}", #item_name, #schema_code, #description, #item_name, #item_name, #item_name, #reexport)
                 }
             }
         }

--- a/tests/branded_newtype_tests/tests.rs
+++ b/tests/branded_newtype_tests/tests.rs
@@ -55,7 +55,7 @@ mod zod_ts_tests {
     /// type beside it keeps `IdType`, its own declaration binding it for real.
     ///
     /// The builder itself carries no `$ZodBranded` — its own bound is the plain `IdType extends
-    /// ZodType`, unlike the non-generic const's own base schema, which names it directly. Only
+    /// z.ZodType`, unlike the non-generic const's own base schema, which names it directly. Only
     /// `$SchemaDefault`, called at the declared default, has a concrete filling to annotate with
     /// one (txsch-bpnj) — the shape `an_unconstrained_generic_brands_default_is_still_branded`
     /// below pins.
@@ -63,7 +63,7 @@ mod zod_ts_tests {
     fn test_branded_newtype_zod_schema() {
         let zod = RoleId::<String>::zod_schema();
         assert!(
-            zod.contains("export const RoleId$SchemaFactory = <IdType extends ZodType>("),
+            zod.contains("export const RoleId$SchemaFactory = <IdType extends z.ZodType>("),
             "Got: {zod}"
         );
         assert!(zod.contains("idType.meta({"), "Got: {zod}");
@@ -75,7 +75,7 @@ mod zod_ts_tests {
 
     /// Shape (b) from txsch-bpnj's capture: an *unconstrained* generic brand — no
     /// `minLength`/`maxLength`/`pattern` at all — still has its `$SchemaDefault` annotated
-    /// `z.core.$ZodBranded<z.ZodString, "RoleId">` rather than `ZodType<RoleId<string>>`: the
+    /// `z.core.$ZodBranded<z.ZodString, "RoleId">` rather than `z.ZodType<RoleId<string>>`: the
     /// factory's chain ends in `.brand()` whether or not there is a check to route, so the same
     /// `_output` mismatch applies with or without one. Every class name is spelled off the `z`
     /// namespace, since none resolves as a bare name under the documented `import { z } from
@@ -977,8 +977,8 @@ mod constrained_generic_branded_tests {
     /// composed onto that argument — exactly the shape the design settled on.
     ///
     /// Annotated `z.core.$ZodBranded<z.ZodString, "StrictDocumentId">` rather than
-    /// `ZodType<StrictDocumentId<string>>`: the factory's own chain always ends in `.brand()`, and
-    /// strict tsc rejects the plain `ZodType<...>` spelling there — the classic interface's
+    /// `z.ZodType<StrictDocumentId<string>>`: the factory's own chain always ends in `.brand()`, and
+    /// strict tsc rejects the plain `z.ZodType<...>` spelling there — the classic interface's
     /// deprecated `_output` field is computed at the pre-brand type and a brand intersection does
     /// not refresh it (txsch-bpnj). `z.core.$ZodBranded` matches the spelling the non-generic const
     /// already carries for the identical reason, and every class name is spelled off the `z`
@@ -1034,7 +1034,7 @@ mod constrained_generic_branded_tests {
     /// has neither.
     ///
     /// Annotated `z.core.$ZodBranded<z.ZodLazy<typeof StrictDocumentId$SchemaDefault>, "OuterId">`
-    /// rather than `ZodType<OuterId<StrictDocumentId<string>>>` — the same `.brand()`-vs-`ZodType`
+    /// rather than `z.ZodType<OuterId<StrictDocumentId<string>>>` — the same `.brand()`-vs-`z.ZodType`
     /// mismatch `the_default_composes_the_factory_with_the_constrained_argument` documents, with
     /// the deferred target's own type spelled through `typeof` (txsch-bpnj), and every class name
     /// spelled off the `z` namespace (txsch-9rcw).
@@ -1101,7 +1101,7 @@ mod constrained_default_names_a_sibling_tests {
     /// thunk, over `InnerString$Schema`'s own base `.check(...)` surface.
     ///
     /// Annotated `z.core.$ZodBranded<z.ZodLazy<typeof InnerString$Schema>, "OuterBrand">` rather
-    /// than `ZodType<OuterBrand<InnerString>>` — the same `.brand()`-vs-`ZodType` mismatch
+    /// than `z.ZodType<OuterBrand<InnerString>>` — the same `.brand()`-vs-`z.ZodType` mismatch
     /// `constrained_generic_branded_tests` documents for the primitive-default case, with the
     /// deferred target's own type spelled through `typeof` (txsch-bpnj), and every class name
     /// spelled off the `z` namespace (txsch-9rcw).
@@ -1628,7 +1628,7 @@ mod branded_generic_inner_tests {
         assert!(zod.contains("  z.array(t).meta({"), "Got:\n{zod}");
         assert!(zod.contains(r#"}).brand<"TagList">();"#), "Got:\n{zod}");
         assert!(
-            zod.contains("export const TagList$SchemaFactory = <T extends ZodType>("),
+            zod.contains("export const TagList$SchemaFactory = <T extends z.ZodType>("),
             "Got:\n{zod}"
         );
         assert_eq!(
@@ -1650,7 +1650,7 @@ mod branded_generic_inner_tests {
         );
         assert!(zod.contains(r#"}).brand<"WeightIndex">();"#), "Got:\n{zod}");
         assert!(
-            zod.contains("export const WeightIndex$SchemaFactory = <T extends ZodType>("),
+            zod.contains("export const WeightIndex$SchemaFactory = <T extends z.ZodType>("),
             "Got:\n{zod}"
         );
         assert_eq!(
@@ -1676,7 +1676,7 @@ mod branded_generic_inner_tests {
         assert!(zod.contains("  t.meta({"), "Got:\n{zod}");
         assert!(zod.contains(r#"}).brand<"BareTag">();"#), "Got:\n{zod}");
         assert!(
-            zod.contains("export const BareTag$SchemaFactory = <T extends ZodType>("),
+            zod.contains("export const BareTag$SchemaFactory = <T extends z.ZodType>("),
             "Got:\n{zod}"
         );
         assert_eq!(
@@ -1763,22 +1763,22 @@ mod branded_generic_inner_tests {
 
     /// A generic alias publishes a factory exactly as the brand beside it does, so neither has an
     /// annotation left to erase an argument out of — the `const` each used to publish claimed
-    /// `ZodType<Name<unknown>>` while the declaration beside it kept the argument, which is a type
+    /// `z.ZodType<Name<unknown>>` while the declaration beside it kept the argument, which is a type
     /// error at any field naming either.
     #[test]
     fn a_generic_alias_publishes_the_factory_the_brand_beside_it_publishes() {
         for (zod, factory) in [
             (
                 tag_seq_schema::Schema::zod_schema(),
-                "export const TagSeqType$SchemaFactory = <T extends ZodType>(",
+                "export const TagSeqType$SchemaFactory = <T extends z.ZodType>(",
             ),
             (
                 weight_seq_schema::Schema::zod_schema(),
-                "export const WeightSeqType$SchemaFactory = <T extends ZodType>(",
+                "export const WeightSeqType$SchemaFactory = <T extends z.ZodType>(",
             ),
             (
                 bare_seq_schema::Schema::zod_schema(),
-                "export const BareSeqType$SchemaFactory = <T extends ZodType>(",
+                "export const BareSeqType$SchemaFactory = <T extends z.ZodType>(",
             ),
         ] {
             assert!(zod.contains(factory), "Got:\n{zod}");
@@ -1859,7 +1859,7 @@ mod branded_javascript_flavour_tests {
     #[test]
     fn a_brand_binding_carries_no_annotation() {
         for zod in [PlainMark::zod_schema(), HeldMark::<String>::zod_schema()] {
-            assert!(!zod.contains("ZodType"), "Got:\n{zod}");
+            assert!(!zod.contains("z.ZodType"), "Got:\n{zod}");
             assert!(!zod.contains("$ZodBranded"), "Got:\n{zod}");
             assert!(!zod.contains("$Schema:"), "Got:\n{zod}");
         }
@@ -2182,7 +2182,7 @@ mod branded_sibling_inner_tests {
         );
         let zod = OpenTag::<String>::zod_schema();
         assert!(
-            zod.contains("const buildOpenTag$Schema = <TagType extends ZodType>("),
+            zod.contains("const buildOpenTag$Schema = <TagType extends z.ZodType>("),
             "Got:\n{zod}"
         );
         assert!(
@@ -2190,7 +2190,7 @@ mod branded_sibling_inner_tests {
             "Got:\n{zod}"
         );
         assert!(
-            zod.contains("export const OpenTag$SchemaFactory = <TagType extends ZodType>("),
+            zod.contains("export const OpenTag$SchemaFactory = <TagType extends z.ZodType>("),
             "Got:\n{zod}"
         );
     }

--- a/tests/enum_tests/tests.rs
+++ b/tests/enum_tests/tests.rs
@@ -481,7 +481,7 @@ fn test_plain_enum_special_chars_zod_has_raw_and_schema() {
         "Should contain $RawSchema. Got:\n{zod}"
     );
     assert!(
-        zod.contains("export const MimeType$Schema: ZodType<MimeType> = MimeType$RawSchema;"),
+        zod.contains("export const MimeType$Schema: z.ZodType<MimeType> = MimeType$RawSchema;"),
         "Should contain exported $Schema referencing $RawSchema. Got:\n{zod}"
     );
     assert!(
@@ -517,7 +517,7 @@ fn test_distribution_mime_type_zod_schema() {
         "Should contain $RawSchema. Got:\n{zod}"
     );
     assert!(
-        zod.contains("export const DistributionValidMimeType$Schema: ZodType<DistributionValidMimeType> = DistributionValidMimeType$RawSchema;"),
+        zod.contains("export const DistributionValidMimeType$Schema: z.ZodType<DistributionValidMimeType> = DistributionValidMimeType$RawSchema;"),
         "Should contain exported $Schema referencing $RawSchema. Got:\n{zod}"
     );
     assert!(

--- a/tests/example_tests/tests.rs
+++ b/tests/example_tests/tests.rs
@@ -34,7 +34,7 @@ fn test_simple_enum_example() {
             "Plain enum with example should have $RawSchema. Got:\n{zod}"
         );
         assert!(
-            zod.contains("export const DataType$Schema: ZodType<DataType> = DataType$RawSchema;"),
+            zod.contains("export const DataType$Schema: z.ZodType<DataType> = DataType$RawSchema;"),
             "Plain enum with example should have $Schema referencing $RawSchema. Got:\n{zod}"
         );
     }
@@ -230,8 +230,8 @@ fn test_typescript_zod_format() {
 
     let zod = Test::zod_schema();
 
-    // Should have TypeScript-style format with ZodType
-    assert!(zod.contains("ZodType<"));
+    // Should have TypeScript-style format with z.ZodType
+    assert!(zod.contains("z.ZodType<"));
     assert!(zod.contains("$RawSchema"));
     assert!(zod.contains("example:"));
 }
@@ -251,8 +251,8 @@ fn test_javascript_zod_format() {
 
     let zod = Test::zod_schema();
 
-    // Should have JavaScript-style format without ZodType
-    assert!(!zod.contains("ZodType<"));
+    // Should have JavaScript-style format without z.ZodType
+    assert!(!zod.contains("z.ZodType<"));
     assert!(zod.contains("example:"));
 }
 
@@ -656,7 +656,7 @@ fn a_plain_const_still_carries_its_example_on_the_exported_binding() {
     #[cfg(feature = "typescript")]
     assert!(
         zod.contains(
-            "export const Kept$Schema: ZodType<Kept> = Kept$RawSchema.meta({\n  example: \
+            "export const Kept$Schema: z.ZodType<Kept> = Kept$RawSchema.meta({\n  example: \
              {\"value\":\"x\"}\n});"
         ),
         "Got: {zod}"

--- a/tests/flatten_tests/tests.rs
+++ b/tests/flatten_tests/tests.rs
@@ -2449,7 +2449,7 @@ fn test_a_named_non_nullable_flatten_type_is_byte_identical() {
 #[cfg(feature = "zod")]
 fn test_a_named_non_nullable_flatten_schema_is_byte_identical() {
     #[cfg(feature = "typescript")]
-    const EXPECTED: &str = "const NamedPlainHolder$RawSchema = z.strictObject({\n  own: z.string(),\n}).and(z.lazy(() => PlainOptBase$Schema));\n\nexport const NamedPlainHolder$Schema: ZodType<NamedPlainHolder> = NamedPlainHolder$RawSchema;";
+    const EXPECTED: &str = "const NamedPlainHolder$RawSchema = z.strictObject({\n  own: z.string(),\n}).and(z.lazy(() => PlainOptBase$Schema));\n\nexport const NamedPlainHolder$Schema: z.ZodType<NamedPlainHolder> = NamedPlainHolder$RawSchema;";
     #[cfg(not(feature = "typescript"))]
     const EXPECTED: &str = "export const NamedPlainHolder$Schema = z.strictObject({\n  own: z.string(),\n}).and(z.lazy(() => PlainOptBase$Schema));";
 
@@ -2548,7 +2548,7 @@ fn test_a_non_optional_flatten_type_is_byte_identical() {
 #[cfg(feature = "zod")]
 fn test_a_non_optional_flatten_schema_is_byte_identical() {
     #[cfg(feature = "typescript")]
-    const EXPECTED: &str = "const MultiFlatten$RawSchema = z.strictObject({\n  id: z.string(),\n}).and(z.lazy(() => BasePart$Schema)).and(z.lazy(() => ExtraPart$Schema));\n\nexport const MultiFlatten$Schema: ZodType<MultiFlatten> = MultiFlatten$RawSchema;";
+    const EXPECTED: &str = "const MultiFlatten$RawSchema = z.strictObject({\n  id: z.string(),\n}).and(z.lazy(() => BasePart$Schema)).and(z.lazy(() => ExtraPart$Schema));\n\nexport const MultiFlatten$Schema: z.ZodType<MultiFlatten> = MultiFlatten$RawSchema;";
     #[cfg(not(feature = "typescript"))]
     const EXPECTED: &str = "export const MultiFlatten$Schema = z.strictObject({\n  id: z.string(),\n}).and(z.lazy(() => BasePart$Schema)).and(z.lazy(() => ExtraPart$Schema));";
 
@@ -2570,7 +2570,7 @@ fn test_a_non_optional_flatten_schema_is_byte_identical() {
 #[cfg(feature = "zod")]
 fn test_the_untagged_flatten_schema_multiplies_the_object_over_the_unions_members() {
     #[cfg(feature = "typescript")]
-    const EXPECTED: &str = "const FlatOverUntagged$OwnSchema = z.strictObject({\n  own: z.string(),\n});\n\nconst FlatOverUntagged$RawSchema = z.union([\n  FlatOverUntagged$OwnSchema.and(z.lazy(() => FlatFirst$Schema)),\n  FlatOverUntagged$OwnSchema.and(z.lazy(() => FlatSecond$Schema)),\n]);\n\nexport const FlatOverUntagged$Schema: ZodType<FlatOverUntagged> = FlatOverUntagged$RawSchema;";
+    const EXPECTED: &str = "const FlatOverUntagged$OwnSchema = z.strictObject({\n  own: z.string(),\n});\n\nconst FlatOverUntagged$RawSchema = z.union([\n  FlatOverUntagged$OwnSchema.and(z.lazy(() => FlatFirst$Schema)),\n  FlatOverUntagged$OwnSchema.and(z.lazy(() => FlatSecond$Schema)),\n]);\n\nexport const FlatOverUntagged$Schema: z.ZodType<FlatOverUntagged> = FlatOverUntagged$RawSchema;";
     #[cfg(not(feature = "typescript"))]
     const EXPECTED: &str = "const FlatOverUntagged$OwnSchema = z.strictObject({\n  own: z.string(),\n});\n\nexport const FlatOverUntagged$Schema = z.union([\n  FlatOverUntagged$OwnSchema.and(z.lazy(() => FlatFirst$Schema)),\n  FlatOverUntagged$OwnSchema.and(z.lazy(() => FlatSecond$Schema)),\n]);";
 
@@ -2719,7 +2719,7 @@ fn test_a_union_declared_below_the_object_is_named_as_one_operand() {
 #[cfg(feature = "zod")]
 fn test_an_internally_tagged_flatten_schema_is_byte_identical() {
     #[cfg(feature = "typescript")]
-    const EXPECTED: &str = "const DataElementSampleValueEntry$RawSchema = z.strictObject({\n  dataElementId: z.string(),\n}).and(z.lazy(() => DataElementSampleValueVariant$Schema));\n\nexport const DataElementSampleValueEntry$Schema: ZodType<DataElementSampleValueEntry> = DataElementSampleValueEntry$RawSchema;";
+    const EXPECTED: &str = "const DataElementSampleValueEntry$RawSchema = z.strictObject({\n  dataElementId: z.string(),\n}).and(z.lazy(() => DataElementSampleValueVariant$Schema));\n\nexport const DataElementSampleValueEntry$Schema: z.ZodType<DataElementSampleValueEntry> = DataElementSampleValueEntry$RawSchema;";
     #[cfg(not(feature = "typescript"))]
     const EXPECTED: &str = "export const DataElementSampleValueEntry$Schema = z.strictObject({\n  dataElementId: z.string(),\n}).and(z.lazy(() => DataElementSampleValueVariant$Schema));";
 
@@ -2733,7 +2733,7 @@ fn test_an_internally_tagged_flatten_schema_is_byte_identical() {
 #[cfg(feature = "zod")]
 fn test_a_standalone_union_with_a_scalar_member_is_byte_identical() {
     #[cfg(feature = "typescript")]
-    const EXPECTED: &str = "const FlatScalarEither$RawSchema = z.union([FlatFirst$Schema, z.string()]);\n\nexport const FlatScalarEither$Schema: ZodType<FlatScalarEither> = FlatScalarEither$RawSchema;";
+    const EXPECTED: &str = "const FlatScalarEither$RawSchema = z.union([FlatFirst$Schema, z.string()]);\n\nexport const FlatScalarEither$Schema: z.ZodType<FlatScalarEither> = FlatScalarEither$RawSchema;";
     #[cfg(not(feature = "typescript"))]
     const EXPECTED: &str =
         "export const FlatScalarEither$Schema = z.union([FlatFirst$Schema, z.string()]);";
@@ -2750,10 +2750,10 @@ fn test_a_standalone_union_with_a_scalar_member_is_byte_identical() {
 fn test_standalone_unions_the_merge_now_refuses_are_byte_identical() {
     #[cfg(feature = "typescript")]
     const EXPECTED: [&str; 4] = [
-        "const FlatNullableEither$RawSchema = z.union([FlatFirst$Schema, z.nullable(FlatSecond$Schema)]);\n\nexport const FlatNullableEither$Schema: ZodType<FlatNullableEither> = FlatNullableEither$RawSchema;",
-        "const MemberSlugEither$RawSchema = z.union([FlatFirst$Schema, MemberSlug$Schema]);\n\nexport const MemberSlugEither$Schema: ZodType<MemberSlugEither> = MemberSlugEither$RawSchema;",
-        "const MemberSwitchEither$RawSchema = z.union([FlatFirst$Schema, MemberSwitch$Schema]);\n\nexport const MemberSwitchEither$Schema: ZodType<MemberSwitchEither> = MemberSwitchEither$RawSchema;",
-        "const MemberHueEither$RawSchema = z.union([FlatFirst$Schema, MemberHue$Schema]);\n\nexport const MemberHueEither$Schema: ZodType<MemberHueEither> = MemberHueEither$RawSchema;",
+        "const FlatNullableEither$RawSchema = z.union([FlatFirst$Schema, z.nullable(FlatSecond$Schema)]);\n\nexport const FlatNullableEither$Schema: z.ZodType<FlatNullableEither> = FlatNullableEither$RawSchema;",
+        "const MemberSlugEither$RawSchema = z.union([FlatFirst$Schema, MemberSlug$Schema]);\n\nexport const MemberSlugEither$Schema: z.ZodType<MemberSlugEither> = MemberSlugEither$RawSchema;",
+        "const MemberSwitchEither$RawSchema = z.union([FlatFirst$Schema, MemberSwitch$Schema]);\n\nexport const MemberSwitchEither$Schema: z.ZodType<MemberSwitchEither> = MemberSwitchEither$RawSchema;",
+        "const MemberHueEither$RawSchema = z.union([FlatFirst$Schema, MemberHue$Schema]);\n\nexport const MemberHueEither$Schema: z.ZodType<MemberHueEither> = MemberHueEither$RawSchema;",
     ];
     #[cfg(not(feature = "typescript"))]
     const EXPECTED: [&str; 4] = [
@@ -2957,9 +2957,9 @@ fn test_a_named_map_member_keeps_its_merged_document() {
 fn test_the_named_wire_unions_are_byte_identical_standing_alone() {
     #[cfg(feature = "typescript")]
     const EXPECTED: [&str; 3] = [
-        "const MemberBagEither$RawSchema = z.union([FlatFirst$Schema, MemberBag$Schema]);\n\nexport const MemberBagEither$Schema: ZodType<MemberBagEither> = MemberBagEither$RawSchema;",
-        "const MemberBucketEither$RawSchema = z.union([FlatFirst$Schema, MemberBucket$Schema]);\n\nexport const MemberBucketEither$Schema: ZodType<MemberBucketEither> = MemberBucketEither$RawSchema;",
-        "const MemberMaybeEither$RawSchema = z.union([FlatFirst$Schema, MemberMaybeSecond$Schema]);\n\nexport const MemberMaybeEither$Schema: ZodType<MemberMaybeEither> = MemberMaybeEither$RawSchema;",
+        "const MemberBagEither$RawSchema = z.union([FlatFirst$Schema, MemberBag$Schema]);\n\nexport const MemberBagEither$Schema: z.ZodType<MemberBagEither> = MemberBagEither$RawSchema;",
+        "const MemberBucketEither$RawSchema = z.union([FlatFirst$Schema, MemberBucket$Schema]);\n\nexport const MemberBucketEither$Schema: z.ZodType<MemberBucketEither> = MemberBucketEither$RawSchema;",
+        "const MemberMaybeEither$RawSchema = z.union([FlatFirst$Schema, MemberMaybeSecond$Schema]);\n\nexport const MemberMaybeEither$Schema: z.ZodType<MemberMaybeEither> = MemberMaybeEither$RawSchema;",
     ];
     #[cfg(not(feature = "typescript"))]
     const EXPECTED: [&str; 3] = [
@@ -3073,8 +3073,8 @@ fn test_an_all_object_tagged_enum_member_keeps_its_merged_document() {
 fn test_the_tagged_enums_are_byte_identical_standing_alone() {
     #[cfg(feature = "typescript")]
     const EXPECTED: [&str; 2] = [
-        "const MemberExtBare$RawSchema = z.union([z.literal(\"Bare\"), z.strictObject({\n  \"Wrapped\": FlatSecond$Schema,\n})]);\n\nexport const MemberExtBare$Schema: ZodType<MemberExtBare> = MemberExtBare$RawSchema;",
-        "const MemberExtObjects$RawSchema = z.union([z.strictObject({\n  \"One\": FlatFirst$Schema,\n}), z.strictObject({\n  \"Two\": FlatSecond$Schema,\n})]);\n\nexport const MemberExtObjects$Schema: ZodType<MemberExtObjects> = MemberExtObjects$RawSchema;",
+        "const MemberExtBare$RawSchema = z.union([z.literal(\"Bare\"), z.strictObject({\n  \"Wrapped\": FlatSecond$Schema,\n})]);\n\nexport const MemberExtBare$Schema: z.ZodType<MemberExtBare> = MemberExtBare$RawSchema;",
+        "const MemberExtObjects$RawSchema = z.union([z.strictObject({\n  \"One\": FlatFirst$Schema,\n}), z.strictObject({\n  \"Two\": FlatSecond$Schema,\n})]);\n\nexport const MemberExtObjects$Schema: z.ZodType<MemberExtObjects> = MemberExtObjects$RawSchema;",
     ];
     #[cfg(not(feature = "typescript"))]
     const EXPECTED: [&str; 2] = [

--- a/tests/generic_types_tests/tests.rs
+++ b/tests/generic_types_tests/tests.rs
@@ -321,7 +321,7 @@ mod zod {
         assert!(
             zod.contains(
                 "const buildKeyedAliasType$Schema = \
-                 <KeyType extends ZodType, ValueType extends ZodType>(\n  keyType: KeyType,"
+                 <KeyType extends z.ZodType, ValueType extends z.ZodType>(\n  keyType: KeyType,"
             ),
             "Got: {zod}"
         );
@@ -489,7 +489,7 @@ mod zod {
         let zod = Wrapper::<String>::zod_schema();
         assert!(
             zod.contains(
-                "export const Wrapper$SchemaDefault: ZodType<Wrapper<string>> = \
+                "export const Wrapper$SchemaDefault: z.ZodType<Wrapper<string>> = \
                  Wrapper$SchemaFactory(z.string());"
             ),
             "Got: {zod}"
@@ -655,43 +655,43 @@ mod zod {
         let zod = Wrapper::<String>::zod_schema();
         assert!(
             zod.contains(
-                "const buildWrapper$Schema = <IdType extends ZodType>(\n  idType: IdType,\n) =>"
+                "const buildWrapper$Schema = <IdType extends z.ZodType>(\n  idType: IdType,\n) =>"
             ),
             "Got: {zod}"
         );
         assert!(
             zod.contains(
-                "type Wrapper$SchemaOf<IdType extends ZodType> = ReturnType<\n  typeof \
+                "type Wrapper$SchemaOf<IdType extends z.ZodType> = ReturnType<\n  typeof \
                  buildWrapper$Schema<IdType>\n>;"
             ),
             "Got: {zod}"
         );
         assert!(
             zod.contains(
-                "export const Wrapper$SchemaFactory = <IdType extends ZodType>(\n  idType: \
+                "export const Wrapper$SchemaFactory = <IdType extends z.ZodType>(\n  idType: \
                  IdType,\n): Wrapper$SchemaOf<IdType> => {"
             ),
             "Got: {zod}"
         );
     }
 
-    /// Each parameter is a parameter of the function for real. A bare `ZodType` annotation compiles
-    /// and infers nothing — `ZodType` defaults its own parameters — so a field validated through
+    /// Each parameter is a parameter of the function for real. A bare `z.ZodType` annotation compiles
+    /// and infers nothing — `z.ZodType` defaults its own parameters — so a field validated through
     /// one would come back as the opaque value whatever the caller supplied.
     #[cfg(feature = "typescript")]
     #[test]
     fn every_parameter_is_a_type_parameter_rather_than_a_bare_annotation() {
         let zod = Pair::<String, u32>::zod_schema();
         assert!(
-            zod.contains("<KeyType extends ZodType, ValueType extends ZodType>"),
+            zod.contains("<KeyType extends z.ZodType, ValueType extends z.ZodType>"),
             "Got: {zod}"
         );
         assert!(
             zod.contains("\n  keyType: KeyType,\n  valueType: ValueType,\n)"),
             "Got: {zod}"
         );
-        assert!(!zod.contains("keyType: ZodType"), "Got: {zod}");
-        assert!(!zod.contains("valueType: ZodType"), "Got: {zod}");
+        assert!(!zod.contains("keyType: z.ZodType"), "Got: {zod}");
+        assert!(!zod.contains("valueType: z.ZodType"), "Got: {zod}");
     }
 
     /// One parameter collapses to a single interface and a single lookup.
@@ -701,9 +701,9 @@ mod zod {
         let zod = Wrapper::<String>::zod_schema();
         assert!(
             zod.contains(
-                "interface Wrapper$SchemaFactoryCache {\n  get<IdType extends ZodType>(key: \
+                "interface Wrapper$SchemaFactoryCache {\n  get<IdType extends z.ZodType>(key: \
                  IdType): Wrapper$SchemaOf<IdType> | undefined;\n  set<IdType extends \
-                 ZodType>(key: IdType, value: Wrapper$SchemaOf<IdType>): this;\n}"
+                 z.ZodType>(key: IdType, value: Wrapper$SchemaOf<IdType>): this;\n}"
             ),
             "Got: {zod}"
         );
@@ -723,12 +723,12 @@ mod zod {
     fn each_cache_level_carries_the_parameters_resolved_above_it() {
         let zod = Quintet::<u32, u32, u32, u32, u32>::zod_schema();
         for level in [
-            "interface Quintet$SchemaFactoryCacheL1<AType extends ZodType> {\n  get<BType extends \
-             ZodType>(key: BType): Quintet$SchemaFactoryCacheL2<AType, BType> | undefined;",
-            "interface Quintet$SchemaFactoryCacheL4<AType extends ZodType, BType extends ZodType, \
-             CType extends ZodType, DType extends ZodType> {\n  get<EType extends ZodType>(key: \
+            "interface Quintet$SchemaFactoryCacheL1<AType extends z.ZodType> {\n  get<BType extends \
+             z.ZodType>(key: BType): Quintet$SchemaFactoryCacheL2<AType, BType> | undefined;",
+            "interface Quintet$SchemaFactoryCacheL4<AType extends z.ZodType, BType extends z.ZodType, \
+             CType extends z.ZodType, DType extends z.ZodType> {\n  get<EType extends z.ZodType>(key: \
              EType): Quintet$SchemaOf<AType, BType, CType, DType, EType> | undefined;",
-            "interface Quintet$SchemaFactoryCache {\n  get<AType extends ZodType>(key: AType): \
+            "interface Quintet$SchemaFactoryCache {\n  get<AType extends z.ZodType>(key: AType): \
              Quintet$SchemaFactoryCacheL1<AType> | undefined;",
             "    byCType = createSchemaCache<Quintet$SchemaFactoryCacheL2<AType, BType>>();",
         ] {
@@ -774,7 +774,7 @@ mod zod {
             "Got: {zod}"
         );
         assert!(!zod.contains("interface "), "Got: {zod}");
-        assert!(!zod.contains("ZodType"), "Got: {zod}");
+        assert!(!zod.contains("z.ZodType"), "Got: {zod}");
     }
 
     /// The alias and the brand write the same untyped factory, and the brand's marker drops the
@@ -788,13 +788,13 @@ mod zod {
             alias.contains("const buildBoxed$Schema = (\n  valueType,\n) =>"),
             "Got: {alias}"
         );
-        assert!(!alias.contains("ZodType"), "Got: {alias}");
+        assert!(!alias.contains("z.ZodType"), "Got: {alias}");
         assert!(!alias.contains("$Schema:"), "Got: {alias}");
 
         let brand = Tagged::<String>::zod_schema();
         assert!(brand.contains("}).brand();"), "Got: {brand}");
         assert!(!brand.contains(".brand<"), "Got: {brand}");
-        assert!(!brand.contains("ZodType"), "Got: {brand}");
+        assert!(!brand.contains("z.ZodType"), "Got: {brand}");
     }
 
     /// An alias and a branded newtype are generic publishers like any other, so each binds an

--- a/tests/generic_types_tests/whole_type_tests.rs
+++ b/tests/generic_types_tests/whole_type_tests.rs
@@ -422,7 +422,7 @@ mod readme {
             "pub struct Node<IdType> {",
             &Node::<String>::zod_schema(),
             &[
-                "const buildNode$Schema = <IdType extends ZodType>(",
+                "const buildNode$Schema = <IdType extends z.ZodType>(",
                 "  idType: IdType,",
                 ") =>",
                 "  z.strictObject({",

--- a/tests/semantic_types_tests/tests.rs
+++ b/tests/semantic_types_tests/tests.rs
@@ -386,7 +386,9 @@ fn test_scalar_alias_zod_schema() {
         "Scalar alias should bind its Zod to $RawSchema. Got: {zod}"
     );
     assert!(
-        zod.contains("export const DocumentId$Schema: ZodType<DocumentId> = DocumentId$RawSchema;"),
+        zod.contains(
+            "export const DocumentId$Schema: z.ZodType<DocumentId> = DocumentId$RawSchema;"
+        ),
         "Scalar alias should re-export an annotated $Schema. Got: {zod}"
     );
     assert!(
@@ -410,7 +412,7 @@ fn test_tuple_alias_zod_schema() {
     );
     assert!(
         zod.contains(
-            "export const CompactLinkRow$Schema: ZodType<CompactLinkRow> = CompactLinkRow$RawSchema;"
+            "export const CompactLinkRow$Schema: z.ZodType<CompactLinkRow> = CompactLinkRow$RawSchema;"
         ),
         "Tuple alias should re-export an annotated $Schema. Got: {zod}"
     );

--- a/tests/tuple_struct_tests/tests.rs
+++ b/tests/tuple_struct_tests/tests.rs
@@ -149,13 +149,13 @@ fn test_a_wider_tuple_struct_describes_a_fixed_tuple_in_zod() {
     assert!(!zod.contains("strictObject"), "Got: {zod}");
 }
 
-/// The `ZodType<...> = ...$RawSchema` framing only appears when typescript is also enabled.
+/// The `z.ZodType<...> = ...$RawSchema` framing only appears when typescript is also enabled.
 #[cfg(all(feature = "zod", feature = "typescript"))]
 #[test]
 fn test_a_tuple_struct_zod_schema_is_annotated_with_its_typescript_type() {
     let zod = Pair::zod_schema();
     assert!(
-        zod.contains("export const Pair$Schema: ZodType<Pair> = Pair$RawSchema;"),
+        zod.contains("export const Pair$Schema: z.ZodType<Pair> = Pair$RawSchema;"),
         "Got: {zod}"
     );
 }

--- a/tests/typescript_feature_tests/tests.rs
+++ b/tests/typescript_feature_tests/tests.rs
@@ -106,7 +106,7 @@ fn test_typescript_enabled_plain_enum_zod_schema() {
         "const TypeScriptTestStatus$RawSchema = z.enum([\"active\", \"inactive\", \"pending\"])"
     ));
     // Should contain typed $Schema referencing $RawSchema
-    assert!(zod_schema.contains("export const TypeScriptTestStatus$Schema: ZodType<TypeScriptTestStatus> = TypeScriptTestStatus$RawSchema;"));
+    assert!(zod_schema.contains("export const TypeScriptTestStatus$Schema: z.ZodType<TypeScriptTestStatus> = TypeScriptTestStatus$RawSchema;"));
     // Now includes .meta() with description
     assert!(zod_schema.contains(".meta({"));
 
@@ -137,7 +137,7 @@ fn test_typescript_enabled_discriminated_enum_zod_schema() {
     assert!(zod_schema.contains("const TypeScriptTestPayment$RawSchema = "));
     assert!(zod_schema.contains("z.discriminatedUnion"));
     // Should contain typed $Schema referencing $RawSchema
-    assert!(zod_schema.contains("export const TypeScriptTestPayment$Schema: ZodType<TypeScriptTestPayment> = TypeScriptTestPayment$RawSchema;"));
+    assert!(zod_schema.contains("export const TypeScriptTestPayment$Schema: z.ZodType<TypeScriptTestPayment> = TypeScriptTestPayment$RawSchema;"));
 
     // Should NOT contain TypeScript type definition
     assert!(!zod_schema.contains("export type TypeScriptTestPayment"));
@@ -169,7 +169,7 @@ fn test_typescript_disabled_struct_zod_schema_javascript_style() {
     assert!(zod_schema.contains("active: z.boolean()"));
 
     // Should NOT contain TypeScript type annotations
-    assert!(!zod_schema.contains(": ZodType<TypeScriptTestUser>"));
+    assert!(!zod_schema.contains(": z.ZodType<TypeScriptTestUser>"));
     assert!(!zod_schema.contains("export type TypeScriptTestUser"));
 }
 
@@ -183,7 +183,7 @@ fn test_typescript_disabled_plain_enum_zod_schema_typescript_not_serde_style() {
     assert!(zod_schema.contains(
         "const TypeScriptTestStatus$RawSchema = z.enum([\"Active\", \"Inactive\", \"Pending\"])"
     ));
-    assert!(zod_schema.contains("export const TypeScriptTestStatus$Schema: ZodType<TypeScriptTestStatus> = TypeScriptTestStatus$RawSchema;"));
+    assert!(zod_schema.contains("export const TypeScriptTestStatus$Schema: z.ZodType<TypeScriptTestStatus> = TypeScriptTestStatus$RawSchema;"));
     assert!(zod_schema.contains(".meta({"));
 
     assert!(!zod_schema.contains("export type TypeScriptTestStatus"));
@@ -199,7 +199,7 @@ fn test_typescript_disabled_plain_enum_zod_schema_typescript_serde_style() {
     assert!(zod_schema.contains(
         "const TypeScriptTestStatus$RawSchema = z.enum([\"active\", \"inactive\", \"pending\"])"
     ));
-    assert!(zod_schema.contains("export const TypeScriptTestStatus$Schema: ZodType<TypeScriptTestStatus> = TypeScriptTestStatus$RawSchema;"));
+    assert!(zod_schema.contains("export const TypeScriptTestStatus$Schema: z.ZodType<TypeScriptTestStatus> = TypeScriptTestStatus$RawSchema;"));
     assert!(zod_schema.contains(".meta({"));
 
     assert!(!zod_schema.contains("export type TypeScriptTestStatus"));
@@ -218,7 +218,7 @@ fn test_typescript_disabled_plain_enum_zod_schema_javascript_serde_style() {
     assert!(zod_schema.contains(".meta({"));
 
     // Should NOT contain TypeScript type annotations
-    assert!(!zod_schema.contains(": ZodType<TypeScriptTestStatus>"));
+    assert!(!zod_schema.contains(": z.ZodType<TypeScriptTestStatus>"));
     assert!(!zod_schema.contains("export type TypeScriptTestStatus"));
 }
 
@@ -235,7 +235,7 @@ fn test_typescript_disabled_plain_enum_zod_schema_javascript_not_serde_style() {
     assert!(zod_schema.contains(".meta({"));
 
     // Should NOT contain TypeScript type annotations
-    assert!(!zod_schema.contains(": ZodType<TypeScriptTestStatus>"));
+    assert!(!zod_schema.contains(": z.ZodType<TypeScriptTestStatus>"));
     assert!(!zod_schema.contains("export type TypeScriptTestStatus"));
 }
 
@@ -249,7 +249,7 @@ fn test_typescript_disabled_discriminated_enum_zod_schema_javascript_style() {
     assert!(zod_schema.contains("z.discriminatedUnion"));
 
     // Should NOT contain TypeScript type annotations
-    assert!(!zod_schema.contains(": ZodType<TypeScriptTestPayment>"));
+    assert!(!zod_schema.contains(": z.ZodType<TypeScriptTestPayment>"));
     assert!(!zod_schema.contains("export type TypeScriptTestPayment"));
 }
 
@@ -266,7 +266,8 @@ fn test_typescript_and_zod_both_enabled() {
 
     // Zod schema should be available and contain TypeScript-style type annotations
     assert!(
-        zod_schema.contains("export const TypeScriptTestUser$Schema: ZodType<TypeScriptTestUser>")
+        zod_schema
+            .contains("export const TypeScriptTestUser$Schema: z.ZodType<TypeScriptTestUser>")
     );
     assert!(!zod_schema.contains("export type TypeScriptTestUser"));
 }
@@ -278,7 +279,7 @@ fn test_typescript_disabled_zod_enabled() {
 
     // Zod schema should be available but in JavaScript style (no type annotations)
     assert!(zod_schema.contains("export const TypeScriptTestUser$Schema = z.strictObject({"));
-    assert!(!zod_schema.contains(": ZodType<TypeScriptTestUser>"));
+    assert!(!zod_schema.contains(": z.ZodType<TypeScriptTestUser>"));
 
     // TypeScript definition should NOT be available
     // (We can't test the compilation failure directly, but the method shouldn't exist)

--- a/tests/untagged_tests/tests.rs
+++ b/tests/untagged_tests/tests.rs
@@ -339,10 +339,10 @@ fn test_tuple_single_union_zod() {
         "Got:\n{zod}"
     );
     assert!(zod.contains("DateValue$Schema"), "Got:\n{zod}");
-    // The `ZodType<...> = ...$RawSchema` framing only appears when typescript is also enabled.
+    // The `z.ZodType<...> = ...$RawSchema` framing only appears when typescript is also enabled.
     #[cfg(feature = "typescript")]
     assert!(
-        zod.contains("export const DateValue$Schema: ZodType<DateValue> = DateValue$RawSchema;"),
+        zod.contains("export const DateValue$Schema: z.ZodType<DateValue> = DateValue$RawSchema;"),
         "Got:\n{zod}"
     );
 }

--- a/tests/zod_tests/tests.rs
+++ b/tests/zod_tests/tests.rs
@@ -155,7 +155,7 @@ fn test_zod_with_typescript_feature_includes_type_annotations() {
     );
     assert!(
         zod.contains(
-            "export const BasicStruct$Schema: ZodType<BasicStruct> = BasicStruct$RawSchema;"
+            "export const BasicStruct$Schema: z.ZodType<BasicStruct> = BasicStruct$RawSchema;"
         ),
         "Should export typed schema when typescript feature enabled. Got: {zod}"
     );
@@ -261,7 +261,7 @@ fn test_plain_enum_with_typescript_has_type_annotation() {
         "Plain enum with typescript should have $RawSchema. Got: {zod}"
     );
     assert!(
-        zod.contains("export const Status$Schema: ZodType<Status> = Status$RawSchema;"),
+        zod.contains("export const Status$Schema: z.ZodType<Status> = Status$RawSchema;"),
         "Plain enum with typescript should have typed $Schema. Got: {zod}"
     );
 }
@@ -436,7 +436,7 @@ fn test_zod_without_typescript_uses_simple_export() {
         "Without typescript, should use simple export. Got: {zod}"
     );
     assert!(
-        !zod.contains("ZodType"),
+        !zod.contains("z.ZodType"),
         "Without typescript, should not have type annotations. Got: {zod}"
     );
     assert!(


### PR DESCRIPTION
Bare `ZodType` — factory bounds, cache-interface bounds, and every plain `ZodType<...>` annotation — does not resolve under the `import { z } from "zod";` line the documented generation pattern gives consumers; it is a top-level type export usable only via an explicit type import or qualified as `z.ZodType`.

- The five emission sites now write `z.ZodType`; the brand-annotation names were already namespaced by the previous change.
- Acceptance capture: a full real emitted module (struct, enum, non-branded generic with factory + cache + default, generic brand, non-generic brand) passes `tsc --noEmit --strict` under exactly the documented single import (zod 4.4.3) — exit 0.
- Pinned strings across eleven test files, the rustdoc samples, README, and CLAUDE.md updated from real output.

Gate: `just lint-all` and `just test` (full feature powerset) green.