### PR TITLE
describe char as the one-character string serde writes

### DIFF
--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -77,6 +77,10 @@ pub enum VariantKind {
 pub enum FieldDefType {
     /// Boolean primitive - maps to boolean.
     Boolean,
+    /// `char` primitive - serde writes it as a one-character string and reads only that back, so
+    /// it is described as one: TypeScript `string`, Zod `z.string().length(1)`, JSON Schema
+    /// `{"type": "string", "minLength": 1, "maxLength": 1}`.
+    Char,
     #[cfg(feature = "chrono")]
     /// Chrono `DateTime<Tz>` type - requires "`chrono`" feature.
     /// Maps to `string` in TS (ISO 8601 format: "2025-11-29T14:30:00Z").
@@ -275,6 +279,7 @@ impl FieldDef {
             | FieldDefType::Unknown
             | FieldDefType::StringLiteral(_)
             | FieldDefType::Boolean
+            | FieldDefType::Char
             | FieldDefType::String
             | FieldDefType::U8
             | FieldDefType::U16
@@ -354,6 +359,7 @@ impl FieldDef {
             | FieldDefType::Unknown
             | FieldDefType::StringLiteral(_)
             | FieldDefType::Boolean
+            | FieldDefType::Char
             | FieldDefType::String
             | FieldDefType::U8
             | FieldDefType::U16
@@ -415,6 +421,7 @@ impl FieldDef {
             | FieldDefType::Unknown
             | FieldDefType::StringLiteral(_)
             | FieldDefType::Boolean
+            | FieldDefType::Char
             | FieldDefType::String
             | FieldDefType::U8
             | FieldDefType::U16
@@ -524,6 +531,7 @@ impl FieldDef {
             | FieldDefType::Unknown
             | FieldDefType::StringLiteral(_)
             | FieldDefType::Boolean
+            | FieldDefType::Char
             | FieldDefType::String
             | FieldDefType::U8
             | FieldDefType::U16
@@ -656,6 +664,7 @@ impl FieldDef {
             | FieldDefType::Unknown
             | FieldDefType::StringLiteral(_)
             | FieldDefType::Boolean
+            | FieldDefType::Char
             | FieldDefType::String
             | FieldDefType::U8
             | FieldDefType::U16
@@ -711,6 +720,7 @@ impl FieldDef {
             | FieldDefType::Unknown
             | FieldDefType::StringLiteral(_)
             | FieldDefType::Boolean
+            | FieldDefType::Char
             | FieldDefType::String
             | FieldDefType::U8
             | FieldDefType::U16
@@ -764,6 +774,7 @@ impl FieldDef {
             | FieldDefType::Unknown
             | FieldDefType::StringLiteral(_)
             | FieldDefType::Boolean
+            | FieldDefType::Char
             | FieldDefType::String
             | FieldDefType::U8
             | FieldDefType::U16
@@ -825,6 +836,7 @@ impl FieldDef {
             | FieldDefType::Unknown
             | FieldDefType::StringLiteral(_)
             | FieldDefType::Boolean
+            | FieldDefType::Char
             | FieldDefType::String
             | FieldDefType::U8
             | FieldDefType::U16
@@ -901,6 +913,7 @@ impl FieldDef {
             | FieldDefType::Unknown
             | FieldDefType::StringLiteral(_)
             | FieldDefType::Boolean
+            | FieldDefType::Char
             | FieldDefType::String
             | FieldDefType::U8
             | FieldDefType::U16
@@ -1005,7 +1018,7 @@ impl FieldDef {
                 )
             }
             FieldDefType::Boolean => "boolean".to_owned(),
-            FieldDefType::String => "string".to_owned(),
+            FieldDefType::Char | FieldDefType::String => "string".to_owned(),
             FieldDefType::StringLiteral(literal) => format!("\"{literal}\""),
             FieldDefType::U8
             | FieldDefType::U16
@@ -1203,6 +1216,10 @@ impl FieldDef {
                 format!("z.record({}, {})", k.zod_map_key_type(), v.zod_slot_type())
             }
             FieldDefType::Boolean => "z.boolean()".to_owned(),
+            // serde writes a `char` as a one-character string and reads only that back, so the
+            // length is fixed rather than read from `model_schema_prop` — a `char` field carries
+            // none of those constraints.
+            FieldDefType::Char => "z.string().length(1)".to_owned(),
             FieldDefType::String => self.zod_string_type(),
             FieldDefType::StringLiteral(literal) => format!("z.literal(\"{literal}\")"),
             FieldDefType::U8
@@ -1833,6 +1850,7 @@ fn get_field_def_type_or_sibling(t_name: &str) -> FieldDefType {
     }
     match t_name {
         "bool" => FieldDefType::Boolean,
+        "char" => FieldDefType::Char,
         // `str` and `Path` are the borrowed forms of `String` and `PathBuf`, and each writes the
         // same JSON string its owned form does. Both are reachable only behind a wrapper or a
         // reference, and the parser reads through either to land here. `OsString`/`OsStr` are
@@ -1890,19 +1908,21 @@ fn get_field_def_type_or_sibling(t_name: &str) -> FieldDefType {
 /// The dispatch above is total by construction: a name it does not recognise is taken for a sibling
 /// — another `model_schema` item, named before or after this one — and rendered as a reference to
 /// the module that item publishes. That is the right reading of `Foo`, which may well be declared
-/// below, and it is gibberish for `char`: no module named `char_schema` will ever exist, so the
-/// reference resolves to nothing and the author reads an `E0433` about a module they never wrote.
+/// below, and it is gibberish for a reserved primitive name the dispatch has no arm for: no module
+/// of that name will ever exist, so the reference resolves to nothing and the author reads an
+/// `E0433` about a module they never wrote.
 ///
 /// The two cannot be told apart by tokens, so only what is *provably* not a sibling is named here:
-/// the primitive names the language reserves, minus the ones the dispatch does answer for. A
-/// caller refusing on this answer refuses exactly the spellings that cannot become siblings later.
+/// the primitive names the language reserves, minus the ones the dispatch does answer for — `char`
+/// among them since it gained [`FieldDefType::Char`]. A caller refusing on this answer refuses
+/// exactly the spellings that cannot become siblings later.
 ///
-/// `f16` and `f128` are listed with `char`, `i128` and `u128` although the language does not yet
-/// stabilise them: they are reserved primitive names either way, and a build that gains them
-/// should reach a refusal naming the limitation rather than the phantom module.
+/// `f16` and `f128` are listed with `i128` and `u128` although the language does not yet stabilise
+/// them: they are reserved primitive names either way, and a build that gains them should reach a
+/// refusal naming the limitation rather than the phantom module.
 #[cfg(feature = "jsonschema")]
 pub fn is_undescribable_primitive(name: &str) -> bool {
-    matches!(name, "char" | "i128" | "u128" | "f16" | "f128")
+    matches!(name, "i128" | "u128" | "f16" | "f128")
 }
 
 /// Parses serde attributes from struct/enum attributes (requires "serde" feature).

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -3478,7 +3478,10 @@ fn non_string_inner_shape(inner: &FieldDef) -> Option<&'static str> {
         | FieldDefType::F32
         | FieldDefType::F64 => Some("numeric"),
         FieldDefType::TypeParam(_) | FieldDefType::Unknown => Some("opaque"),
-        FieldDefType::String | FieldDefType::StringLiteral(_) => None,
+        // A `char` writes the one-character string every other string-shaped arm here does, and
+        // `validate()` reaches it the same way it reaches a numeric or boolean inner: through
+        // `Display`.
+        FieldDefType::Char | FieldDefType::String | FieldDefType::StringLiteral(_) => None,
         #[cfg(feature = "object_id")]
         FieldDefType::ObjectId => None,
         #[cfg(feature = "chrono")]
@@ -3567,7 +3570,9 @@ const fn scalar_json_type_keyword(field_type: &FieldDefType) -> Option<&'static 
         | FieldDefType::U32
         | FieldDefType::U64
         | FieldDefType::Usize => Some("integer"),
-        FieldDefType::String | FieldDefType::StringLiteral(_) => Some("string"),
+        FieldDefType::Char | FieldDefType::String | FieldDefType::StringLiteral(_) => {
+            Some("string")
+        }
         #[cfg(feature = "chrono")]
         FieldDefType::DateTime
         | FieldDefType::NaiveDate
@@ -5114,6 +5119,7 @@ fn branded_inner_composite(inner: &FieldDef) -> Option<BrandedComposite> {
         FieldDefType::Tuple(..) => Some(BrandedComposite::Tuple),
         FieldDefType::TypeParam(_) | FieldDefType::Unknown => Some(BrandedComposite::Opaque),
         FieldDefType::Boolean
+        | FieldDefType::Char
         | FieldDefType::F32
         | FieldDefType::F64
         | FieldDefType::I8
@@ -7491,7 +7497,9 @@ fn tagged_content(inner: &FieldDef) -> TaggedContent {
         | FieldDefType::U32
         | FieldDefType::U64
         | FieldDefType::Usize => TaggedContent::Refused("an integer"),
-        FieldDefType::String | FieldDefType::StringLiteral(_) => TaggedContent::Refused("a string"),
+        FieldDefType::Char | FieldDefType::String | FieldDefType::StringLiteral(_) => {
+            TaggedContent::Refused("a string")
+        }
         #[cfg(feature = "chrono")]
         FieldDefType::DateTime
         | FieldDefType::NaiveDate
@@ -8204,6 +8212,9 @@ fn field_json_schema_value(fld: &FieldDef) -> proc_macro2::TokenStream {
             sibling_json_schema_value(name, arguments, fld.type_span)
         }
         FieldDefType::String => string_field_json_schema_value(fld),
+        FieldDefType::Char => {
+            quote! { serde_json::json!({ "type": "string", "minLength": 1, "maxLength": 1 }) }
+        }
         FieldDefType::StringLiteral(literal) => {
             quote! { serde_json::json!({ "type": "string", "const": #literal }) }
         }
@@ -9426,6 +9437,7 @@ const fn chrono_json_schema_format(field_type: &FieldDefType) -> Option<&'static
         FieldDefType::NaiveTime => Some("time"),
         FieldDefType::NaiveDateTime | FieldDefType::DateTime => Some("date-time"),
         FieldDefType::Boolean
+        | FieldDefType::Char
         | FieldDefType::F32
         | FieldDefType::F64
         | FieldDefType::I8
@@ -9470,6 +9482,9 @@ fn chrono_json_schema_item(field_type: &FieldDefType) -> Option<proc_macro2::Tok
 fn scalar_field_json_schema_item(fld: &FieldDef) -> Option<proc_macro2::TokenStream> {
     let item_schema = match &fld.field_type {
         FieldDefType::String => quote! { { "type": "string" } },
+        // Fixed at 1 rather than read from `model_schema_prop`: a `char` carries none of those
+        // constraints, and this is what serde writes for it wherever it stands.
+        FieldDefType::Char => quote! { { "type": "string", "minLength": 1, "maxLength": 1 } },
         FieldDefType::StringLiteral(literal) => {
             quote! { { "type": "string", "const": #literal } }
         }
@@ -9856,6 +9871,7 @@ fn map_key_path(key: &FieldDef) -> MapKeyPath<'_> {
         FieldDefType::SiblingType(..)
         | FieldDefType::Unknown
         | FieldDefType::Boolean
+        | FieldDefType::Char
         | FieldDefType::StringLiteral(_)
         | FieldDefType::U8
         | FieldDefType::U16
@@ -9921,6 +9937,7 @@ fn map_key_element_name(key: &FieldDef) -> String {
         }
         FieldDefType::String | FieldDefType::StringLiteral(_) => "String".to_owned(),
         FieldDefType::Boolean => "bool".to_owned(),
+        FieldDefType::Char => "char".to_owned(),
         FieldDefType::U8 => "u8".to_owned(),
         FieldDefType::U16 => "u16".to_owned(),
         FieldDefType::U32 => "u32".to_owned(),
@@ -9993,6 +10010,7 @@ fn map_key_rejection(fld: &FieldDef) -> Option<MapKeyRejection> {
         | FieldDefType::Unknown
         | FieldDefType::StringLiteral(_)
         | FieldDefType::Boolean
+        | FieldDefType::Char
         | FieldDefType::String
         | FieldDefType::U8
         | FieldDefType::U16
@@ -10239,6 +10257,7 @@ fn build_map_member_item(value: &FieldDef) -> Result<MapMemberItem, MapMemberRej
         // `None`. Named exhaustively rather than caught by a wildcard: a new variant must be given
         // a member schema, not silently widened into an open object.
         FieldDefType::Boolean
+        | FieldDefType::Char
         | FieldDefType::F32
         | FieldDefType::F64
         | FieldDefType::I8
@@ -10526,6 +10545,20 @@ fn build_boolean_field_schema(fld: &FieldDef, field_name_str: &str) -> proc_macr
     }
 }
 
+/// Builds the JSON schema for a `char` field: the one-character string serde writes for it, with
+/// `minLength`/`maxLength` fixed at 1 rather than read from `model_schema_prop` — a `char` field
+/// carries none of those constraints.
+#[cfg(feature = "jsonschema")]
+fn build_char_field_schema(fld: &FieldDef, field_name_str: &str) -> proc_macro2::TokenStream {
+    let schema = arrayed_json_schema_value(
+        fld,
+        quote! { serde_json::json!({ "type": "string", "minLength": 1, "maxLength": 1 }) },
+    );
+    quote! {
+        properties.insert(#field_name_str.to_string(), { #schema });
+    }
+}
+
 /// Builds the JSON schema for a `SiblingType` field (references to other generated types).
 #[cfg(feature = "jsonschema")]
 fn build_sibling_type_field_schema(
@@ -10696,6 +10729,7 @@ fn build_field_type_schema(fld: &FieldDef, field_name_str: &str) -> proc_macro2:
             build_numeric_field_schema(fld, field_name_str, keyword)
         }
         FieldDefType::Boolean => build_boolean_field_schema(fld, field_name_str),
+        FieldDefType::Char => build_char_field_schema(fld, field_name_str),
         #[cfg(feature = "object_id")]
         FieldDefType::ObjectId => build_object_id_field_schema(fld, field_name_str),
         #[cfg(feature = "chrono")]

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -4445,14 +4445,16 @@ fn a_default_types_refusal_is_spanned_on_what_earned_it() {
 }
 
 /// A filling is rendered through the dispatch a field's type is, and that dispatch takes a name it
-/// has no arm for to be another `#[model_schema]` item — right for `Foo`, gibberish for `char`,
-/// which emitted a call into a `char_schema` module nothing publishes and left the author reading
-/// an `E0433` about a module they never wrote plus two `E0425`s about the generated body's own
-/// bindings. Refused at the entry instead, in words that name the type and the limitation.
+/// has no arm for to be another `#[model_schema]` item — right for `Foo`, gibberish for a reserved
+/// primitive name the dispatch has no arm for, which emitted a call into a module nothing publishes
+/// and left the author reading an `E0433` about a module they never wrote plus two `E0425`s about
+/// the generated body's own bindings. Refused at the entry instead, in words that name the type and
+/// the limitation. `char` is no longer among them: it gained `FieldDefType::Char` and is asserted
+/// admitted in `a_renderable_or_sibling_named_filling_is_left_alone` instead.
 #[cfg(feature = "jsonschema")]
 #[test]
 fn a_filling_no_document_can_be_built_from_is_refused_at_the_entry() {
-    for written in ["char", "i128", "u128", "f16", "f128"] {
+    for written in ["i128", "u128", "f16", "f128"] {
         let messages = default_types_messages(
             "pub struct Probe<ValueType> { pub held: ValueType }",
             &format!("default_types(ValueType = {written})"),
@@ -4482,10 +4484,10 @@ fn a_filling_no_document_can_be_built_from_is_refused_at_the_entry() {
 fn an_undescribable_filling_refusal_is_spanned_on_the_filling() {
     let refusals = default_types_refusals(
         "pub struct Probe<WideType, NarrowType> { pub wide: WideType, pub narrow: NarrowType }",
-        "default_types(WideType = String, NarrowType = char)",
+        "default_types(WideType = String, NarrowType = i128)",
     );
     assert_eq!(refusals.len(), 1, "got: {refusals:?}");
-    assert_eq!(refusals[0].span().source_text().as_deref(), Some("char"));
+    assert_eq!(refusals[0].span().source_text().as_deref(), Some("i128"));
 }
 
 /// Only what is provably not a sibling is refused. A bare `Foo` is a legitimate forward reference
@@ -4498,6 +4500,7 @@ fn a_renderable_or_sibling_named_filling_is_left_alone() {
         "Foo",
         "String",
         "bool",
+        "char",
         "u8",
         "u64",
         "i64",

--- a/tests/generic_types_tests/tests.rs
+++ b/tests/generic_types_tests/tests.rs
@@ -1098,6 +1098,20 @@ mod jsonschema {
         assert_eq!(properties["name"], serde_json::json!({ "type": "string" }));
     }
 
+    /// A `char` default renders the one-character string serde writes for it — the document
+    /// `is_undescribable_primitive` refused before `char` gained a `FieldDefType` arm, naming a
+    /// `char_schema` module nothing publishes instead.
+    #[test]
+    fn a_char_default_describes_the_one_character_string() {
+        use super::Initialed;
+
+        let schema = Initialed::<char>::json_schema();
+        assert_eq!(
+            schema["properties"]["initial"],
+            serde_json::json!({ "type": "string", "minLength": 1_i32, "maxLength": 1_i32 })
+        );
+    }
+
     #[test]
     fn the_shape_around_a_parameter_is_still_described() {
         let schema = Pair::<String, u32>::json_schema();
@@ -1369,6 +1383,17 @@ pub struct Wrapper<IdType> {
     pub children: Vec<IdType>,
     pub id: IdType,
     pub name: String,
+}
+
+/// A `char` filling for a parameter's declared default — refused before `char` gained a
+/// `FieldDefType` arm of its own: the dispatch had no arm for it and named a `char_schema` module
+/// nothing publishes. The fixture compiling is part of the assertion; the document it renders is
+/// the rest.
+#[cfg(feature = "jsonschema")]
+#[model_schema(default_types(InitialType = char))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Initialed<InitialType> {
+    pub initial: InitialType,
 }
 
 #[model_schema(default_types(KeyType = String, ValueType = u32))]

--- a/tests/primitive_types_tests/tests.rs
+++ b/tests/primitive_types_tests/tests.rs
@@ -1,18 +1,33 @@
 #[cfg(all(
     test,
-    any(feature = "typescript", feature = "jsonschema", feature = "zod")
+    any(
+        feature = "typescript",
+        feature = "jsonschema",
+        feature = "zod",
+        feature = "serde"
+    )
 ))]
 use serde::{Deserialize, Serialize};
 #[cfg(all(test, feature = "jsonschema"))]
 use serde_json::Value;
 #[cfg(all(
     test,
-    any(feature = "typescript", feature = "jsonschema", feature = "zod")
+    any(
+        feature = "typescript",
+        feature = "jsonschema",
+        feature = "zod",
+        feature = "serde"
+    )
 ))]
 use std::collections::HashMap;
 #[cfg(all(
     test,
-    any(feature = "typescript", feature = "jsonschema", feature = "zod")
+    any(
+        feature = "typescript",
+        feature = "jsonschema",
+        feature = "zod",
+        feature = "serde"
+    )
 ))]
 use tixschema::model_schema;
 
@@ -98,6 +113,29 @@ struct PrimitiveTypesShowcase {
     tiny_unsigned: u8,
 }
 
+/// `char` in every position it can be written: a field, an array element, an optional field, a map
+/// value, and a tuple slot. Gated on the union of every consuming test's own gate, including the
+/// serde-only round-trip, so every feature combination sees the fixture either used or absent.
+#[cfg(all(
+    test,
+    any(
+        feature = "typescript",
+        feature = "jsonschema",
+        feature = "zod",
+        feature = "serde"
+    )
+))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct CharTypesShowcase {
+    array_of_char: Vec<char>,
+    initial: char,
+    map_to_char: HashMap<String, char>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    opt_char: Option<char>,
+    pair: (char, char),
+}
+
 #[cfg(any(feature = "typescript", feature = "jsonschema", feature = "zod"))]
 #[test]
 fn test_primitive_structs_constructible() {
@@ -154,6 +192,121 @@ fn test_primitive_structs_constructible() {
         tiny_unsigned: 0,
     };
     assert!(showcase.array_f64.is_empty());
+}
+
+#[cfg(any(feature = "typescript", feature = "jsonschema", feature = "zod"))]
+#[test]
+fn test_char_struct_constructible() {
+    let showcase = CharTypesShowcase {
+        array_of_char: vec!['a', 'b'],
+        initial: 'x',
+        map_to_char: HashMap::from([("k".to_owned(), 'v')]),
+        opt_char: Some('o'),
+        pair: ('p', 'q'),
+    };
+    assert_eq!(showcase.initial, 'x');
+}
+
+/// serde writes a `char` as the one-character string it renders through `Display`, and reads only
+/// that back — the wire every surface's rendering is fixed from.
+#[cfg(feature = "serde")]
+#[test]
+fn test_char_serde_roundtrip() {
+    let showcase = CharTypesShowcase {
+        array_of_char: vec!['a', 'b'],
+        initial: 'x',
+        map_to_char: HashMap::from([("k".to_owned(), 'v')]),
+        opt_char: Some('o'),
+        pair: ('p', 'q'),
+    };
+    let json = serde_json::to_value(&showcase).unwrap();
+    assert_eq!(json["initial"], serde_json::json!("x"));
+    assert_eq!(json["array_of_char"], serde_json::json!(["a", "b"]));
+    assert_eq!(json["map_to_char"]["k"], serde_json::json!("v"));
+    assert_eq!(json["opt_char"], serde_json::json!("o"));
+    assert_eq!(json["pair"], serde_json::json!(["p", "q"]));
+
+    let round_tripped: CharTypesShowcase = serde_json::from_value(json).unwrap();
+    assert_eq!(round_tripped, showcase);
+}
+
+#[cfg(all(feature = "typescript", feature = "zod"))]
+#[test]
+fn test_char_types_typescript_and_zod() {
+    let ts_definition = CharTypesShowcase::ts_definition();
+    assert!(
+        ts_definition.contains("initial: string;"),
+        "Got: {ts_definition}"
+    );
+    assert!(
+        ts_definition.contains("array_of_char: Array<string>;"),
+        "Got: {ts_definition}"
+    );
+    assert!(
+        ts_definition.contains("map_to_char: Partial<Record<string, string>>;"),
+        "Got: {ts_definition}"
+    );
+    assert_ts_omitted_fields_contain(&ts_definition, &["opt_char"], "string");
+    assert!(
+        ts_definition.contains("pair: [string, string];"),
+        "Got: {ts_definition}"
+    );
+
+    let zod_schema = CharTypesShowcase::zod_schema();
+    assert!(
+        zod_schema.contains("initial: z.string().length(1)"),
+        "Got: {zod_schema}"
+    );
+    assert!(
+        zod_schema.contains("array_of_char: z.array(z.string().length(1))"),
+        "Got: {zod_schema}"
+    );
+    assert!(
+        zod_schema.contains("map_to_char: z.record(z.string(), z.string().length(1))"),
+        "Got: {zod_schema}"
+    );
+    assert!(
+        zod_schema.contains("opt_char: z.union([z.string().length(1), z.undefined()])"),
+        "Got: {zod_schema}"
+    );
+    assert!(
+        zod_schema.contains("pair: z.tuple([z.string().length(1), z.string().length(1)])"),
+        "Got: {zod_schema}"
+    );
+}
+
+#[cfg(feature = "jsonschema")]
+#[test]
+fn test_char_types_json_schema() {
+    let schema = CharTypesShowcase::json_schema();
+    let properties = schema["properties"].as_object().unwrap();
+
+    let one_character_string =
+        serde_json::json!({ "type": "string", "minLength": 1_i32, "maxLength": 1_i32 });
+    assert_eq!(properties["initial"], one_character_string);
+    assert_eq!(
+        properties["array_of_char"],
+        serde_json::json!({ "type": "array", "items": one_character_string })
+    );
+    assert_eq!(
+        properties["map_to_char"],
+        serde_json::json!({ "type": "object", "additionalProperties": one_character_string })
+    );
+    assert_eq!(properties["opt_char"], one_character_string);
+    assert_eq!(
+        properties["pair"],
+        serde_json::json!({
+            "type": "array",
+            "prefixItems": [one_character_string, one_character_string],
+            "items": false,
+            "minItems": 2_u64,
+            "maxItems": 2_u64
+        })
+    );
+
+    let required = schema["required"].as_array().unwrap();
+    assert!(required.contains(&Value::String("initial".to_owned())));
+    assert!(!required.contains(&Value::String("opt_char".to_owned())));
 }
 
 #[cfg(feature = "jsonschema")]


### PR DESCRIPTION
A `char` anywhere — field, tuple slot, map value, or `default_types` filling — was classified as a sibling type and emitted a reference to a `char_schema` module nothing writes, failing the consumer's build with E0433. serde writes a `char` as a string of one character and reads only that back, so the description is fixed by the wire.

- New `FieldDefType::Char`: TypeScript `string`, Zod `z.string().length(1)`, JSON Schema `{"type":"string","minLength":1,"maxLength":1}`; `validate()` measures Display like every scalar; map keys classify with the stringified-key bucket, verified by round-trip.
- `is_undescribable_primitive` shrinks by exactly the char arm — `i128`/`u128`/`f16`/`f128` stay refused.
- Red-first coverage across field/array/optional/map/tuple positions, a char `default_types` filling, and a serde round-trip.

Gate: `just lint-all` and `just test` (full feature powerset) green.