### PR TITLE
defer zero-argument forward references and collection-wrapped default siblings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -389,24 +389,30 @@ decides which, and `zod_published_binding` the one seam that writes either.
 Beside the factory, a generic type also exports `X$SchemaDefault` — the factory called at the
 type's own declared `default_types`, so a consumer who wants the ordinary filling shares the memo
 rather than building a second schema for it. `zod_default_block` builds the const, through
-`default_zod_argument`, the same `get_field_def` path every field renders through; where a
+`default_zod_rendering`, the same `get_field_def` path every field renders through; where a
 declared default names another generic item at exactly the arguments that item calls its own,
 the rendered argument folds onto that item's `$SchemaDefault` instead of reconstructing a factory
 call the memo would not share with it — see `record_zod_default_arguments`. `zod_binding_reexport`
 covers both bindings wherever a renamed item re-exports its factory.
 
-`X$SchemaDefault` is a module-scope `const`, and any argument `default_zod_argument` renders as a
+`X$SchemaDefault` is a module-scope `const`, and any argument `default_zod_rendering` renders as a
 reference to another item — the fold above, or an ordinary (non-folding) call to that item's own
 `X$SchemaFactory` — names one more module-scope `const`. One macro invocation sees one type, so
 nothing here can know whether that `const` is written above this one in the generated module or
-below it; `default_zod_argument` defers every such reference through `deferred_zod_operand`, the
+below it; `default_zod_rendering` defers every such reference through `deferred_zod_operand`, the
 same `z.lazy(() => …)` wrap `.and(...)` already relies on for a flattened base. A self-contained
-expression like `z.string()` names no sibling `const` and is left eager. The deferral is also what
-ends a cycle between two declared defaults — `CycleLeader`'s naming `CycleFollower` and
-`CycleFollower`'s naming `CycleLeader` back: neither can have registered the other's arguments yet
-when it expands, so neither side folds, and both calls read the other's factory behind `z.lazy`
-rather than at the top of a `const` initializer — the module loads regardless of which of the two
-names the consuming project's entity list writes first.
+expression like `z.string()` names no sibling `const` and is left eager. The fold's own gate
+(`array_depth == 0 && !is_optional()`, a *direct* sibling) only scopes the fold — a default
+wrapped in a `Vec`/`Option`/`Map`/`Tuple` has no bare binding to fold onto — but deferral is not
+bounded by it: `FieldDef::names_a_sibling_binding` walks the whole rendered tree, so
+`Tagged$SchemaFactory` inside `z.array(Tagged$SchemaFactory(z.string()))` defers exactly as a bare
+`Tagged$SchemaFactory(z.string())` does, the `z.lazy` wrapping the whole expression rather than the
+factory call alone. The deferral is also what ends a cycle between two declared defaults —
+`CycleLeader`'s naming `CycleFollower` and `CycleFollower`'s naming `CycleLeader` back: neither can
+have registered the other's arguments yet when it expands, so neither side folds, and both calls
+read the other's factory behind `z.lazy` rather than at the top of a `const` initializer — the
+module loads regardless of which of the two names the consuming project's entity list writes
+first.
 
 Each factory memoizes on the identity of its arguments, one cache level per parameter, so two
 calls with the same argument objects return the identical schema and no two argument lists
@@ -433,10 +439,14 @@ than where the binding is finally spelled: the fields are rendered before then, 
 on the item's own registry entry would be read before the item had put one there.
 
 `write_field_type_and_schema` defers a member whose type reaches the item being defined, and one
-that reaches a type declared *below* it — `reaches_a_type_declared_later`. The second is what ends
-a cycle spanning two types: every cycle contains at least one reference pointing forward, since
-declaration positions cannot strictly decrease all the way round one, and what is left once those
-are deferred cannot cycle. The deferral is a getter rather than `z.lazy`, which at an operand
+that reaches a type declared *below* it — `reaches_a_type_declared_later`. The rule applies whether
+or not the referenced type declares a parameter of its own: a zero-argument sibling not yet
+registered is exactly as much a forward reference as a generic one, since its `X$Schema` is read
+eagerly at the top of the referencing item's own module-scope const initializer. The second clause
+is what ends a cycle spanning two types: every cycle contains at least one reference pointing
+forward, since declaration positions cannot strictly decrease all the way round one, and what is
+left once those are deferred cannot cycle. The deferral is a getter rather than `z.lazy`, which at
+an operand
 position collapses the factory's inferred return type to `any`.
 
 ### Declaring a Default Type per Parameter

--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -648,6 +648,62 @@ impl FieldDef {
         }
     }
 
+    /// Whether this field's rendering reads any other item's own module-scope Zod binding — a
+    /// factory call or a bare `$Schema` const — at any depth, wrapped in a `Vec`/`Option`/`Map`/
+    /// `Tuple` or named directly. [`default_zod_rendering`](crate::model_schema) asks this once its
+    /// own direct-sibling fold gate declines, since that gate answers a narrower question (can this
+    /// argument fold onto a bare `$SchemaDefault`) than deferral needs (does the rendered tree name
+    /// a sibling's binding at all) — `Tagged$SchemaFactory` inside
+    /// `z.array(Tagged$SchemaFactory(z.string()))` is exactly as much a module-scope `const` read as
+    /// a bare `Tagged$SchemaFactory(z.string())` is.
+    ///
+    /// Unlike [`Self::reaches_a_type_declared_later`], registration is never consulted: a declared
+    /// default is rendered once, standing alone rather than beside the fields of the item that
+    /// declares it, so nothing here can say whether the sibling it names has registered by the time
+    /// this runs — deferring unconditionally is the same answer [`deferred_zod_operand`]'s other
+    /// callers already give for a flattened base and the fold above. The recursion shape matches
+    /// [`Self::contains_type_reference`]: sibling generics, map values, tuple elements. A sequence
+    /// wrapper's own name is not itself a sibling — it renders as the array its elements describe,
+    /// never a binding of its own — so it is excluded exactly as
+    /// [`Self::reaches_a_type_declared_later`] excludes it, while its element is still walked. A map
+    /// key is left unwalked entirely: `HashMap<String, T>` is the only key this crate accepts, and
+    /// `String` can never itself be a sibling reference.
+    #[cfg(feature = "zod")]
+    pub fn names_a_sibling_binding(&self) -> bool {
+        match &self.field_type {
+            FieldDefType::SiblingType(name, generics) => {
+                !is_sequence_wrapper(name) || generics.iter().any(Self::names_a_sibling_binding)
+            }
+            FieldDefType::Map(_, value) => value.names_a_sibling_binding(),
+            FieldDefType::Tuple(elements) => elements.iter().any(Self::names_a_sibling_binding),
+            FieldDefType::TypeParam(_)
+            | FieldDefType::Unknown
+            | FieldDefType::StringLiteral(_)
+            | FieldDefType::Boolean
+            | FieldDefType::Char
+            | FieldDefType::String
+            | FieldDefType::U8
+            | FieldDefType::U16
+            | FieldDefType::U32
+            | FieldDefType::U64
+            | FieldDefType::I8
+            | FieldDefType::I16
+            | FieldDefType::I32
+            | FieldDefType::I64
+            | FieldDefType::Usize
+            | FieldDefType::Isize
+            | FieldDefType::F32
+            | FieldDefType::F64 => false,
+            #[cfg(feature = "object_id")]
+            FieldDefType::ObjectId => false,
+            #[cfg(feature = "chrono")]
+            FieldDefType::NaiveDate
+            | FieldDefType::NaiveTime
+            | FieldDefType::NaiveDateTime
+            | FieldDefType::DateTime => false,
+        }
+    }
+
     /// The defs written inside this one, which is every position a type parameter can be reached
     /// at below the top: a `SiblingType`'s generic arguments, a `Map`'s key and value, a `Tuple`'s
     /// elements. Every other variant names a type outright and holds no def.
@@ -798,21 +854,29 @@ impl FieldDef {
         }
     }
 
-    /// Whether this field reaches a generic type the registry does not hold yet — a
-    /// `#[model_schema]` item declared below the one being expanded.
+    /// Whether this field reaches a type the registry does not hold yet — a `#[model_schema]` item
+    /// declared below the one being expanded, whether or not that item declares a parameter of its
+    /// own.
     ///
-    /// Such a reference is written as a call to the factory that item goes on to publish, which is
-    /// the only binding that can take the arguments written here. Spliced in as it stands, the call
-    /// runs while the containing builder's own body is being evaluated — and where the item below
-    /// points back at this one, that call re-enters this factory before it has reached its cache,
-    /// and the pair recurses until the stack ends.
+    /// A generic reference is written as a call to the factory that item goes on to publish, the
+    /// only binding that can take the arguments written here; a zero-argument reference is written
+    /// as a bare read of that item's own `$Schema` const. Both are spliced in as they stand into
+    /// the containing object literal, and each carries a different danger for it. A factory call
+    /// only runs when the enclosing factory is itself later called, well after every module has
+    /// loaded — but where the item below points back at this one, that call re-enters this factory
+    /// before it has reached its cache, and the pair recurses until the stack ends. A bare `$Schema`
+    /// read carries no such call to defer re-entering, but the object literal reading it eagerly
+    /// *is* that other item's own top-level const initializer — so the danger is reading a name a
+    /// module below has not declared yet, the same temporal-dead-zone hazard `deferred_zod_operand`
+    /// exists to solve for a flattened base and a declared default.
     ///
-    /// Deferring exactly these references is enough to end that, and it needs no cycle to be found.
+    /// Deferring exactly these references is enough to end both, and it needs no cycle to be found.
     /// Every cycle contains at least one of them: if every reference in a cycle named something
     /// already registered, declaration positions would strictly decrease all the way round, which
     /// no cycle can do. What is left once they are deferred is a graph whose every remaining
     /// reference names something declared earlier, so it cannot cycle and every chain of eager
-    /// calls ends.
+    /// calls ends — and a lone forward reference belonging to no cycle at all is ended the same way,
+    /// since nothing here needs one to exist.
     ///
     /// The same partial-answer regime the export name and the map-key registry already run under:
     /// a name the registry does not hold is a name expanded later, and one it does hold was
@@ -821,9 +885,7 @@ impl FieldDef {
     pub fn reaches_a_type_declared_later(&self) -> bool {
         match &self.field_type {
             FieldDefType::SiblingType(name, generics) => {
-                (!generics.is_empty()
-                    && !is_sequence_wrapper(name)
-                    && lookup_alias_info(name).is_none())
+                (!is_sequence_wrapper(name) && lookup_alias_info(name).is_none())
                     || generics.iter().any(Self::reaches_a_type_declared_later)
             }
             FieldDefType::Map(key, value) => {

--- a/src/field_type/tests.rs
+++ b/src/field_type/tests.rs
@@ -1,5 +1,8 @@
 use super::{FieldDef, FieldDefType};
 
+#[cfg(feature = "zod")]
+use crate::utils::{AliasKind, register_alias_info};
+
 /// The wrappers whose fields write a JSON array of their element, named here as they reach the
 /// renderers — `Vec` excluded, the parser having collapsed it long before.
 const SEQUENCE_WRAPPERS: [&str; 5] = [
@@ -548,4 +551,55 @@ fn test_a_substitution_inside_a_written_shape_is_read_through() {
         let parsed = super::get_field_def("items", &ty, "");
         assert_reads_alike(&parsed, &expected, &format!("for {written}"));
     }
+}
+
+/// [`FieldDef::reaches_a_type_declared_later`]'s zero-argument arm — see txsch-8r4v: a bare
+/// sibling reference to a `#[model_schema]` item not yet registered (declared below the one being
+/// expanded) has to defer exactly as a generic forward reference already does; a registered name
+/// (declared above) stays the safe, eager baseline the predicate always answered correctly.
+#[cfg(feature = "zod")]
+#[test]
+fn test_reaches_a_type_declared_later_answers_for_a_zero_argument_sibling() {
+    let unregistered = field(FieldDefType::SiblingType(
+        "NotYetDeclaredSibling".to_owned(),
+        Vec::new(),
+    ));
+    assert!(
+        unregistered.reaches_a_type_declared_later(),
+        "an unregistered zero-argument sibling is a forward reference"
+    );
+
+    register_alias_info(
+        "AlreadyDeclaredSibling",
+        "AlreadyDeclaredSibling",
+        "already_declared_sibling_schema",
+        AliasKind::NoEnumMembers,
+    );
+    let registered = field(FieldDefType::SiblingType(
+        "AlreadyDeclaredSibling".to_owned(),
+        Vec::new(),
+    ));
+    assert!(
+        !registered.reaches_a_type_declared_later(),
+        "a registered zero-argument sibling is not a forward reference"
+    );
+}
+
+/// A sequence wrapper's own name is never itself a forward reference, registered or not — it
+/// renders as the array its element describes rather than a binding of its own — while an
+/// unregistered element inside it still is, through the `any()` clause beside the exclusion.
+#[cfg(feature = "zod")]
+#[test]
+fn test_a_sequence_wrapper_name_is_never_itself_a_forward_reference() {
+    let wrapper_around_a_primitive = sequence_of("HashSet", FieldDefType::String);
+    assert!(!wrapper_around_a_primitive.reaches_a_type_declared_later());
+
+    let wrapper_around_a_forward_element = field(FieldDefType::SiblingType(
+        "HashSet".to_owned(),
+        vec![field(FieldDefType::SiblingType(
+            "StillUnregisteredSibling".to_owned(),
+            Vec::new(),
+        ))],
+    ));
+    assert!(wrapper_around_a_forward_element.reaches_a_type_declared_later());
 }

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -12641,6 +12641,17 @@ fn declared_default_field(parameter: &str, default_types: &[(syn::Ident, syn::Ty
 /// pinned to — which is also what carries in whatever checks and brand the sibling's own default
 /// declared, rather than reconstructing a plain instantiation beside them. See
 /// [`record_zod_default_arguments`].
+///
+/// The fold's own gate (`array_depth == 0 && !is_optional()`, a *direct* sibling reference) scopes
+/// the fold correctly — a default wrapped in a `Vec` or `Option` has no bare sibling binding to
+/// fold onto — but it is not the deferral boundary: `Tagged$SchemaFactory` inside
+/// `z.array(Tagged$SchemaFactory(z.string()))` is exactly as much a module-scope `const` read as
+/// it is bare, only reached one level down. So a declared default that misses the direct-sibling
+/// gate falls through to [`FieldDef::names_a_sibling_binding`], which asks the same question the
+/// gate cannot: does the rendered tree name a sibling *anywhere*, wrapped or not. Where it does,
+/// the whole rendered expression is what `z.lazy` wraps — not the factory call alone — since the
+/// `$SchemaDefault` const carries its own explicit annotation, so nothing needs to infer through
+/// the wrapper.
 #[cfg(feature = "zod")]
 fn default_zod_rendering(field: &FieldDef) -> DefaultZodRendering {
     if field.array_depth == 0
@@ -12658,6 +12669,9 @@ fn default_zod_rendering(field: &FieldDef) -> DefaultZodRendering {
                 ));
             }
         }
+        return DefaultZodRendering::Deferred(field.zod_type());
+    }
+    if field.names_a_sibling_binding() {
         return DefaultZodRendering::Deferred(field.zod_type());
     }
     DefaultZodRendering::Eager(field.zod_type())

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -2683,6 +2683,67 @@ fn declared_default_renders_each_shape_the_table_describes() {
     }
 }
 
+/// The direct-sibling fold gate (`array_depth == 0 && !is_optional()`) scopes the fold correctly —
+/// a wrapped default has no bare `DocumentId$SchemaDefault` binding to fold onto — but is not the
+/// deferral boundary: [`super::default_zod_rendering`] falls through to
+/// [`crate::field_type::FieldDef::names_a_sibling_binding`] for everything the fold gate declines,
+/// which asks whether the rendered tree names a sibling *anywhere*, `Vec`/`Option`/`Map`/`Tuple`
+/// wrapped or not. The `Vec<String>` row is the control: nothing inside it names a sibling, so it
+/// stays eager exactly as the bare-primitive rows above do.
+#[cfg(feature = "zod")]
+#[test]
+fn declared_default_renders_each_wrapped_shape_the_table_describes() {
+    register_alias_info(
+        "DocumentId",
+        "DocumentId",
+        "document_id_schema",
+        AliasKind::NoEnumMembers,
+    );
+    super::record_zod_factory("DocumentId", true);
+    super::record_zod_default_arguments("DocumentId", vec!["z.string()".to_owned()]);
+
+    for (parameter, filled_at, expected) in [
+        (
+            "IdType",
+            quote::quote! { Vec<DocumentId<String>> },
+            "z.lazy(() => z.array(DocumentId$SchemaFactory(z.string())))",
+        ),
+        (
+            "IdType",
+            quote::quote! { Option<DocumentId<String>> },
+            "z.lazy(() => \
+             z.union([DocumentId$SchemaFactory(z.string()), z.undefined()]).prefault(undefined))",
+        ),
+        (
+            "IdType",
+            quote::quote! { Vec<String> },
+            "z.array(z.string())",
+        ),
+        (
+            "IdType",
+            quote::quote! { HashMap<String, DocumentId<String>> },
+            "z.lazy(() => z.record(z.string(), DocumentId$SchemaFactory(z.string())))",
+        ),
+        (
+            "IdType",
+            quote::quote! { (String, DocumentId<String>) },
+            "z.lazy(() => z.tuple([z.string(), DocumentId$SchemaFactory(z.string())]))",
+        ),
+    ] {
+        let ty: syn::Type = syn::parse2(filled_at.clone()).unwrap();
+        let default_types = vec![(
+            syn::Ident::new(parameter, proc_macro2::Span::call_site()),
+            ty,
+        )];
+        let field = super::declared_default_field(parameter, &default_types);
+        assert_eq!(
+            super::default_zod_rendering(&field).into_argument(),
+            expected,
+            "for `{parameter} = {filled_at}`"
+        );
+    }
+}
+
 /// The fold only fires where the written arguments match the sibling's own recorded default; a
 /// reference to the same generic sibling at a *different* argument still calls its factory, exactly
 /// as an ordinary field naming it does — and that call is deferred exactly as the fold's own

--- a/tests/advanced_tests/tests.rs
+++ b/tests/advanced_tests/tests.rs
@@ -366,10 +366,10 @@ fn test_complex_nested_ts_definition() {
     let company_zod_schema = Company::zod_schema();
     let employee_zod_schema = Employee::zod_schema();
 
-    assert!(company_zod_schema.contains("employees: z.array(Employee$Schema)"));
+    assert!(company_zod_schema.contains("get employees() { return z.array(Employee$Schema); },"));
     assert!(company_zod_schema.contains("department_names: z.array(z.string())"));
     assert!(company_zod_schema.contains("headquarters: Address$Schema"));
-    assert!(company_zod_schema.contains("settings: CompanySettings$Schema"));
+    assert!(company_zod_schema.contains("get settings() { return CompanySettings$Schema; },"));
     assert!(employee_zod_schema.contains("manager: z.union([z.string(), z.undefined()])"));
 }
 

--- a/tests/alias_reference_tests/tests.rs
+++ b/tests/alias_reference_tests/tests.rs
@@ -421,11 +421,11 @@ fn every_schema_a_forward_alias_reference_names_is_defined_by_the_emission() {
     .join("\n\n");
     for (written, referenced) in [
         (
-            "counts: z.array(LaterDeclaredCount$Schema)",
+            "get counts() { return z.array(LaterDeclaredCount$Schema); },",
             "LaterDeclaredCount",
         ),
         (
-            "ids: z.record(z.string(), LaterDeclaredId$Schema)",
+            "get ids() { return z.record(z.string(), LaterDeclaredId$Schema); },",
             "LaterDeclaredId",
         ),
     ] {

--- a/tests/generic_types_tests/tests.rs
+++ b/tests/generic_types_tests/tests.rs
@@ -238,10 +238,10 @@ mod zod {
     #[cfg(all(feature = "chrono", feature = "object_id"))]
     use super::MixedArguments;
     use super::{
-        Adjacent, Carried, CycleFollower, CycleLeader, EchoedDefault, EcmDocument, Envelope,
-        External, FolderTree, Holder, Internal, KeyedByParameter, LifetimeStruct,
-        OverriddenDefault, Pair, PlainConst, Positional, Quintet, Referrer, Summarised, Tagged,
-        Untagged, WireFolder, Wrapper, keyed_alias_schema,
+        Adjacent, BatchedDefault, Carried, CycleFollower, CycleLeader, EchoedDefault, EcmDocument,
+        Envelope, External, FolderTree, Holder, Internal, KeyedByParameter, LifetimeStruct,
+        ListedDefault, OverriddenDefault, Pair, PlainConst, Positional, Quintet, Referrer,
+        SlottedDefault, Summarised, Tagged, Untagged, WireFolder, Wrapper, keyed_alias_schema,
     };
     #[cfg(all(feature = "typescript", feature = "serde"))]
     use super::{ConstrainedEchoedDefault, ConstrainedId, DeepEchoedDefault};
@@ -544,6 +544,50 @@ mod zod {
             ),
             "Got: {zod}"
         );
+    }
+
+    /// A `default_types` entry wrapping a sibling reference in a `Vec` is deferred exactly like a
+    /// bare one — `Tagged$SchemaFactory` inside `z.array(...)` is as much a module-scope `const`
+    /// read as `Tagged$SchemaFactory` bare — so the whole wrapped expression is what `z.lazy`
+    /// wraps, not merely the factory call sitting inside it.
+    #[test]
+    fn a_default_wrapping_a_sibling_in_vec_defers_the_whole_expression() {
+        let zod = BatchedDefault::<Vec<Tagged<String>>>::zod_schema();
+        assert!(
+            zod.contains(
+                "= BatchedDefault$SchemaFactory(z.lazy(() => \
+                 z.array(Tagged$SchemaFactory(z.string()))));"
+            ),
+            "Got: {zod}"
+        );
+    }
+
+    /// The same hazard one level deeper through `Option` rather than `Vec`: the fold gate requires
+    /// `!is_optional()`, so this also falls through to the ordinary rendering, and that rendering
+    /// is deferred whole for the same reason the `Vec`-wrapped case above is.
+    #[test]
+    fn a_default_wrapping_a_sibling_in_option_defers_the_whole_expression() {
+        let zod = SlottedDefault::<Option<Tagged<String>>>::zod_schema();
+        assert!(
+            zod.contains(
+                "= SlottedDefault$SchemaFactory(z.lazy(() => \
+                 z.union([Tagged$SchemaFactory(z.string()), z.undefined()]).prefault(undefined)));"
+            ),
+            "Got: {zod}"
+        );
+    }
+
+    /// A `Vec`-wrapped default with nothing but a primitive inside names no sibling `const` at any
+    /// depth, so it stays eager exactly as a bare primitive default does — the deferral is keyed
+    /// on what the tree names, not on whether it is wrapped.
+    #[test]
+    fn a_default_wrapping_only_a_primitive_in_vec_stays_eager() {
+        let zod = ListedDefault::<Vec<String>>::zod_schema();
+        assert!(
+            zod.contains("= ListedDefault$SchemaFactory(z.array(z.string()));"),
+            "Got: {zod}"
+        );
+        assert!(!zod.contains("z.lazy"), "Got: {zod}");
     }
 
     /// Nothing else in this crate constructs `ConstrainedId` directly — every other use names it
@@ -1795,6 +1839,35 @@ pub struct EchoedDefault<HolderType> {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OverriddenDefault<HolderType> {
     pub held: HolderType,
+}
+
+/// A declared default wrapping a sibling reference in a `Vec` — the direct-sibling fold gate
+/// requires `array_depth == 0`, so this falls through to the ordinary rendering, and that
+/// rendering names `Tagged$SchemaFactory` exactly as much as a bare reference does: it just does
+/// so from inside `z.array(...)` rather than at the argument's own top level.
+#[cfg(feature = "zod")]
+#[model_schema(default_types(Items = Vec<Tagged<String>>))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BatchedDefault<Items> {
+    pub items: Items,
+}
+
+/// The same hazard one level deeper through `Option` rather than `Vec`.
+#[cfg(feature = "zod")]
+#[model_schema(default_types(Slot = Option<Tagged<String>>))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SlottedDefault<Slot> {
+    pub slot: Slot,
+}
+
+/// A `Vec`-wrapped default with nothing but a primitive inside — nothing here names a sibling
+/// `const` at any depth, so the wrapped expression stays eager exactly as a bare primitive
+/// default does.
+#[cfg(feature = "zod")]
+#[model_schema(default_types(Items = Vec<String>))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ListedDefault<Items> {
+    pub items: Items,
 }
 
 /// A generic branded newtype whose inner is a bare type parameter, carrying string constraints —

--- a/tests/item_rename_tests/tests.rs
+++ b/tests/item_rename_tests/tests.rs
@@ -389,9 +389,12 @@ fn every_schema_a_forward_item_reference_names_is_defined_by_the_emission() {
     ]
     .join("\n\n");
     for (written, referenced) in [
-        ("gauge: LaterRenamedGauge$Schema", "LaterRenamedGauge"),
         (
-            "grades: z.array(LaterRenamedGrade$Schema)",
+            "get gauge() { return LaterRenamedGauge$Schema; },",
+            "LaterRenamedGauge",
+        ),
+        (
+            "get grades() { return z.array(LaterRenamedGrade$Schema); },",
             "LaterRenamedGrade",
         ),
     ] {

--- a/tests/recursive_type_tests/tests.rs
+++ b/tests/recursive_type_tests/tests.rs
@@ -465,6 +465,23 @@ pub struct Person {
     pub name: String,
 }
 
+/// Two non-generic structs cycling through a `Vec` — `Chapter` names `Section` before `Section`
+/// is declared, and `Section` names `Chapter` back afterward. Legal Rust, no `Box` needed, since
+/// the cycle runs through a collection on both sides; this is the zero-argument counterpart of
+/// `CycleLeader`/`CycleFollower` in `generic_types_tests`.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Chapter {
+    pub sections: Vec<Section>,
+}
+
+/// Declared BELOW `Chapter`, which names it first — the forward half of the cycle.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Section {
+    pub back_refs: Vec<Chapter>,
+}
+
 /// Recursive enum with `HashMap` of self.
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -669,4 +686,26 @@ fn test_recursive_boxed_option_struct() {
         zod.contains("label: z.string()"),
         "Non-recursive label field should use normal property syntax. Got: {zod}"
     );
+}
+
+/// Test 10: A non-generic forward reference — a bare, zero-argument sibling declared BELOW the
+/// type naming it — has to defer exactly as a generic forward reference already does, or the
+/// module the pair is written into throws at import in every concatenation order: whichever half
+/// of the cycle lands first names a `const` the other half has not published yet.
+#[test]
+fn test_non_generic_forward_reference_defers_through_a_getter() {
+    let chapter_zod = Chapter::zod_schema();
+    assert!(
+        chapter_zod.contains("get sections() { return z.array(Section$Schema); },"),
+        "The forward reference to Section should defer through a getter. Got: {chapter_zod}"
+    );
+
+    // The backward half — Section naming Chapter, already registered by the time Section is
+    // expanded — stays eager exactly as every non-cyclic sibling reference already does.
+    let section_zod = Section::zod_schema();
+    assert!(
+        section_zod.contains("back_refs: z.array(Chapter$Schema),"),
+        "The backward reference to Chapter should stay eager. Got: {section_zod}"
+    );
+    assert!(!section_zod.contains("get "), "Got: {section_zod}");
 }


### PR DESCRIPTION
Two gaps in the emission-order deferral rules, one change:

**Zero-argument forward references.** `reaches_a_type_declared_later`'s sibling arm required arguments before it would look at registration, so a field naming a non-generic sibling declared below was always read eagerly — a bare `X$Schema` inside another type's top-level const initializer, the same temporal-dead-zone hazard the deferral exists for, and the one forward-reference shape the documented every-cycle-composes argument didn't actually cover. Dropping the arguments conjunct routes it through the getter deferral fields already use; backward references stay eager and byte-identical.

**Collection-wrapped default siblings.** A `default_types` entry wrapping a sibling in `Vec`/`Option`/map/tuple missed the direct-reference gate and rendered eagerly at the top of the `$SchemaDefault` initializer. A new tree-walk predicate (`names_a_sibling_binding`) defers the whole wrapped expression whenever any depth names a sibling binding; self-contained wrapped defaults stay eager, and the fold gate is untouched.

Red-first fixtures pin both (a two-struct Vec cycle whose module now loads either way; Vec/Option/map/tuple wrapped defaults), pre-fix captures recorded on the tasks, and the forward-reference pins across three existing suites updated from real output.

Gate: `just lint-all` and `just test` (full feature powerset) green.