### PR TITLE
strip every issue-tracker reference from the source and cut the commentary back to what a reader cannot get from the code

### DIFF
--- a/src/features/chrono/tests.rs
+++ b/src/features/chrono/tests.rs
@@ -26,7 +26,6 @@ fn test_datetime_number_zod_schema_is_self_contained_arrow() {
     assert!(schema.contains("arg instanceof Date) return arg.getTime();"));
     assert!(schema.contains("typeof arg === \"string\") return Date.parse(arg);"));
     assert!(schema.ends_with("z.number())"));
-    // Must not reference a named helper or the ISO datetime renderer.
     assert!(!schema.contains("z.iso.datetime"));
 }
 

--- a/src/features/jsonschema.rs
+++ b/src/features/jsonschema.rs
@@ -41,12 +41,6 @@ pub const fn should_generate_json_schema() -> bool {
 }
 
 /// One type parameter of a generic item, as that item's own schema module reads it.
-///
-/// JSON Schema has no type parameters, so every document is written at one filling. The two members
-/// are the two ends of that: `binding` is the local the item's body reaches this parameter's
-/// argument document through — every position that renders the parameter names it — and `default`
-/// is the document the standalone form fills the slot with, the item's own declared filling
-/// rendered through the dispatch every other type position is rendered through.
 pub struct SchemaParameter {
     pub binding: proc_macro2::Ident,
     pub default: proc_macro2::TokenStream,
@@ -62,37 +56,6 @@ fn defs_pointer(def_name: &str) -> String {
 }
 
 /// The JSON-schema methods a schema module publishes.
-///
-/// `json_schema` is the document a caller asks for. `json_schema_within` is that same description
-/// written into a document already being built, and carries the two things that have to travel
-/// with it: the names whose descriptions are still being written, and the definitions the
-/// document's root must hold.
-///
-/// A cycle is only knowable there. A type names another by inlining it, and no expansion can see
-/// the cycle it is part of — the other type may not have been expanded yet, and one that has been
-/// cannot be revisited. So the name is recognized while the description runs: a name re-entered
-/// while still in flight describes as a `$ref` into `$defs`, and the frame that put it in flight
-/// hoists its body to the root that pointer resolves against.
-///
-/// What travels beside each name is the filling its body is being written at, because a pointer
-/// resolves to that body and nothing else. A name re-entered at the same filling is the cycle the
-/// `$ref` describes; one re-entered at another is a body the document has no second place to hold,
-/// and is refused rather than pointed at the wrong one.
-///
-/// An item declaring type parameters publishes each of those two at a filling as well: JSON Schema
-/// has no parameters, so a document exists only once each of them names a type, and which types
-/// those are is the reference site's to say. So `json_schema_with` and `json_schema_within_with`
-/// take the fillings positionally, in the order the item declares its parameters, and the two
-/// argumentless forms are those same two applied to what the item declared for itself. An item
-/// declaring none publishes the pair alone: there is no slot to fill, and nothing to pass.
-///
-/// Which of the argumentless forms evaluates that declared filling is not free to choose. A
-/// filling may name another item, and such a document is written by asking that item's own
-/// `within` — which reads the names in flight and the definitions being hoisted. Only
-/// `json_schema_within` holds those, so it is the one that evaluates the declared documents, and
-/// `json_schema` reaches its own filling the same way every other rooted document is reached: by
-/// running `within` against a fresh document. An item declaring parameters is rooted exactly as
-/// one declaring none is.
 pub fn json_schema_methods(
     def_name: &str,
     body: &proc_macro2::TokenStream,
@@ -208,13 +171,6 @@ fn guarded_description(
 
 /// How a reference coming back around to a name at another filling refuses, as the tokens the
 /// guard raises it with.
-///
-/// A pointer resolves to one body, and the document holds one definition per name — so the
-/// reference has nowhere to put the body its own arguments describe, and writing the pointer anyway
-/// would stand the other filling's members where this one's belong. Both fillings are named because
-/// which of them is the mistake is the author's to say, and the way past is named beside them: write
-/// the reference at the filling already being written, or give each filling a definition of its own
-/// by keying `$defs` by name and filling rather than by name.
 fn refilled_cycle_refusal(def_name: &str) -> proc_macro2::TokenStream {
     let message = format!(
         "`{def_name}`: a reference closes a cycle at a filling the document is not being written \
@@ -259,15 +215,6 @@ fn rooted_document(described: &proc_macro2::TokenStream) -> proc_macro2::TokenSt
 
 /// The filling an item declared for itself, handed on to the form that takes fillings — the body
 /// of the argumentless `within`, which is the one frame that owns the recursion state.
-///
-/// The documents are bound to a local before the delegation rather than written into the call. A
-/// filling naming another item describes through that item's own `within`, which reads the run's
-/// two values; a borrow taken for the delegation would still be live while the filling asked for
-/// its own, and neither value exists at all in a frame that does not receive them. Bound here,
-/// each filling runs to completion in turn and the borrows are handed on only once the array
-/// holds them all — the remedy a reference site carrying a nested generic argument already uses.
-///
-/// Declaration order, which is the order the fillings are read back off the argument list in.
 fn declared_delegation(parameters: &[SchemaParameter]) -> proc_macro2::TokenStream {
     let declared = parameters.iter().map(|parameter| &parameter.default);
     quote::quote! {
@@ -277,13 +224,6 @@ fn declared_delegation(parameters: &[SchemaParameter]) -> proc_macro2::TokenStre
 }
 
 /// The locals the body reads its parameters through, bound off the argument list positionally.
-///
-/// A caller supplying fewer arguments than the item declares parameters leaves the rest at the
-/// permissive empty schema, which is what a parameter with nothing said about it always described
-/// as. The names are underscore-led because a parameter the declaration binds need not reach the
-/// document at all — one written only in a bound, or behind a key serde writes as a string
-/// whatever fills it — and an item is not owed a warning for a parameter it declares and the wire
-/// does not carry.
 fn argument_bindings(parameters: &[SchemaParameter]) -> proc_macro2::TokenStream {
     let bound = parameters.iter().enumerate().map(|(position, parameter)| {
         let binding = &parameter.binding;
@@ -426,19 +366,6 @@ fn merge_readers() -> proc_macro2::TokenStream {
 }
 
 /// What the merge holds while it multiplies, as the tokens that declare it.
-///
-/// The spelling travels with the source that used it, because the two spellings say different
-/// things about a payload more than one branch admits. A discriminated enum's members are
-/// exclusive, so `oneOf` costs it nothing; an untagged enum is first-match-wins, and members whose
-/// key sets overlap admit each other's payloads as a matter of course — under `oneOf` the document
-/// would reject exactly what serde writes for the narrower member. So the branches a source
-/// multiplies out are held under that source's own wrapper, and a second source multiplies each of
-/// them again from there: the wrappers nest rather than flatten into one, and each branch set keeps
-/// the rule its own union was written under.
-///
-/// A source is a tree rather than a list for the same reason: a branch that is itself a union was
-/// written under a spelling of its own, and grafting its leaves onto the source's wrapper would
-/// answer for them under a rule they were not written under.
 fn merged_tree() -> proc_macro2::TokenStream {
     quote::quote! {
         enum Branches<'defs> {
@@ -560,12 +487,6 @@ fn merged_tree() -> proc_macro2::TokenStream {
 }
 
 /// How the expansion refuses a schema it cannot merge, as the tokens that declare the refusals.
-///
-/// The whole merged body and a branch any depth down are the same two failures, so one expansion
-/// answers for both and each refusal carries both wordings: an empty position is the body itself,
-/// and any other names the branch it was reached through. A branch's position is the trail of
-/// one-based choices taken to reach it, so a member of a nested union is named `1.2` rather than
-/// twice as `2`.
 fn expansion_refusals(diagnostic: &MergeDiagnostic<'_>) -> proc_macro2::TokenStream {
     let MergeDiagnostic {
         cycle_remedy,
@@ -633,19 +554,6 @@ fn expansion_refusals(diagnostic: &MergeDiagnostic<'_>) -> proc_macro2::TokenStr
 }
 
 /// The branch tree one merged schema contributes, as the tokens that declare how it is read.
-///
-/// A union names no type of its own, so the branch is where the questions the whole merged body was
-/// asked are asked again — and serde cannot write a branch that is not an object into the object
-/// being written any more than it could write the whole value that way. A branch that is a deferred
-/// name carries none of the members it stands for, so it is read back out of the definitions first,
-/// the same way the whole merged body is. A branch that is itself a union names no members either,
-/// so the questions are asked again below it, and again, until every leaf is an object the base can
-/// merge or a refusal.
-///
-/// Two things bound the descent. Plain nesting reaches a strictly smaller part of a finite document,
-/// so it ends on its own; a deferred name does not, because the body it resolves to may name it
-/// back. So the names resolved on the way down are carried, and a name reached twice on one path is
-/// a cycle by construction.
 fn branch_expansion() -> proc_macro2::TokenStream {
     quote::quote! {
         fn expanded_branches<'defs>(
@@ -726,31 +634,6 @@ fn branch_expansion() -> proc_macro2::TokenStream {
 }
 
 /// A base object's members with the members of every schema merged beside them.
-///
-/// serde writes a `#[serde(flatten)]` base and an internally tagged variant's newtype content the
-/// same way — what is merged contributes its members to the object the base is writing — so both
-/// describe through this one merge rather than each spelling its own. `base` is a
-/// `serde_json::Map` expression and every entry of `merged` a `serde_json::Value` one; the result
-/// is a `serde_json::Value`.
-///
-/// A merged schema that is itself a union multiplies out rather than collapsing, so each branch
-/// stays a closed object naming exactly the members that branch writes. Both spellings of a union
-/// are read: a discriminated enum's `oneOf` and an untagged one's `anyOf` alike name what serde
-/// picked one of, and the merged schema is the union of the merges. A source reached through an
-/// `Option` offers its own absence beside whatever it described as, the two key sets being what the
-/// field actually writes.
-///
-/// Only a value serde writes as an object has members to contribute, and the expansion cannot
-/// always tell which types those are — a name reaches the merge without saying what it writes. The
-/// schema it produces does say, so the merge reads it there: a description naming any type but
-/// `object` is refused rather than merged, which is the last point at which the wrong schema can
-/// still be stopped. The one exception is the `null` of a choice the edge itself offers, which is
-/// the source's own absence written out and is read as that. A flatten edge that closes a cycle is
-/// refused on the same terms, named for the frame that read it.
-///
-/// The reading itself is the tokens [`merge_readers`] emits, and what the multiplication is carried
-/// in is [`merged_tree`]; both are written into the block this returns, so the whole merge is one
-/// expression the caller can place wherever a `serde_json::Value` is wanted.
 pub fn merged_object_value(
     base: &proc_macro2::TokenStream,
     merged: &[MergedSource],

--- a/src/features/object_id.rs
+++ b/src/features/object_id.rs
@@ -6,13 +6,6 @@
 /// The 24-character hex an `ObjectId`'s `$oid` member holds, as the regex every surface constrains
 /// it by. Written once so no position can describe the same string a different way: the JSON
 /// Schema `pattern` keyword and the Zod literal both read it from here.
-///
-/// Spelled in the members both engines agree on rather than with a `\d`, for the same reason the
-/// guard refuses an author one. The `regex` crate reads that class as the Unicode digits and a
-/// flagless JavaScript literal reads the ASCII ones, so `[a-f\d]` admits twenty-four ARABIC-INDIC
-/// digits in the generated Rust validator and refuses them wherever the schema is loaded. Hex is
-/// ASCII, so writing `0-9` out leaves the value set this constant is for exactly where it was and
-/// leaves one contract in place of two.
 #[cfg(any(test, feature = "zod", feature = "jsonschema"))]
 pub const OBJECT_ID_HEX_PATTERN: &str = "^[a-f0-9]{24}$";
 
@@ -32,15 +25,6 @@ pub fn get_object_id_zod_schema() -> String {
 }
 
 /// The `$oid` object's Zod schema with `hex_checks` appended to the hex string it holds.
-///
-/// String checks belong on that member and never on the object around it: `$oid` is the only
-/// string an `ObjectId` writes, and a `z.object` has no string check to take.
-///
-/// The literal carries no flags, so it constrains `$oid` by exactly what the JSON Schema `pattern`
-/// keyword beside it constrains it by. A `pattern` is a flagless ECMA-262 regex with nowhere to
-/// hold an `i`, so a flag here would be case-insensitivity granted on one surface and unobtainable
-/// on the other — from the one constant both splice, and for a member `ObjectId::to_hex()` only
-/// ever writes in lower-case.
 #[cfg(all(feature = "object_id", any(test, feature = "zod")))]
 pub fn get_object_id_zod_schema_with(hex_checks: &str) -> String {
     format!(

--- a/src/features/serde.rs
+++ b/src/features/serde.rs
@@ -53,14 +53,6 @@ impl SerdeKeyOmission {
 
     /// Whether the attributes take the member out of exactly one of serde's two directions, which
     /// leaves what serde writes and what serde reads two different payloads.
-    ///
-    /// Where the member has a key, the two payloads still overlap — the key is simply absent from
-    /// one of them, which an optional key describes. Where it has only a place in a tuple there is
-    /// no such spelling, so the question is the positional seams' to ask.
-    ///
-    /// Not gated on any feature, for the reason [`Self::absent_from_wire`] is not: the variant walk
-    /// that reads it runs in every build, and a toggle that changed the answer would leave one
-    /// declaration refused in one build and described in another.
     pub const fn drops_one_direction_only(self) -> bool {
         self.omits_key != self.skips_deserializing
     }
@@ -145,24 +137,12 @@ fn consume_unread_value(nested: &ParseNestedMeta<'_>) -> syn::Result<()> {
 
 /// Whether the field writes a value for itself when its key is missing, in either spelling
 /// (`default` and `default = "path"`).
-///
-/// Asked of the attributes rather than carried on [`SerdeFieldMeta`]: nothing the generated
-/// surfaces describe turns on it — it is read where a serde hook is written, to decide whether
-/// that hook has a missing key to answer for, and where a guard asks whether a dropped key can be
-/// read back.
 pub fn has_serde_default(attrs: &[Attribute]) -> bool {
     parse_serde_key_omission(attrs).defaulted
 }
 
 /// The rejection for a `cfg_attr` carrying a `serde(...)` attribute, or `None` for every other
 /// `cfg_attr` — gated derives and gated docs stay legal.
-///
-/// A `cfg_attr` on a field or a variant is expanded only after the attribute proc-macro has been
-/// handed the item, so a serde attribute written inside one arrives here unexpanded and would
-/// otherwise be walked past in silence. (An item's own attribute list is resolved by rustc first,
-/// so those arrive already expanded or already stripped and never reach this check.) Reading the
-/// payload would mean applying it in builds where the consumer's cfg predicate is false, and that
-/// predicate cannot be evaluated from a proc macro, so the attribute is rejected, not guessed at.
 #[cfg(feature = "serde")]
 fn cfg_attr_serde_rejection(attr: &Attribute) -> Option<Error> {
     let Meta::List(list) = &attr.meta else {

--- a/src/features/serde/tests.rs
+++ b/src/features/serde/tests.rs
@@ -2,26 +2,22 @@ use super::*;
 
 #[test]
 fn test_rename_all_transformations() {
-    // Test camelCase
     assert_eq!(apply_rename_all("user_name", Some("camelCase")), "userName");
     assert_eq!(
         apply_rename_all("first_name", Some("camelCase")),
         "firstName"
     );
 
-    // Test PascalCase
     assert_eq!(
         apply_rename_all("user_name", Some("PascalCase")),
         "UserName"
     );
 
-    // Test kebab-case
     assert_eq!(
         apply_rename_all("user_name", Some("kebab-case")),
         "user-name"
     );
 
-    // Test no transformation
     assert_eq!(apply_rename_all("user_name", None), "user_name");
 }
 
@@ -35,7 +31,6 @@ fn test_final_field_name() {
         untagged: false,
     };
 
-    // Test field with explicit rename
     let field_meta_with_rename = SerdeFieldMeta {
         cfg_attr_rejection: None,
         rename: Some("customName".to_owned()),
@@ -47,7 +42,6 @@ fn test_final_field_name() {
         "customName"
     );
 
-    // Test field with rename_all
     let field_meta_no_rename = SerdeFieldMeta {
         cfg_attr_rejection: None,
         rename: None,

--- a/src/features/tests.rs
+++ b/src/features/tests.rs
@@ -2,11 +2,9 @@ use super::*;
 
 #[test]
 fn test_feature_detection() {
-    // Test that we can detect features at compile time
     let enabled = Features::enabled_features();
     log::debug!("Enabled features: {enabled:?}");
 
-    // In default configuration, all features should be enabled
     #[cfg(all(
         feature = "serde",
         feature = "zod",

--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -54,25 +54,6 @@ pub enum VariantKind {
 }
 
 /// Enum representing the possible types a field can have in the schema generation system.
-///
-/// This enum is central to tixschema's type mapping system. It categorizes Rust types into
-/// categories that can be translated to TypeScript types and Zod schemas. The variants cover
-/// primitive types, complex structures, and special cases like `ObjectId` (feature-dependent).
-///
-/// Key points from crate documentation:
-/// - Primitives map to TS equivalents (e.g., String -> string, numbers -> number)
-/// - Collections like Vec<T> become Array<T> (handled via `FieldDef`'s `array_depth` count)
-/// - `HashMap`<String, T> becomes Partial<Record<string, T>> (Map variant)
-/// - Enums and nested structs use `SiblingType`
-/// - All types must follow naming conventions (e.g., end with Json suffix for structs)
-///
-/// Feature dependencies:
-/// - "`object_id"`: Enables `ObjectId` variant for `MongoDB` support
-/// - Without features, falls back to basic mappings
-///
-/// Equality is the question `as = Type` asks: do two written types describe the same value on every
-/// surface? The variants a spelling collapses onto answer it — `Path` reaching `String` is the same
-/// type here as `PathBuf` is — and the nested defs answer it through [`FieldDef`]'s own `PartialEq`.
 #[derive(Clone, Debug, PartialEq)]
 pub enum FieldDefType {
     /// Boolean primitive - maps to boolean.
@@ -136,13 +117,6 @@ pub enum FieldDefType {
     /// Tuple type - generates anonymous object in TS/Zod.
     Tuple(Vec<FieldDef>),
     /// One of the enclosing item's own type parameters — `IdType` in `struct Wrapper<IdType>`.
-    ///
-    /// Held apart from [`FieldDefType::SiblingType`] because the three surfaces answer for it
-    /// differently, and none of them answers with a reference to a generated type of that name:
-    /// TypeScript binds the parameter for real and renders the name it was written with, Zod binds
-    /// the argument its factory takes for it, and JSON Schema — which has no parameters at all —
-    /// writes the document of whatever filled it. [`FieldDef::erase_type_parameters`] is where that
-    /// rule is written down and where a written name becomes this.
     TypeParam(String),
     U16,
     U32,
@@ -154,68 +128,6 @@ pub enum FieldDefType {
 }
 
 /// Struct representing a field's definition for schema generation.
-///
-/// This is the core data structure used to analyze and generate schemas for each field
-/// in a struct or enum variant. It's created by `get_field_def()` and used in
-/// `model_schema.rs` to build the full type definitions.
-///
-/// Fields:
-/// - `nullable_levels`: which array levels the field was written with an `Option` at. Level 0 is
-///   what `field_type` names and level `array_depth` is the field as a whole, so `Vec<Option<T>>`
-///   records level 0 and `Option<Vec<T>>` records level 1 — two different values on the wire
-///   (`[null]` against `null`) that a single flag could not tell apart. `is_optional` asks it for
-///   the outermost level, the only one whose `None` is not written inside an array and so the only
-///   one whose flavor depends on where the field sits: a dropped or `| undefined`-valued key /
-///   `z.union([type, z.undefined()])` in struct-field position — `omits_value` deciding which of
-///   the two the key gets — and `| null` / `z.nullable(type)` in a tuple element or map value,
-///   neither of which can be dropped the way an object key can.
-/// - name: Safe field name (uses serde rename if feature enabled)
-/// - docs: Doc comments from Rust - included in generated TS as `JSDoc`
-/// - `field_type`: The core type classification (see `FieldDefType`)
-/// - `array_depth`: How many array levels wrap the type — one per `Vec`/slice/array/set the field
-///   was written under, so `Vec<Vec<T>>` is 2. Zero is a bare value, which is what `is_array` asks.
-/// - `array_lengths`: the element count of every level written as a fixed-size `[T; N]` with a
-///   literal `N`, one entry per such level and numbered the way `nullable_levels` numbers them. A
-///   level absent from the list holds however many items were written — what every other sequence
-///   spelling holds, and what a non-literal `N` records, the expansion having no value to read a
-///   const generic or a computed length from. Only the two validating surfaces spend it: the JSON
-///   schema pins the level with `minItems`/`maxItems` and Zod with `.length(N)`, so both reject the
-///   wrong-length payload serde itself refuses to deserialize. TypeScript keeps `Array<T>` — the
-///   fixed-length form its type system has is the N-element tuple, written out element by element,
-///   which stops being readable long before `N` stops being legal.
-/// - `model_schema_prop_meta`: Optional metadata from #[`model_schema_prop`] attribute
-///   - Used for overrides like literals, minLength, etc.
-///   - See Phase 5 in `notes/20250707_field_features.md` for minLength details
-/// - `omits_value`: whether the serde attributes on a *named* field leave its value out of the
-///   serialized output entirely rather than writing it — a `None` under a
-///   `skip_serializing_if = "Option::is_none"`, an empty `Vec` under a `Vec::is_empty`, every
-///   value at all under a bare `skip`. Only a named field has a key to drop: a positional one is
-///   written by its place in a tuple, where nothing can be omitted. A field carrying it is one
-///   whose key serde may never write, which is what the object surfaces ask before choosing
-///   between the two spellings of an optional member — the key-optional `field?: T` for a key
-///   that may be absent, `field: T | undefined` for one that is always written — and what takes
-///   the field out of the JSON surface's `required`. Read in every build: the attribute stating
-///   it is on the field whatever the features say, and one declaration describes one wire.
-/// - `absent_from_wire`: whether the serde attributes on a *named* field take its key out of both
-///   directions at once — nothing serde writes carries it and nothing serde reads keeps what a
-///   payload put under it. A bare `skip` says so, and so do `skip_serializing` and
-///   `skip_deserializing` written side by side, which is the same wire spelled out. A field
-///   carrying it is one no surface describes at all: the surfaces describe the payload serde
-///   writes, and there is no such key in any of them. Read in every build, for the same reason
-///   `omits_value` is.
-/// - `type_span`: where the type this field carries was written — the name segment of a path, the
-///   whole type otherwise, and the innermost name under a wrapper, so `Vec<Inner>` points at
-///   `Inner`. The JSON schema is the one surface that emits a Rust path built from a type name, so
-///   it is the one that can fail to resolve, and this is what its reference carries so the failure
-///   is reported at the user's type instead of at `#[model_schema()]`. Present only under
-///   `jsonschema` for that reason.
-///
-/// Usage notes:
-/// - Created recursively for nested types
-/// - Handles Option<T> by recording its array level in `nullable_levels`
-/// - For `HashMap`, only String keys allowed
-/// - Feature "serde" affects name (rename attributes)
-/// - Feature "zod" enables `zod_type()` method
 #[derive(Clone, Debug)]
 pub struct FieldDef {
     pub absent_from_wire: bool,
@@ -249,20 +161,6 @@ impl PartialEq for FieldDef {
 impl FieldDef {
     /// The enclosing item's own type parameter this field reaches *below* its own position — the
     /// `T` a `Later<T>` hands to the type it names, and the same `T` inside a tuple or a map.
-    ///
-    /// [`Self::parameter_shape_name`] answers for the field itself, this for everything it is
-    /// written over, and a field answering either one describes a value the expansion never sees a
-    /// type for. What differs is what can still be said about it: a field that *is* a parameter has
-    /// no shape at all, while one merely written over a parameter keeps the shape it was written
-    /// with — an array stays an array — and only the leaf goes opaque. So a bound written against
-    /// the shape still reaches something, and a bound written against the leaf reaches nothing on
-    /// any surface however the instantiation fills it.
-    ///
-    /// The first such parameter in declaration order is the one named; a field reaching two names
-    /// them both for the same reason, and one is enough to say what the answer is.
-    ///
-    /// Reads a def already rewritten by [`Self::erase_type_parameters`], for the reason
-    /// `parameter_shape_name` does.
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
     pub fn argument_parameter_name(&self) -> Option<&str> {
         match &self.field_type {
@@ -304,18 +202,6 @@ impl FieldDef {
     }
 
     /// The element of a collection wrapper, as the field the wrapper's own serialization makes it.
-    ///
-    /// A `Vec<T>` and a set of `T` both write a JSON array of `T`, so the element carries the
-    /// array-ness and answers for what the array holds. The field's own constraints ride along:
-    /// they have nothing but the element to land on, exactly as on the `Vec` spelling, which the
-    /// parser hands over already collapsed onto its element.
-    ///
-    /// Every array level survives the move: the element's own, the one this wrapper adds, and the
-    /// ones the wrapper itself sits under. The result therefore stands for the whole field, and a
-    /// caller must not re-apply the field's own levels on top of it. Each level keeps what it was
-    /// written with — its nullability, and the fixed length of a `[T; N]` — renumbered where it
-    /// moved: the element's levels are the innermost and keep their numbers, while the wrapper's
-    /// own sit above the array it adds.
     pub fn collection_element_field(&self, element: &Self) -> Self {
         let mut arrayed = element.clone();
         arrayed.name.clone_from(&self.name);
@@ -337,12 +223,6 @@ impl FieldDef {
 
     /// The shape this field renders when the values a bound could be spelled against are its
     /// members rather than the field itself.
-    ///
-    /// A map writes its keys and its values, a tuple writes each of its elements, and every surface
-    /// builds those from the inner field defs — which carry no meta, the field's own sitting on the
-    /// outer def none of them reads. A length, a pattern or a range names one value, and
-    /// `model_schema_prop` has no way to say which member it meant, so a bound written here reaches
-    /// nothing on any surface; the caller turns that into a guard error naming the field.
     pub const fn composite_shape_name(&self) -> Option<&'static str> {
         match &self.field_type {
             FieldDefType::Map(_, _) => Some("a map"),
@@ -387,16 +267,6 @@ impl FieldDef {
 
     #[cfg(feature = "zod")]
     /// Checks if this field contains a reference to the given type name.
-    ///
-    /// This is used to detect recursive types where a type references itself.
-    /// For example, `Vec<DynamicValue>` inside `DynamicValue` would return true.
-    ///
-    /// The check is recursive, looking into:
-    /// - `SiblingType` direct references
-    /// - `Map` key and value types
-    /// - `Tuple` element types
-    /// - array wrappers (Vec<T>)
-    /// - `is_optional` wrappers (Option<T>)
     pub fn contains_type_reference(&self, type_name: &str) -> bool {
         match &self.field_type {
             FieldDefType::SiblingType(name, generics) => {
@@ -405,7 +275,6 @@ impl FieldDef {
                 if name == type_name || stripped_name == type_name {
                     return true;
                 }
-                // Also check generic arguments
                 generics
                     .iter()
                     .any(|g| g.contains_type_reference(type_name))
@@ -448,35 +317,6 @@ impl FieldDef {
     /// Rewrites every name that is one of the enclosing item's own type parameters into
     /// [`FieldDefType::TypeParam`], so the surfaces stop reading it as a reference to another
     /// generated type.
-    ///
-    /// This is the one rule the two validating surfaces read a type parameter under, and the one
-    /// place they part company with TypeScript over it. A parameter names no type at expansion, so
-    /// neither surface can leave it standing: each renders the filling that reached it instead —
-    /// the argument the enclosing Zod factory binds, the document the JSON caller supplied or the
-    /// item declared for itself — while the shape it sits in, a tuple's arity, an array, a map's
-    /// keys, stays described either way. TypeScript needs no such rule: it is a type surface, and
-    /// `export type Wrapper<IdType> = { id: IdType }` binds the parameter for real, so it renders
-    /// the name.
-    ///
-    /// Zod is why the rule cannot stop at JSON. Zod publishes *values*, and a `const` cannot be
-    /// parameterised, so a parameter left to render as the `Name$Schema` binding every unresolved
-    /// type is named after would reference a binding no emitted module declares — the consumer
-    /// pasting the output gets a `ReferenceError` before a payload is read. That is why only the
-    /// enclosing item's *own* parameters are rewritten: a genuinely unresolved sibling type keeps
-    /// its `$Schema` reference, because the type it names does publish that binding.
-    ///
-    /// The rewrite carries into what a schema surface may then claim about the value. Each surface
-    /// reaches a parameter through a filling of its own — Zod through the argument the enclosing
-    /// factory binds, JSON through the one document written for the instantiation that asked — so a
-    /// branded newtype constraining one of its own parameters is refused, through the opaque arm of
-    /// `non_string_inner_shape` this rewrite puts it in front of. Three surfaces answering three
-    /// ways is the refusal: a `minLength` written at the declaration would hold against one filling
-    /// on each schema surface, while `validate()` measures `Display` at every instantiation.
-    ///
-    /// Recurses through `SiblingType` generics, `Map` keys/values, and `Tuple` elements. Applied
-    /// after the field guards have read the field, so every guard asks its question of the type
-    /// the author wrote — and in every build, features or none, because which of the two a name is
-    /// is a fact about the declaration rather than about the surfaces reading it.
     pub fn erase_type_parameters(&mut self, parameters: &[String]) {
         if let FieldDefType::SiblingType(name, _) = &self.field_type
             && parameters.iter().any(|parameter| parameter == name)
@@ -502,16 +342,6 @@ impl FieldDef {
 
     /// The name of the type this field renders as, when that type's schema is one the crate writes
     /// whole and a `model_schema_prop` bound has no place in.
-    ///
-    /// Each of these renders a shape fixed here rather than the plain string or number a length, a
-    /// pattern or a range is spelled against: a chrono value as its own ISO spelling, an `ObjectId`
-    /// as the `{"$oid": …}` object serde writes it as. None of the three surfaces reads a bound for
-    /// them and neither does the Rust validator, so a bound written on one reaches nothing; the
-    /// caller turns that into a guard error naming the field instead of dropping it.
-    ///
-    /// Only the field's own rendering is asked about. A map or a tuple holding one of these
-    /// describes its members separately, and a bound on the field around them is
-    /// [`Self::composite_shape_name`]'s to answer for.
     pub const fn fixed_shape_name(&self) -> Option<&'static str> {
         match &self.field_type {
             #[cfg(feature = "object_id")]
@@ -602,11 +432,6 @@ impl FieldDef {
     /// Whether every payload serde writes carries a key for this field — what the JSON surface's
     /// `required` names, and the one question there that a field's `Option`-ness alone cannot
     /// answer.
-    ///
-    /// An `Option` in struct-field position may write no key. A serde attribute that omits the
-    /// value means the same thing for a field of any type. Either one is enough to take the field
-    /// out of `required`, because `required` is a claim about every payload and one payload
-    /// without the key is enough to falsify it.
     #[cfg(feature = "jsonschema")]
     pub fn key_is_required(&self) -> bool {
         !self.is_optional() && !self.omits_value
@@ -615,18 +440,6 @@ impl FieldDef {
     /// Whether the object key this field writes may be absent, which is the question the two
     /// spellings of an optional member answer differently — `field?: T` admits the payload with no
     /// such key, `field: T | undefined` demands the key and lets its value be `undefined`.
-    ///
-    /// Two things say it, and either alone is enough. `ts_optional` says it for the TypeScript
-    /// surface on the author's word, which only an `Option` field may give. A serde attribute that
-    /// omits the value says it off the wire, whatever the field is written as: the payload serde
-    /// writes simply has no key there. That second one asks nothing about `Option`-ness on purpose
-    /// — a `Vec` behind a `Vec::is_empty` predicate has no `None` anywhere in it and its key still
-    /// goes missing, so a rule keyed on `Option` would describe a payload serde does not write.
-    ///
-    /// The two overlap on every field that carries both, which leaves the flag deciding this only
-    /// where no such attribute was written — a field the `serde` feature's `Option`-null guard
-    /// refuses, so the flag's own answer is one a build with that feature off is the only place to
-    /// read.
     fn key_may_be_absent(&self) -> bool {
         self.omits_value
             || (self.is_optional()
@@ -656,18 +469,6 @@ impl FieldDef {
     /// a sibling's binding at all) — `Tagged$SchemaFactory` inside
     /// `z.array(Tagged$SchemaFactory(z.string()))` is exactly as much a module-scope `const` read as
     /// a bare `Tagged$SchemaFactory(z.string())` is.
-    ///
-    /// Unlike [`Self::reaches_a_type_declared_later`], registration is never consulted: a declared
-    /// default is rendered once, standing alone rather than beside the fields of the item that
-    /// declares it, so nothing here can say whether the sibling it names has registered by the time
-    /// this runs — deferring unconditionally is the same answer [`deferred_zod_operand`]'s other
-    /// callers already give for a flattened base and the fold above. The recursion shape matches
-    /// [`Self::contains_type_reference`]: sibling generics, map values, tuple elements. A sequence
-    /// wrapper's own name is not itself a sibling — it renders as the array its elements describe,
-    /// never a binding of its own — so it is excluded exactly as
-    /// [`Self::reaches_a_type_declared_later`] excludes it, while its element is still walked. A map
-    /// key is left unwalked entirely: `HashMap<String, T>` is the only key this crate accepts, and
-    /// `String` can never itself be a sibling reference.
     #[cfg(feature = "zod")]
     pub fn names_a_sibling_binding(&self) -> bool {
         match &self.field_type {
@@ -751,15 +552,6 @@ impl FieldDef {
     }
 
     /// The name of the first `OsString`/`OsStr` this field reaches, at any depth.
-    ///
-    /// Neither has a primitive mapping and neither can get one: serde writes them as an externally
-    /// tagged enum whose variant is the target platform — `{"Unix":[u8, …]}` or
-    /// `{"Windows":[u16, …]}` — so the same Rust field has two wire forms and no schema can
-    /// describe both. Left unmapped they read as an ordinary `SiblingType`, and the generated code
-    /// would reference a schema module the user never wrote; the caller turns this into a guard
-    /// error naming the field instead.
-    ///
-    /// Recurses through `SiblingType` generics, `Map` keys/values, and `Tuple` elements.
     pub fn os_string_name(&self) -> Option<&str> {
         match &self.field_type {
             FieldDefType::SiblingType(name, generics) => {
@@ -810,17 +602,6 @@ impl FieldDef {
 
     /// The enclosing item's own type parameter this field renders as, when a bound spelled against
     /// it names a value whose type the expansion never sees.
-    ///
-    /// A parameter names no type at expansion — the instantiation names one, and one schema is
-    /// written for every instantiation. So the two validating surfaces describe the value as the
-    /// opaque one, which takes no length, no pattern and no range, while the generated validator
-    /// and serde read whatever type the instantiation supplied and hold it to nothing written here.
-    /// A bound therefore reaches nothing on any surface, exactly as one written beside a map's
-    /// members does; the caller turns that into a guard error naming the parameter.
-    ///
-    /// Only a field already read through [`Self::erase_type_parameters`] answers here: which of
-    /// the two a written name is — the item's own parameter or a reference to another type — is
-    /// that rewrite's question, and asking it twice is how the two answers come to differ.
     pub fn parameter_shape_name(&self) -> Option<&str> {
         match &self.field_type {
             FieldDefType::TypeParam(name) => Some(name),
@@ -857,30 +638,6 @@ impl FieldDef {
     /// Whether this field reaches a type the registry does not hold yet — a `#[model_schema]` item
     /// declared below the one being expanded, whether or not that item declares a parameter of its
     /// own.
-    ///
-    /// A generic reference is written as a call to the factory that item goes on to publish, the
-    /// only binding that can take the arguments written here; a zero-argument reference is written
-    /// as a bare read of that item's own `$Schema` const. Both are spliced in as they stand into
-    /// the containing object literal, and each carries a different danger for it. A factory call
-    /// only runs when the enclosing factory is itself later called, well after every module has
-    /// loaded — but where the item below points back at this one, that call re-enters this factory
-    /// before it has reached its cache, and the pair recurses until the stack ends. A bare `$Schema`
-    /// read carries no such call to defer re-entering, but the object literal reading it eagerly
-    /// *is* that other item's own top-level const initializer — so the danger is reading a name a
-    /// module below has not declared yet, the same temporal-dead-zone hazard `deferred_zod_operand`
-    /// exists to solve for a flattened base and a declared default.
-    ///
-    /// Deferring exactly these references is enough to end both, and it needs no cycle to be found.
-    /// Every cycle contains at least one of them: if every reference in a cycle named something
-    /// already registered, declaration positions would strictly decrease all the way round, which
-    /// no cycle can do. What is left once they are deferred is a graph whose every remaining
-    /// reference names something declared earlier, so it cannot cycle and every chain of eager
-    /// calls ends — and a lone forward reference belonging to no cycle at all is ended the same way,
-    /// since nothing here needs one to exist.
-    ///
-    /// The same partial-answer regime the export name and the map-key registry already run under:
-    /// a name the registry does not hold is a name expanded later, and one it does hold was
-    /// expanded before.
     #[cfg(feature = "zod")]
     pub fn reaches_a_type_declared_later(&self) -> bool {
         match &self.field_type {
@@ -924,20 +681,6 @@ impl FieldDef {
 
     /// Rewrites any `Self` type reference to the concrete enclosing type name, at the parameters
     /// the enclosing item declares.
-    ///
-    /// A recursive type may refer to itself with the `Self` keyword (e.g. `Array(Vec<Self>)`). The
-    /// macro detects recursion and renders references by comparing type names, so `Self` must be
-    /// resolved to the actual type name before that logic runs; afterwards `Vec<Self>` is treated
-    /// exactly like `Vec<EnclosingType>`.
-    ///
-    /// `Self` on a *generic* item names that item at its own parameters — it is the one spelling
-    /// whose arguments are implied rather than written — so the parameters are restored here, where
-    /// the name is. Left off, the reference reads as a name with no arguments at all: the Zod
-    /// surface calls the item's factory with none of the arguments it requires, and the TypeScript
-    /// one writes a bare name beside a declaration that binds parameters. `Self` cannot be written
-    /// with arguments of its own, so there is nothing here to overwrite.
-    ///
-    /// Recurses through `SiblingType` generics, `Map` keys/values, and `Tuple` elements.
     pub fn resolve_self_references(&mut self, type_name: &str, parameters: &[String]) {
         match &mut self.field_type {
             FieldDefType::SiblingType(name, generics) => {
@@ -1002,10 +745,6 @@ impl FieldDef {
     /// The members of the untagged union this field names as an object flattening it spells them,
     /// as the registry recorded them — and nothing for a field that names no such union, and for one
     /// whose members carry no exclusion the union's own name does not already describe.
-    ///
-    /// Answered under the same bound [`Self::zod_union_members`] is answered under, and for the same
-    /// reason: what is spliced in the name's place has to be the whole of what the operand
-    /// describes.
     #[cfg(all(feature = "serde", feature = "typescript"))]
     pub fn ts_union_members(&self) -> Vec<String> {
         let wrapped = self
@@ -1123,19 +862,6 @@ impl FieldDef {
     /// The key a `Partial<Record<…>>` is written with: the key's own type, except where the key is
     /// one of the enclosing item's type parameters, which states `string` — the same answer
     /// [`Self::zod_map_key_type`] gives, for the same reason.
-    ///
-    /// This is the one place the type surface stops rendering a parameter as itself, and the
-    /// declaration is what forces it. `Record<K, T>` is declared `K extends keyof any`, so a
-    /// declaration that hands it a parameter it binds without bounding does not type-check at all —
-    /// the consumer pasting the emitted `.ts` gets the error before writing a value. Bounding the
-    /// parameter instead moves the failure rather than fixing it: the bound propagates to every
-    /// name written over the item, and `unknown` — what a binding annotated for the erased value
-    /// fills the parameter with — does not satisfy it either.
-    ///
-    /// What the member gives up is naming the parameter. What it gains is the guarantee serde
-    /// already makes: an instantiation either writes this map's keys as strings or refuses the
-    /// whole map at serialization, so no filling of the parameter ever reaches the wire as
-    /// anything else. The value beside the key still names whatever parameter it was written with.
     fn typescript_map_key_typename(&self) -> String {
         if self.parameter_shape_name().is_some() {
             return "string".to_owned();
@@ -1145,12 +871,6 @@ impl FieldDef {
 
     /// What this field contributes to an object that writes its members beside its own, on the
     /// TypeScript surface: the value itself, with no answer for the outermost `Option`.
-    ///
-    /// A merged source has no key of its own, so that `Option` is not the question
-    /// [`Self::typescript_typename`] answers. There, a `None` is a key the object leaves out; here
-    /// it is every one of the source's keys left out at once — the object writes its own members
-    /// merged with the source's or writes its own alone, and a choice between two key sets belongs
-    /// where the merge is assembled rather than on the operand it is assembled from.
     #[cfg(feature = "typescript")]
     pub fn typescript_merged_typename(&self) -> String {
         self.typescript_base()
@@ -1171,28 +891,6 @@ impl FieldDef {
     }
 
     /// Generates the TypeScript type name for this field.
-    ///
-    /// This method is the core of TypeScript type generation. It recursively builds
-    /// the TS type string based on `field_type`, `array_depth`, and `nullable_levels`.
-    ///
-    /// Process:
-    /// 1. Match on `field_type` to get base type
-    /// 2. Wrap in Array<...> once per `array_depth` level, adding `| null` inside the wrap at each
-    ///    level written as an `Option` — the array is always written, so the `None` is an item
-    /// 3. If `is_optional`, which is that question asked of the outermost level: struct-field
-    ///    position adds `| undefined`, or nothing at all where the key itself may be absent and
-    ///    [`Self::optional_key_marker`] writes the `?` that says so; tuple-element and map-value
-    ///    positions add `| null` (neither can be omitted like an object key, so a `None` there
-    ///    serializes as `null`)
-    ///
-    /// Feature notes:
-    /// - "`object_id"`: Uses special `ObjectId` type
-    /// - Ignores `model_schema_prop_meta` currently (except implicitly through `field_type`)
-    /// - For `StringLiteral`, generates quoted string literal
-    /// - All Rust numbers map to 'number' in TS
-    ///
-    /// See the emitters in `model_schema.rs` for how this is spliced into a full type definition.
-    /// Examples in README.md show generated output.
     pub fn typescript_typename(&self) -> String {
         let pre_result = self.typescript_base();
         if self.is_optional() {
@@ -1226,14 +924,6 @@ impl FieldDef {
     /// The type match plus one `z.array(…)` per array level, each carrying the `z.nullable(…)` of
     /// the level it wraps and the `.length(N)` of a level written as a fixed-size `[T; N]`, before
     /// the preprocess wrap.
-    ///
-    /// Zod is a validator, so it says what the JSON schema says: serde reads a `[T; N]` back only
-    /// from an array of exactly `N` items, and `.length` is that constraint spelled directly. The
-    /// TypeScript surface takes the other answer and stays `Array<T>` — see `array_lengths`.
-    ///
-    /// A set's element re-enters the rendering here rather than at `zod_base`: it carries a copy of
-    /// the field's own metadata, and the preprocess wrap belongs once, outside the array — where
-    /// the `Vec` spelling of the same field puts it.
     #[cfg(feature = "zod")]
     fn zod_array_base(&self) -> String {
         let result = match &self.field_type {
@@ -1348,17 +1038,6 @@ impl FieldDef {
 
     /// The key schema a `z.record(…)` is written with: the key's own, except where the key is one
     /// of the enclosing item's type parameters.
-    ///
-    /// A record key has to produce string keys, and the opaque value a parameter describes as
-    /// everywhere else declines to say anything at all about them — the one position where saying
-    /// nothing says less than the wire already guarantees. serde is what guarantees it: an
-    /// instantiation either writes this map's object keys as strings or refuses the whole map at
-    /// serialization with `key must be a string`, with no fallback form, so `z.string()` holds for
-    /// every instantiation that serializes at all. It is also the answer the JSON surface reads off
-    /// the same key through its own classification, which is what keeps the two saying one thing.
-    ///
-    /// Only a bare key reaches the parameter arm: a key written under a sequence or an `Option`
-    /// wrapper is refused before any surface renders the map.
     #[cfg(feature = "zod")]
     fn zod_map_key_type(&self) -> String {
         if self.parameter_shape_name().is_some() {
@@ -1409,19 +1088,16 @@ impl FieldDef {
     #[cfg(feature = "zod")]
     fn zod_string_type(&self) -> String {
         let mut result = "z.string()".to_owned();
-        // Add min length validation if specified
         if let Some(meta) = &self.model_schema_prop_meta
             && let Some(min_len) = meta.min_length
         {
             result = format!("{result}.min({min_len})");
         }
-        // Add max length validation if specified
         if let Some(meta) = &self.model_schema_prop_meta
             && let Some(max_len) = meta.max_length
         {
             result = format!("{result}.max({max_len})");
         }
-        // Add pattern validation if specified
         if let Some(meta) = &self.model_schema_prop_meta
             && let Some(pattern) = &meta.pattern
         {
@@ -1433,29 +1109,6 @@ impl FieldDef {
 
     #[cfg(feature = "zod")]
     /// Generates the Zod schema string for this field (requires "zod" feature).
-    ///
-    /// Similar to `typescript_typename()` but generates Zod validation schema.
-    /// Uses z.* functions appropriate to the type.
-    ///
-    /// Additional logic:
-    /// - For String: Adds .`min(min_len)` if `model_schema_prop_meta` has `min_length`
-    /// - For literals: Uses z.literal(...)
-    /// - For `ObjectId`: Uses regex validation for hex string
-    /// - Wraps with `z.array()` once per `array_depth` level, wrapping `z.nullable(…)` inside it
-    ///   at each level written as an `Option` and appending `.length(N)` at each level written as a
-    ///   fixed-size `[T; N]`
-    /// - If `is_optional`, which is that question asked of the outermost level: struct-field
-    ///   position wraps `z.union([type, z.undefined()])`; tuple-element and map-value positions wrap
-    ///   `z.nullable(type)` (neither can be omitted like an object key, so a `None` there
-    ///   serializes as `null`)
-    /// - Otherwise, if the key may still go missing — a serde attribute dropping the value of a
-    ///   field that is no `Option` — appends `.optional()`. The value under the key is unchanged,
-    ///   so the type is left as it stands and only its presence is relaxed. Recorded against zod
-    ///   4.4.3: inside a `z.strictObject`, that member admits the payload with the key absent and
-    ///   the payload carrying it, still rejects `null`, and still rejects an unrecognized key.
-    ///
-    /// Requires Zod v4 in frontend - generates v4-compatible syntax.
-    /// See `notes/20250706_features.md` for Zod feature details.
     pub fn zod_type(&self) -> String {
         let pre_result = self.zod_base();
         if self.is_optional() {
@@ -1469,16 +1122,6 @@ impl FieldDef {
 
     /// The members of the untagged union this field names, as the registry recorded them, and
     /// nothing for a field that names no such union.
-    ///
-    /// A merge cannot join a union as one operand — an intersection recognizes exactly the keys its
-    /// operands name, and a `z.union` names none — so it joins one member per branch instead, and
-    /// these are the branches. The members are recorded already multiplied out, so a member that is
-    /// itself a union has already contributed its own.
-    ///
-    /// Answered only for a field whose whole Zod spelling *is* the name the registry keys — an
-    /// array level or a preprocess wrap is part of what the operand validates, and a member spliced
-    /// in the name's place would drop it. The outermost `Option` is not one of those: it is what
-    /// [`Self::zod_merged_schema`] already leaves to the merge.
     #[cfg(feature = "zod")]
     pub fn zod_union_members(&self) -> Vec<ZodUnionMember> {
         let wrapped = self
@@ -1513,12 +1156,6 @@ fn zod_factory_call(name: &str, arguments: &[FieldDef]) -> String {
 }
 
 /// The one list of std wrappers the crate renders as arrays, shared by every surface.
-///
-/// Membership is decided on the wire and nothing else: serde writes each of these as a JSON array
-/// of its single element type, so each describes as the `Vec` of that element does. The maps are
-/// absent because they write objects; `Vec` is listed even though the parser collapses it onto its
-/// element as an array level long before anything asks a wrapper's name, so that a `Vec` written
-/// where a wrapper name is read still takes the wrapper path.
 pub fn is_sequence_wrapper(name: &str) -> bool {
     matches!(
         name,
@@ -1528,17 +1165,6 @@ pub fn is_sequence_wrapper(name: &str) -> bool {
 
 /// The number of leading type arguments a std container's wire form is written from, or `None` for
 /// a name that is not one of them.
-///
-/// std's hashed maps and sets carry a hasher past the types they write, and each of these
-/// containers takes an allocator beside it. Neither reaches the wire — serde writes the same bytes
-/// whichever is named — so neither is part of what the container describes as, and an argument past
-/// this count is dropped rather than read as a type of its own.
-///
-/// The count is what the container is claimed on, not what it is written with: a spelling carrying
-/// fewer arguments than this is not the container at all, and is left to fall through as the
-/// sibling it was written as, where the schema module it names is reported unresolvable against the
-/// author's own type. The one-argument list is the surfaces' shared answer for what writes a JSON
-/// array, so a wrapper cannot be read here as a container and there as a name of its own.
 fn container_wire_arity(name: &str) -> Option<usize> {
     if name == "HashMap" || name == "BTreeMap" {
         Some(2)
@@ -1550,28 +1176,11 @@ fn container_wire_arity(name: &str) -> Option<usize> {
 }
 
 /// The one list of std wrappers the crate reads straight through to what they hold.
-///
-/// Membership is decided on the wire and nothing else: serde writes each of these as its inner
-/// value, with nothing of its own around it, so a field written under one is the very field its
-/// inner type is. The parser therefore collapses them onto that inner field and no surface ever
-/// learns a wrapper was written — which is what keeps a wrapper name out of the generated output,
-/// where none of the three surfaces has any meaning for it.
-///
-/// `Cow` is covered on the same terms despite carrying a lifetime beside its type: the lifetime is
-/// not a type argument and never reaches the collected arguments, so a `Cow` arrives with the one
-/// argument a `Box` arrives with. The interior-mutability wrappers are absent — that is a wider
-/// list than this defect was measured over, not a claim that they write anything else.
 pub fn is_transparent_wrapper(name: &str) -> bool {
     matches!(name, "Arc" | "Box" | "Cow" | "Rc")
 }
 
 /// Classifies a `syn::Variant` into its `VariantKind`.
-///
-/// This determines how the variant should be rendered in TypeScript/Zod:
-/// - Unit → no content field
-/// - Named → individual named fields
-/// - `TupleSingle` → flattened `value: T`
-/// - `TupleMultiple` → tuple `value: [T1, T2, ...]`
 pub fn classify_variant(variant: &Variant) -> VariantKind {
     match &variant.fields {
         Fields::Unit => VariantKind::Unit,
@@ -1590,29 +1199,6 @@ pub fn classify_variant(variant: &Variant) -> VariantKind {
 }
 
 /// Main function to create `FieldDef` from `syn::Type`.
-///
-/// This is the entry point for field analysis. It recursively parses the Rust type
-/// syntax tree to build the `FieldDef` structure.
-///
-/// Handles:
-/// - Primitives and simple types (via `get_field_def_type_or_sibling`)
-/// - Generics (Option<T>, Vec<T>, `HashMap`<K,V>)
-/// - Tuples, arrays, slices, references
-/// - Falls back to Unknown for unsupported types
-///
-/// Key behaviors:
-/// - Strips references (&T -> T)
-/// - Counts an `array_depth` level for each Vec, slice, array
-/// - Records a nullable level for each Option, at the array level it was written at
-/// - Only supports `HashMap`<String, T> (panics or errors otherwise per rules)
-/// - Uses `safe_type_name()` to strip Json suffix
-///
-/// Called from `process_field()` in `model_schema.rs` for each struct field.
-///
-/// Builds a `FieldDef` for a `Type::Path` (named type, possibly with generic arguments).
-///
-/// Handles `Option<T>`, `Vec<T>`, `HashMap`/`BTreeMap`, `DateTime<Tz>`, and falls back to
-/// `SiblingType`/`Unknown` for everything else.
 fn get_field_def_from_type_path(
     type_path: &syn::TypePath,
     safe_name: String,
@@ -1671,13 +1257,6 @@ fn get_field_def_from_type_path(
 }
 
 /// Builds a `FieldDef` for a named type written with generic arguments.
-///
-/// Handles `Option<T>`, `Vec<T>`, the transparent wrappers, `HashMap`/`BTreeMap` and
-/// `DateTime<Tz>`, and falls back to `SiblingType` for everything else.
-///
-/// Only the type arguments are read. A lifetime writes nothing, so a type carrying one arrives here
-/// with the arguments it would have without it — which is what lets `Cow<'a, T>` be answered for by
-/// the same single-argument arms as `Box<T>`.
 fn get_field_def_from_generic_type(
     type_ident: &Ident,
     args: &syn::AngleBracketedGenericArguments,
@@ -1778,16 +1357,6 @@ fn get_field_def_from_generic_type(
 }
 
 /// The def a single-argument wrapper collapses onto, for the wrappers that collapse.
-///
-/// A collapse keeps the field and drops only the wrapper. The docs were written where the field
-/// was, not around what it holds, so they cross onto the element the field's own name crosses onto
-/// — the element was parsed with none of its own to lose. Everything a wrapper could sit around or
-/// inside is already on that element and rides along untouched: `Option` lifts its optionality onto
-/// the outermost level, a sequence counts one more level, and a wrapper that is not on the wire at
-/// all adds nothing for the field to carry and hands the element over whole.
-///
-/// `None` for every other name, which is a wrapper this does not answer for rather than one that
-/// collapses to nothing — the caller goes on to its own arms.
 fn collapsed_wrapper_def(
     ident: &str,
     element: &FieldDef,
@@ -1824,12 +1393,6 @@ fn literal_array_length(len: &syn::Expr) -> Option<usize> {
 }
 
 /// Debug logging: Set `RUST_LOG=trace` to see HashMap/SiblingType creation.
-///
-/// The arms below classify by the shape they are handed, so what they are handed is the type as
-/// written: a `macro_rules!` substitution arrives grouped, and the grouping is read off before any
-/// arm looks. Everything reached from here comes back through this function, so a substitution
-/// nested inside a written shape — `Vec<$t>`, `&$t`, `($a, $b)` — is read through on its own way
-/// down.
 pub fn get_field_def(name: &str, ty: &Type, field_docs: &str) -> FieldDef {
     let safe_name = safe_type_name(name);
     let written = written_type(ty);
@@ -1894,18 +1457,6 @@ pub fn get_field_def(name: &str, ty: &Type, field_docs: &str) -> FieldDef {
 }
 
 /// Helper to map Rust type name strings to `FieldDefType`.
-///
-/// Used in `get_field_def` for types without generics.
-///
-/// Mapping rules:
-/// - Built-in primitives to their variants
-/// - Types ending with "Json" to `SiblingType` (strips suffix in TS)
-/// - Other types to `SiblingType`
-/// - `ObjectId`: Special handling if feature enabled, else `SiblingType` with warning
-///
-/// Feature "`object_id"`:
-/// - Enables special `ObjectId` variant
-/// - Without: Prints compile-time warning and treats as custom type
 fn get_field_def_type_or_sibling(t_name: &str) -> FieldDefType {
     if lookup_alias_info(t_name).is_some() {
         return FieldDefType::SiblingType(t_name.to_owned(), vec![]);
@@ -1966,22 +1517,6 @@ fn get_field_def_type_or_sibling(t_name: &str) -> FieldDefType {
 
 /// Whether a name is one the language reserves for a primitive type that
 /// [`get_field_def_type_or_sibling`] has no arm for.
-///
-/// The dispatch above is total by construction: a name it does not recognise is taken for a sibling
-/// — another `model_schema` item, named before or after this one — and rendered as a reference to
-/// the module that item publishes. That is the right reading of `Foo`, which may well be declared
-/// below, and it is gibberish for a reserved primitive name the dispatch has no arm for: no module
-/// of that name will ever exist, so the reference resolves to nothing and the author reads an
-/// `E0433` about a module they never wrote.
-///
-/// The two cannot be told apart by tokens, so only what is *provably* not a sibling is named here:
-/// the primitive names the language reserves, minus the ones the dispatch does answer for — `char`
-/// among them since it gained [`FieldDefType::Char`]. A caller refusing on this answer refuses
-/// exactly the spellings that cannot become siblings later.
-///
-/// `f16` and `f128` are listed with `i128` and `u128` although the language does not yet stabilise
-/// them: they are reserved primitive names either way, and a build that gains them should reach a
-/// refusal naming the limitation rather than the phantom module.
 #[cfg(feature = "jsonschema")]
 pub fn is_undescribable_primitive(name: &str) -> bool {
     matches!(name, "i128" | "u128" | "f16" | "f128")
@@ -2010,12 +1545,6 @@ pub fn parse_serde_field_attributes(attrs: &[Attribute]) -> SerdeFieldMeta {
 }
 
 /// Utility to check if an enum is a plain unit enum (no fields in variants).
-///
-/// Used in `model_schema.rs` to distinguish plain enums (union types) from
-/// tagged enums (discriminated unions).
-///
-/// Plain enums generate string unions in TS/Zod.
-/// See enum examples in README.md.
 pub fn is_plain_enum(item_enum: &ItemEnum) -> bool {
     item_enum
         .variants

--- a/src/field_type/tests.rs
+++ b/src/field_type/tests.rs
@@ -553,10 +553,10 @@ fn test_a_substitution_inside_a_written_shape_is_read_through() {
     }
 }
 
-/// [`FieldDef::reaches_a_type_declared_later`]'s zero-argument arm — see txsch-8r4v: a bare
-/// sibling reference to a `#[model_schema]` item not yet registered (declared below the one being
-/// expanded) has to defer exactly as a generic forward reference already does; a registered name
-/// (declared above) stays the safe, eager baseline the predicate always answered correctly.
+/// [`FieldDef::reaches_a_type_declared_later`]'s zero-argument arm: a bare sibling reference to a
+/// `#[model_schema]` item not yet registered (declared below the one being expanded) has to defer
+/// exactly as a generic forward reference already does; a registered name (declared above) stays
+/// the eager baseline.
 #[cfg(feature = "zod")]
 #[test]
 fn test_reaches_a_type_declared_later_answers_for_a_zero_argument_sibling() {

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -158,20 +158,8 @@ const KNOWN_ARGS: &[&str] = &[
 const FLATTENED_PLAIN_ENUM_SCOPE: &str = "Only a type the registry has already classified reaches this guard; one it has not keeps its \
      TypeScript and Zod intersection, and is refused by the JSON surface when the merge runs.";
 
-/// The two shapes a map key can write that `serde_json` will not use as an object key, as
-/// [`MapKeyRejection::Unwritable`] names them.
 /// The one helper every generated module carries above its per-type definitions, and the only
 /// assertion anything here writes.
-///
-/// A factory's cache maps an argument to the schema built from *that* argument, so the value type
-/// depends on the key type. TypeScript can declare that dependency — each level's `get` and `set`
-/// are written generic over the key — but cannot construct a map that satisfies it, since a
-/// `WeakMap`'s two parameters are fixed at construction. So the dependency is declared in the
-/// interfaces, where it does the work, and asserted exactly once here, where a reader can see the
-/// whole of what was asserted.
-///
-/// A `WeakMap` is what makes an argument nobody else holds collectable rather than pinned for the
-/// life of the module.
 #[cfg(all(feature = "zod", feature = "typescript"))]
 const TYPESCRIPT_PREAMBLE: &str = "const createSchemaCache = <Cache extends object>(): Cache => new WeakMap() as unknown as Cache;";
 
@@ -200,11 +188,6 @@ struct DiscriminatedVariant {
 /// Per-variant data collected from a discriminated enum, plus the collected serde validators, the
 /// `compile_error!` tokens for any field-level guard violations, and the `validate()` match arms,
 /// empty where no variant carries a constrained member and there is nothing to aggregate.
-///
-/// The variants are a sequence, not a map: their order is the enum's declaration order and it
-/// reaches the emitted output verbatim (JSON-schema `oneOf`, the TypeScript union, the Zod
-/// `discriminatedUnion`). Any hash-ordered container here would re-randomize that output per
-/// build.
 type DiscriminatedVariantData = (
     Vec<DiscriminatedVariant>,
     Vec<proc_macro2::TokenStream>,
@@ -290,14 +273,6 @@ struct BrandedValidation {
 
 /// What a branded newtype's inner writes when what it writes is a composite: an array, a map, a
 /// tuple, or a value the parser could not classify at all.
-///
-/// These are the shapes no one `"type"` keyword and no one Zod class names, so a brand over one of
-/// them is described by nothing but the type it holds — the array, the object, or the fixed-arity
-/// array `#[serde(transparent)]` puts on the wire.
-///
-/// A `SiblingType` is absent: it is a name, not a shape. This expansion cannot resolve it, and the
-/// type it names may itself be a brand over one string — which is a shape the brand's own
-/// constraints *are* permitted over — so it keeps the description it has.
 #[cfg(any(feature = "jsonschema", all(feature = "typescript", feature = "zod")))]
 enum BrandedComposite {
     Array,
@@ -327,15 +302,6 @@ enum BrandedJsonInner {
 }
 
 /// Whether the schema a brand narrows already states a `pattern` of its own.
-///
-/// One JSON Schema string carries one `pattern` keyword, so where the inner type states the one
-/// every payload it writes already satisfies, the brand's cannot be written over it — the type's
-/// own would be gone, and the surface would admit strings the value can never hold. The brand's
-/// narrows from inside an `allOf` beside it instead, where a payload has to match both. That is
-/// what the Zod side already does: the type's own check runs, and the brand's runs after it.
-///
-/// The `$oid` object's hex member is the one base that states a pattern, so without the type that
-/// writes it there is no such base to narrow — which is what the gate on `Stated` says.
 #[cfg(feature = "jsonschema")]
 #[derive(Clone, Copy)]
 enum BasePattern {
@@ -361,12 +327,6 @@ enum ConstraintLeaf {
     /// The bare Rust numeric type, which is the validator's parameter type.
     Number(&'static str),
     /// A filesystem path, whose checks read its `to_string_lossy` rendering.
-    ///
-    /// serde writes a path as the string its `to_str` yields and refuses to write one that has
-    /// none, so that rendering is the exact wire value for every path a payload can carry, and the
-    /// paths where it substitutes replacement characters are the ones no payload holds. That is
-    /// what lets a length or a pattern land on a path at all: it measures what the three surfaces
-    /// render a constrained string for.
     Path,
     Str,
 }
@@ -419,10 +379,6 @@ struct FieldValidationCode {
 /// A map member's rendering with the slot wraps still to apply: a `json!` literal fragment, which
 /// only a caller writing inside `serde_json::json!` can inline, or a standalone `serde_json::Value`
 /// expression, which either caller can take as it stands.
-///
-/// The form rides on the item because the two wrap differently, and a caller that needs a value can
-/// always lift a fragment into one — so one dispatcher serves both the `String`-key path, which
-/// inlines its member as `additionalProperties`, and the enum-key path, which binds it.
 #[cfg(feature = "jsonschema")]
 enum MapMemberItem {
     Fragment(proc_macro2::TokenStream),
@@ -463,11 +419,6 @@ enum MapKeyPath<'key> {
 /// Why a map key a field reaches has no rendering. Every reason carries the name the author can act
 /// on, and every one stands on every surface, the key being read off the field all three render
 /// from.
-///
-/// Below the first, they are all one fact wearing different spellings: a JSON object key is a
-/// string, and serde raises `key must be a string` — refusing the whole map at serialization rather
-/// than falling back to any other form — for every key whose own wire form is not one. So the
-/// spelling is refused rather than described: there is no wire here to describe badly.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[derive(Debug)]
 enum MapKeyRejection {
@@ -517,9 +468,6 @@ struct ModelSchemaArgs {
     /// were written: `default_types(IdType = String, DateType = f64)`. Read by JSON-schema
     /// generation, which has no type parameters of its own and so has to build its document from
     /// one concrete filling.
-    ///
-    /// The parameter is kept as the ident it was written as rather than its text, because a
-    /// refusal of an entry is spanned on it and only the ident carries that span.
     default_types: Vec<(syn::Ident, syn::Type)>,
     max_length: Option<usize>,
     min_length: Option<usize>,
@@ -541,12 +489,6 @@ struct ModelSchemaArgs {
 
 /// One `#[serde(flatten)]` source as a surface writes it: the spelling of what its members are, and
 /// whether the object writes them at all.
-///
-/// The two travel together for the reason the JSON-schema surface keeps them together in
-/// `MergedSource`. What the `Option` around a source says is not what an `Option` on any other
-/// field says — a merged source has no key to leave out, so the absence is every one of its keys at
-/// once, and the payloads the object writes are its own keys merged with the source's or its own
-/// keys alone. Where that choice is spelled is each surface's to answer.
 #[cfg(any(feature = "typescript", feature = "zod"))]
 struct MergedOperand {
     absence: SourceAbsence,
@@ -560,12 +502,6 @@ struct MergedOperand {
 }
 
 /// Which absence a merged source offers beside its members, and none where it always writes them.
-///
-/// One question to the merge that only counts key sets, and two to the surface that has to name the
-/// keys the absent branch leaves out. A source written `Option<T>` is spelled as the `T` inside it,
-/// so those keys are the spelling's own; a source naming an item whose published surface is nullable
-/// is spelled as that name, whose keys are the ones its value side names and not the name's — a
-/// choice has no keys of its own to read.
 #[cfg(any(feature = "typescript", feature = "zod"))]
 #[derive(Clone, Copy)]
 enum SourceAbsence {
@@ -603,12 +539,6 @@ impl SourceAbsence {
 
 /// Both answers the registry holds about what a `#[model_schema()]` item publishes, built together
 /// from one reading of the declaration so the two cannot come apart.
-///
-/// The shape is the constrained-brand guard's question — what a string check would be appended to.
-/// The wire is the flatten merge's — whether an object can be joined to what serde writes. One word
-/// cannot hold both: an `integer` and a `number` are one shape and two documents, an array and a map
-/// are one shape and opposite answers, and a nullable surface carries its leaves a level below the
-/// name rather than at it.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 struct Surface {
     shape: PublishedShape,
@@ -629,13 +559,6 @@ enum RecordedWire {
 }
 
 /// What a tuple struct publishes, which is not always the tuple of its declared slots.
-///
-/// serde writes a struct declaring exactly one slot as that slot's value alone, with nothing around
-/// it, and every other arity as an array of the slots it still carries. The two are separated here,
-/// at the one place that knows both how many slots were declared and which of them reach the wire,
-/// so no renderer downstream has to guess which shape a slot list stands for — a distinction the
-/// list alone cannot carry, since a two-slot struct with one slot off the wire writes a one-element
-/// array while a one-slot struct writes a bare value.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 enum TupleStructShape {
     /// The fixed-arity array serde writes for every other declared arity, holding the slots the
@@ -699,14 +622,6 @@ struct BrandedDefaultChecks {
 /// What [`zod_default_block`] and [`zod_factory_block`] need beyond the item's own name and
 /// parameter list, bundled into one reference because the two already carry as many positional
 /// parameters as `clippy::too_many_arguments` admits.
-///
-/// `constrained` is `None` for every item but a branded newtype's own — see
-/// [`zod_default_block`]'s doc comment for what it names.
-///
-/// `brand` is `None` for every item but a branded newtype's own, exactly like `constrained` —
-/// but unlike `constrained`, it is `Some` whether or not the brand carries any check at all: a
-/// `.brand()` call is in the factory's chain either way, so the annotation question it answers
-/// (see [`branded_default_annotation`]) applies whether or not there is a check to route.
 #[cfg(feature = "zod")]
 struct ZodDefaultInputs<'defaults> {
     #[cfg(feature = "typescript")]
@@ -819,16 +734,6 @@ impl Surface {
     }
 
     /// The union an externally tagged enum writes, as the leaves a merge descending it reaches.
-    ///
-    /// serde writes a data-carrying variant as the single-key object the variant's name tags, and
-    /// writes a unit variant as that name alone — a bare string, which carries no members and which
-    /// no object can be merged with. The JSON-schema merge descends the `oneOf` this publishes and
-    /// names such a variant by its position in it, so the leaves are recorded at those same
-    /// positions: what a flattened member naming the enum is refused at on one surface is what it
-    /// is refused at on the other, in one set of words.
-    ///
-    /// The tagged shapes that write an object for every variant keep [`Self::union`]: their leaves
-    /// would be unmarked to the last one, which is what the single unmarked leaf already says.
     #[cfg(all(feature = "serde", any(feature = "zod", feature = "typescript")))]
     fn externally_tagged(variants: &Punctuated<syn::Variant, Token![,]>) -> Self {
         Self {
@@ -1022,14 +927,6 @@ fn length_arg(meta: &Meta, name: &str) -> syn::Result<usize> {
 }
 
 /// The pairs a `default_types(…)` argument was written as, in that order.
-///
-/// A list with no pair in it is refused rather than read as an empty declaration: the argument
-/// exists to name a filling per parameter, so one that names none says nothing that leaving it off
-/// does not already say — and on an item that declares parameters it would read as a declaration
-/// while declaring nothing.
-///
-/// A parameter named twice is refused for the mirror reason: the argument names one filling per
-/// parameter, and a second entry names a filling nothing can read.
 fn default_types_arg(meta: &Meta) -> syn::Result<Vec<(syn::Ident, syn::Type)>> {
     let takes = "a list of `Parameter = Type` pairs, written `default_types(IdType = String, \
                  DateType = f64)`";
@@ -1216,22 +1113,6 @@ pub fn exec_model_schema(args: TokenStream, input: TokenStream) -> TokenStream {
 }
 
 /// Classifies what an alias resolves to, for the registry.
-///
-/// An alias *is* the type it names — a type path resolves straight through it — so the registry's
-/// question, what serde writes for a value spelled this way, is asked of the target and the answer
-/// stands under the alias's own exported name. That is the same question a brand answers for its
-/// inner, so it is read through the same dispatch, and the four verdicts carry across whole: a
-/// target serde writes as a bare string keys a map the way `String` does; a target serde stringifies
-/// for the author — a number, a `bool`, a chrono rendering, a generic spelling this expansion has no
-/// members for — keys the open object its bare spelling already describes as; a target serde writes
-/// as no key at all leaves the alias refused, under its own name rather than under the target's, so
-/// the diagnostic still points at what the author wrote; and a target that can still reach a plain
-/// enum stays on the enumerating path.
-///
-/// Only that last verdict consults the registry, and it answers with whatever the named type
-/// registered: an alias of an alias of an enum inherits `EnumMembers` down the chain. A target
-/// registered after its alias reads as `Unknown`, which callers must treat as "cannot rule it out"
-/// rather than as a negative.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn alias_target_kind(alias_field_def: &FieldDef) -> AliasKind {
     match map_key_path(alias_field_def) {
@@ -1259,23 +1140,6 @@ fn alias_map_key_guard_error(
 }
 
 /// The name of a flattened value's type when the registry proves that type is a plain enum.
-///
-/// Both flattened positions — an internally tagged newtype variant's content and a
-/// `#[serde(flatten)]` field — put what the value writes into the object being written, so only a
-/// value serde writes as an object belongs there. A plain enum writes its own variant name instead,
-/// which joins nothing and which every closed schema built here rejects.
-///
-/// The registry is the only thing the expansion holds that can rule this out, and it answers for a
-/// name it has already seen: `Unknown` is not a negative, and a struct and a branded newtype
-/// register alike. So this is a partial answer by construction, and the merge is where the rest is
-/// caught.
-///
-/// The name is looked up directly rather than through the map-key dispatch: what is asked here is
-/// whether the named type publishes `enum_members()`, and that stays true of an `Option<Slot>`
-/// whose `Some` writes the variant name straight into the object — where the key dispatch, asking
-/// what serde writes for a *key*, refuses the `Option` for its `None`. A generic spelling and an
-/// array are excluded because neither is the enum: they are a type this expansion has no members
-/// for, and the collection holding it.
 #[cfg(all(
     feature = "serde",
     any(feature = "typescript", feature = "zod", feature = "jsonschema")
@@ -1295,9 +1159,6 @@ fn flattened_plain_enum(inner: &FieldDef) -> Option<&str> {
 /// `#module_ident::Schema::json_schema()`. So the module and its `register_alias_info` call are
 /// driven by the union: gating them on `typescript` alone left the jsonschema references
 /// dangling. The module's *contents* are chosen per feature while building the tokens.
-///
-/// The module is named from the Rust ident, not from the export name, so that a type naming the
-/// alias before it has expanded assumes the module the alias goes on to publish.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn process_type_alias(item_type: ItemType, args: &ModelSchemaArgs) -> TokenStream {
     let mut alias = item_type;
@@ -1446,21 +1307,6 @@ const fn enum_schema_example_method(
 /// The type a doc example's value is annotated with: the item's own name, with every type parameter
 /// it declares instantiated at the type `default_types` declares for it, or at `String` where it
 /// declares none.
-///
-/// The example is Rust the expansion has to compile, and a parameter names no type to compile it
-/// at — a bare ident is `E0107` before anything runs. `default_types` is the one argument that
-/// names a concrete type per parameter, so a parameter it fills is annotated at the author's own
-/// statement of what the item holds: an annotation picked over that filling would contradict it
-/// (`E0308`) and would fail any bound the filling satisfies and the picked type does not
-/// (`E0277`). Where the filling itself fails a bound, the item is refused on the declaration that
-/// named it rather than here. A parameter with no filling falls back to `String`, the one concrete
-/// type an example can be written against absent a statement of what the item holds; with
-/// `jsonschema` on the fillings are already required for every parameter, so the fallback is
-/// reached only in a build without it. The argument list is as long as the parameter list rather
-/// than one long, so an item declaring two parameters is annotated with two arguments.
-///
-/// Lifetimes and consts are not here, [`type_parameters_in_scope`] leaving both out: a lifetime in
-/// a `let` annotation elides, and a const has no filling this convention could name.
 #[cfg(feature = "zod")]
 fn schema_example_value_type(
     name: &syn::Ident,
@@ -1523,18 +1369,6 @@ const fn item_schema_example_method(
 }
 
 /// Builds the delegating impl methods (on the type itself) that forward to its schema module.
-///
-/// The `zod_schema` delegate injects the example into `.meta()` here rather than in the module,
-/// because `Self::schema_example()` is reachable here but not from the nested module for
-/// function-local types.
-///
-/// The injection lands on the exported binding, which the module writes the ident re-export after,
-/// so the re-export is taken off the end while the example goes in and put back after it. An item
-/// exported under its own ident publishes no re-export and the delegate writes what it always
-/// wrote.
-///
-/// Which binding that is depends on what the item publishes, so the anchor does too — see
-/// [`zod_example_injection`].
 #[cfg(any(feature = "zod", feature = "typescript", feature = "jsonschema"))]
 fn build_struct_delegate_items(
     module_ident: &Ident,
@@ -1598,11 +1432,6 @@ fn build_struct_delegate_items(
 /// Assembles the final macro output for a struct or enum: the item itself, its schema module
 /// (with the per-field validation functions), the type's delegate impl, and its standalone
 /// default-only `validate()` impl when it has one.
-///
-/// The delegate impl carries the item's own generics through `split_for_impl`, the way
-/// [`assemble_branded_output`] already does: the block is written for the type as declared, so it
-/// has to repeat every parameter the declaration binds — a lifetime and a const included, neither
-/// of which reaches a schema — or it names a type that does not exist.
 #[cfg(any(feature = "zod", feature = "typescript", feature = "jsonschema"))]
 fn assemble_schema_output<T>(parts: &SchemaOutputParts<T>) -> TokenStream
 where
@@ -1737,11 +1566,6 @@ fn variant_check_pattern(
 
 /// The match arms the enum-level `validate()` runs — empty when no variant carries a constrained
 /// member, which is the parity a constraint-free struct has: it publishes no `validate()` either.
-///
-/// Every variant is named, so the match stays exhaustive without a wildcard standing in for shapes
-/// the declaration already lists. The ones with nothing to check share a single arm: their bodies
-/// would be the same empty body written once per variant, which is the arm an or-pattern says in
-/// one place.
 fn build_member_check_arms(
     per_variant: Vec<(proc_macro2::TokenStream, Vec<proc_macro2::TokenStream>)>,
 ) -> Vec<proc_macro2::TokenStream> {
@@ -1765,14 +1589,6 @@ fn build_member_check_arms(
 
 /// Builds the type-level `validate()` method for an enum, aggregating the checks of whichever
 /// variant the value holds, or `None` when no variant carries a constrained member.
-///
-/// The per-member validators are the ones a struct's fields already generate, so the enum's
-/// accessor answers in the same words for the same violation: what differs is only that a value
-/// carries one variant's members at a time, so the walk is a match rather than a straight run
-/// through every field.
-///
-/// The arms are built from what `serde`'s own attributes name, so without that feature there are
-/// none to aggregate and the gate here is the one every emitted `impl` item already sits under.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn build_enum_validate_method(
     arms: &[proc_macro2::TokenStream],
@@ -1798,11 +1614,6 @@ fn build_enum_validate_method(
 /// Computes the TypeScript types and Zod schemas contributed by a struct's `#[serde(flatten)]`
 /// fields, each beside the answer for whether the object writes those members at all (an empty
 /// vector for either disabled output feature).
-///
-/// The `Option` around a source is read here and spent by the surfaces rather than folded into the
-/// spelling: `typescript_typename` and `zod_type` answer the question a field with a key of its own
-/// asks, and a merged source has no key to leave out. It is the same `Option` the JSON-schema
-/// surface reads in `flatten_merged_source`.
 #[cfg(any(feature = "typescript", feature = "zod"))]
 fn compute_flatten_outputs(
     flattened_fields: &[FieldDef],
@@ -1837,17 +1648,6 @@ fn compute_flatten_outputs(
 
 /// Whether the registration a flattened source names offers its own absence, which is the second
 /// key set the merge owes it.
-///
-/// The two spellings of reaching a nullable source are one declaration to serde: it writes the
-/// value's own keys or writes nothing, and reads the payload carrying none of them back as the
-/// absent value either way. A source written `Option<T>` says so in the type and is read through
-/// [`FieldDef::is_optional`]; one naming an item whose published surface is nullable says so a name
-/// away, and this is where that is read — off the leaves the name recorded, so the two spellings
-/// reach the multiplication by one answer.
-///
-/// The name has to be the whole of what the source writes. An array level is the array around
-/// whatever the name publishes, and the choice behind the name is one its items offer rather than
-/// one the source does.
 #[cfg(all(feature = "serde", any(feature = "zod", feature = "typescript")))]
 fn flattened_name_offers_absence(fld: &FieldDef) -> bool {
     if fld.is_array() {
@@ -1868,21 +1668,6 @@ const fn flattened_name_offers_absence(_fld: &FieldDef) -> bool {
 
 /// The operands an object joins one per branch for a flattened source, and none for a source that
 /// contributes one key set and is joined as the one operand it is.
-///
-/// Two recordings answer here, one per choice a source can name. An untagged enum's members are the
-/// alternatives the source itself offers and are recorded as those. An externally tagged enum's
-/// variants are recorded in the spelling a merge joins, which is not the one the union publishes —
-/// serde writes a unit variant as a bare name standing alone and as that name holding `null` where
-/// the enum is flattened.
-///
-/// Every recorded variant is read, whatever its leaves prove. A Zod intersection recognizes exactly
-/// the keys its operands name and a `z.union` names none, so joining the object to the union as one
-/// operand describes a payload set no value inhabits — including the tagged enum every variant of
-/// which serde writes as an object, whose branches prove nothing and whose single-operand join
-/// nonetheless admits nothing.
-///
-/// A source declared below the object has recorded neither, and takes the fallback the merge
-/// documents.
 #[cfg(all(feature = "serde", feature = "zod"))]
 fn flattened_zod_branches(fld: &FieldDef) -> Vec<String> {
     let members = fld.zod_union_members();
@@ -1908,20 +1693,6 @@ fn flattened_zod_branches(fld: &FieldDef) -> Vec<String> {
 /// What one flattened source is written as where the TypeScript merge names it: the parenthesised
 /// union of the key sets the choice it names recorded for this position, and the name itself
 /// everywhere else.
-///
-/// TypeScript distributes an intersection over a union on its own, so a name standing for a choice
-/// of objects reaches every branch the multiplication would write. Two things it does not reach are
-/// what the recorded operands carry. One is a branch that is no object: the bare string a unit
-/// variant publishes standing alone intersects the object to `never`, and the payload serde actually
-/// writes for that variant — the variant's name holding `null` — belongs to no branch of the result.
-/// The other is what each branch says about its siblings: the excess-property check reads the union
-/// of every branch's keys, so a branch that names one of them is still satisfied by a payload
-/// carrying the rest, and the type describes payloads serde writes for no value. The recorded
-/// operands close each branch against the keys the others name, which is a thing only two branches
-/// or more have to say.
-///
-/// A name the registry proves nothing about, and a source declared below the object, keep the
-/// spelling they always had.
 #[cfg(all(feature = "serde", feature = "typescript"))]
 fn flattened_ts_spelling(fld: &FieldDef) -> String {
     let named = fld.typescript_merged_typename();
@@ -1954,12 +1725,6 @@ fn flattened_ts_spelling(fld: &FieldDef) -> String {
 
 /// The schema methods a struct's module publishes — the JSON-schema document, the TypeScript
 /// definition, the Zod schema — each built only where its feature is on.
-///
-/// The module emits `zod_schema` without examples; example injection happens in the delegating
-/// method on the type, to avoid `super::` issues.
-///
-/// `flattened_fields` are the ones whose own members join the object the struct writes; every
-/// other field is written under a key of its own.
 #[cfg(any(feature = "zod", feature = "typescript", feature = "jsonschema"))]
 fn struct_schema_impl_items(
     field_defs: Vec<FieldDef>,
@@ -2045,17 +1810,6 @@ fn render_struct_field_bodies(
 }
 
 /// The schema module a refused item publishes in place of the one it has no description for.
-///
-/// A reference resolves to the module [`ident_schema_module_name`] names whatever became of the
-/// item it names — that is what lets a reference stand before the item — so an expansion that
-/// emits no module leaves every type naming the refused one with an `E0433` on a module the author
-/// never wrote, sitting on top of the diagnostic they can act on. Publishing the module absorbs
-/// the reference and leaves the guard's own error as the only one.
-///
-/// The bodies are unreachable by construction: the `compile_error!` emitted beside this module
-/// means no build that could call them exists. They panic rather than answer, because an item the
-/// expansion refused has no description, and a schema that describes nothing is one this crate
-/// refuses to publish.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn refused_item_schema_module(ident: &syn::Ident) -> proc_macro2::TokenStream {
     let module_ident = Ident::new(&ident_schema_module_name(&ident.to_string()), ident.span());
@@ -2122,12 +1876,6 @@ fn refused_item_schema_module(ident: &syn::Ident) -> proc_macro2::TokenStream {
 
 /// Emits the original item followed by the `compile_error!` tokens of every violated field guard,
 /// or `None` when there are none.
-///
-/// The item itself is kept so downstream references still resolve and the guard message stays the
-/// primary error; the schema surface is deliberately dropped, since it would encode a contract the
-/// field has already been shown to break. What stays is the schema module the surface would have
-/// lived in — see [`refused_item_schema_module`] — which carries no description and exists so the
-/// guard's error is the only one the author reads.
 fn guard_failure_output<ItemT>(
     item: &ItemT,
     ident: Option<&syn::Ident>,
@@ -2162,11 +1910,6 @@ fn cfg_attr_guard_error(rejection: &syn::Error, item: &str) -> proc_macro2::Toke
 
 /// Turns a rejected `pattern` into `compile_error!` tokens naming what carries it, keeping the
 /// literal's span so the diagnostic points at the pattern as written.
-///
-/// Why a pattern is refused is the guard that refused it's to say — [`crate::utils::portable_pattern`]
-/// where the crate cannot parse it or JavaScript reads it as something else,
-/// [`crate::utils::constraining_pattern`] where it admits every value — so the refusal is quoted
-/// rather than restated.
 fn pattern_guard_error(rejection: &syn::Error, subject: &str) -> proc_macro2::TokenStream {
     syn::Error::new(
         rejection.span(),
@@ -2178,11 +1921,6 @@ fn pattern_guard_error(rejection: &syn::Error, subject: &str) -> proc_macro2::To
 /// Turns this crate's own attribute parser's refusal — of a `model_schema` argument or of a
 /// `model_schema_prop` key — into `compile_error!` tokens naming what carries it, keeping the
 /// refusal's span so the diagnostic points at the argument, key or value as written.
-///
-/// Reading the attribute is the only thing that acts on it, so a name or value the parser stops at
-/// is one no emitter ever sees: without this the surface is emitted as though the attribute had
-/// been left off, and what it was written to say — a field's constraint, a type's name — goes
-/// unsaid.
 fn attr_guard_error(rejection: &syn::Error, subject: &str) -> proc_macro2::TokenStream {
     syn::Error::new(
         rejection.span(),
@@ -2230,14 +1968,6 @@ const fn item_schema_ident(item: &Item) -> Option<&syn::Ident> {
 }
 
 /// Records which of the two Zod bindings an item publishes, ahead of the shape it is dispatched to.
-///
-/// The decision is whether the item declares type parameters: one publishes a factory, taking one
-/// argument per parameter, and one that declares none publishes the single schema it has. Taken
-/// here rather than where the binding is finally spelled — which is after the item's own fields
-/// have been rendered — because a field written at the item's own name is a reference like any
-/// other and reads the answer off the store while those fields are being rendered.
-///
-/// An item shape this attribute does not expand declares nothing and publishes nothing.
 #[cfg(feature = "zod")]
 fn record_own_zod_binding(item: &Item) {
     let Some(generics) = item_generics(item) else {
@@ -2273,15 +2003,6 @@ const fn item_generics(item: &Item) -> Option<&syn::Generics> {
 /// The `compile_error!` tokens a `default_types` declaration earns against the item it was written
 /// on, checked in both directions: an entry naming nothing the item declares, and — where a JSON
 /// document is generated — a parameter the declaration left out.
-///
-/// The comparison is the item's to make, not the parser's: the parser reads the attribute alone and
-/// never sees the declaration the entries are held against. It is made at the one seam every
-/// expanded shape is dispatched from, so a struct, an enum and an alias cannot come to answer
-/// differently, and a branded newtype is answered before the struct path splits it off.
-///
-/// Only the missing-entry direction is gated. An entry that names nothing declares a filling no
-/// reader will ever find a parameter for, in any build; a parameter with no entry is only short of
-/// something where something is generated from the default.
 fn default_types_guard_errors(
     item: &Item,
     args: &ModelSchemaArgs,
@@ -2389,21 +2110,6 @@ fn missing_default_message(name: &syn::Ident, declared: &[&syn::Ident]) -> Strin
 
 /// The refusal every `default_types` entry earns whose filling names a value no document can be
 /// built from, spanned on the filling as written.
-///
-/// A filling is rendered through the same dispatch a field's type is, and that dispatch takes a
-/// name it does not recognise for a sibling — another `model_schema` item, whose schema module the
-/// emission then names. For `Foo` that is right even when `Foo` is declared below. For `char` it is
-/// gibberish: the emission names `char_schema`, no such module is ever published, and the author
-/// reads an `E0433` about a module they never wrote plus two `E0425`s about bindings that belong to
-/// the generated body — three diagnostics, none of which mentions `char`.
-///
-/// The guard cannot separate the two by tokens, so it refuses only what is provably not a sibling:
-/// see [`is_undescribable_primitive`]. A forward-referenced sibling keeps compiling exactly as it
-/// does today.
-///
-/// Gated, on the same footing as the missing-entry direction: the filling is read to build a
-/// document and nowhere else, so a build that generates none is not short of anything. The same
-/// fixture compiles and passes under `serde,typescript,zod`.
 #[cfg(feature = "jsonschema")]
 fn fillings_no_document_can_be_built_from(args: &ModelSchemaArgs) -> Vec<syn::Error> {
     args.default_types
@@ -2456,31 +2162,6 @@ fn undescribable_filling_message(name: &syn::Ident, written: &str) -> String {
 /// The compile-time checks a `default_types` declaration earns against the bounds its parameters
 /// declare — one per bounded parameter, and one more carrying jointly whatever bound reads a
 /// neighbour — emitted beside the expansion rather than in place of it.
-///
-/// A filling is the author's statement of what the item holds; a parameter's bounds are the item's
-/// statement of what it can hold. The two can disagree, and nothing here can tell them apart: a
-/// proc macro reads tokens, not trait impls, so whether `String` is `Copy` is a question only the
-/// compiler answers. What is emitted is that question — the filling handed to a generic function
-/// carrying the parameter's own bounds — so the answer arrives as the compiler's own `E0277`,
-/// spanned on the filling as written, in every build. It is not a `compile_error!` and so does not
-/// take the expansion's place: the item and its schema surface still stand, and the one diagnostic
-/// the author reads is about the one entry that earned it.
-///
-/// Ungated, on the same footing as the refusal of an entry naming no parameter: a filling that no
-/// value of the parameter can take describes an item that is uninhabitable at it, which is as true
-/// in a build that generates no document as in one that does.
-///
-/// A parameter with no bounds earns nothing: it admits every filling, so the expansion is left
-/// exactly as it was. A bound naming another parameter of the item earns nothing *here* — the
-/// neighbour's name reproduced beside a single filling would resolve to nothing — and is carried
-/// instead by [`joint_bound_check`], which declares the whole parameter list at once so every name
-/// the bound reads stands at the filling declared for it.
-///
-/// An alias earns nothing at all. Rust does not enforce a bound written on a type alias's
-/// parameter — `type_alias_bounds` exists to say the bound is inert and to offer its deletion — so
-/// a filling that fails one still names a type every use site of the alias accepts, and a refusal
-/// here would refuse a program the language admits. Saying an alias's bound is empty is that lint's
-/// job, not this attribute's.
 fn default_types_bound_checks(
     item: &Item,
     args: &ModelSchemaArgs,
@@ -2502,16 +2183,6 @@ fn default_types_bound_checks(
 
 /// The check one filling earns against the bounds its parameter declares alone, or `None` where it
 /// declares none such.
-///
-/// The parameter keeps the ident the author declared it under, so a bound written in terms of the
-/// parameter itself still reads, and the bounds keep the spans they were written at, so the
-/// compiler's `required by this bound` note points at the declaration rather than at anything
-/// emitted here.
-///
-/// A bound reading a neighbour is left out of this function rather than taking the whole parameter
-/// out of it: the two kinds partition the parameter's bounds, so a parameter bounded both ways is
-/// checked against each half exactly once — the neighbour-free half here, the rest in
-/// [`joint_bound_check`].
 fn filling_bound_check(
     generics: &syn::Generics,
     name: &syn::Ident,
@@ -2534,24 +2205,6 @@ fn filling_bound_check(
 
 /// The one check carrying every bound the per-filling pass left behind for reading a neighbour, or
 /// `None` where it left none behind or where the item cannot be spelled jointly.
-///
-/// A bound like `WideType: From<NarrowType>` is a statement about two fillings at once, so it is
-/// asked of both at once: one function declaring the item's whole parameter list, carrying in its
-/// `where` clause exactly the bounds the per-filling functions could not, called at every declared
-/// filling in declaration order. Every name such a bound reads is then in scope, and the failure
-/// arrives as an `E0277` on the argument that fails — the entry the author wrote — with the
-/// `required by this bound` note on the bound as written.
-///
-/// Lifetimes are declared as written, bounds and all, and left out of the call, where they elide.
-/// Consts are declared nowhere: a const takes no filling from a convention that names types, so a
-/// joint function declaring one could not be called at all (`E0107` with the const omitted,
-/// `E0284` with it inferred). A bound reading a const is therefore still left to the item's own use
-/// sites, as every bound reading a neighbour was before.
-///
-/// The whole check is withheld unless every type parameter has a filling to stand at. A parameter
-/// left without one is only possible where no JSON document is built, and a bound joining it to its
-/// neighbours states nothing about fillings the author declared — inventing one to complete the
-/// call would ask the compiler a question nobody asked.
 fn joint_bound_check(
     generics: &syn::Generics,
     args: &ModelSchemaArgs,
@@ -2690,15 +2343,6 @@ fn reads_any_name(tokens: proc_macro2::TokenStream, names: &[String]) -> bool {
 
 /// Emits the expansion with the tokens it earned beside it standing ahead of it, or the expansion
 /// untouched where it earned none.
-///
-/// Both callers hand over statements *about* the item rather than reasons to withhold it — the
-/// checks a `default_types` declaration earned, and the refusals a constrained brand written above
-/// this declaration was owed — so everything naming the item still resolves and those diagnostics
-/// are the ones the author reads, rather than a cascade of unresolved names on top of them.
-///
-/// They go ahead of it because a doc example is annotated at the same filling, and where the
-/// filling does not hold that annotation fails on the whole attribute. Both diagnostics are the one
-/// disagreement, and the author should meet the one that names the entry first.
 fn with_prefixed_tokens(expanded: TokenStream, prefix: &[proc_macro2::TokenStream]) -> TokenStream {
     if prefix.is_empty() {
         return expanded;
@@ -2797,25 +2441,6 @@ fn const_parameter_example_message(consts: &[&syn::Ident]) -> String {
 
 /// The `compile_error!` tokens an item earns for handing one of its own const parameters to a
 /// generic type it writes, or none where no type written on it does that.
-///
-/// A const parameter reaches the emitted surfaces in two ways, and only one of them is renderable.
-/// As an array length — `[u8; N]` — it describes as an unbounded array, which README.md states
-/// outright as the reading of every length the expansion cannot read, alongside a `const` item and
-/// any computed expression. As an *argument* to another type it is renderable nowhere: the argument
-/// list of a written type is read as a list of types, so `ConstLeaf<N>` puts `N` where a type
-/// belongs and every surface takes it for one. The JSON side emits a call into an `n_schema` module
-/// nothing publishes; the TypeScript side writes `ConstLeaf<N>` into a declaration that binds no
-/// `N` and beside a `ConstLeaf` that binds no parameter, a const being dropped from the declaration
-/// it was written on. Neither is a document the author can act on, and neither names the const.
-///
-/// Answered at the one seam every expanded shape is dispatched from, beside the example refusal a
-/// const already earns, so a struct, an enum and an alias cannot come to answer differently.
-///
-/// Gated on the two surfaces that render the argument. Zod names the schema the *item* publishes
-/// and a const-declaring item publishes the one schema it has, so a build with neither of those two
-/// on renders this correctly and is owed nothing. An item whose const reaches no argument — a const
-/// no type is written around, which is what `PlainConst` and `Padded` carry — earns nothing in any
-/// build.
 #[cfg(any(feature = "typescript", feature = "jsonschema"))]
 fn const_parameter_argument_errors(item: &Item) -> Vec<proc_macro2::TokenStream> {
     let Some(generics) = item_generics(item) else {
@@ -2871,11 +2496,6 @@ fn item_written_types(item: &Item) -> Vec<&syn::Type> {
 
 /// Every place one of `consts` is handed to a written type as an argument, collected as the ident
 /// it was written at so the refusal points there.
-///
-/// An array length is walked *through* rather than read: `[ConstLeaf<N>; 4]` holds an argument and
-/// `[u8; N]` holds a length, and only the first is what this collects. A bare ident inside angle
-/// brackets can reach here as either a type or a const argument depending on what `syn` could
-/// decide from the tokens alone, so both spellings are read.
 #[cfg(any(feature = "typescript", feature = "jsonschema"))]
 fn collect_const_arguments(written: &syn::Type, consts: &[String], found: &mut Vec<syn::Ident>) {
     match written {
@@ -3015,19 +2635,6 @@ fn enum_cfg_attr_guard_errors(
 
 /// The `compile_error!` tokens for a branded newtype whose inner type is `Option`, or `None` for
 /// every other inner type.
-///
-/// The shape is refused outright instead of being guarded, because no attribute can repair it.
-/// `#[serde(transparent)]` puts the inner value on the wire by itself, so a `None` arrives as
-/// `null`, and nothing suppresses that: `skip_serializing_if` needs a key to omit and a
-/// transparent newtype has none. Meanwhile every generated surface contradicts that wire — the
-/// TypeScript brand renders `T | undefined & $brand<"Name">`, which parses as
-/// `T | (undefined & $brand<"Name">)` and so admits an unbranded `T`; the Zod schema brands a
-/// `z.union([T, z.undefined()])` while its own annotation still claims the un-unioned inner; and
-/// the JSON schema keeps the inner's `type`, which rejects `null`. The generic arm is no better:
-/// it renders the type parameter and drops the `Option` entirely.
-///
-/// `is_optional` off the same `get_field_def` call the renderers make keeps the guard and the
-/// contract from ever disagreeing about what counts as an `Option`.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn branded_option_inner_error(
     name: &Ident,
@@ -3053,64 +2660,6 @@ fn branded_option_inner_error(
 /// The `compile_error!` tokens for a branded newtype that applies `pattern`, `minLength`, or
 /// `maxLength` to an inner type whose schema is not a string, or `None` when the inner can carry
 /// them.
-///
-/// The three constraints are string checks on every surface the brand renders, and each surface
-/// reads them differently the moment the inner stops being a string. A `u64` inner with
-/// `minLength = 3` renders `z.number().int().min(3)`, where `.min` is a numeric bound that admits
-/// `42`; renders `{"type": "number", "minLength": 3}`, where `minLength` is a string-only keyword
-/// that goes inert and enforces nothing; and validates in Rust against `to_string()`, which
-/// demands three decimal digits and so rejects `42`. Zod also has no `z.regex` check to apply to a
-/// number schema at all. A container inner never reaches that disagreement — it has no `Display`
-/// to render.
-///
-/// A `SiblingType` inner is asked of the registry, where the named item recorded what it publishes
-/// as it expanded. That is where the checks actually land: the brand emits `Inner$Schema.min(3)`,
-/// so a name whose recorded surface carries no such check is the very disagreement spelled one
-/// module out — `Blob$Schema.min(3)` against `const Blob$Schema = z.unknown().brand<"Blob">()` is a
-/// `TypeError` at load, before a payload is read. A name the registry cannot answer for keeps
-/// today's emission *here*, and leaves the question for whichever expansion registers it — see
-/// [`deferred_shape_question`] and [`crate::utils::record_value_shape`]. That is also why the constrained
-/// path asserts `Display` separately: the guard bounds the schema surfaces, the assertion bounds
-/// the Rust one. A sequence wrapper is the one `SiblingType` spelling that says its shape outright
-/// without being asked, and is refused as the array it is.
-///
-/// One of the brand's *own* type parameters is not asked of the registry — nothing is registered
-/// under a parameter's own name — but nor is it refused outright the way it once was. It is asked
-/// of the item's own `default_types` declaration instead, the same declaration
-/// [`default_zod_rendering`] reads when it composes `$SchemaDefault`'s arguments: the *factory*'s
-/// parameter still says its shape outright, because a caller supplying `ObjectId$Schema` must not
-/// inherit string bounds meant for `String`, so [`branded_zod_inner`] never appends a check to the
-/// bare parameter it renders inside the builder. What the checks reach instead is the default
-/// argument the factory is called with to produce `$SchemaDefault` — and a declared default is a
-/// concrete filling, which is exactly the case the next paragraph already admits for a *named*
-/// argument. So this guard resolves the same declaration [`declared_default_field`] resolves and
-/// asks [`non_string_inner_shape`] the same question of it: string-shaped, the checks compose onto
-/// that default and the declaration compiles; not string-shaped, the refusal below names the
-/// default rather than the parameter, because the default is what the author has to change. An
-/// entry the declaration left out is not asked here at all — a build generating JSON documents
-/// already refuses that under `jsonschema`, and a build that does not falls back to the same
-/// `String` every other reader of an absent entry falls back to, which carries the checks same as
-/// a written one would.
-///
-/// A name written *over* one of those parameters is the same answer reached one module out, and is
-/// refused ahead of the registry entirely. `Later<T>` names a type whose schema the brand composes
-/// from the argument the caller supplies, so the checks land on whatever that argument turns out to
-/// be: Zod appends them to a shape the call site decides, the one JSON document written for every
-/// instantiation still holds the `{}` a parameter describes as, and `validate()` still measures
-/// `Display` — a numeric filling being rejected for its digit count rather than for its value.
-/// Asking it first is what makes the refusal a fact about the declaration rather than about what
-/// the named item happened to record: the argument is what a recorded position would be filled
-/// with, and a parameter fills it with nothing any surface can name.
-///
-/// A concrete argument is the opposite case, and it is where the registry earns its consult. The
-/// checks compose onto the schema the *argument* resolves to, because that is what the emission
-/// hands the named item's factory — so a name recorded as publishing its own parameter answers
-/// with that argument's shape, and `Later<String>` carries the checks where `Later<u32>` cannot.
-/// One recorded word could not say either: it would have to stand for every instantiation, and the
-/// only word that does is the opaque one, which would refuse the working declaration outright.
-///
-/// Resolved through the same `get_field_def` call the renderers make, so the guard and the
-/// contract cannot disagree about what a shape is.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn branded_constraint_inner_error(
     generics: &syn::Generics,
@@ -3217,12 +2766,6 @@ fn declared_default_syn_type(
 /// every type parameter is replaced by [`declared_default_syn_type`], while a lifetime or const
 /// parameter carries through unchanged — `default_types` only ever fills a type parameter, so
 /// there is nothing declared for the other two to substitute.
-///
-/// Substituting types (rather than reusing the item's own generics, the way its schema delegates
-/// do) is what lets a downstream author write their own `impl Name<Other> { fn validate(&self) }`
-/// alongside the one this crate emits: Rust inherent impls do not specialize, so a blanket
-/// `impl<T> Name<T> { fn validate(&self) }` would collide with it, but a concrete `impl
-/// Name<String> { .. }` does not.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn default_instantiation(
     name: &Ident,
@@ -3268,10 +2811,6 @@ fn default_instantiation(
 /// into its own `impl Name<DeclaredDefault> { .. }` block rather than sitting on the same
 /// `impl<T> Name<T>` the schema delegates (`ts_definition`, `zod_schema`, …) still share — those
 /// do not depend on the constraints, so they are unaffected.
-///
-/// Returns `(for_the_generic_impl, standalone_default_impl)`. A non-generic type is untouched:
-/// `validate()` comes back on the first element and the second is empty, so its emission stays
-/// exactly what it was before this function existed.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn place_validate_method(
     validate_method: Option<proc_macro2::TokenStream>,
@@ -3320,16 +2859,6 @@ fn branded_validate_split(
 
 /// The consult a constrained brand leaves unanswered, for the expansion that registers the name to
 /// answer, or `None` for every brand the registry could answer at its own expansion.
-///
-/// Read after the brand has passed its guards, so that a brand refused outright — over one of its
-/// own parameters, over a pattern that is no regex — leaves nothing behind: it publishes no schema,
-/// and a second diagnostic arriving at another declaration would name a brand the author has
-/// already been told to fix.
-///
-/// The arguments are resolved here rather than kept as tokens because this is the expansion that
-/// holds them, and they are resolved through the very call [`instantiated_value_shape`] fills a
-/// recorded position with — so an answer reached one declaration later is the answer the other
-/// order reaches now.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn deferred_shape_question(
     item_struct: &syn::ItemStruct,
@@ -3359,10 +2888,6 @@ fn deferred_shape_question(
 /// What a name a brand asked about publishes, once the registration answering it has landed —
 /// `None` where that is a shape a string check lands on, and where the reference wrote no argument
 /// at the position the registration published.
-///
-/// The same filling [`instantiated_value_shape`] performs, over shapes the asking expansion had
-/// already resolved rather than over the argument defs it no longer holds. Both readings are of one
-/// record, so the two orders of a pair cannot come to different verdicts.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn answered_shape(
     published: PublishedShape,
@@ -3376,13 +2901,6 @@ fn answered_shape(
 
 /// The `compile_error!` tokens an item owes the constrained brands that asked about its name before
 /// it existed, spanned on the item's own name — the only tokens this expansion holds.
-///
-/// Read off the registry rather than off the questions alone, so an item its own guards refused
-/// answers nothing: it registered no shape, and a brand over a name that publishes nothing is
-/// already reading a crate that will not compile.
-///
-/// A question the registration proves is a string settles silently, and a question no registration
-/// ever reaches stays unanswered — which is the foreign-type admission, kept exactly as it was.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn deferred_shape_refusals(registering: Option<&Ident>) -> Vec<proc_macro2::TokenStream> {
     let Some(name) = registering else {
@@ -3418,12 +2936,6 @@ const fn deferred_shape_refusals(
 
 /// How a constrained brand over a name the registry proves publishes no string is refused, in the
 /// one wording both orders of the two declarations reach it by.
-///
-/// Written once and read from both the brand's own expansion and the named item's, because those
-/// two are the same fact about the same pair and an author moving one declaration past the other
-/// should read the same sentence. Only the span differs: the brand's expansion holds the inner it
-/// wrote, and the named item's holds nothing but itself — which is why the message names the brand
-/// rather than leaving the span to say which one it is.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn named_inner_constraint_message(brand: &str, inner: &str, shape: &str) -> String {
     format!(
@@ -3439,21 +2951,6 @@ fn named_inner_constraint_message(brand: &str, inner: &str, shape: &str) -> Stri
 
 /// Names the shape an inner type resolves to that has no string for the constraints to measure, or
 /// `None` when it writes exactly one and so can carry them.
-///
-/// An `ObjectId` answers `None` on that reading rather than on its schema's shape: it writes the
-/// `$oid` object, whose single hex member is both what `Display` renders and where every surface
-/// puts the checks.
-///
-/// A sequence is asked for through the two spellings it reaches here as — the array levels the
-/// parser collapses a `Vec` or a `[T; N]` onto, and the wrapper name it keeps for a `BTreeSet` and
-/// its siblings — because both write the same JSON array, and every renderer already reads them as
-/// one. Reading only the first would let the second escape with the constraints reinterpreted: the
-/// JSON schema drops `minLength` outside a string, while Zod's `.min` on an array is a bound on
-/// how many items it holds rather than on how long any string is.
-///
-/// A name is asked of the registry rather than read off the declaration: the schema the checks are
-/// appended to is the one the *named* item published, which only that item's own expansion could
-/// have said anything about.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn non_string_inner_shape(inner: &FieldDef) -> Option<&'static str> {
     if inner.is_array() || sequence_wrapper_element(inner).is_some() {
@@ -3495,21 +2992,6 @@ fn non_string_inner_shape(inner: &FieldDef) -> Option<&'static str> {
 /// What a registered name filled with `arguments` publishes as a value, and `None` for a name the
 /// registry has no answer for — one declared below the type reading it, or one this crate never
 /// expands at all.
-///
-/// Those two are the same absence *at this moment* and take the same answer, which is the emission
-/// the name has always had. Refusing on absence would refuse the unresolved user type the guard
-/// admits on purpose, and would make a diagnostic out of declaration order: moving a declaration
-/// would turn a compiling program into a refused one without changing what it means, and an author
-/// cannot act on a guard that fires on where a type is written rather than on what it is.
-///
-/// What tells the two apart is not available here and does arrive later: one of them registers. So
-/// the admission stands and the consult is kept — see [`deferred_shape_question`] — for the
-/// expansion that can answer it. A name nothing registers keeps the admission for good.
-///
-/// A name that recorded a parameter position publishes a family, and the argument written at that
-/// position is the member of it this reference names — the same argument the emission composes the
-/// checks onto, so the guard's answer and the emitted schema cannot disagree. The recursion walks
-/// one written argument in per step and so cannot cycle, however the arguments nest.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn instantiated_value_shape(rust_ident: &str, arguments: &[FieldDef]) -> Option<&'static str> {
     match lookup_alias_info(rust_ident)?.value_shape {
@@ -3520,18 +3002,6 @@ fn instantiated_value_shape(rust_ident: &str, arguments: &[FieldDef]) -> Option<
 
 /// The JSON type keyword a registered name's wire describes as, when the registry proves that wire
 /// is no object, and `None` for every name it cannot prove one way or the other.
-///
-/// Read off the wire the named item recorded rather than off the word the constrained-brand guard
-/// reads: that word answers what a string check can be appended to, which is a coarser question
-/// than this one and cannot be sharpened without changing what the brand's refusals say. An
-/// `integer` and a `number` are one shape and two documents; an array and a map are one shape and
-/// opposite answers, serde flattening the map and writing the array as an array no object can be
-/// merged with. The wire holds each apart because it is recorded as the keyword itself.
-///
-/// A choice is not answered here at all — it has no one position to be answered at, its leaves
-/// sitting below the name rather than at it — and is spliced by [`named_wire_leaves`] instead. A
-/// map, an object and a name nothing has classified answer alike, which is the fallback the merge
-/// already documents for a source declared below the object that flattens it.
 #[cfg(all(feature = "serde", any(feature = "zod", feature = "typescript")))]
 fn registered_non_object_wire(rust_ident: &str) -> Option<&'static str> {
     match lookup_alias_info(rust_ident)?.wire.as_slice() {
@@ -3543,15 +3013,6 @@ fn registered_non_object_wire(rust_ident: &str) -> Option<&'static str> {
 /// The JSON type keyword a value one keyword describes writes, and `None` for every type that
 /// writes a document no single keyword names — a composite, a name, an `ObjectId`'s `$oid` object,
 /// an opaque value.
-///
-/// The one mapping every surface asking that question reads, because the answer has to be the same
-/// wherever it is asked. Read off the type, never off the TypeScript name it renders under: that
-/// name collapses every width of integer and every float alike onto `number`, so a keyword taken
-/// from it cannot say which of the two a value publishes — and the same `u32` then describes as an
-/// `integer` written as a field and as a `number` written under a brand, one wire named twice.
-///
-/// Named exhaustively rather than caught by a wildcard: a new variant must be classified here, not
-/// silently collapsed into whichever arm sits last.
 #[cfg(any(
     feature = "jsonschema",
     all(feature = "serde", any(feature = "zod", feature = "typescript"))
@@ -3591,21 +3052,6 @@ const fn scalar_json_type_keyword(field_type: &FieldDefType) -> Option<&'static 
 /// What the value surface a `#[model_schema()]` item publishes under a name is, as the
 /// constrained-brand guard reads shapes — the answer [`crate::utils::record_value_shape`] stores
 /// for every name a brand can then reach through.
-///
-/// An optional target is its own answer: it is written as `z.nullable(...)` or as the absent form,
-/// and neither carries the string checks the schema beneath it would have. The brand path never
-/// reaches this arm — an `Option` inner has its own refusal, which says the representable thing to
-/// say — but an item registering a name can be written over one.
-///
-/// A target that *is* one of the item's own parameters records that parameter's position rather
-/// than a word. Every word available at the declaration would be a word about the declaration, and
-/// the only one true of every instantiation is the opaque one a parameter describes as on both
-/// validating surfaces — which is a fact about what the item writes for itself, not about what a
-/// reference to it composes. A reference fills the position, and only then is there a shape to
-/// name.
-///
-/// The target is read through the same erasure every surface reads it through, so which of the two
-/// a written name is — the item's own parameter or a reference to another type — is settled once.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn published_value_shape(written: &FieldDef, parameters: &[String]) -> PublishedShape {
     let mut target = written.clone();
@@ -3621,11 +3067,6 @@ fn published_value_shape(written: &FieldDef, parameters: &[String]) -> Published
 
 /// The position of the item's own parameter a written target *is*, and `None` for every target that
 /// fixes a shape of its own around one.
-///
-/// The sequence spellings are turned away first, through the same pair [`non_string_inner_shape`]
-/// reads them as: the parser collapses a `Vec<T>` onto array levels over the `T` itself, so the
-/// parameter is reached at the leaf there exactly as it is when written bare. An array is an array
-/// however the instantiation fills it — a shape the record keeps, rather than the family it defers.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn published_parameter_position(target: &FieldDef, parameters: &[String]) -> Option<usize> {
     if target.is_array() || sequence_wrapper_element(target).is_some() {
@@ -3696,22 +3137,6 @@ fn branded_inner_value_surface(generics: &syn::Generics, inner_field: &Field) ->
 }
 
 /// What the registry records for a brand.
-///
-/// A brand is `#[serde(transparent)]`, so its wire form is its inner's, and the registry's question
-/// is what serde writes: the brand's answer is the inner's answer, read through the very dispatch a
-/// map key is read by. A brand over a string is written as that bare string, which is exactly what a
-/// JSON object key is, so it keys a map the way `String` does; a brand over a value serde
-/// stringifies — a number, a `bool`, a chrono rendering — writes the object its bare inner writes,
-/// so it describes as that inner does, with nothing said about the members; a brand over a struct, a
-/// container, an `ObjectId` or a tuple writes no key at all, and stays refused. Either way the
-/// nominal surfaces keep the brand's own name, which is all the brand adds to its inner's wire.
-///
-/// It is never `EnumMembers`: the brand publishes no `enum_members()` of its own, whatever it wraps.
-/// A brand over a plain enum is `StringWire` instead — serde writes the variant name, which is a
-/// bare string — so the object is open under the brand's name rather than closed to members the
-/// brand has no method to supply. An inner this expansion has not classified keeps the refusal it
-/// had: what serde writes for it is exactly what cannot be told yet, and the brand has no members of
-/// its own to fall back on.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn branded_alias_kind(inner_field: &Field) -> AliasKind {
     let inner = get_field_def("", &inner_field.ty, "");
@@ -3729,13 +3154,6 @@ fn branded_alias_kind(inner_field: &Field) -> AliasKind {
 
 /// The `compile_error!` tokens for a branded newtype whose inner reaches a map key no surface can
 /// write, or `None` when it reaches none.
-///
-/// The brand renders its inner straight into the brand rather than walking it as a field, so the
-/// guard every field position runs never sees it — leaving a brand over a map with an unwritable key
-/// to emit a `Record` keyed by a type that supplies no keys, on every feature set that builds no
-/// JSON schema to catch it. The key is the same value read through the same walk, so the brand earns
-/// the diagnostic a field of that map type earns, spanned on the inner type, which is where the map
-/// was written.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn branded_map_key_error(name: &Ident, inner_field: &Field) -> Option<proc_macro2::TokenStream> {
     let inner = get_field_def("", &inner_field.ty, "");
@@ -3748,9 +3166,6 @@ fn branded_map_key_error(name: &Ident, inner_field: &Field) -> Option<proc_macro
 /// serde attribute on the type or on its inner slot, an `Option` inner type, string constraints
 /// over an inner type that cannot carry them, a `pattern` that is not a regex, and a map key the
 /// inner reaches that no surface can write.
-///
-/// The branded path renders the inner type straight into the brand instead of walking fields, so
-/// it has to collect these itself; the ordinary struct walk never sees a transparent newtype.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn branded_guard_errors(
     item_struct: &syn::ItemStruct,
@@ -3823,16 +3238,6 @@ fn declaration_attrs(field: &Field) -> Vec<syn::Attribute> {
 }
 
 /// Writes the serde attributes generation held back onto the fields they were generated for.
-///
-/// An item its guards refused is emitted as written and without the schema module its surfaces
-/// would have lived in — see [`guard_failure_output`] — so a `#[serde(deserialize_with = "…")]`
-/// naming a function in that module would outlive the module and earn an `E0425` beside the
-/// refusal, pointing at the attribute rather than at anything the author wrote. Holding the
-/// injection back until the item has cleared every guard leaves the refusal the only diagnostic,
-/// and leaves nothing to unwrite when it fires.
-///
-/// One entry was pushed per field, in the order the collecting walk visited them, so the same walk
-/// hands each field back its own.
 fn apply_deferred_field_attrs<'field>(
     fields: impl Iterator<Item = &'field mut Field>,
     deferred: Vec<Vec<syn::Attribute>>,
@@ -3844,19 +3249,6 @@ fn apply_deferred_field_attrs<'field>(
 
 /// The `compile_error!` tokens for a `#[serde(flatten)]` field whose recorded wire proves serde
 /// does not write an object where the merge needs one, or `None` for every other field.
-///
-/// Both operands the edge reaches are answered here, in the two wordings the JSON-schema merge
-/// already refuses the same declaration in: a member of an untagged union the field names, named by
-/// the branch it sits at, and the field's own operand, named at no position at all. What the
-/// multiplication would write for either is the object intersected with a scalar, a branch no
-/// payload satisfies and nothing reports; serde refuses the value outright. Refused at expansion
-/// because that is the only place holding the field the author would have to change.
-///
-/// The union itself is left alone — an untagged enum may hold a scalar, and it is only the merge
-/// that has no object to join one to.
-///
-/// A name declared below the object has recorded nothing, so this answers for neither operand of it
-/// — the same bound the multiplication itself has, and the same one the merge's fallback documents.
 #[cfg(all(feature = "serde", feature = "zod"))]
 fn flatten_edge_guard_error(
     field: &syn::Field,
@@ -3894,13 +3286,6 @@ fn flatten_edge_guard_error(
 /// The JSON type keyword the item a flattened field names publishes, where the name is the whole of
 /// what the field writes and the registry proves that wire is no object — and `None` everywhere the
 /// declaration is left as it stands.
-///
-/// A plain enum publishes the same proof, its member name being a `string`, and is left to the guard
-/// written for it: those words name the variant key serde writes rather than the keyword, which is
-/// what an author of that declaration has to act on. An array level is the array around whatever the
-/// name publishes, and an object can be joined to no array either — but it is the array the field
-/// wrote rather than anything the name proves, so it is left where every other directly written
-/// shape is left, to the merge that reads the document.
 #[cfg(all(feature = "serde", feature = "zod"))]
 fn flattened_name_non_object_wire(inner: &FieldDef) -> Option<&'static str> {
     if inner.is_array() || flattened_plain_enum(inner).is_some() {
@@ -3914,21 +3299,6 @@ fn flattened_name_non_object_wire(inner: &FieldDef) -> Option<&'static str> {
 
 /// The branch a flattened field's own name proves is no object, beside the JSON type keyword that
 /// branch describes as — and `None` for every name whose leaves prove no such branch.
-///
-/// [`registered_non_object_wire`] answers a name publishing one leaf, which is a name that has no
-/// position of its own to be named at. A name publishing a choice does: a registration whose surface
-/// is nullable writes its value or writes nothing, so it publishes the value's own leaves beside its
-/// published absence, and the merge that reads the document names that value by the branch it sits
-/// at. The absence itself needs no refusal — serde writes the object's own keys alone for it and
-/// reads them back as the absent value, which is the multiplication the merge already writes — so
-/// what the declaration turns on is whether every leaf beside it is proved to be no object. Where
-/// they all are, the value side is unwritable at the flatten edge whichever leaf it took, and the
-/// refusal names the first of them in the branch-naming words the JSON-schema merge refuses the same
-/// declaration in.
-///
-/// A nullable object keeps its absence multiplication, having no leaf proved to be no object beside
-/// the `null`. The array and plain-enum carve-outs are [`flattened_name_non_object_wire`]'s, for its
-/// reasons.
 #[cfg(all(feature = "serde", feature = "zod"))]
 fn flattened_name_refused_branch(inner: &FieldDef) -> Option<(String, &'static str)> {
     if inner.is_array() || flattened_plain_enum(inner).is_some() {
@@ -4049,16 +3419,6 @@ fn is_branded_newtype(item_struct: &syn::ItemStruct) -> bool {
 
 /// Computes the TypeScript name, schema-module name, and module ident for a struct, and registers
 /// it in the alias registry so other types can resolve references to it.
-///
-/// The registration carries the exported name, so a `name = "…"` override reaches every reference
-/// to the struct as well as its own surfaces — a sibling names it in Rust and resolves to the name
-/// it is exported under.
-///
-/// The module is named from the Rust ident, not from the export name, so that a type naming the
-/// struct before it has expanded assumes the module the struct goes on to publish.
-///
-/// `surface` is what the struct publishes as a value and what it puts on the wire, for a brand
-/// written over its name and for a merge flattening it to read back — see [`Surface`].
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn struct_module_idents(
     name: &syn::Ident,
@@ -4143,7 +3503,6 @@ fn struct_rename_all(item_struct: &syn::ItemStruct) -> Result<Option<String>, To
 }
 
 fn process_struct(mut item_struct: syn::ItemStruct, args: &ModelSchemaArgs) -> TokenStream {
-    // Check if this is a branded newtype (transparent single-field tuple struct)
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
     if is_branded_newtype(&item_struct) {
         return process_branded_newtype(item_struct, args);
@@ -4288,11 +3647,6 @@ const fn is_tuple_struct(item_struct: &syn::ItemStruct) -> bool {
 
 /// Whether the slot at `index` of a tuple struct declaring `declared_slots` slots carries serde
 /// attributes the wire answers for.
-///
-/// Captured from serde: a struct declaring exactly one slot writes and reads that slot's value
-/// whatever `skip`, `skip_serializing` or `skip_deserializing` says about it — a one-slot
-/// `#[serde(skip)]` struct holding `"s"` writes `"s"` and reads `"s"` back. So the slot spellings
-/// below are read only where serde reads them, which is a struct declaring more than one.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 const fn slot_attributes_reach_the_wire(declared_slots: usize) -> bool {
     declared_slots > 1
@@ -4300,25 +3654,6 @@ const fn slot_attributes_reach_the_wire(declared_slots: usize) -> bool {
 
 /// Rejects a tuple-struct slot whose serde attributes drop it out of one of serde's two directions
 /// and not the other.
-///
-/// Captured from serde, on `struct S(#[serde(...)] Option<String>, String)` holding
-/// `(Some("s"), "x")`:
-/// - `skip_serializing` alone writes `["x"]` and reads only `["s","x"]`, refusing `["x"]` as
-///   `invalid length 1, expected tuple struct S with 2 elements`;
-/// - `skip_deserializing` alone writes `["s","x"]` and reads only `["x"]`, refusing `["s","x"]` as
-///   `trailing characters`;
-/// - `skip_serializing_if` writes `["s","x"]` or `["x"]` as its predicate decides, and reads only
-///   `["s","x"]`.
-///
-/// In each of them the array serde writes is not an array serde reads. A named field in the same
-/// position is describable — the key is simply absent from one payload and present in the other,
-/// which an optional key covers — but a slot is written by its place, so the two payloads differ in
-/// their arity and no fixed-arity tuple describes both. The declaration is refused rather than
-/// described, the way the named field whose omitted key serde cannot read back already is.
-///
-/// Not gated on the `serde` feature, and neither is the drop this stands beside: both read only the
-/// omission walk, which every build performs, and a toggle that changed the answer would leave one
-/// declaration refused in one build and described in another.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn check_slot_wire_is_readable(
     field: &Field,
@@ -4346,19 +3681,6 @@ fn check_slot_wire_is_readable(
 
 /// Walks a tuple struct's slots, returning the shape they publish and the `compile_error!` tokens
 /// of every guard a slot violates.
-///
-/// Unlike [`collect_struct_fields`] the walk does not split on `#[serde(flatten)]`: a positional
-/// slot has no key for a flattened member to merge into, and dropping one here would silently
-/// change the arity the surfaces describe. The per-slot validators are dropped because a
-/// positional slot cannot carry a constraint — the guard that says so is what comes back instead.
-///
-/// A slot serde carries in neither direction is the one thing that does leave the walk. Captured:
-/// `struct S(#[serde(skip)] Option<String>, String)` holding `(Some("s"), "x")` writes `["x"]` and
-/// reads `["x"]` back, refusing `["s","x"]` as `trailing characters` — the slot is absent from the
-/// array in both directions, and the slots after it move up. So the described tuple is the slots
-/// that remain, which shrinks its arity, its `prefixItems` and its element types together. Every
-/// slot's def is still built before that decision, so a slot leaves the wire without taking the
-/// guards it violates with it.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn collect_tuple_slots(
     fields: &mut syn::Fields,
@@ -4533,12 +3855,6 @@ fn tuple_struct_surface(fields: &syn::Fields, parameters: &[String]) -> Surface 
 }
 
 /// Processes a tuple struct that is not a branded newtype.
-///
-/// serde writes a one-slot tuple struct as the slot's value alone and every other arity as a
-/// fixed-arity array, so neither shape is the object the named-field emitters describe. Both are
-/// rendered from the slots read in slot position — the position a tuple field's elements are
-/// already read in, where a `None` reaches the wire as `null` rather than as an omitted key — so
-/// a tuple struct describes as the tuple of its slot types does wherever that tuple is written.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn process_tuple_struct(
     mut item_struct: syn::ItemStruct,
@@ -4732,13 +4048,6 @@ fn build_branded_validation(
 
 /// Whether a brand's constrained checks reach its inner value as a path rather than through
 /// `Display`.
-///
-/// A brand's constrained value is the inner field itself, with no walk to reach it, so only an
-/// inner that *is* a path answers here — one merely holding paths writes no string of its own for
-/// the checks to measure, and is refused by [`branded_constraint_inner_error`] before this. A
-/// transparent wrapper is nothing on the wire and derefs to what it holds, so a path written under
-/// any stack of them is still that same path, borrowed one coercion further out; an `Option` or a
-/// sequence is not, which is why only the transparent wraps pass.
 #[cfg(all(
     feature = "serde",
     any(feature = "typescript", feature = "zod", feature = "jsonschema")
@@ -4774,10 +4083,6 @@ fn branded_checked_value(
 /// Builds the schema a branded newtype's constraints are written into: `base_inserts` first — what
 /// the inner type describes as before the brand narrows it — then one insert per constraint the
 /// brand declares.
-///
-/// A length keyword is the brand's alone, so it is written beside the base. A `pattern` is only the
-/// brand's where the base states none; `base_pattern` is what says which, and where the base states
-/// one the brand's is layered rather than written over it.
 #[cfg(feature = "jsonschema")]
 fn branded_schema_obj_over(
     args: &ModelSchemaArgs,
@@ -4871,14 +4176,6 @@ fn branded_object_id_hex_schema(args: &ModelSchemaArgs) -> proc_macro2::TokenStr
 /// dispatch gives that type, so the brand describes as the type it wraps describes wherever else
 /// it is written. An inner the dispatch cannot render replaces the body with the single diagnostic
 /// naming the brand, as an unrenderable slot does in every other position.
-///
-/// The brand's own constraints are layered around that description rather than written into it.
-/// [`branded_constraint_inner_error`] refuses them over an array, a sequence wrapper, a map, a
-/// tuple, and an opaque inner, so the one inner reaching here with any is a named type — whose
-/// description is an expression this expansion cannot read, and may be a reference into the
-/// document's definitions, which carries no keyword beside it. An `allOf` narrows either without
-/// touching it, and is what the Zod value already writes: the named schema, then the brand's own
-/// checks after it.
 #[cfg(feature = "jsonschema")]
 fn branded_slot_json_schema(
     args: &ModelSchemaArgs,
@@ -4944,17 +4241,6 @@ fn build_branded_json_schema_method(
 
 /// The `FieldDef` every surface renders from: the written one with each name that is one of the
 /// enclosing item's own type parameters classified as the parameter it is.
-///
-/// All three surfaces read this one def, which is why a parameter cannot come to mean two things
-/// about one declaration. What each of them then makes of it differs — the two validating surfaces
-/// write the filling that reached the parameter, TypeScript renders the name its own declaration
-/// binds — and that difference is [`FieldDef::erase_type_parameters`]'s to state rather than this
-/// seam's. A name left unclassified reads as a reference to a generated type of that name on every
-/// surface at once, which is what puts a parameter in a `Record<…>` key position TypeScript cannot
-/// bind.
-///
-/// A struct reaches the same def by erasing each field as it is collected; this is where the item
-/// shapes holding a single written target — an alias, a brand — reach it.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn surface_field_def(generics: &syn::Generics, written: &FieldDef) -> FieldDef {
     let mut erased = written.clone();
@@ -4970,16 +4256,6 @@ fn branded_value_inner(generics: &syn::Generics, inner_ty: &syn::Type) -> FieldD
 }
 
 /// Resolves the TypeScript inner type name and generic parameter list for a branded newtype.
-///
-/// The inner is read the same way whether or not the brand declares parameters: what the brand
-/// publishes is what `#[serde(transparent)]` puts on the wire, and a parameter appearing inside the
-/// inner leaves that wire the inner's own — a `Vec<T>` writes its array however `T` is filled in.
-/// A parameter reached on its own renders as the name it was written with, which is what
-/// `typescript_base` gives every unresolvable name and what a generic alias's target already
-/// publishes for one.
-///
-/// The parameter list is the struct's, because it is the exported type's own list and has to name
-/// every parameter the type carries — not just the ones the inner happens to reach.
 #[cfg(feature = "typescript")]
 fn branded_ts_type_and_generics(
     generic_params: &[String],
@@ -4996,21 +4272,6 @@ fn branded_ts_type_and_generics(
 
 /// Resolves the JSON schema shape for a branded newtype's inner field, read off the def
 /// [`surface_field_def`] has already erased the brand's own type parameters out of.
-///
-/// So a parameter is described by the filling that reached it while the shape it sits in — an
-/// array, a map's keys, a tuple's arity — is still described, which is what
-/// `#[serde(transparent)]` puts on the wire.
-///
-/// An `ObjectId`, a composite and a named type are then read off that same `FieldDef`, because none
-/// of them writes a value one `"type"` keyword describes; a chrono type writes a string one keyword
-/// names but not the only one it carries. Every remaining inner takes its keyword from
-/// [`scalar_json_type_keyword`], the one mapping the field path reads it from — not from the
-/// resolved TypeScript type name, which spells an `integer` and a `number` alike and so published a
-/// `number` for a value every other spelling of publishes an `integer` for.
-///
-/// The composite question is asked before the other two, so an inner written under array levels
-/// answers for the array around whatever it holds — which is what `#[serde(transparent)]` puts on
-/// the wire — rather than for the item.
 #[cfg(feature = "jsonschema")]
 fn branded_json_inner(inner: &FieldDef) -> BrandedJsonInner {
     #[cfg(feature = "object_id")]
@@ -5094,15 +4355,6 @@ const fn branded_inner_is_object_id(inner: &FieldDef) -> bool {
 
 /// What a branded newtype's inner writes when it writes a composite, and `None` when it writes a
 /// value one `"type"` keyword and one Zod class already name.
-///
-/// The array level is asked first, so an arrayed inner answers for the array around whatever it
-/// holds — which is what `#[serde(transparent)]` puts on the wire — rather than for the item. That
-/// is the same question [`branded_inner_is_object_id`] asks to exclude an arrayed `ObjectId`, whose
-/// array reaches here instead. A sequence wrapper is that same array under another name, and is
-/// read through the one list every surface reads it through.
-///
-/// Named exhaustively rather than caught by a wildcard: a new variant must be classified, not
-/// silently collapsed into the scalar mapping.
 #[cfg(any(feature = "jsonschema", all(feature = "typescript", feature = "zod")))]
 fn branded_inner_composite(inner: &FieldDef) -> Option<BrandedComposite> {
     if inner.is_array() {
@@ -5146,18 +4398,6 @@ fn branded_inner_composite(inner: &FieldDef) -> Option<BrandedComposite> {
 }
 
 /// Resolves the Zod base schema for a branded newtype's inner type, applying string constraints.
-///
-/// The constraints measure the inner's `Display` rendering, which for every inner but an
-/// `ObjectId` is the value the schema itself describes. An `ObjectId` writes `{"$oid": hex}`, so
-/// its `Display` is the `$oid` member and the checks land there.
-///
-/// The inner is the def [`surface_field_def`] has already erased the brand's own type
-/// parameters out of, so a parameter composes into the value as the argument the factory binds
-/// for it rather than as a binding nothing declares. A bare parameter carries no checks here even
-/// when the brand declares them: the factory's argument is whatever a caller supplies, and a
-/// caller supplying `ObjectId$Schema` must not inherit string bounds meant for the declared
-/// default. Those checks are appended once, to the default argument `$SchemaDefault` composes the
-/// factory with — see [`zod_default_block`] — never to the parameter this function renders.
 #[cfg(feature = "zod")]
 fn branded_zod_inner(args: &ModelSchemaArgs, inner: &FieldDef) -> String {
     if !inner.is_array() && matches!(inner.field_type, FieldDefType::TypeParam(_)) {
@@ -5173,24 +4413,6 @@ fn branded_zod_inner(args: &ModelSchemaArgs, inner: &FieldDef) -> String {
 
 /// The Zod class a branded newtype's base schema is an instance of, for the exported binding's
 /// type annotation.
-///
-/// Read off the inner's own `FieldDef` rather than off its TypeScript name, so a user type merely
-/// spelled `ObjectId` is not mistaken for the `$oid` object, and so a composite is annotated with
-/// the class its own value rendering produces instead of falling through to `ZodString`.
-///
-/// Each name is written bare (`ZodObject`, ...), never qualified off the `z` namespace: a consuming
-/// module names these classes through its own type imports, and the annotation is read as that name
-/// (txsch-0cnq). Every one of them defaults its type parameters, so the annotation widens the raw
-/// schema rather than restating its element types.
-///
-/// A named inner has no class of its own to name — the type it names publishes one, and this
-/// expansion cannot resolve it — so the annotation is the type of the very binding the value is
-/// composed from, read back off that same rendering (a local `const`/factory name, not a `zod`
-/// export, so it is written bare). A check the brand adds returns the schema it was called on, so
-/// the binding's type is the base schema's type whether or not the brand constrains it.
-///
-/// A type parameter reaches this off the erased def, as `z.unknown()` — the opaque arm — so the
-/// annotation follows the value rather than naming a binding the value no longer composes from.
 #[cfg(all(feature = "zod", feature = "typescript"))]
 fn branded_zod_type_name(inner: &FieldDef) -> String {
     #[cfg(feature = "object_id")]
@@ -5271,13 +4493,6 @@ fn zod_brand_call(item_name: &str) -> String {
 
 /// The value a branded newtype's binding holds: the inner's own schema, the brand, and the
 /// description, in the order the receiver's type admits.
-///
-/// A brand that declares no parameter brands a schema this expansion wrote and describes the
-/// result. Inside a factory the receiver is the parameter the caller filled, and `.meta()` is
-/// declared to return `this` — which TypeScript resolves back to that bare parameter, dropping the
-/// marker `.brand<"Name">()` had just added and handing the caller an unbranded schema. Describing
-/// first and branding last is the same schema at runtime, and it is the order that keeps the brand
-/// in the type the factory hands back.
 #[cfg(feature = "zod")]
 fn branded_zod_expression(
     args: &ModelSchemaArgs,
@@ -5297,21 +4512,6 @@ fn branded_zod_expression(
 }
 
 /// Builds the `zod_schema()` method for a branded newtype's schema module.
-///
-/// A brand is a generic publisher like any other: it declares parameters or it does not, and the
-/// binding follows through [`zod_published_binding`]. So a parameter inside its inner composes the
-/// argument the factory binds for it and the brand lands on the caller's own filling, where before
-/// it landed on a value pinned to whatever the first instantiation happened to be.
-///
-/// The `const` a brand that declares no parameter still publishes is annotated with the branded
-/// class read off its inner, rather than with the `ZodType<Name>` every other `const` carries: the
-/// brand is what the annotation has to state, and only the value it wraps says which class it is.
-/// A factory needs no such annotation — its return type is read back off the builder.
-///
-/// When the brand carries string constraints over a bare-parameter inner — the case
-/// [`branded_constraint_inner_error`] admits rather than refuses — the checks are routed onto
-/// `$SchemaDefault`'s argument for that parameter, never onto the factory's own. See
-/// [`zod_default_block`].
 #[cfg(feature = "zod")]
 fn build_branded_zod_schema_method(
     args: &ModelSchemaArgs,
@@ -5485,12 +4685,6 @@ fn build_branded_display_impl(
 
 /// Builds a branded newtype's `Display` impl together with the static assertion guarding it.
 /// `no_display` drops the impl; it drops the assertion only when nothing else needs `Display`.
-///
-/// A constrained brand validates through `value.to_string()`, so the requirement outlives the impl
-/// the brand opted out of. Keeping the assertion is what turns that into an `E0277` at the inner
-/// field instead of the `E0599` the `to_string()` call raises against the attribute. A path inner
-/// is the exception: its checks read the path's own rendering and call no `to_string()`, so there
-/// is nothing left for the assertion to blame.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn build_branded_display_tokens(
     generics: &syn::Generics,
@@ -5522,10 +4716,6 @@ fn build_branded_display_tokens(
 /// Builds a static assertion that the branded newtype's inner type implements `Display`, spanned
 /// on the inner field so a violation surfaces as an `E0277` naming the trait at the field instead
 /// of the `E0599` raised by `self.0.fmt(f)` deep inside the generated impl.
-///
-/// Emits nothing when the inner type mentions one of the struct's generic parameters: a `const`
-/// item cannot name them, and the `Display` bound the impl adds to every type parameter already
-/// carries the requirement to the instantiation site.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn build_branded_display_assertion(
     inner_field: &Field,
@@ -5743,24 +4933,6 @@ fn branded_guard_failure_output(
 /// Processes a branded newtype — a `#[serde(transparent)]` struct holding exactly one unnamed
 /// field — into the parts [`assemble_branded_output`] joins: the struct itself, the `Display` impl
 /// it earns, its schema module, and the delegate impl forwarding to that module.
-///
-/// A brand adds its own name to what its inner already writes, and each surface says so in the
-/// spelling that surface has for the marker. TypeScript intersects the inner's rendering with
-/// `$brand<"Name">`, the marker the `zod` runtime supplies; without `zod` there is no such marker
-/// to name, so the intersection is written against a `unique symbol` declared beside the type, and
-/// those two lines are the whole emission. Zod brands the inner's own schema with
-/// `.brand<"Name">()`, carries the item's description in the `.meta({ description })` every item
-/// carries it in, and annotates the exported binding `$ZodBranded<Class, "Name">` for the `Class`
-/// read off the very inner that rendering was built from — every class name written bare, the
-/// consuming module naming it through its own type imports (txsch-0cnq).
-///
-/// Generic parameters on the struct are preserved in the TypeScript output, whose declaration
-/// binds them. The two validating surfaces read the inner off the erased def instead, so a
-/// parameter reaching either of them is written as the filling that reached it — see
-/// [`FieldDef::erase_type_parameters`].
-/// Registers a brand under its own name with both answers the registry holds about it: what serde
-/// writes for it where a map key is asked for, and what it publishes as a value where a brand
-/// written over its name asks.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn register_branded_newtype(
     item_struct: &syn::ItemStruct,
@@ -5825,10 +4997,8 @@ fn process_branded_newtype(item_struct: syn::ItemStruct, args: &ModelSchemaArgs)
     #[cfg(feature = "zod")]
     let plain_description = item_description(docs_vec.as_deref(), &item_name);
 
-    // Get generic type parameters from the struct
     let generic_params = type_parameters_in_scope(&item_struct.generics);
 
-    // Get inner field type info
     let inner_field = item_struct.fields.iter().next().unwrap();
     let inner_ty = &inner_field.ty;
 
@@ -6111,12 +5281,6 @@ fn item_lines_or_name(
 }
 
 /// The `JSDoc` body an alias's `export type` is emitted under.
-///
-/// An alias has no surface name of its own and is given the `Type` suffix, which is the name it
-/// falls back to. Everything else is the body every declared item is written from — the same
-/// fallback, over the same lines, closed the same way — so an alias with nothing to say opens
-/// exactly as a struct with nothing to say does. What it keeps of its own is the flattening: an
-/// alias publishes its doc lines as they were written, blank ones included.
 #[cfg(feature = "typescript")]
 fn alias_jsdoc_body(docs_vec: Option<&[String]>, export_name: &str) -> String {
     item_jsdoc_body(&item_lines_or_name(
@@ -6139,12 +5303,6 @@ fn item_jsdoc_body(lines: &[String]) -> String {
 
 /// The complete `JSDoc` block a body is written as, at the indent of whatever it documents: the
 /// opener, the body's own lines carried to that indent, and the `*/` that closes it.
-///
-/// Every surface splices this whole. Spelling the delimiters beside each member instead is what let
-/// a block open at its member's indent and continue at column 0, and let one writer close with a
-/// `**/` that closes nothing — a block comment already ended by the `*/` inside it, trailed by a
-/// stray `/`. The body arrives already prefixed with ` * ` per line, so the indent is all that is
-/// added and the text a block carries is untouched.
 fn jsdoc_block(body: &str, indent: &str) -> String {
     let mut block = format!("{indent}/**\n");
     for line in body.lines() {
@@ -6161,16 +5319,6 @@ fn member_jsdoc_block(body: &str) -> String {
 }
 
 /// The spelling a member key is written as on the text surfaces.
-///
-/// A key serde writes is a wire name rather than an identifier: `#[serde(rename = "reply-to")]`
-/// spells one no JavaScript identifier can hold, and written bare it ends the object the member
-/// sits in — every member after it reads as something else. Quoting is what the wire name always
-/// needed, and a key that already reads as an identifier is left exactly as it was, so no spelling
-/// that parsed before is rewritten.
-///
-/// Identifier is read as the ASCII spelling alone, which is the same span [`name_arg_value`] admits
-/// for a name the macro is given. A key outside it is quoted rather than refused: it is legal as a
-/// string, and it is serde's to name.
 fn ts_member_key(key: &str) -> String {
     let mut chars = key.chars();
     let heads_an_identifier = chars
@@ -6339,7 +5487,6 @@ fn process_plain_enum(
     #[cfg(any(feature = "typescript", feature = "zod"))]
     let docs_and_description = build_item_docs_and_description(docs_vec.as_deref(), item_name);
 
-    // Generate schema module methods
     #[cfg(feature = "jsonschema")]
     // No slot to fill: Rust refuses an all-unit enum that leaves a type parameter unused, so a
     // plain enum reaches here declaring none — whatever consts and lifetimes it also binds.
@@ -6376,7 +5523,6 @@ fn process_plain_enum(
     let schema_example_method =
         enum_schema_example_method(docs_vec.as_deref(), name, &item_enum.generics, args);
 
-    // Build schema module impl items (without schema_example)
     #[cfg(any(feature = "zod", feature = "typescript", feature = "jsonschema"))]
     let schema_impl_items: Vec<proc_macro2::TokenStream> = vec![
         #[cfg(feature = "jsonschema")]
@@ -6396,7 +5542,6 @@ fn process_plain_enum(
             .chain(schema_example_method)
             .collect();
 
-    // Use the enumerated values in the quote! macro
     let enum_values = &enumerated;
 
     // A plain enum publishes `enum_members()` from an `impl` of its own rather than through
@@ -6451,21 +5596,6 @@ fn process_plain_enum(
 }
 
 /// The kind a variant publishes, which is not always the kind it declares.
-///
-/// A variant declaring exactly one slot and taking that slot off the wire is written as a unit
-/// variant, whatever tagging the enum carries. Captured on `V(#[serde(skip)] String)` holding
-/// `"s"`: externally tagged it writes `"One"` and reads `"One"` and `{"One":null}` back; under
-/// `#[serde(tag = "type")]` it writes and reads `{"type":"One"}`; untagged it writes and reads
-/// `null`. Those are the three payloads a declared unit variant writes in the same three places.
-///
-/// This is where the variant seam parts from the tuple-struct one. A one-slot *struct* was captured
-/// ignoring the attribute outright — it writes and reads its slot's value whatever `skip` says — so
-/// there the lone slot's spellings go unread. A one-slot *variant* has the variant name to fall
-/// back on, and serde uses it.
-///
-/// Every other declared arity keeps the kind it declared: captured, a two-slot variant with one
-/// slot off the wire writes `{"One":[7]}` and with both off writes `{"One":[]}` — a shorter array
-/// and then an empty one, never a bare value and never the bare name.
 fn variant_wire_kind(variant: &syn::Variant) -> VariantKind {
     if lone_slot_off_wire(variant) {
         VariantKind::Unit
@@ -6493,33 +5623,6 @@ fn lone_slot_off_wire(variant: &syn::Variant) -> bool {
 
 /// Rejects a tuple-variant slot whose serde attributes drop it out of one of serde's two directions
 /// and not the other.
-///
-/// Captured from serde on `enum E { One(#[serde(...)] String, u32) }` holding `("s", 7)`, and the
-/// same three attributes tell the same story under every tagging:
-/// - `skip_serializing` alone writes `{"One":[7]}` and reads only `{"One":["s",7]}`;
-/// - `skip_deserializing` alone writes `{"One":["s",7]}` and reads only `{"One":[7]}`;
-/// - `skip_serializing_if` writes `{"One":[7]}` or `{"One":["s",7]}` as its predicate decides, and
-///   reads only `{"One":["s",7]}`.
-///
-/// A lone slot splits the same way, into payloads further apart still: `One(#[serde(skip_
-/// serializing)] String)` writes the bare name `"One"` and reads only `{"One":"s"}`, and
-/// `skip_deserializing` writes `{"One":"s"}` and reads only `{"One":null}`. So unlike the
-/// tuple-struct seam, where serde ignores a lone slot's spellings, every declared arity of a
-/// variant is asked.
-///
-/// In each of them what serde writes is not what serde reads. A named field in the same position is
-/// describable — the key is simply absent from one payload and present in the other, which an
-/// optional key covers — but a slot is written by its place, so the two payloads have no common
-/// spelling. The declaration is refused rather than described, the way the named field whose
-/// omitted key serde cannot read back already is.
-///
-/// A named field of a struct variant is left alone here, its key being the spelling that describes
-/// both payloads; the subject is read off the field itself for that reason, the way the omission a
-/// key carries already is.
-///
-/// Not gated on the `serde` feature, and neither is the drop this stands beside: both read only the
-/// omission walk, which every build performs, and a toggle that changed the answer would leave one
-/// declaration refused in one build and described in another.
 fn check_variant_slot_wire_is_readable(
     field: &Field,
     index: usize,
@@ -6547,18 +5650,6 @@ fn check_variant_slot_wire_is_readable(
 /// Processes each variant of a discriminated enum, returning per-variant field defs, doc strings,
 /// and variant kinds in declaration order, plus the collected serde validation functions and the
 /// `validate()` arms those functions are run from.
-///
-/// A member's check is generated here whatever the enum's tagging, so the accessor built from these
-/// arms exists on all three tagged flavors alike — the tag decides how the value is written, not
-/// which of its members carry a bound.
-///
-/// A slot serde carries in neither direction leaves the walk, the way a named field whose key
-/// reaches no payload already does. Captured: `One(#[serde(skip)] String, u32)` holding `("s", 7)`
-/// writes `{"One":[7]}` and reads `{"One":[7]}` back, refusing `{"One":["s",7]}` — the slot is
-/// absent from the array in both directions and the slots after it move up, so the described tuple
-/// is the slots that remain, which shrinks its arity, its `prefixItems` and its element types
-/// together. The def is still built before that decision, so a slot leaves the wire without taking
-/// the guards it violates with it.
 fn collect_discriminated_variants(
     item_enum: &mut syn::ItemEnum,
     rename_all: Option<&str>,
@@ -6720,24 +5811,6 @@ fn discriminated_main_schema_code(
 
 /// Refuses every variant of an adjacently tagged enum whose declared lone slot is off the wire in
 /// both directions, one error per offender so the expansion names them all.
-///
-/// This is the one tagging where the collapse has no payload to be described by. Captured on
-/// `#[serde(tag = "type", content = "value")] enum E { One(#[serde(skip)] String) }` holding `"s"`:
-/// serde writes `{"type":"One"}` and then refuses to read that very payload back — `missing field
-/// value` — while only `{"type":"One","value":null}` reads. The write set and the read set are
-/// disjoint, so there is no payload a schema could hold for the pair, exactly the property that
-/// already refuses a slot dropped from one direction only. The remedy is the control: the same
-/// variant declared as a unit writes the identical `{"type":"One"}` and reads it back.
-///
-/// The other three taggings are untouched, their captured collapses round-tripping — externally
-/// `"One"`, under a bare tag `{"type":"One"}`, untagged `null` — and every other declared arity
-/// keeps the shrink, a two-slot variant with one slot off the wire writing and reading
-/// `{"type":"One","value":[7]}`.
-///
-/// Read against the tag and content keys the declaration named, so the payloads the author is shown
-/// are their own. Gated on the `serde` feature because the tagging flavor is: without it no
-/// declaration can be told apart and the adjacent form stands for all of them, which is the same
-/// reason the untagged refusals are gated.
 #[cfg(feature = "serde")]
 fn adjacent_collapsed_slot_guard_errors(
     item_enum: &syn::ItemEnum,
@@ -6846,7 +5919,6 @@ fn process_discriminated_enum(
     #[cfg(feature = "typescript")]
     let docs = build_jsdoc_body(docs_vec.as_deref(), item_name);
 
-    // Generate schema module methods
     #[cfg(feature = "jsonschema")]
     let json_schema_method =
         enum_json_schema_methods(&main_schema_code, item_name, &item_enum.generics, args);
@@ -6880,7 +5952,6 @@ fn process_discriminated_enum(
     let schema_example_method =
         enum_schema_example_method(docs_vec.as_deref(), name, &item_enum.generics, args);
 
-    // Build schema module impl items (without schema_example)
     #[cfg(any(feature = "zod", feature = "typescript", feature = "jsonschema"))]
     let schema_impl_items: Vec<proc_macro2::TokenStream> = vec![
         #[cfg(feature = "jsonschema")]
@@ -6962,14 +6033,6 @@ fn external_content_rejection_value(
 }
 
 /// Renders what one variant of an externally tagged enum writes under its key.
-///
-/// Returns `(typescript, zod, json_value)` for the content alone — the key is the caller's. A
-/// `Unit` variant has no content and never reaches here: serde writes it as the bare name.
-///
-/// Every content is the value the adjacent form puts under its content key, read through the same
-/// builders: a newtype variant's single slot, a tuple variant's fixed-arity array, and a struct
-/// variant's fields — which the adjacent form spreads beside the tag and this one gathers into an
-/// object.
 #[cfg(feature = "serde")]
 fn render_external_content(
     kind: &VariantKind,
@@ -7056,13 +6119,6 @@ fn render_external_content(
 }
 
 /// Renders one variant of an externally tagged enum as a union member.
-///
-/// Returns `(typescript, zod, json_value)`. A data-carrying variant is a closed object whose sole
-/// key is the variant name; a unit variant is that name alone, which is the whole value serde
-/// writes for it.
-///
-/// The key is quoted on both text surfaces because it is a wire name rather than an identifier: a
-/// `#[serde(rename)]` can spell it as something no JavaScript identifier can hold.
 #[cfg(feature = "serde")]
 fn render_external_variant(
     variant: &DiscriminatedVariant,
@@ -7153,21 +6209,6 @@ fn render_external_variant(
 
 /// Records what an object flattening an externally tagged enum joins for each of its variants, in
 /// the order the union writes them.
-///
-/// A data-carrying variant contributes the single-key object it already renders as: serde writes
-/// exactly that into the object being merged, and the member is the operand on both surfaces. A unit
-/// variant renders as the bare name it is written as standing alone, which no object joins —
-/// flattened, serde writes that name as a key holding `null`, so the operand is written here instead
-/// of taken from the member, in the shape the same variant would have rendered as had it carried
-/// data. That is what puts the two spellings of one variant at one indent and under one `JSDoc`
-/// block.
-///
-/// The TypeScript operand carries one thing beyond that shape: each variant says outright that it
-/// does not tag the keys its siblings tag. Nothing in the key set alone says it — a payload carrying
-/// two variants' keys at once satisfies either of them structurally, and an object joined to the
-/// choice makes both of those keys known — so what serde writes one variant at a time would be
-/// described two at a time. The Zod operand needs no such thing: a `z.strictObject` recognizes
-/// exactly the keys it names and refuses the second variant's on that alone.
 #[cfg(all(feature = "serde", any(feature = "typescript", feature = "zod")))]
 fn record_external_flatten_operands(
     rust_ident: &str,
@@ -7221,15 +6262,6 @@ fn record_external_flatten_operands(
 
 /// Which of a flattened choice's keys each member has to say it does not carry, one list per member
 /// and in the order the union writes them.
-///
-/// A member is closed against every key its siblings name and it does not. Its own are left off
-/// because it carries them, and the excluded keys are the payloads a merge would otherwise describe
-/// and serde never writes: one branch's keys beside another's.
-///
-/// `None` is a member whose keys nothing here proves — a name the registry classified no further, a
-/// map, a scalar. Such a member is left unclosed, and names no key for its siblings to exclude
-/// either: a key it was told to leave out could be one it carries, and an exclusion is only worth
-/// writing where the declaration proves it.
 #[cfg(all(feature = "serde", feature = "typescript"))]
 fn sibling_key_exclusions(member_keys: &[Option<Vec<String>>]) -> Vec<Vec<String>> {
     member_keys
@@ -7326,12 +6358,6 @@ fn join_external_union(
 }
 
 /// Processes an enum that carries no serde tagging attributes and generates its definitions.
-///
-/// Absent `tag` / `content` / `untagged`, serde writes the externally tagged form: a data-carrying
-/// variant becomes a single-key object under the variant's name, and a unit variant becomes that
-/// name as a bare string. The surfaces describe that union — a JSON-schema `oneOf`, a TypeScript
-/// union, and a Zod `z.union`. The key carries the discriminator, so there is no one field every
-/// member shares and `z.discriminatedUnion` has nothing to switch on.
 #[cfg(feature = "serde")]
 fn process_externally_tagged_enum(
     mut item_enum: syn::ItemEnum,
@@ -7463,15 +6489,6 @@ fn process_externally_tagged_enum(
 }
 
 /// How an internally tagged newtype variant's inner value fares beside the tag.
-///
-/// Internal tagging has no key for a content: the variant's data is written as members of the
-/// object the tag is written in, so only a value serde writes as an object has anything to put
-/// there. That is the whole of the split — a named type is one, and every shape that reaches the
-/// wire as a scalar, a sequence or an absence is not.
-///
-/// The wrappers are read before the type they wrap, in the order serde's serializer meets them: an
-/// `Option` is refused as an optional even around a sequence, and a sequence is refused as a
-/// sequence even around a named type.
 #[cfg(feature = "serde")]
 fn tagged_content(inner: &FieldDef) -> TaggedContent {
     if inner.is_optional() {
@@ -7598,15 +6615,6 @@ fn internally_tagged_guard_errors(
 }
 
 /// Renders one variant of an internally tagged enum as a union member.
-///
-/// Returns `(typescript, zod, json_value, flattened)`, where the first three are the member on each
-/// surface and the last says whether it is an intersection rather than a plain object — which is
-/// what a `z.discriminatedUnion` option cannot be.
-///
-/// A unit variant is the tag alone and a struct variant is the tag beside its own fields, both of
-/// which the tagged member already spells. A newtype variant is the one the form differs on: what
-/// its inner type writes are members of the same object, so the inner's own description joins the
-/// tag's rather than sitting under a key.
 #[cfg(feature = "serde")]
 fn render_internal_variant(
     variant: &DiscriminatedVariant,
@@ -7746,11 +6754,6 @@ fn join_internal_union(
 
 /// Processes an internally tagged enum (`#[serde(tag = "...")]` with no `content`) and generates
 /// its definitions.
-///
-/// With no content key there is nowhere for a variant's data to sit but the object the tag is
-/// written in: a struct variant's fields are written beside the tag, and so are the members of a
-/// newtype variant's inner type. Every other content has nothing to contribute there, and the
-/// guards refuse those declarations rather than describing a value serde cannot write.
 #[cfg(feature = "serde")]
 fn process_internally_tagged_enum(
     mut item_enum: syn::ItemEnum,
@@ -7880,24 +6883,6 @@ fn process_internally_tagged_enum(
 }
 
 /// Renders one variant of an untagged enum as a union member.
-///
-/// Returns `(typescript, zod, json_value)` where:
-/// - `typescript` is the member type (e.g. `DateString`, `number`, `{ a: A }`)
-/// - `zod` is the member schema (e.g. `DateString$Schema`, `z.number().int()`)
-/// - `json_value` is a standalone `serde_json::Value` token expression (cfg jsonschema)
-///
-/// Only `TupleSingle` (`S(T)`) and `Named` (`{ a: A }`) variant kinds have a member spelling here;
-/// every other shape is refused as an error spanned on the variant, which the caller collects so
-/// one expansion reports every offender rather than stopping at the first.
-///
-/// The single-member pattern is what rules out a `TupleSingle` carrying no member. That shape is
-/// unreachable — [`variant_wire_kind`] sends both an empty `Foo()` and a lone slot taken off the
-/// wire to `Unit` — and a slice pattern says so structurally, where a length assertion would have
-/// to be written and then never fire.
-///
-/// The arity a refused tuple variant is named by is the one the author declared, not the one that
-/// reached the wire: a slot dropped from the description is still a slot the union has no member
-/// spelling for.
 #[cfg(feature = "serde")]
 fn render_untagged_variant(
     kind: &VariantKind,
@@ -7926,18 +6911,6 @@ fn render_untagged_variant(
 
 /// Refuses an untagged variant that reached the unit wire by taking its lone slot off it, spanned on
 /// the variant.
-///
-/// The treatment is the one a declared unit variant takes and the wire is the same: captured,
-/// `#[serde(untagged)] enum E { One(#[serde(skip)] String) }` writes `null` and reads `null` back,
-/// which is what `enum E { One }` writes and reads in the same place. Only the words part. The
-/// standing refusal offers inner types and named fields as the shapes the union supports, and this
-/// declaration has an inner type on its face — an author reading that is told their code is
-/// something it is not. So the collapse is named instead: the slot is off the wire in both
-/// directions, which is how a declaration holding a type comes to be written as the null a unit
-/// writes.
-///
-/// Whether an untagged union should gain a null member — which would admit both spellings, the two
-/// sharing one wire — is a separate decision this refusal does not take.
 #[cfg(feature = "serde")]
 fn collapsed_untagged_variant_error(variant: &syn::Variant) -> syn::Error {
     let variant_name = &variant.ident;
@@ -8004,7 +6977,6 @@ fn render_untagged_named(
     field_defs: &[FieldDef],
     self_type_name: &str,
 ) -> (String, String, proc_macro2::TokenStream) {
-    // TypeScript: `{ a: A; b: B }`
     let ts_fields = field_defs
         .iter()
         .map(|fld| {
@@ -8019,7 +6991,6 @@ fn render_untagged_named(
         .join("; ");
     let ts = format!("{{ {ts_fields} }}");
 
-    // Zod: `z.strictObject({ a: ..., })`
     #[cfg(feature = "zod")]
     let zod = {
         let mut body = String::from("z.strictObject({ ");
@@ -8134,13 +7105,6 @@ fn untagged_named_json_value(field_defs: &[FieldDef]) -> proc_macro2::TokenStrea
 
 /// Builds the `{ "type": "string", ... }` JSON-schema value token for a `String` field, including
 /// any `pattern` / `minLength` / `maxLength` constraints from its `model_schema_prop` metadata.
-///
-/// The constraints are written as insertions, so the value is a block — and the block is
-/// parenthesized, which is what lets it be a value at all. Its caller hands the result to the array
-/// wrap, which writes it into a `serde_json::json!` literal, where a leading brace opens a JSON
-/// object rather than a Rust block and the macro dies inside its own array expansion. The parens
-/// are the same ones an enum-keyed map's `properties` block is written under, for the same reason:
-/// they are what makes a block an expression the literal can carry.
 #[cfg(all(feature = "serde", feature = "jsonschema"))]
 fn string_field_json_schema_value(fld: &FieldDef) -> proc_macro2::TokenStream {
     let meta = fld.model_schema_prop_meta.as_ref();
@@ -8188,12 +7152,6 @@ fn string_field_json_schema_value(fld: &FieldDef) -> proc_macro2::TokenStream {
 /// Builds a standalone `serde_json::Value` token expression for a single field, with `Vec<T>`
 /// array wrapping. Sibling type of [`flatten_field_json_schema_ref`]; used by untagged enum
 /// members where the JSON value is consumed directly (not inserted under a property name).
-///
-/// Every composite is dispatched through the renderer its own field position uses — the map
-/// machinery reading the key's classification, the tuple machinery writing the arity bounds — so a
-/// member describes as the struct field written from the same type does. An opaque value is the one
-/// shape that stays permissive: it carries no type name to narrow with, which is the reason field
-/// position leaves it open too.
 #[cfg(all(feature = "serde", feature = "jsonschema"))]
 fn field_json_schema_value(fld: &FieldDef) -> proc_macro2::TokenStream {
     // A covered sequence wrapper writes the JSON array of its element, so the member is dispatched
@@ -8262,10 +7220,6 @@ fn field_json_schema_value(fld: &FieldDef) -> proc_macro2::TokenStream {
 /// [`map_member_rejection_error`] for a position that holds a value rather than writing a
 /// statement — an untagged variant's member, whose value is consumed straight into the union's
 /// `anyOf`.
-///
-/// It replaces the member's whole rendering, for the reason field position replaces the insertion:
-/// a schema the expansion has already rejected is not one to hand the author. The subject is the
-/// member as it was written, named the way the guards on this same walk name it.
 #[cfg(all(feature = "serde", feature = "jsonschema"))]
 fn member_rejection_value(
     field_name: &str,
@@ -8352,35 +7306,6 @@ fn untagged_member_field_def(
 /// schema, and the JSON-schema value token, plus the `compile_error!` tokens for any field-level
 /// guard violations. The first three are always returned; the caller selects which to use based on
 /// the enabled features.
-///
-/// This path builds its field defs directly rather than through [`process_field`], so it runs the
-/// field guards itself. A member renders exactly as a struct field of the same written type does —
-/// a named `Option` in the absent form, a map from its key's members, the constraint its
-/// `model_schema_prop` carries — so each guard it escapes would be a rendering this position alone
-/// is allowed to write.
-///
-/// The `model_schema_prop` attribute is read off each member and then stripped, as
-/// [`process_field`] strips it: it is this crate's own and inert to every derive, so a copy left on
-/// the emitted item is one rustc reports as an attribute that does not exist, pointing at the
-/// user's line with a diagnostic naming the wrong macro.
-///
-/// A member's bound reaches the Rust side through the very generation the tagged twin uses — the
-/// validator, the deserializer, and the `deserialize_with` that hangs the one on the other — under
-/// the variant-scoped helper naming. What the hook costs in this position is the variant, not the
-/// read: serde tries the variants in order, and a member whose bound fails takes its variant out of
-/// the candidate set, so a violating value lands on the next branch that accepts it and errors only
-/// when none does — under serde's own `data did not match any variant` rather than the bound's
-/// sentence. That is what the member's schema already means on the other two surfaces, where the
-/// same declaration is one branch of an `anyOf` and one member of a `z.union`; leaving the hook out
-/// is what would have made the Rust side the odd one, reading back values both schemas reject.
-/// Walks one untagged variant's members, stamping each with its validation and collecting the
-/// guards it earns.
-///
-/// A slot serde carries in neither direction leaves the walk, the way it does on every other
-/// positional seam, and a slot dropped from one direction only is refused there. Untagged, a
-/// multi-element tuple variant has no member spelling at all — the caller refuses it whole — so
-/// what the drop reaches here is the lone slot, which takes the variant to the unit it is written
-/// as.
 #[cfg(feature = "serde")]
 fn collect_untagged_variant_members(
     variant: &mut syn::Variant,
@@ -8547,16 +7472,6 @@ fn collect_untagged_members(
 
 /// What an object flattening an untagged enum spells in the enum's name's place, one operand per
 /// member — and nothing where the name already spells the same payload set.
-///
-/// Standing alone the union describes one member at a time and needs no exclusions. Intersected with
-/// an open object it stops doing so: the excess-property check reads the union of every member's
-/// keys, and each member is satisfied structurally by a payload carrying more keys than it names, so
-/// the type admits a payload carrying two members' keys at once and serde, Zod and the JSON-schema
-/// document all refuse. Closing each member against its siblings' keys is what puts the four
-/// surfaces back on one payload set.
-///
-/// A union no member of which proves a key — one written over names alone — has nothing to close,
-/// and the merge keeps naming the enum rather than writing out what the name already says.
 #[cfg(all(feature = "serde", feature = "typescript"))]
 fn ts_flatten_operands(members: &[String], member_keys: &[Option<Vec<String>>]) -> Vec<String> {
     let operands: Vec<String> = sibling_key_exclusions(member_keys)
@@ -8573,13 +7488,6 @@ fn ts_flatten_operands(members: &[String], member_keys: &[Option<Vec<String>>]) 
 
 /// What one rendered member contributes to an object that merges the enum: the members of the union
 /// it names, when it names one the registry has recorded, and the member as rendered otherwise.
-///
-/// This is where the recorded member list is multiplied out, so what the registry hands a merge is
-/// the leaf set rather than a chain to walk.
-///
-/// `branch` is the member's own one-based position, which every leaf below it is reached through
-/// and so keeps as the head of its trail — the multiplication flattens the chain and the trail is
-/// what still says where a leaf was written.
 #[cfg(all(feature = "serde", feature = "zod"))]
 fn zod_merge_branches(
     kind: &VariantKind,
@@ -8613,19 +7521,6 @@ fn zod_merge_branches(
 /// the leaves of the union it names when it names one the registry has recorded, and — where it was
 /// written under an `Option` — those under the choice the value is, beside the choice the absence
 /// is.
-///
-/// An `Option` is a level of the document and not a decoration on one: the value's wire and a bare
-/// `null` are two branches, which is how the JSON-schema merge descends the same member and how it
-/// comes to name a leaf `n.2`. Recording them the same way is what keeps the two merges naming one
-/// member by one position.
-///
-/// The absence is proved to be no object outright. serde writes the flattened `None` as the object's
-/// own keys alone and then refuses to read those same keys back — the untagged enum matches no
-/// member for them — so the write side and the read side describe different payload sets, and no
-/// branch a multiplication could write is a description of the type. A merge that reads this is
-/// left with the refusal, which is what the JSON-schema merge already answers the same declaration
-/// with. The outer `Option` around a whole flattened source is the other case and keeps its
-/// multiplication: there the absence reads back as the absence.
 #[cfg(all(feature = "serde", feature = "zod"))]
 fn zod_member_leaves(fld: &FieldDef, rendered: &str) -> Vec<ZodUnionMember> {
     let nested = fld.zod_union_members();
@@ -8666,13 +7561,6 @@ fn zod_member_leaves(fld: &FieldDef, rendered: &str) -> Vec<ZodUnionMember> {
 /// What serde writes a written type as, when that type proves it is not an object, and `None` when
 /// nothing here proves it. Asked of an untagged union's member and of the whole surface an item
 /// publishes alike, which is what keeps a member and the name standing for it on one answer.
-///
-/// Named by the JSON type keyword the JSON-schema surface writes for the same value, so the two
-/// merges refuse the same declaration in the same words. That surface reads the keyword off a
-/// document it has already built; here there is the type, and for a name the registry's answer for
-/// what the named item published — so the answer is still a partial one by construction, a map and a
-/// name nothing has classified being left to the merge that does read the document, and a union
-/// member not being asked at all, its own leaves having already been recorded.
 #[cfg(all(feature = "serde", any(feature = "zod", feature = "typescript")))]
 fn written_non_object_wire(fld: &FieldDef) -> Option<&'static str> {
     if fld.is_array() {
@@ -8694,15 +7582,6 @@ fn written_non_object_wire(fld: &FieldDef) -> Option<&'static str> {
 /// What a `#[model_schema()]` item publishes, as leaves in the merge's vocabulary — the answer
 /// [`crate::utils::record_wire_leaves`] stores for every name a flattened member can then reach
 /// through.
-///
-/// An optional surface is two choices and not one, exactly as an optional union member is: serde
-/// writes the value's own wire or writes nothing, and the merge descending the same document names
-/// the value `1` and the absence `2`. Recording them the same way is what keeps a member naming
-/// this item and a member written `Option<T>` refused at one position by one set of words.
-///
-/// Everything else publishes one leaf at no position of its own, read through the very dispatch a
-/// directly written member is read through, so what a name answers and what its target answers
-/// cannot come apart.
 #[cfg(all(feature = "serde", any(feature = "zod", feature = "typescript")))]
 fn published_wire_leaves(written: &FieldDef) -> Vec<WireLeaf> {
     if written.is_optional() {
@@ -8729,11 +7608,6 @@ fn published_wire_leaves(written: &FieldDef) -> Vec<WireLeaf> {
 
 /// The leaves an externally tagged enum's variants write, one per variant and in the order the
 /// `oneOf` it publishes writes them.
-///
-/// The classification is [`variant_wire_kind`]'s, which is the one
-/// [`render_external_variant`] writes each variant from — so what is recorded and what is emitted
-/// read the declaration the same way, and a variant that renders as a bare string is a leaf that
-/// says so. A variant whose lone slot is off the wire is one of those: serde writes its name alone.
 #[cfg(all(feature = "serde", any(feature = "zod", feature = "typescript")))]
 fn external_variant_wire_leaves(variants: &Punctuated<syn::Variant, Token![,]>) -> Vec<WireLeaf> {
     variants
@@ -8749,17 +7623,6 @@ fn external_variant_wire_leaves(variants: &Punctuated<syn::Variant, Token![,]>) 
 /// The leaves the item a field names published, where the field's whole wire *is* that name's and
 /// one of those leaves proves serde writes no object at its position — and `None` everywhere the
 /// one-leaf dispatch already answers.
-///
-/// Only a refusable choice is spliced. A name publishing one leaf keeps flowing through the same
-/// single answer it always did, so nothing about a member naming an object, a scalar or a map
-/// moves; and a choice whose every leaf is an object is that same answer written once per branch —
-/// the operand a merge joins is the name whichever branch matched, so splicing it would put one
-/// member where one stood and say nothing the single leaf did not. What only the leaves can carry
-/// is a branch serde writes as something no object joins, sitting below the member's own position
-/// rather than at it.
-///
-/// An array level is not one of those: what the field writes is the array around whatever the name
-/// publishes, and the leaves behind the name describe an item of it rather than the field.
 #[cfg(all(feature = "serde", any(feature = "zod", feature = "typescript")))]
 fn named_wire_leaves(written: &FieldDef) -> Option<Vec<WireLeaf>> {
     if written.is_array() {
@@ -8777,12 +7640,6 @@ fn named_wire_leaves(written: &FieldDef) -> Option<Vec<WireLeaf>> {
 
 /// Builds the schema module's impl items for an untagged enum: its JSON schema, its `TypeScript`
 /// definition, and its Zod schema, in the order the module publishes them.
-///
-/// An untagged member is matched on its own shape rather than on a shared tag, so the three
-/// surfaces join the rendered members as plain alternatives — an `anyOf` with no `type` pinned over
-/// it, a `|` union, a `z.union`. The joins live next to the method that reads them because each is
-/// read exactly once and every one is feature-gated; keeping the pair together is what lets a
-/// disabled surface take its join with it.
 #[cfg(all(
     feature = "serde",
     any(feature = "zod", feature = "typescript", feature = "jsonschema")
@@ -8923,7 +7780,6 @@ fn process_untagged_enum(
     let schema_example_method =
         enum_schema_example_method(docs_vec.as_deref(), name, &item_enum.generics, args);
 
-    // Build schema module impl items (without schema_example)
     #[cfg(any(feature = "zod", feature = "typescript", feature = "jsonschema"))]
     let schema_impl_items = build_untagged_schema_impl_items(
         &item_enum,
@@ -9057,14 +7913,6 @@ fn tagged_variant_json_object(
 }
 
 /// Generates TypeScript and Zod schema code for a discriminated enum variant.
-///
-/// Handles different variant kinds:
-/// - Unit: `{ type: "Variant" }` (no content field)
-/// - Named: `{ type: "Variant", field1: T1, field2: T2 }` (individual named fields)
-/// - `TupleSingle`: `{ type: "Variant", value: T }` (single value flattened)
-/// - `TupleMultiple`: `{ type: "Variant", value: [T1, T2, ...] }` (tuple array)
-///
-/// The `self_type_name` is used to detect recursive type references and use getter syntax.
 fn generate_variant_code(
     tag_name: &str,
     content_name: &str,
@@ -9137,7 +7985,6 @@ fn write_named_variant_fields(
     for fld in field_defs {
         let key = ts_member_key(&fld.name);
 
-        // Add TypeScript type definition
         let _ = writeln!(
             variant_type_code,
             "{}\n  {}{}: {};",
@@ -9147,14 +7994,12 @@ fn write_named_variant_fields(
             fld.typescript_typename()
         );
 
-        // Add Zod schema definition
         #[cfg(feature = "zod")]
         {
             let zod_field_type = fld.zod_type();
             let is_recursive = fld.contains_type_reference(self_type_name);
 
             if is_recursive {
-                // Use getter syntax to defer the reference
                 let _ = writeln!(
                     variant_schema_code,
                     "  get {key}() {{ return {zod_field_type}; }},"
@@ -9227,7 +8072,6 @@ fn write_tuple_single_variant_fields(
     };
     let content_key = ts_member_key(content_name);
 
-    // Add TypeScript type definition with JSDoc comment
     let _ = writeln!(
         variant_type_code,
         "  /** Tuple value */\n  {}: {};",
@@ -9235,14 +8079,12 @@ fn write_tuple_single_variant_fields(
         fld.typescript_slot_typename()
     );
 
-    // Add Zod schema definition
     #[cfg(feature = "zod")]
     {
         let zod_field_type = fld.zod_slot_type();
         let is_recursive = fld.contains_type_reference(self_type_name);
 
         if is_recursive {
-            // Use getter syntax to defer the reference
             let _ = writeln!(
                 variant_schema_code,
                 "  get {content_key}() {{ return {zod_field_type}; }},"
@@ -9265,12 +8107,6 @@ fn write_tuple_single_variant_fields(
 }
 
 /// Writes the multi-element tuple portion of a discriminated enum variant.
-///
-/// Every element is a slot: serde writes each position of the tuple, so a `None` there reaches the
-/// wire as a `null` in place rather than shortening the tuple. All three surfaces read the elements
-/// through the slot spellings for that reason, and the content array is the one
-/// [`tuple_json_schema_value`] renders for a tuple field — serde writes the same array in both
-/// positions.
 fn write_tuple_multiple_variant_fields(
     field_defs: &[FieldDef],
     content_name: &str,
@@ -9287,7 +8123,6 @@ fn write_tuple_multiple_variant_fields(
         .collect();
     let ts_tuple = format!("[{}]", ts_tuple_types.join(", "));
 
-    // Add TypeScript type definition with JSDoc comment explaining tuple structure
     let tuple_desc: Vec<String> = field_defs
         .iter()
         .enumerate()
@@ -9302,7 +8137,6 @@ fn write_tuple_multiple_variant_fields(
         ts_tuple
     );
 
-    // Add Zod schema definition using z.tuple()
     #[cfg(feature = "zod")]
     {
         let zod_tuple_types: Vec<String> = field_defs
@@ -9311,13 +8145,11 @@ fn write_tuple_multiple_variant_fields(
             .collect();
         let zod_tuple = format!("z.tuple([{}])", zod_tuple_types.join(", "));
 
-        // Check if any field in the tuple contains a recursive reference
         let is_recursive = field_defs
             .iter()
             .any(|fld| fld.contains_type_reference(self_type_name));
 
         if is_recursive {
-            // Use getter syntax to defer the reference
             let _ = writeln!(
                 variant_schema_code,
                 "  get {content_key}() {{ return {zod_tuple}; }},"
@@ -9353,23 +8185,6 @@ fn write_tuple_multiple_variant_fields(
 
 /// Arrays `item_schema` once per array level the field carries, and hands it back untouched when
 /// the field carries none.
-///
-/// Every value position that can hold a `Vec` — a field, a tuple element, an enum-keyed map member
-/// — carries the array-ness on the field itself rather than in its type, so the wrap belongs here
-/// once instead of in each renderer. The levels are the ones the field was written at, so a
-/// `Vec<Vec<T>>` describes as the array of arrays serde writes for it.
-///
-/// A level written as an `Option` admits `null` where it sits — inside the array that holds it,
-/// which is always written — rather than around the array, which is what the outermost level does
-/// and is the caller's to apply.
-///
-/// A level written as a fixed-size `[T; N]` carries its bounds, so the wrong-length payload serde
-/// refuses to deserialize is refused here too.
-///
-/// `item_schema` is a `serde_json::Value` expression, as is the result. Callers holding a literal
-/// fragment want [`arrayed_json_schema_fragment`]. It is written into a `serde_json::json!`
-/// literal, where a value that opens with a brace reads as a JSON object rather than as a Rust
-/// block, so a caller whose value is a block hands it over parenthesized.
 #[cfg(feature = "jsonschema")]
 fn arrayed_json_schema_value(
     fld: &FieldDef,
@@ -9419,14 +8234,6 @@ fn fixed_length_json_schema_bounds(fld: &FieldDef, level: u8) -> proc_macro2::To
 
 /// Which instant a chrono type's string spells, as the JSON-schema `"format"` keyword that names
 /// it, and `None` for every type that writes no such string.
-///
-/// Written once so no position can name the same instant a different way: the field, the slot and
-/// the branded path all read this one mapping, where each of them used to spell the keyword itself
-/// — and the branded path, reaching the string through the TypeScript name every chrono type
-/// shares with `String`, spelled nothing at all.
-///
-/// Named exhaustively rather than caught by a wildcard: a new variant must be classified, not
-/// silently answered for.
 #[cfg(all(feature = "jsonschema", feature = "chrono"))]
 const fn chrono_json_schema_format(field_type: &FieldDefType) -> Option<&'static str> {
     match *field_type {
@@ -9472,9 +8279,6 @@ fn chrono_json_schema_item(field_type: &FieldDefType) -> Option<proc_macro2::Tok
 /// which a caller writing inside a `serde_json::json!` inlines and one needing a standalone
 /// `serde_json::Value` wraps — or `None` for the composite types (sibling references, maps,
 /// tuples, unknowns) that have no inline rendering.
-///
-/// Neither the array levels nor `is_optional` are consulted: both describe the slot the value sits
-/// in, not its type, so each caller wraps this item itself.
 #[cfg(feature = "jsonschema")]
 fn scalar_field_json_schema_item(fld: &FieldDef) -> Option<proc_macro2::TokenStream> {
     let item_schema = match &fld.field_type {
@@ -9523,9 +8327,6 @@ fn scalar_field_json_schema_item(fld: &FieldDef) -> Option<proc_macro2::TokenStr
 /// renders as the fixed-arity array its own field position renders, which is the one value the map
 /// path has no renderer for. An element is dispatched by the tuple builder itself, so the nesting
 /// costs nothing but the recursion.
-///
-/// Every other value is the member the map path renders, at every depth, so a type describes the
-/// same in either slot.
 #[cfg(feature = "jsonschema")]
 fn build_tuple_element_item(value: &FieldDef) -> Result<MapMemberItem, MapMemberRejection> {
     if let FieldDefType::Tuple(elements) = &value.field_type {
@@ -9536,14 +8337,6 @@ fn build_tuple_element_item(value: &FieldDef) -> Result<MapMemberItem, MapMember
 
 /// Builds the base JSON schema for a tuple element, ignoring `is_optional`, or `None` when the
 /// element holds a value the dispatch cannot render.
-///
-/// The element is dispatched in the form its slot normalizes it to, so a sequence wrapper here
-/// describes as the `Vec` of the same element does. Everything else is the map path's member
-/// dispatch: a sibling is carried by the same reference the field and map-member positions carry,
-/// a map carries its own members' renderings, and an opaque value carries the permissive empty
-/// schema field position carries — so the type an element holds is described by that type wherever
-/// it is named. The nullable wrap is applied by `build_tuple_element_json_schema`, off the element
-/// as it was written.
 #[cfg(feature = "jsonschema")]
 fn build_tuple_element_base_json_schema(
     fld: &FieldDef,
@@ -9557,9 +8350,6 @@ fn build_tuple_element_base_json_schema(
 /// or a map entry — or `None` when the value is not an `Option`. Only an object key can be
 /// omitted; in either of these positions serde writes a `None` as JSON `null`, so the schema has
 /// to admit it.
-///
-/// The tokens are a JSON value: a caller writing inside a `serde_json::json!` literal inlines
-/// them, one needing a standalone `serde_json::Value` wraps them in `serde_json::json!`.
 #[cfg(feature = "jsonschema")]
 fn nullable_slot_json_schema(
     fld: &FieldDef,
@@ -9581,18 +8371,6 @@ fn nullable_slot_json_schema_value(
 }
 
 /// The schema module a sibling type's `Schema::json_schema()` lives in.
-///
-/// The registry answers first, for a name this expansion has already seen. A name it does not hold
-/// is one expanded later, or one from another crate, and takes the ident-derived naming — all a
-/// reference standing before the type has to go on. That naming is what every `#[model_schema()]`
-/// item publishes under, so a reference resolves in either declaration order however the item is
-/// renamed.
-///
-/// The ident is spanned on where the sibling was named rather than on the attribute. Nothing the
-/// macro can read tells it whether the module will be in scope — a generated module reaches its
-/// siblings through `use super::*`, which a type declared inside a function body never joins — so
-/// the `E0433` naming a module the author never wrote is the only report there is, and the span is
-/// what lands it on the type they did write.
 #[cfg(feature = "jsonschema")]
 fn sibling_schema_module_ident(name: &str, span: proc_macro2::Span) -> Ident {
     let module_name = match lookup_alias_info(name) {
@@ -9604,27 +8382,6 @@ fn sibling_schema_module_ident(name: &str, span: proc_macro2::Span) -> Ident {
 
 /// A sibling's own schema as a standalone `serde_json::Value` expression: the module the reference
 /// resolves to, asked for the schema it publishes.
-///
-/// Every position that carries a sibling by reference — a field, a map member, a tuple element, a
-/// flattened base — emits this one call, so a type cannot describe as itself in one position and as
-/// an open object in another.
-///
-/// It is the guarded form that is asked for, not the standalone document: the sibling is being
-/// written into a document already in progress, and it is the run that knows whether asking has
-/// come back around to a name still being written. So the names in flight and the definitions the
-/// root will carry travel into the call.
-///
-/// A reference carrying arguments asks for the schema at those arguments instead. JSON Schema has
-/// no type parameters, so the named type's own document is written at one filling, and the filling
-/// the field carries is the reference site's — a stored-shape field embedding the wire-shape
-/// document would reject every payload it holds. Genericness is read off the reference rather than
-/// off the registry because Rust cannot name a generic type without arguments, so a reference
-/// carrying them names a type that declares them.
-///
-/// The whole call is spanned on where the sibling was named, so every failure it can raise — the
-/// unresolved module a function-local sibling produces, the missing method a type expanded without
-/// `#[model_schema()]` produces — is reported at the type rather than at the attribute. Only the
-/// spans change; the tokens are the ones a reference has always carried.
 #[cfg(feature = "jsonschema")]
 fn sibling_json_schema_value(
     name: &str,
@@ -9654,14 +8411,6 @@ fn sibling_json_schema_value(
 }
 
 /// One reference-site argument as the document that fills the parameter it stands at.
-///
-/// Rendered through the dispatch a positional slot uses — the one total over the types the crate
-/// renders — so an argument describes as a field written with the same type describes, and one that
-/// is itself a reference composes at whatever depth it was written at.
-///
-/// The rejection is the field's own, reached only where the field-level key guard did not already
-/// refuse the reference: it names the type the argument was written into, that being what the
-/// author can act on.
 #[cfg(feature = "jsonschema")]
 fn argument_json_schema_value(name: &str, argument: &FieldDef) -> proc_macro2::TokenStream {
     build_tuple_element_json_schema(argument).unwrap_or_else(|rejection| {
@@ -9672,11 +8421,6 @@ fn argument_json_schema_value(name: &str, argument: &FieldDef) -> proc_macro2::T
 
 /// The local the enclosing item's document reaches one of its own type parameters through, as the
 /// `serde_json::Value` expression a position holding that parameter is described by.
-///
-/// A parameter names no type at expansion, so what it describes as is whatever filled it: the
-/// argument the reference site supplied, or the item's own declared filling where the document was
-/// asked for standing alone. Cloned rather than borrowed because a parameter may be written at more
-/// than one position, and each of them owns the document it writes.
 #[cfg(feature = "jsonschema")]
 fn json_argument_value(parameter: &str) -> proc_macro2::TokenStream {
     let binding = json_argument_ident(parameter);
@@ -9705,13 +8449,6 @@ fn opaque_json_schema_value(fld: &FieldDef) -> proc_macro2::TokenStream {
 
 /// The argument slots an item's schema module publishes: one per type parameter it declares, in
 /// declaration order, each carrying the document the standalone form fills it with.
-///
-/// Declaration order rather than the order the fillings were written in, because that is the order
-/// a reference site supplies its arguments in — the two lists are read against each other
-/// positionally and nothing outside the generated code names either.
-///
-/// Empty for an item that declares no type parameter, which is what leaves its module publishing
-/// the one pair of methods it has always published.
 #[cfg(feature = "jsonschema")]
 fn schema_parameters(generics: &syn::Generics, args: &ModelSchemaArgs) -> Vec<SchemaParameter> {
     type_parameters_in_scope(generics)
@@ -9726,11 +8463,6 @@ fn schema_parameters(generics: &syn::Generics, args: &ModelSchemaArgs) -> Vec<Sc
 /// The document a parameter's declared filling describes as, rendered through the dispatch every
 /// other type position is rendered through — so the filling describes exactly as a field written
 /// with that type describes.
-///
-/// A parameter the declaration left out falls back to the permissive empty schema, which is what a
-/// parameter with nothing said about it always described as. An item reaching here with one has
-/// already been refused where it was written: a build generating JSON documents requires a filling
-/// for every parameter, so the fallback stands only for a build that reads none of this.
 #[cfg(feature = "jsonschema")]
 fn declared_filling_json_schema_value(
     parameter: &str,
@@ -9750,10 +8482,6 @@ fn declared_filling_json_schema_value(
 /// Builds JSON schema for a tuple element (used for tuple fields and for tuple variants), or the
 /// rejection when the element holds a value the dispatch cannot render — which the callers turn
 /// into the single diagnostic naming the field.
-///
-/// An alias's target is rendered through here too: an alias names a type, and this is the dispatch
-/// total over the types the crate renders, so what the alias publishes is what a field written as
-/// the target would carry.
 #[cfg(feature = "jsonschema")]
 fn build_tuple_element_json_schema(
     fld: &FieldDef,
@@ -9766,12 +8494,6 @@ fn build_tuple_element_json_schema(
 
 /// The fixed-arity array a tuple describes as — the form serde writes it in — or the rejection when
 /// any element holds a value the dispatch cannot render.
-///
-/// A tuple field, a tuple nested in a slot, and a multi-element tuple variant's content are the
-/// same array, so all three are built here rather than each spelling the bounds itself. The bounds
-/// are what pins the minimum an array of `prefixItems` leaves open: draft 2020-12's `"items": false`
-/// closes the tail, so without `minItems` a shorter array — one serde can neither write nor read
-/// back — still validates.
 #[cfg(feature = "jsonschema")]
 fn tuple_json_schema_value(
     elements: &[FieldDef],
@@ -9811,35 +8533,12 @@ fn sequence_wrapper_element(fld: &FieldDef) -> Option<&FieldDef> {
 
 /// The field a sequence-spelled type stands for: its element, carrying the array level the wrapper
 /// writes — and `None` for everything else.
-///
-/// Every position that renders a wrapper renders it through here, so the detection and the unwrap
-/// live in one place: a field, a slot, and an untagged variant's member cannot answer differently
-/// for the same name, and none of them can name a schema module after a wrapper the expansion never
-/// declares. The result stands for the whole field, so a caller re-dispatches it in place of the
-/// field rather than wrapping it again.
 #[cfg(feature = "jsonschema")]
 fn sequence_wrapper_field(fld: &FieldDef) -> Option<FieldDef> {
     sequence_wrapper_element(fld).map(|element| fld.collection_element_field(element))
 }
 
 /// The classification every position reads a map key through.
-///
-/// The rule it applies is serde's own: a JSON object key is a string, so a key serde writes as a
-/// string keys a map and a key it writes as anything else refuses the map outright at serialization
-/// (`key must be a string`, with no fallback form). What the expansion refuses is therefore what
-/// serde refuses — never what merely is not a `String`. The keys serde stringifies for the author,
-/// the numbers and the `bool` and the chrono renderings, keep the open object they have always
-/// described as.
-///
-/// The wrapper spellings come first, in the order they were written: they are the key as written,
-/// and reading past one would answer for the inner instead — enumerating an enum's members as keys
-/// the map cannot hold. A sequence writes an array; an `Option` writes its inner or nothing at all.
-///
-/// Below them, only a bare type path can name an enum, an alias or a brand, and the registry says
-/// which by saying what serde writes for it: a bare string opens the object, a value serde
-/// stringifies leaves its members unnarrowed, and anything else stays on the enumerating path,
-/// where a name the registry positively rules out earns the refusal. A generic spelling is a type
-/// this expansion has no `enum_members()` for, and every other type names keys it cannot enumerate.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn map_key_path(key: &FieldDef) -> MapKeyPath<'_> {
     if key.array_depth > 0 || sequence_wrapper_element(key).is_some() {
@@ -9917,12 +8616,6 @@ fn key_rejection(key: &FieldDef) -> Option<MapKeyRejection> {
 }
 
 /// The Rust spelling of what a map key holds, for the diagnostic a key with no rendering earns.
-///
-/// The sequence wrapper itself is not named: a `Vec` or a `[T; N]` reaches here as the array levels
-/// the parser collapsed it onto, so naming one spelling would name a spelling the author may not
-/// have written. The element survives that, so it is what the message says — by its own name where
-/// it has one, and by the shape it is written as where it has none, the arity of a tuple key not
-/// being what the refusal turns on.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn map_key_element_name(key: &FieldDef) -> String {
     if let Some(element) = sequence_wrapper_element(key) {
@@ -9986,15 +8679,6 @@ fn registered_key_kind(key_type_name: &str) -> Option<AliasKind> {
 }
 
 /// Why the first map key this field reaches, at any depth, has no rendering.
-///
-/// Every surface renders such a key: TypeScript writes it as a `Record`'s key type, Zod as a
-/// `z.record` key schema, and the JSON schema calls `enum_members()` on it to spell the object's
-/// properties. So the key is answered for once, off the field all three render from, rather than
-/// by whichever of them a build happens to enable.
-///
-/// Recurses through `SiblingType` generics, `Map` keys/values, and `Tuple` elements — the walk
-/// [`FieldDef::os_string_name`] makes. What position the map sits in is not what decides whether
-/// its key can be written.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn map_key_rejection(fld: &FieldDef) -> Option<MapKeyRejection> {
     match &fld.field_type {
@@ -10042,11 +8726,6 @@ fn non_enum_map_key_message(subject: &str, key_type_name: &str) -> String {
 
 /// What a sequence-wrapped key is reported as, worded like its sibling above and carrying the same
 /// `subject`.
-///
-/// serde is the whole reason: it writes a JSON object key as a string, a sequence writes an array,
-/// and rather than falling back to any other form it refuses the map outright — so there is no wire
-/// here to describe, not a wire described badly. The element is named because the wrapper cannot
-/// be: the parser has already collapsed every sequence spelling onto array levels.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn sequenced_map_key_message(subject: &str, element_name: &str) -> String {
     format!(
@@ -10056,12 +8735,6 @@ fn sequenced_map_key_message(subject: &str, element_name: &str) -> String {
 
 /// What an `Option`-wrapped key is reported as, worded like its siblings above and carrying the same
 /// `subject`.
-///
-/// The `Some` half writes exactly what the inner writes — a transparent wrapper on the wire — so the
-/// schema the expansion would emit is the bare-keyed map's, byte for byte. It is the `None` half
-/// that has no wire form: serde raises `key must be a string` for it and refuses the whole map, so a
-/// schema describing only the `Some` half would validate documents the type cannot produce and stay
-/// silent about the ones it errors on. The inner is named because it is also the remedy.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn optional_map_key_message(subject: &str, inner_name: &str) -> String {
     format!(
@@ -10071,13 +8744,6 @@ fn optional_map_key_message(subject: &str, inner_name: &str) -> String {
 
 /// What a key serde writes as neither a string nor anything it stringifies for the author is
 /// reported as, worded like its siblings above and carrying the same `subject`.
-///
-/// This is the same refusal the sequence spelling earns, reached by the key's own type rather than
-/// by a wrapper around it: a tuple writes a JSON array, a nested map and an `ObjectId` write JSON
-/// objects, and serde will not use any of them as an object key. What is written is named beside
-/// the key so the diagnostic says why, and the numbers, the `bool` and the chrono renderings are
-/// deliberately absent — serde stringifies those into keys, so they describe as the open object
-/// they always have.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn unwritable_map_key_message(subject: &str, key_name: &str, written_as: &str) -> String {
     format!(
@@ -10104,16 +8770,6 @@ fn map_key_rejection_message(subject: &str, rejection: &MapKeyRejection) -> Stri
 }
 
 /// Rejects a field reaching a map key no surface can write.
-///
-/// A key the registry proves carries no `enum_members()` is one such: those members are what every
-/// surface writes the map's keys from, so a key that has none leaves each of them describing an
-/// object whose keys nothing can supply — and leaves the JSON schema calling a method the author
-/// never wrote, which rustc blames `#[model_schema()]` for. The key is written as a *type path*,
-/// which resolves through any alias, so an alias of a non-enum is named here as the alias the
-/// author wrote.
-///
-/// A sequence-wrapped key is the other: serde writes no object for it at all, so every surface
-/// would be describing a shape the map can never take.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn check_map_key(field: &Field, field_def: &FieldDef, label: &str) -> Result<(), syn::Error> {
     let Some(rejection) = map_key_rejection(field_def) else {
@@ -10190,17 +8846,6 @@ fn map_member_slot_value(
 }
 
 /// The `FieldDef` a value in a slot — a map member, a tuple element — dispatches as.
-///
-/// Every sequence wrapper writes a JSON array of its element, so the value describes as the `Vec`
-/// of that element does: the array-ness moves onto the element, which is the one form a parsed
-/// `Vec` value already arrives in, at whatever nesting it was written. Which wrappers those are is
-/// the surfaces' one shared answer, so no name reaches a slot as an array on one surface and a
-/// schema module of its own on another.
-///
-/// An `Option` on either side of the wrapper survives the normalization at the level it was
-/// written at — inside, it is a `null` among the array's items; outside, it stands in place of the
-/// whole array, which a slot cannot drop the way an object key can. The two are different values on
-/// the wire, so the member schema keeps them apart.
 #[cfg(feature = "jsonschema")]
 fn normalized_slot_value(value: &FieldDef) -> FieldDef {
     let mut normalized = value.clone();
@@ -10212,16 +8857,6 @@ fn normalized_slot_value(value: &FieldDef) -> FieldDef {
 
 /// The rendering a value in a slot carries, with the slot wraps left to the caller, or the
 /// rejection when the value type has no rendering here.
-///
-/// A map value is dispatched through this same function, so a nested map carries the rendering its
-/// own key and value types give it at every depth rather than an open object. A tuple element is
-/// dispatched through it too (via [`build_tuple_element_item`]), so the two slot positions cannot
-/// disagree about what a type describes as.
-///
-/// A tuple is the one value type the mapping cannot render — a tuple element overrides that arm
-/// with the array its own field position renders, a map member has no such renderer — and a nested
-/// map can be turned away for its key. Either way the callers turn the rejection into the single
-/// diagnostic naming the field.
 #[cfg(feature = "jsonschema")]
 fn build_map_member_item(value: &FieldDef) -> Result<MapMemberItem, MapMemberRejection> {
     Ok(match &value.field_type {
@@ -10310,11 +8945,6 @@ fn map_member_rejection_message(subject: &str, rejection: &MapMemberRejection) -
 
 /// The one diagnostic a slot the mapping cannot render produces — on either key path, at any depth,
 /// and in a tuple slot the value is reached through.
-///
-/// It replaces the branch's whole output rather than joining it: an emission left in place hands
-/// the author a schema the expansion has already rejected, and on the enum-key path a second error
-/// on the `value_schema` the failed binding never bound — macro-internal state the author cannot
-/// act on. The field and the type are what the author can act on, so each message names both.
 #[cfg(feature = "jsonschema")]
 fn map_member_rejection_error(
     field_name_str: &str,
@@ -10346,25 +8976,6 @@ fn string_key_map_json_schema_value(
 /// property per member the key enumerates, each carrying the value type's own rendering, and closed
 /// to every other key. `Err` when the value has no rendering here, or when the registry proves the
 /// key carries no members.
-///
-/// The members are built by a block rather than spelled into a literal — only the expansion's own
-/// runtime knows them — and the block is bound inside a `serde_json::json!`, which makes the whole
-/// emission an expression. That is what lets one rendering serve every position a map is written
-/// in: a field's insertion, a member of an enclosing map, a tuple's `prefixItems` slot. A key that
-/// enumerates its members therefore enumerates them at any depth.
-///
-/// [`check_non_enum_map_key`] walks every field an item renders from and drops the whole schema
-/// surface when one reaches a key with no members, so no such key should arrive here. The question
-/// is asked again because the `enum_members()` call is *this* function's to emit, and it is only
-/// sound for a key that has them: whatever reaches this dispatch, a key the registry rules out
-/// leaves with a diagnostic naming it rather than with rustc blaming `#[model_schema()]` for a
-/// method the author never wrote.
-///
-/// The registry rules out only what it has already seen, and it is filled as items expand: a key
-/// declared after the type that writes the map, like one foreign to this crate, is unclassified
-/// here and keeps the emitting path — it must, since nothing distinguishes it from a type that
-/// does carry `enum_members()`. So the call is spanned on the key the field names, and the `E0599`
-/// a key without the method raises is reported at the user's type instead of at `#[model_schema()]`.
 #[cfg(feature = "jsonschema")]
 fn enum_key_map_json_schema_value(
     key_type_name: &str,
@@ -10400,10 +9011,6 @@ fn enum_key_map_json_schema_value(
 /// The object a map describes as, as a standalone `serde_json::Value` expression, dispatched on the
 /// classification its key earns — or the rejection when the key has no rendering here, or the value
 /// none the member dispatch can write.
-///
-/// Written once so every position holding a map reads the same key classification: a field, an
-/// untagged variant's member, whatever comes next. A key that enumerates its members enumerates
-/// them wherever the map is written, and one that opens the object opens it there too.
 #[cfg(feature = "jsonschema")]
 fn map_json_schema_value(
     key: &FieldDef,
@@ -10420,13 +9027,6 @@ fn map_json_schema_value(
 }
 
 /// The `properties` insertion a map-typed field produces.
-///
-/// Every key path builds the map as a standalone value, which is then wrapped for the slot the
-/// field is: a sequence wrapper around a map is the *field's* array, not the map's, so the wrap
-/// every other field type applies is applied here too and a `Vec<HashMap<..>>` field describes as
-/// the array the map-member and tuple-element positions already describe it as. Nullability stays
-/// the `required` list's business, as it is for every other field type — only a slot that cannot be
-/// dropped spells a `None` as `null`.
 #[cfg(feature = "jsonschema")]
 fn build_map_field_schema(
     fld: &FieldDef,
@@ -10464,7 +9064,6 @@ fn build_string_field_schema(fld: &FieldDef, field_name_str: &str) -> proc_macro
         .as_ref()
         .and_then(|m| m.pattern.as_deref().map(str::to_owned));
 
-    // Generate constraint insertion statements
     let min_len_insert = min_len_opt.map(|min_len| {
         quote! { schema_obj.insert("minLength".to_string(), serde_json::json!(#min_len)); }
     });
@@ -10589,15 +9188,6 @@ fn build_sibling_type_field_schema(
 
 /// The `json!` literal an `ObjectId` describes as — the closed `$oid` object serde writes — with
 /// `hex_schema` as the schema of the hex string it holds.
-///
-/// Every position reads this one spelling: a field, a slot (a tuple element, a tuple struct, a
-/// brand over a container), a member of a map on either key path, and an untagged member. So the
-/// same `ObjectId` cannot describe two ways depending on where it is written, and a brand cannot
-/// drift from the inner it wraps.
-///
-/// The object is closed because serde writes that one member and every other object this crate
-/// emits is closed, and the hex member is patterned because that is what the string always holds —
-/// both are true of every payload serde writes, so neither turns one away.
 #[cfg(all(feature = "jsonschema", feature = "object_id"))]
 fn object_id_json_schema_item(hex_schema: &proc_macro2::TokenStream) -> proc_macro2::TokenStream {
     quote! { {
@@ -10653,14 +9243,6 @@ fn build_string_format_field_schema(
 }
 
 /// Builds JSON schema for a tuple struct field.
-///
-/// A Rust tuple field `(A, B, ...)` serializes (via serde) as a fixed-length JSON array, which is
-/// what [`tuple_json_schema_value`] renders — the same array a tuple nested in a slot and a
-/// multi-element tuple variant's content render, so the positions cannot drift apart.
-///
-/// An element the dispatch cannot render replaces the whole insertion with the lone diagnostic,
-/// as an unrenderable map value does: a schema left in place would describe a field the expansion
-/// has already rejected.
 #[cfg(feature = "jsonschema")]
 fn build_tuple_field_schema(
     fld: &FieldDef,
@@ -10681,11 +9263,6 @@ fn build_tuple_field_schema(
 /// Builds the JSON schema for a field with no type of its own — one of the enclosing item's type
 /// parameters, or an opaque value: a `serde_json::Value`, a function pointer, or any other type the
 /// parser could not classify.
-///
-/// A parameter is described by the filling that reached it. An opaque value carries no type name at
-/// all, so there is no schema module to reference and no filling to read: the field admits any
-/// value, which is the permissive empty schema. That matches the `unknown` TypeScript type and the
-/// `z.unknown()` Zod schema emitted for the same field.
 #[cfg(feature = "jsonschema")]
 fn build_unknown_field_schema(fld: &FieldDef, field_name_str: &str) -> proc_macro2::TokenStream {
     log::trace!("Unknown => field_name: {field_name_str}, fld: {fld:?}");
@@ -10807,7 +9384,6 @@ fn write_field_type_and_schema(
             || fld.reaches_a_type_declared_later();
 
         if defer {
-            // Use getter syntax to defer the reference
             format!("  get {key}() {{ return {zod_type}; }},\n")
         } else {
             // Normal property syntax
@@ -10831,12 +9407,6 @@ fn wrap_binding(depth: usize) -> proc_macro2::Ident {
 }
 
 /// The name a variant's constrained member is bound under in the arm that matched it.
-///
-/// The member cannot keep its own name there: the body it is bound for reads `errors`, and a member
-/// spelled that way would take the accumulator's name out from under the very pushes it is being
-/// checked to feed. The prefix is what keeps the arm's bindings clear of every name the body
-/// already spells — the accumulator and the walk's own `value_{depth}` steps — and clear of each
-/// other, two members differing wherever their idents do.
 fn member_binding(field_ident: &proc_macro2::Ident) -> proc_macro2::Ident {
     proc_macro2::Ident::new(
         &format!("member_{field_ident}"),
@@ -10861,15 +9431,6 @@ fn member_access_expr(
 
 /// Builds the `validate()` contribution for a field, reaching through its wrappers to run the
 /// check on the value the constraint actually describes.
-///
-/// A bare field is checked in place, which is the whole of the body when there is nothing to reach
-/// through. Otherwise the chain is bound once and walked: the head binding keeps every later step
-/// dereferencing a binding rather than a fresh borrow, and the block keeps its names off the
-/// enclosing body, where the next field's chain reuses them.
-///
-/// Only where the value is reached differs between a struct's field and a variant's member; the
-/// walk and the check are the same, so both positions run the identical rule and report it in the
-/// identical words.
 #[cfg(feature = "serde")]
 fn build_field_validation(
     wraps: &[ConstraintWrap],
@@ -10946,12 +9507,6 @@ fn walk_wraps(
 /// Builds the serde hook for a field written under wrappers: it deserializes the field's own
 /// declared type and then runs the same walk `validate()` runs, so the wire is gated where the
 /// constraint lands rather than where the field happens to be spelled.
-///
-/// The declared type is the field's own tokens, both where it is returned and where it is checked,
-/// so a type naming a lifetime needs that lifetime declared here — nothing of the struct's generics
-/// reaches a free function. The check's parameter is typed rather than inferred: inference reaches
-/// the walk before it reaches the return type, and the walk's own leaf call would otherwise settle
-/// the helper's `T` as the validator's parameter type instead of the field's.
 #[cfg(feature = "serde")]
 fn build_wrapped_deserializer(
     deserialize_fn_ident: &proc_macro2::Ident,
@@ -11005,15 +9560,6 @@ fn helper_name_stem(field_ident: &str, variant_ident: Option<&str>) -> String {
 
 /// The check a `pattern` constraint holds `value` to, taking `failure` where the value is turned
 /// away.
-///
-/// A pattern that a regex engine is avoidable work for — see [`crate::utils::trivial_pattern`] for
-/// which those are — is emitted as the `str` call it says the same thing as, because the
-/// `regex::Regex::new` otherwise emitted here lands in the consumer's crate, where
-/// `clippy::trivial_regex` reports it against a `#[model_schema]` attribute that has no edit
-/// available to answer it. Everything else keeps the regex, built once per process.
-///
-/// `failure` is spliced in unchanged either way: the two paths turn away the same values, and say
-/// the same words about the pattern as written when they do.
 #[cfg(feature = "serde")]
 fn pattern_check(pattern: &str, failure: &proc_macro2::TokenStream) -> proc_macro2::TokenStream {
     trivial_pattern(pattern).map_or_else(
@@ -11100,12 +9646,6 @@ fn checked_value_parts(
 /// Generates the static validator for a string-shaped field with constraints, plus the serde
 /// deserializer — written against the constrained value itself when the field is bare, and against
 /// the field's declared type when it is wrapped.
-///
-/// A path leaf differs only in how the checked value is reached: the validator takes the borrowed
-/// path — which every wrap of the walk already ends at — and renders it once, so the checks below
-/// are the very ones a `String` field is held to, over the string serde writes for that path.
-///
-/// Returns (`module_items`, `validate_body`) — both go into the schema module and `validate()` respectively.
 #[cfg(feature = "serde")]
 fn generate_string_validation_code(
     field_ident: &str,
@@ -11128,7 +9668,6 @@ fn generate_string_validation_code(
 
     let field_name_lit = field_ident.to_owned();
 
-    // Build validation checks
     let mut checks: Vec<proc_macro2::TokenStream> = Vec::new();
 
     if let Some(min_len) = meta.min_length {
@@ -11311,14 +9850,6 @@ fn generate_numeric_validation_code(
 
 /// Reads a field's type down to the value a constraint can land on, collecting the wrappers on the
 /// way.
-///
-/// The three generated surfaces read the same collapsed field, so the constraint they render sits
-/// on the innermost value however it was written; this is what lets the Rust validator land it in
-/// the same place. Anything else — a sibling type, a map, a tuple, a multi-argument generic — has no
-/// value for a length or a range to apply to and yields nothing.
-///
-/// Each level is read as written before it is matched: a `macro_rules!` substitution arrives
-/// grouped, and the walk descends into types that may be substituted in turn.
 #[cfg(feature = "serde")]
 fn constrained_shape(ty: &syn::Type) -> Option<ConstrainedShape> {
     let mut wraps = Vec::new();
@@ -11458,19 +9989,6 @@ fn field_ident_string(field: &Field) -> String {
 /// Hands the field def the two serde facts the object surfaces spend: whether the field's value
 /// leaves the key out of the serialized object rather than writing it, and whether the key is out
 /// of both directions at once.
-///
-/// Only a named field has a key to leave out. A positional one is written by its place in a tuple,
-/// where nothing can be dropped and a `None` reaches the wire as a `null`, so the omission the
-/// attribute names never happens there and the slot spellings stand as written.
-///
-/// The second fact is the first one plus serde declining to read the field: the key is written into
-/// no payload and kept out of every payload that supplies one, which leaves the surfaces with
-/// nothing to describe. It is the conjunction that is read rather than the word `skip`, because
-/// `skip_serializing` and `skip_deserializing` side by side are that same wire written out.
-///
-/// Not gated on the `serde` feature. The attribute is on the field in every build and the surfaces
-/// claim to describe the payload serde writes in every build, so a toggle that changed the answer
-/// would make one declaration describe two different wires.
 fn apply_serde_key_omission(field_def: &mut FieldDef, field: &Field) {
     let omission = parse_serde_key_omission(&field.attrs);
     field_def.omits_value = field.ident.is_some() && omission.omits_key;
@@ -11479,19 +9997,6 @@ fn apply_serde_key_omission(field_def: &mut FieldDef, field: &Field) {
 
 /// Adds the field to the list every surface is built from, unless the wire carries its key in
 /// neither direction.
-///
-/// A field serde writes into no payload and reads out of none leaves all three surfaces with
-/// nothing to describe, so it is dropped once here rather than at each of the renderers — one list
-/// of described members, and no way for the three to disagree about who is on it.
-///
-/// Dropping it is stricter than serde on the read side: a `z.strictObject` and an
-/// `additionalProperties: false` both reject a payload carrying the key, while serde accepts that
-/// payload and throws the value away. That is the price of describing the payload serde *writes*,
-/// where the key never appears at all — the alternative spelling, a member under an optional key,
-/// would instead claim the key is sometimes written and would describe a value nothing reads.
-///
-/// The field is still the Rust type's, so whatever validation it earned still runs; what it is not
-/// is part of the wire.
 fn push_described_field(field_defs: &mut Vec<FieldDef>, field_def: FieldDef) {
     if !field_def.absent_from_wire {
         field_defs.push(field_def);
@@ -11499,17 +10004,6 @@ fn push_described_field(field_defs: &mut Vec<FieldDef>, field_def: FieldDef) {
 }
 
 /// Rejects a named `Option` field whose serde attributes let a `None` reach the wire as `null`.
-///
-/// The generated contract renders such a field in the absent form — `T` under an absent-able key
-/// and a `z.union([T, z.undefined()]).prefault(undefined)` inside a `z.strictObject` — which admits
-/// a missing key but never `null`. `is_optional` is the same signal that drives that rendering,
-/// which keeps the guard and the contract from ever disagreeing. Positional fields are exempt: a
-/// tuple slot cannot be omitted, so there `None` correctly renders as nullable.
-///
-/// The subject is the outermost `Option` and only that one, `is_optional` being the question asked
-/// of that level. An `Option` written inside a sequence wrapper has no bare `null` to write: the
-/// array around it is always written, so the key is always present and the `None` is an item, which
-/// the field's own schema describes as nullable.
 #[cfg(feature = "serde")]
 fn check_optional_field_serialization(field: &Field, is_optional: bool) -> Result<(), syn::Error> {
     let Some(ident) = field.ident.as_ref() else {
@@ -11531,20 +10025,6 @@ fn check_optional_field_serialization(field: &Field, is_optional: bool) -> Resul
 
 /// Rejects a named field whose serde attributes drop its key on the way out while serde still
 /// insists on finding that key on the way in.
-///
-/// `skip_serializing` and `skip_serializing_if` suppress the key but leave deserialization alone,
-/// so the field is still looked for by name — and a field with no `default` behind it has nothing
-/// to be when the key is missing. Recorded from serde itself: a `Vec` field carrying
-/// `skip_serializing_if = "Vec::is_empty"` and nothing else serializes to `{"id":"1"}` and then
-/// fails to deserialize that very payload, reporting the field as missing. The generated surfaces
-/// are now written to admit the absent key, so leaving this spelling alone would publish a
-/// contract whose own author cannot read what it describes.
-///
-/// Three spellings are exempt, each because serde already answers the missing key:
-/// - a bare `skip`, which stops deserializing too and so supplies `Default` itself;
-/// - an `Option` field, which serde reads back as `None` from a missing key with no `default`
-///   written (the `Option`-null guard above is what polices those);
-/// - a `default` on the field or on the container, either of which writes the value.
 #[cfg(feature = "serde")]
 fn check_omitted_key_is_readable(
     field: &Field,
@@ -11612,15 +10092,6 @@ fn field_guard_errors(
 /// Every guard error the field violates: the two the type earns — the `OsString` guard and the
 /// map-key guard, neither of which any attribute can hide — then everything the
 /// `model_schema_prop` attribute earned, then the serde-side guards when any fired.
-///
-/// `field_def` is the field as the surfaces will render it, every reference to one of the enclosing
-/// item's own parameters already the opaque value: a guard and the renderer standing behind it read
-/// one def, so neither can answer for a parameter the other has not. `written_def` is the same
-/// field as the author spelled it, which only [`check_as_type_override`] reads — `as` names a type,
-/// and a parameter is one of the names it may name.
-///
-/// The map-key guard stands under every subset that emits a schema at all, which is the same set
-/// the registry it reads is populated under.
 fn collect_field_guard_errors(
     field: &Field,
     field_def: &FieldDef,
@@ -11657,11 +10128,6 @@ fn collect_field_guard_errors(
 /// Every guard the field's `model_schema_prop` attribute earns: what the parser refused, then an
 /// unparseable `pattern`, then a bound written where the type renders none, an `as` naming a type
 /// the field is not written as, and the three misuses the flag validators answer for.
-///
-/// All of them stand under every feature subset. The attribute is read in one place and acted on
-/// nowhere else, so a key that stops at any of these reaches no emitter under any toggle — the
-/// field would be emitted as though the key had been left off, which is the loss each of these
-/// exists to report instead of taking.
 fn model_schema_prop_guard_errors(
     field: &Field,
     field_def: &FieldDef,
@@ -11733,14 +10199,6 @@ fn written_constraint_keys(prop_meta: &ModelSchemaPropMeta) -> Vec<&'static str>
 }
 
 /// Rejects a length, pattern or range written on a field no surface reads one beside.
-///
-/// Three shapes earn it. The types [`FieldDef::fixed_shape_name`] answers for render a shape fixed
-/// in this crate rather than the plain string or number a bound is spelled against; the ones
-/// [`FieldDef::composite_shape_name`] answers for render their members, which are built from inner
-/// field defs that carry no meta; and the one [`FieldDef::parameter_shape_name`] answers for
-/// renders a value whose type no instantiation has yet supplied. Every one of them writes the field
-/// without ever reading the bound — so it is accepted at expansion and reaches nothing, which
-/// leaves the author holding a contract that says the value is checked when nothing checks it.
 fn check_fixed_shape_constraints(
     field: &Field,
     field_def: &FieldDef,
@@ -11795,15 +10253,6 @@ fn check_fixed_shape_constraints(
 }
 
 /// Rejects an `as = Type` naming anything but the type the field already renders.
-///
-/// Every surface is written from the field's declared type because that is the type serde reads and
-/// writes, and the expansion has no second source for the wire: a `serialize_with` names a function
-/// whose output type a proc macro cannot see. So a target that renders differently asks the schemas
-/// to describe a payload nothing produces, while one that renders the same is already what every
-/// surface emits — the only reading of the key the expansion can stand behind.
-///
-/// The target may name the field itself or the value under its wrappers, an `Option<T>` and a
-/// `Vec<T>` both rendering the `T` the parser collapsed them onto.
 fn check_as_type_override(
     field: &Field,
     field_def: &FieldDef,
@@ -11884,13 +10333,6 @@ fn check_os_string_field(
 /// Processes a field and returns its definition, optional module items (validators/deserializers),
 /// optional `validate_body` (contribution to the type-level `validate()` method), and the
 /// `compile_error!` tokens for every guard the field violates.
-///
-/// The serde attributes generation writes for the field are not written onto it here — they are
-/// pushed onto `deferred_attrs`, one entry per field in walk order, for
-/// [`apply_deferred_field_attrs`] to write once the whole item has cleared its guards. What is
-/// written here is only the stripping every path performs: `model_schema_prop` is this crate's own
-/// and inert to every derive, so a copy left on the emitted item is one rustc reports as an
-/// attribute that does not exist.
 fn process_field(
     ctx: &FieldContext<'_>,
     field: &mut Field,
@@ -11914,7 +10356,6 @@ fn process_field(
     #[cfg(not(feature = "serde"))]
     let field_rename: Option<String> = None;
 
-    // Get raw field ident (before renaming) for validation function name
     let raw_field_ident = field_ident_string(field);
 
     // Parse model_schema_prop attributes before filtering them out
@@ -11950,7 +10391,6 @@ fn process_field(
         get_final_field_name(&raw_field_ident, field_rename.as_deref(), ctx.rename_all);
     let field_docs = build_jsdoc_body(get_field_docs(field).as_deref(), &final_name);
 
-    // Create the field definition and apply any model_schema_prop overrides
     let mut field_def = get_field_def(&final_name, field_type, &field_docs);
 
     // Resolve `Self` references to the concrete type name so recursive fields
@@ -12000,17 +10440,6 @@ fn process_field(
 }
 
 /// Whether the field needs a `#[serde(default)]` written for it alongside the `deserialize_with`.
-///
-/// serde reads a missing key as a `None` for any field that deserializes as an option — but only
-/// while the field deserializes itself. A `deserialize_with` makes that same missing key a hard
-/// error, and the generated schemas say the key may be left out, so such a field is given the
-/// default that restores what its absence already meant: `None`, wrapped as it was written. A
-/// field that already carries a default keeps the one it was written with.
-///
-/// A transparent wrapper hands its inner type the deserializer it was given, so a run of them
-/// changes nothing about which key is optional; a sequence does not, and neither does a `None`
-/// found beneath one. So the question is asked of the first wrapper that is not transparent, and
-/// anything else is a field whose key was never optional — its absence stays the error it was.
 #[cfg(feature = "serde")]
 fn needs_injected_default(wraps: &[ConstraintWrap], has_default: bool) -> bool {
     let first_opaque = wraps
@@ -12045,12 +10474,6 @@ fn positional_constraint_guard_error(
 /// Generates per-field serde validation code (static validator + `deserialize_with`) and, when
 /// constraints apply, collects the corresponding `#[serde(deserialize_with = ...)]` attribute into
 /// `injected_attrs` — plus the `#[serde(default)]` that keeps an optional key optional under one.
-///
-/// The attributes are collected rather than written: they name functions in the schema module, and
-/// an item its guards refuse publishes no such module. [`apply_deferred_field_attrs`] writes them
-/// once the item has cleared every guard.
-///
-/// Returns (`module_items`, `validate_body`, `guard_error`).
 #[cfg(feature = "serde")]
 fn generate_field_validation(
     field: &Field,
@@ -12139,14 +10562,6 @@ fn generate_field_validation(
 
 /// Hands the field the `model_schema_prop` metadata the surfaces read it back off, and applies the
 /// one key that names the type rather than constrains it.
-///
-/// A meta carrying nothing is not attached at all: the surfaces ask whether the field has one
-/// before reading it, so an empty meta and no meta would have to render the same, and only one of
-/// the two can be checked. `literal` is applied here rather than in a renderer because all three
-/// surfaces render the literal type, not the written one.
-///
-/// Every path that builds a field def runs this, so a member of an untagged variant carries its
-/// attribute exactly as the same field written in a tagged one does.
 fn apply_model_schema_prop_meta(
     field_def: &mut FieldDef,
     prop_meta: ModelSchemaPropMeta,
@@ -12258,17 +10673,6 @@ fn flatten_merged_sources(flattened_fields: &[FieldDef]) -> Vec<MergedSource> {
 /// What a value whose members join the object being written contributes to it, labelled with the
 /// name the author gave it: the type for a named one, the field otherwise — a shape with no name of
 /// its own is only ever pointed at through where it was written.
-///
-/// An `Option` around it travels too. What it wraps says which members the value contributes, and
-/// the `Option` says whether it contributes them at all — the merge owes the object both answers,
-/// and nothing below this point can still see the wrapper.
-///
-/// A parameter contributes the document its filling describes as, read through the one binding
-/// every other position holding that parameter reads it through — the merge expands whatever it is
-/// handed, so an object filling's members join the base exactly as a named source's do. Whether a
-/// filling is an object at all is the merge's to answer and not the declaration's: which type fills
-/// a parameter is the reference site's to name, so the declaration cannot know it, and the merge is
-/// where it finally is known.
 #[cfg(feature = "jsonschema")]
 fn flatten_merged_source(fld: &FieldDef) -> MergedSource {
     if let FieldDefType::SiblingType(name, arguments) = &fld.field_type {
@@ -12291,21 +10695,6 @@ fn flatten_merged_source(fld: &FieldDef) -> MergedSource {
 }
 
 /// What one merged source is written as inside the intersection.
-///
-/// A source that offers its absence writes all of its members or none of them, so what it
-/// contributes is a choice: the source itself, or an object carrying no member of it. The second
-/// branch is the source's own keys mapped to `never`, which is the spelling that excludes a source
-/// written in part — `{}` is every object, so a payload carrying some of the source's members
-/// passes through it, and that payload is one the object never writes.
-///
-/// Which type those keys are read off is what the two absences differ on. A source written
-/// `Option<T>` is spelled as the `T`, and `keyof` it names the members serde writes. A source naming
-/// an item whose published surface is nullable is spelled as that name, and the name is a choice:
-/// `keyof` a union is the members its branches share, which for a value beside `null` is none at all
-/// — an empty mapped type, and one that admits the base written in part. `NonNullable` is the value
-/// side of that choice, whose keys are the ones serde writes together or not at all. The value
-/// branch keeps the name itself: an intersection distributes over the choice behind it and the
-/// `null` side carries no key an object could be joined to, so that branch is already the value's.
 #[cfg(feature = "typescript")]
 fn ts_merged_operand(operand: &MergedOperand) -> String {
     let spelling = &operand.spelling;
@@ -12338,7 +10727,6 @@ fn generate_ts_definition_method(
         acc
     });
 
-    // TypeScript type generation (only available when typescript feature is enabled)
     let typescript_type_gen = if fields_empty {
         if has_flatten {
             quote::quote! {
@@ -12375,13 +10763,6 @@ fn generate_ts_definition_method(
 
 /// A schema an intersection is built from, written so the name it carries is read when the
 /// intersection is used rather than while the `const` holding it is being initialized.
-///
-/// A flattened base is rendered as the base's own exported `const`. Spliced in as it stands, that
-/// name is read the moment the containing `const`'s initializer runs — which fails outright when
-/// the base is declared below, and no declaration order puts each of two bases that flatten each
-/// other above the other. Deferring the read is what makes every emitted module load whatever
-/// order they are assembled in; a pair that does flatten each other then fails when something asks
-/// it to validate, rather than at the import of everything declared alongside it.
 #[cfg(feature = "zod")]
 fn deferred_zod_operand(schema: &str) -> String {
     format!("z.lazy(() => {schema})")
@@ -12404,10 +10785,6 @@ pub fn typescript_preamble_tokens(input: proc_macro2::TokenStream) -> proc_macro
 /// The suffix the binding an item publishes is named with. A generic type publishes a factory —
 /// one schema per filling, built on demand — where a type that declares no parameter publishes the
 /// one schema it has.
-///
-/// Recorded on the item's registry entry as it is decided, because a reference to the item is
-/// written from it too and cannot read it off its own spelling — see [`record_zod_factory`]. This
-/// is the one place the decision is taken, so the binding and every reference to it move together.
 #[cfg(feature = "zod")]
 fn zod_binding_suffix(rust_ident: &str, parameters: &[String]) -> &'static str {
     record_zod_factory(rust_ident, !parameters.is_empty());
@@ -12612,43 +10989,6 @@ fn declared_default_field(parameter: &str, default_types: &[(syn::Ident, syn::Ty
 /// binding — its factory, called with fresh arguments exactly as an ordinary field naming it does,
 /// or, where the default names that item at exactly the arguments it calls its own, that item's
 /// `$SchemaDefault` directly (the fold).
-///
-/// Either shape is deferred for the reason [`deferred_zod_operand`]'s own doc comment states for a
-/// flattened base: `{name}$SchemaFactory` and `{name}$SchemaDefault` are each another module-scope
-/// `const`, one macro invocation sees one type, and a generated module concatenates one string per
-/// type in whatever order the consuming project's entity list produces — so nothing here can know
-/// whether that `const` is written above this one or below it. `X$SchemaDefault` still goes
-/// through `X$SchemaFactory` either way — the deferral only wraps the argument, never bypasses the
-/// call — so the identity guarantee that composes never turns on which of the two names the
-/// argument; only the moment the name is read moves, from the instant this `const`'s initializer
-/// runs to the first time something asks the resulting schema to validate. A self-contained
-/// expression like `z.string()` names no sibling `const` at all, so it is left eager.
-///
-/// Deferring both shapes — not only the fold — is also what ends a cycle between two declared
-/// defaults without a diagnostic refusing either side: two generic items whose defaults name each
-/// other compile fine (Rust resolves types in a module regardless of declaration order), but
-/// neither can have registered the other's `$SchemaDefault` arguments yet when it is itself
-/// expanded, so neither side folds and both would otherwise call the other's factory eagerly, at
-/// the top of a `const` initializer, with nothing to say which of the two names the module either
-/// side ends up written into declares first.
-///
-/// The fold matters beyond spelling: the factory's memo keys on argument identity, so two
-/// `z.string()` literals written at two call sites are two different objects and share nothing,
-/// while reading the sibling's own binding back reuses the very object its `$SchemaDefault` is
-/// pinned to — which is also what carries in whatever checks and brand the sibling's own default
-/// declared, rather than reconstructing a plain instantiation beside them. See
-/// [`record_zod_default_arguments`].
-///
-/// The fold's own gate (`array_depth == 0 && !is_optional()`, a *direct* sibling reference) scopes
-/// the fold correctly — a default wrapped in a `Vec` or `Option` has no bare sibling binding to
-/// fold onto — but it is not the deferral boundary: `Tagged$SchemaFactory` inside
-/// `z.array(Tagged$SchemaFactory(z.string()))` is exactly as much a module-scope `const` read as
-/// it is bare, only reached one level down. So a declared default that misses the direct-sibling
-/// gate falls through to [`FieldDef::names_a_sibling_binding`], which asks the same question the
-/// gate cannot: does the rendered tree name a sibling *anywhere*, wrapped or not. Where it does,
-/// the whole rendered expression is what `z.lazy` wraps — not the factory call alone — since the
-/// `$SchemaDefault` const carries its own explicit annotation, so nothing needs to infer through
-/// the wrapper.
 #[cfg(feature = "zod")]
 fn default_zod_rendering(field: &FieldDef) -> DefaultZodRendering {
     if field.array_depth == 0
@@ -12678,25 +11018,6 @@ fn default_zod_rendering(field: &FieldDef) -> DefaultZodRendering {
 /// declared default, so `X$SchemaDefault === X$SchemaFactory(<the same arguments>)` by
 /// construction — through the very factory a hand-written call would go through, never the
 /// builder, which skips the memo and would build a second schema for the same filling.
-///
-/// Its own argument list is recorded through [`record_zod_default_arguments`] before this
-/// returns, so an item declared below this one can read it back through [`default_zod_argument`]
-/// and fold onto this very binding where its own declared default names this item at the same
-/// arguments.
-///
-/// `defaults.constrained` names the one parameter, if any, a branded newtype's own
-/// `pattern`/`minLength`/`maxLength` land on — the parameter its bare-parameter inner *is* —
-/// together with the two check-chain spellings [`BrandedDefaultChecks`] built for it. Every
-/// ordinary generic struct, tuple struct, enum and alias passes `None`: only a brand carries
-/// type-level string constraints, and [`branded_zod_inner`] already keeps them off the factory's
-/// own parameter, so the one place left for them is the default argument built here.
-///
-/// Which spelling applies follows [`default_zod_rendering`]'s own answer for that argument: an
-/// eager rendering (a self-contained expression such as `z.string()`) takes the chained spelling
-/// directly, exactly as before this function had any deferred shape to consider; a deferred one
-/// takes the base spelling *inside* the `z.lazy(...)` thunk `into_argument` would otherwise close
-/// over untouched — appending after the thunk would land the checks on `ZodLazy`, which carries
-/// neither `.min`/`.max` nor any refinement of the schema it resolves to.
 #[cfg(feature = "zod")]
 fn zod_default_block(
     item_name: &str,
@@ -12747,8 +11068,8 @@ fn zod_default_block(
 /// in `.brand()` (see [`branded_zod_expression`]), so its return type is always some
 /// `$ZodBranded<Argument, Name>` — never the plain `Name<...>` instantiation `ZodType`
 /// names — and the annotation has to read the same way, exactly as [`branded_zod_const_block`]
-/// already annotates the non-generic case. See txsch-bpnj. The class is written bare throughout,
-/// per [`branded_zod_type_name`] (txsch-0cnq).
+/// already annotates the non-generic case. The class is written bare throughout, per
+/// [`branded_zod_type_name`].
 #[cfg(all(feature = "zod", feature = "typescript"))]
 fn branded_default_annotation(
     item_name: &str,
@@ -12807,17 +11128,6 @@ fn branded_default_argument_class(field: &FieldDef, rendering: &DefaultZodRender
 
 /// What a generic type's Zod surface is written as: the builder holding the schema its arguments
 /// compose into, the return type read back off it, the cache interfaces, and the exported factory.
-///
-/// A Zod schema is a runtime value and TypeScript generics do not exist at runtime, so a generic
-/// type has no one schema to publish — the caller has to say what fills each parameter before
-/// anything can validate. What it publishes instead is the function that answers that, and the
-/// cache is what keeps a filling asked for twice from becoming two schemas.
-///
-/// Beside the factory, this also publishes `$SchemaDefault` — see [`zod_default_block`] — the
-/// factory called at the item's own declared defaults, so a consumer who wants the ordinary
-/// filling never has to construct the argument list by hand.
-///
-/// `defaults` is passed straight through to [`zod_default_block`].
 #[cfg(feature = "zod")]
 fn zod_factory_block(
     item_name: &str,
@@ -12894,12 +11204,6 @@ fn zod_const_block(item_name: &str, preamble: &str, expression: &str, reexport: 
 
 /// The whole of what a type publishes on the Zod surface: a factory when it declares parameters,
 /// and the annotated `const` when it declares none.
-///
-/// The one seam every item takes that decision at, so a struct, a tuple struct, an enum and an
-/// alias cannot come to answer it differently. A branded newtype takes the same decision beside
-/// this one, because only its `const` half differs — see [`branded_zod_const_block`]. None of
-/// these items carries type-level string constraints — that is a brand's alone — so the factory is
-/// always built with no constrained parameter to route checks onto.
 #[cfg(feature = "zod")]
 fn zod_published_binding(
     item_name: &str,
@@ -12927,19 +11231,6 @@ fn zod_published_binding(
 
 /// The expression the delegate builds its schema-with-example from, read off the same decision
 /// [`zod_published_binding`] takes: where the example goes depends on what the item published.
-///
-/// A type that declares no parameter publishes the annotated `const`, and the example belongs on
-/// the value that `const` names — closed by the final `;`, which is the last one in the text.
-///
-/// A generic type publishes a factory, and a factory's last `;` closes its arrow function, so the
-/// same anchor would attach `.meta()` to a closing brace. The example belongs instead on the
-/// statement binding the schema the factory is about to cache: the one place that is both on the
-/// value every call hands back — a hit returns what was stored — and ahead of the store, so two
-/// calls with the same arguments stay the same schema. `return schema` satisfies the first and
-/// breaks the second, `.meta()` handing back a new instance rather than the memoized one.
-///
-/// The generated body reads `defined` (the module's schema with the re-export taken off) and
-/// `example_json`, both bound by the delegate this is spliced into.
 #[cfg(feature = "zod")]
 fn zod_example_injection(item_name: &str, parameters: &[String]) -> proc_macro2::TokenStream {
     if parameters.is_empty() {
@@ -12978,29 +11269,6 @@ fn zod_operand_contributions(operand: &MergedOperand) -> Vec<&str> {
 
 /// What the object's schema is written as: the statements bound ahead of it, and the expression
 /// itself.
-///
-/// A source offers a choice on two counts. One reached through an `Option` contributes its members
-/// or contributes nothing; one that is an untagged union contributes the members of whichever of
-/// its own members matched. Every other source contributes one key set, always. So what the object
-/// writes is one intersection per combination — the multiplication the JSON-schema document is
-/// written from, in the order that document writes it.
-///
-/// Zod can only say that as a union around the intersections. An intersection recognizes exactly
-/// the keys its operands name, and an operand that is itself a choice leaves each of its branches
-/// answering for the keys the other branch carries — which rejects every payload the object writes
-/// rather than admitting each of them. `z.discriminatedUnion` is the one union Zod does read a key
-/// set off, so a source spelled as one is an operand like any other and never reaches the
-/// multiplication.
-///
-/// With one combination there is no choice to write, so the object's own keys stay where they were.
-/// With more, they are bound to a name the branches read: they are the same keys in every branch,
-/// and a branch says what it adds to them rather than repeating them.
-///
-/// A source declared *below* the object has no registry entry to read members off, so it is written
-/// as the one operand it names — the same fallback a forward reference already takes for the name
-/// itself (see [`deferred_zod_operand`]). Nothing at the merge tells that source apart from a plain
-/// struct declared below, so an untagged union flattened by an object above it must be declared
-/// above the object for the multiplication to reach it.
 #[cfg(feature = "zod")]
 fn zod_merged_statements(
     item_name: &str,
@@ -13092,9 +11360,7 @@ fn generate_zod_schema_method(
             flatten_schemas,
         );
         quote::quote! {
-            // Zod schema method not available - zod feature disabled
-            // To enable: add "zod" to your features
-            // Example: tixschema = { features = ["zod"] }
+            // No method: the `zod` feature is off.
         }
     }
 }
@@ -13102,10 +11368,6 @@ fn generate_zod_schema_method(
 /// Binds the `docs` local an item's `ts_definition()` opens with: the item's `JSDoc` block, its
 /// body enriched with the item's JSON schema where the caller says this build can produce one, and
 /// a trailing newline, so what the block documents is the line straight beneath it.
-///
-/// The block cannot be built by [`jsdoc_block`] here — the JSON schema is only there once the
-/// expanded code runs — so this is where its shape is spelled for the runtime side, once, rather
-/// than once per item kind.
 #[cfg(feature = "typescript")]
 fn bind_item_jsdoc_local(docs: &str, with_json_schema: bool) -> proc_macro2::TokenStream {
     if with_json_schema {
@@ -13147,9 +11409,7 @@ fn generate_plain_enum_json_schema_method(
     {
         let _: &_ = &(enumerated, def_name); // Suppress unused variable warning
         quote::quote! {
-            // JSON schema method not available - jsonschema feature disabled
-            // To enable: add "jsonschema" to your features
-            // Example: tixschema = { features = ["jsonschema"] }
+            // No method: the `jsonschema` feature is off.
         }
     }
 }
@@ -13168,7 +11428,6 @@ fn generate_plain_enum_ts_definition_method(
         let json_docs_gen = generate_enum_json_docs_part(docs);
         let reexport = ident_reexport_ts(rust_ident, item_name, ts_generics);
 
-        // TypeScript type generation (only available when typescript feature is enabled)
         let typescript_type_gen = quote::quote! {
             format!("{}export type {}{} =\n{};{}", docs, #item_name, #ts_generics, #type_code, #reexport)
         };
@@ -13184,9 +11443,7 @@ fn generate_plain_enum_ts_definition_method(
     #[cfg(not(feature = "typescript"))]
     {
         quote::quote! {
-            // TypeScript definition method not available - typescript feature disabled
-            // To enable: add "typescript" to your features
-            // Example: tixschema = { features = ["typescript"] }
+            // No method: the `typescript` feature is off.
         }
     }
 }
@@ -13232,9 +11489,7 @@ fn generate_plain_enum_zod_schema_method(
     {
         let _: &_ = &(item_name, rust_ident, schema_code, description);
         quote::quote! {
-            // Zod schema method not available - zod feature disabled
-            // To enable: add "zod" to your features
-            // Example: tixschema = { features = ["zod"] }
+            // No method: the `zod` feature is off.
         }
     }
 }
@@ -13280,9 +11535,7 @@ fn generate_discriminated_enum_ts_definition_method(
     #[cfg(not(feature = "typescript"))]
     {
         quote::quote! {
-            // TypeScript definition method not available - typescript feature disabled
-            // To enable: add "typescript" to your features
-            // Example: tixschema = { features = ["typescript"] }
+            // No method: the `typescript` feature is off.
         }
     }
 }
@@ -13326,9 +11579,7 @@ fn generate_discriminated_enum_zod_schema_method(
             schema_code,
         );
         quote::quote! {
-            // Zod schema method not available - zod feature disabled
-            // To enable: add "zod" to your features
-            // Example: tixschema = { features = ["zod"] }
+            // No method: the `zod` feature is off.
         }
     }
 }
@@ -13336,13 +11587,6 @@ fn generate_discriminated_enum_zod_schema_method(
 /// Builds the alias module's `ts_definition()`, or nothing when `typescript` is off. The doc
 /// block and the generic parameter list are only meaningful to TypeScript, so they are gathered
 /// inside the gate rather than by the caller.
-///
-/// The target is read through [`surface_field_def`], the same seam the two validating methods
-/// beside this one read it through, so the alias classifies its own parameters exactly as a struct
-/// classifies its fields. TypeScript still renders each parameter as the name the declaration binds
-/// — that is what a classified parameter renders as here — with the one exception the declaration
-/// itself forces: a parameter reached in a map's key position states the string keys serde writes,
-/// because `Record<K, V>` binds `K extends keyof any` and a parameter satisfies no such bound.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn generate_alias_ts_definition_method(
     alias: &ItemType,
@@ -13397,11 +11641,6 @@ fn generate_ts_alias_method(
 
 /// The diagnostic an alias whose target the dispatch cannot render emits, in place of the whole
 /// `json_schema()` body.
-///
-/// It replaces the body rather than joining it: a schema left there would describe a type the
-/// expansion has already rejected, and every slot naming the alias would carry it. The tokens are
-/// the body's tail expression — no trailing semicolon, so the method's return type raises no second
-/// error on top of the one the author can act on.
 #[cfg(feature = "jsonschema")]
 fn alias_json_schema_rejection(
     export_name: &str,
@@ -13412,14 +11651,6 @@ fn alias_json_schema_rejection(
 }
 
 /// Builds the alias module's `json_schema()`, or nothing when `jsonschema` is off.
-///
-/// An alias names a type, so it publishes that type's own schema: the target `FieldDef` — the one
-/// the TypeScript and Zod methods render from — through the dispatch a positional slot uses, that
-/// being the dispatch total over the types the crate renders and the one whose `ObjectId` is the
-/// field-position object. So the alias describes what a field written as the target describes. A
-/// sibling target is carried by the shared reference, which resolves through the registry: an alias
-/// of an alias lands on the type at the end of the chain, and an alias of a type that never
-/// expanded fails on the module it names, exactly as a field of that type does.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn generate_alias_json_schema_method(
     alias: &ItemType,
@@ -13447,17 +11678,6 @@ fn generate_alias_json_schema_method(
 }
 
 /// Builds the alias module's `zod_schema()`, or nothing when `zod` is off.
-///
-/// The value is rendered from the target read through [`surface_field_def`], so a parameter
-/// is the argument the alias's own factory binds for it rather than the `Name$Schema` binding an
-/// unresolved type is named after — a binding no emitted module declares.
-///
-/// Which binding carries that value is [`zod_published_binding`]'s, the seam every declared item
-/// already takes the decision at: an alias that declares parameters publishes a factory, exactly
-/// as a struct of the same parameters does. The alternative is the `const` an alias used to
-/// publish whatever it was declared with, whose annotation had to erase every argument the
-/// declaration beside it keeps — and a field naming such an alias then fails to type-check against
-/// the very declaration it renders from.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn generate_alias_zod_method(
     alias: &ItemType,

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -1278,10 +1278,6 @@ fn field_map_key_error(field_type: &proc_macro2::TokenStream) -> String {
 /// The registry proves a struct-keyed map has no members to name, and it proves it whatever surface
 /// is being generated: the key is read off the field every one of them renders from, so the same
 /// source cannot be a schema under one feature set and a refusal under another.
-///
-/// Every depth the key can be written at is covered, those being the positions the surfaces reach
-/// it through: a field's own map, a map nested under either key flavor, a tuple slot, a sequence
-/// wrapper, and a sibling's generic argument.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
 fn a_map_key_proved_to_lack_enum_members_is_refused_wherever_it_is_written() {
@@ -1358,9 +1354,6 @@ fn a_sequence_wrapped_map_key_is_refused_wherever_it_is_written() {
 /// sequence-wrapped one does, and for the same reason: serde raises `key must be a string` and
 /// refuses the whole map, so there is no object for any surface to describe. The key is named by the
 /// shape it was written as, and what serde writes for it is named beside it.
-///
-/// Every depth is covered, the position a map sits in not being what decides whether its key can be
-/// written.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn assert_unwritable_map_key(field_type: &proc_macro2::TokenStream, key_name: &str) {
     let error = field_map_key_error(field_type);
@@ -1663,12 +1656,6 @@ fn enum_fields(item: &syn::ItemEnum) -> impl Iterator<Item = &syn::Field> {
 
 /// A refused pattern leaves the item without the `deserialize_with` naming the module the refusal
 /// drops.
-///
-/// A pattern is recorded as written whether or not a guard refused it, so the constraint is still
-/// a string constraint by the time the hook is generated: the item was emitted carrying
-/// `#[serde(deserialize_with = "probe_caret_schema::deserialize_anything")]` beside the
-/// `compile_error!`, while the module holding that function was replaced by the absorbing one —
-/// an `E0425` pointing at the attribute rather than at anything the author wrote.
 #[cfg(feature = "serde")]
 #[test]
 fn a_refused_pattern_leaves_no_hook_naming_the_dropped_module() {
@@ -1847,10 +1834,6 @@ fn a_container_short_of_its_wire_arity_still_falls_through_as_a_sibling() {
 /// Runs the field walk the way [`super::process_field`] does and renders the guard failures its
 /// `model_schema_prop` attributes earn, so a refused key and an unparseable `pattern` are read off
 /// the same channel that carries them to the emitted item.
-///
-/// `parameters` names what the enclosing item declares, which is what decides whether a name the
-/// field is written with is a reference to another type or one of the item's own parameters — the
-/// same list [`super::process_field`] hands the walk.
 fn field_prop_guard_errors_in_scope(item: &syn::ItemStruct, parameters: &[String]) -> Vec<String> {
     let field = item.fields.iter().next().unwrap();
     let name = field
@@ -3325,10 +3308,6 @@ fn string_constraints_over_a_non_string_inner_are_rejected() {
 /// unresolved user type — is admitted because expansion cannot know its shape; the constrained
 /// path's `Display` assertion is what covers it. A name carrying one argument that is not a
 /// sequence wrapper is such a name too, and stays admitted.
-///
-/// `U` is written where the brand declares no such parameter, so it is one of those unresolved
-/// names rather than a parameter: that is the whole of the line the classifier draws, and the
-/// brand's own `T` is on the other side of it in the test below.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
 fn string_constraints_over_a_string_shaped_inner_pass() {
@@ -3388,10 +3367,6 @@ fn brand_over_named_inner_errors(inner: &str) -> Vec<String> {
 /// A named inner is where the checks actually land — the brand emits `Inner$Schema.min(3)` — so a
 /// name the registry says publishes something other than a string takes the refusal the same shape
 /// spelled directly takes, and names both the brand and the inner.
-///
-/// Spelled directly, `serde_json::Value` is refused through the opaque arm; one module out it was
-/// admitted, and `Blob$Schema.min(3)` over `const Blob$Schema = z.unknown().brand<"Blob">()` is a
-/// `TypeError` at load, before a payload is read.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
 fn string_constraints_over_a_named_inner_the_registry_answers_for_are_rejected() {
@@ -3427,19 +3402,6 @@ fn string_constraints_over_a_named_inner_the_registry_calls_a_string_pass() {
 
 /// A name the registry has no answer for keeps the emission it has always had, at the consult
 /// itself.
-///
-/// The two names that reach this are the same absence here: one written above the item that
-/// registers it, and one this crate never expands at all — an unresolved user type whose schema the
-/// author supplies. Refusing on absence would refuse the second for the sake of the first, and the
-/// argument alone tells them apart no better, a publisher being free to write a string whatever its
-/// parameter is handed. The `Display` assertion still bounds the Rust surface either way.
-///
-/// What the guard does *not* do is forget the question: the first of the two is answered by the
-/// registration that follows, which is what takes the verdict off declaration order without
-/// touching this admission. See the deferred tests below.
-///
-/// Both of them name a type the declaration has already fixed, which is what the admission rests
-/// on; a name written over one of the brand's own parameters has not, and is refused below.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
 fn string_constraints_over_a_name_the_registry_cannot_answer_for_pass() {
@@ -3464,17 +3426,6 @@ fn string_constraints_over_a_name_the_registry_cannot_answer_for_pass() {
 
 /// A name written over one of the brand's own type parameters is refused, wherever the parameter
 /// sits inside it.
-///
-/// The registry's silence is not consent here. The brand composes the named type's schema from the
-/// argument the caller supplies, so the checks land on whatever that argument turns out to be: Zod
-/// appends them to a shape the call site decides, the one JSON document written for every
-/// instantiation still holds the `{}` a parameter describes as, and `validate()` measures the
-/// inner's `Display` — a numeric filling rejected for its digit count rather than for its value.
-/// The same two items written in the other order already refuse through the registry, so admitting
-/// this one puts the diagnostic back on declaration order the long way round.
-///
-/// The refusal names the brand, the inner and the parameter, so the author reads which declaration
-/// to fix and which name in it.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
 fn string_constraints_over_a_name_written_over_the_brands_own_parameter_are_rejected() {
@@ -3511,12 +3462,6 @@ fn string_constraints_over_a_name_written_over_the_brands_own_parameter_are_reje
 
 /// A name the registry calls a string publisher is refused too, once one of the brand's own
 /// parameters is written into it.
-///
-/// That registration answers for the declaration, and the declaration here is one whose value the
-/// filling supplies: `Later<T>` publishes a string for a `Later<String>` and something else for
-/// every other filling, so the checks still land on whatever the call site handed over. The
-/// registry's own arm cannot tell this case from an unregistered one — a string publisher records
-/// no shape, exactly as an absence records none — which is why it is the parameter that decides.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
 fn string_constraints_over_a_registered_name_carrying_the_brands_parameter_are_rejected() {
@@ -3613,10 +3558,6 @@ fn brand_surface(item: &syn::ItemStruct) -> super::Surface {
 /// A recorded position is filled with the argument the reference writes, so one declaration answers
 /// per instantiation: the checks compose onto that argument's schema, and the guard names the shape
 /// the argument resolves to rather than the opaque one the declaration alone could say.
-///
-/// The same answer whichever way the two declarations are written — the record is the same record —
-/// which is what takes the guard's verdict off declaration order for every reference that reaches
-/// it at all.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
 fn string_constraints_over_a_parameter_publisher_read_the_argument_written_for_it() {
@@ -3691,11 +3632,6 @@ fn deferred_refusals_for(rust_ident: &str) -> Vec<String> {
 /// A consult the registry could not answer is kept, and the expansion that finally registers the
 /// name answers it — filling the position that registration published with the argument shape the
 /// brand resolved when it asked.
-///
-/// The brand is admitted at its own expansion whatever the argument, because a name declared below
-/// it and a name this crate never expands are one absence there. What closes the half is that the
-/// absence is temporary: the registry is a compile-local recording the later expansion also writes
-/// to, so the answer arrives one declaration later rather than never.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
 fn a_question_left_where_the_registry_was_silent_is_answered_by_the_later_registration() {
@@ -8817,11 +8753,6 @@ fn a_direct_flatten_of_a_plain_enum_is_left_to_the_guard_written_for_it() {
 /// A registration publishing a choice reaches the same refusal, named by the branch its value sits
 /// at rather than at no position at all — the wording the JSON-schema merge, which reads that same
 /// choice back as a union, already refuses the declaration in.
-///
-/// The absence beside it is not what is refused: serde writes the object's own keys alone for it and
-/// reads them back as the absent value, which is the branch the merge already writes. What no
-/// spelling describes is the value, and one declaration cannot carry a branch that round-trips and a
-/// branch no payload satisfies.
 #[cfg(all(feature = "serde", feature = "zod"))]
 #[test]
 fn a_direct_flatten_of_a_nullable_scalar_registration_is_refused_at_its_value_branch() {
@@ -9270,13 +9201,6 @@ fn the_empty_string_pattern_keeps_the_call_it_was_already_emitted_as() {
 
 /// `\b` is trivial to `clippy::trivial_regex` and names no `str` call, so it keeps the regex — and
 /// the lint keeps firing on it in the consumer, which is the one case left standing here.
-///
-/// The verdict is from a probe, not an assumption: `#[model_schema_prop(pattern = r"\b")]` run
-/// through `cargo clippy --all-targets -- -D warnings` in a crate denying `clippy::nursery`
-/// reported `error: trivial regex ... the regex is unlikely to be useful as it is`, against the
-/// `#[model_schema()]` attribute. It is left standing because `\b` turns a value away — the empty
-/// string holds no word boundary — so there is a check here to keep, and answering the lint would
-/// mean dropping it.
 #[cfg(feature = "serde")]
 #[test]
 fn a_word_boundary_pattern_keeps_its_regex() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -21,22 +21,10 @@ use syn::ItemStruct;
 
 /// The JavaScript engine generation the emitted Zod regex literals and JSON Schema `pattern`
 /// keywords are written for, and therefore the line the guard admits and refuses along.
-///
-/// A pattern this crate emits is read by whatever engine loads the generated schema, not by the
-/// one that happened to be installed where the derive ran, so the admission list has to be
-/// decided against a version written down rather than measured. ES2018 is the floor because it is
-/// what the guard's own translations already assume: `(?P<name>...)` is rewritten to
-/// `(?<name>...)`, and named capture groups are ES2018. Nothing else the crate emits needs
-/// anything newer, so nothing is bought by raising it.
 const JS_ENGINE_BASELINE: &str = "ES2018";
 
 /// What a JavaScript regex literal makes of the three flags the ECMA-262 regular expression
 /// modifiers proposal did add.
-///
-/// An engine at [`JS_ENGINE_BASELINE`] predates the proposal and rejects the group opening; a
-/// recent one parses it and matches what the `regex` crate matches. That is why these are refused
-/// against the recorded baseline rather than against whichever runtime is at hand — the schema is
-/// read wherever it is loaded, not where it was generated.
 const MODIFIER_GROUP_ABOVE_BASELINE_READ_AS: &str = "a group opening the ECMA-262 regular \
                                                      expression modifiers proposal added, which \
                                                      an engine predating it rejects as it parses \
@@ -83,10 +71,6 @@ enum Divergence {
 /// asks of a name: what does serde write for a key spelled this way. A plain unit enum answers with
 /// its members, the enumeration the JSON-schema map-key expansion calls `enum_members()` for; every
 /// other answer is about the key's own wire form, a JSON object key being a string.
-///
-/// A type path sees straight through an alias and a `#[serde(transparent)]` brand writes what its
-/// inner writes, so both answer for their target and their inner rather than for themselves — and
-/// through the registry, so a chain of either carries its end's answer to every link.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum AliasKind {
@@ -133,18 +117,6 @@ pub enum TrivialPattern {
 
 /// One member of an untagged union as the Zod surface writes it, beside the two things a merge
 /// that flattens the union has to know about it and cannot recover from the spelling.
-///
-/// `branch` is the trail of one-based choices the member sits at, so a member of a nested union is
-/// named `1.2` rather than twice as `2` — the position the JSON-schema merge names the same member
-/// by, the recording being already multiplied out where that merge descends.
-///
-/// `non_object` is what serde writes the member as when that is provably not an object, named by
-/// the JSON type keyword the other surface writes for it. serde flattens structs and maps and
-/// nothing else, so such a member is one no object can be merged with, on any surface.
-///
-/// Both travel under `serde` alone, which is the feature that reads `#[serde(untagged)]` and
-/// `#[serde(flatten)]` at all: without it nothing records a member and nothing merges one, and the
-/// spelling is all the Zod surface still writes.
 #[cfg(feature = "zod")]
 #[derive(Clone)]
 pub struct ZodUnionMember {
@@ -169,18 +141,6 @@ impl ZodUnionMember {
 
 /// One leaf of the value surface a `#[model_schema()]` item published, in the vocabulary the
 /// flatten-member refusal names a wire by.
-///
-/// `branch` is the trail of one-based choices the leaf sits at behind the name, empty for a surface
-/// that offers no choice at all — so an item publishing `anyOf[value, null]` carries its null at
-/// `2`, and a member naming that item carries it at the member's own position followed by that `2`.
-/// `non_object` is the JSON type keyword the leaf describes as where the registration proves it is
-/// no object, and `None` where nothing there proves it — a map, an object, and a name nothing has
-/// classified alike.
-///
-/// Recorded and read wherever `serde` meets a surface that writes a merge of its own — `zod`, which
-/// multiplies the object over the source's branches, and `typescript`, which spells the source's
-/// absence beside it. Without `serde` no field reaches a merge at all, and without either surface
-/// there is nothing that would ask.
 #[cfg(all(feature = "serde", any(feature = "zod", feature = "typescript")))]
 #[derive(Clone)]
 pub struct WireLeaf {
@@ -202,12 +162,6 @@ impl WireLeaf {
 
     /// Whether this leaf is the absence the name itself offers: the `null` of a choice the
     /// registration publishes at its own top level, one position in from the name and no deeper.
-    ///
-    /// That depth is what the answer turns on. serde writes no member at all for this leaf and
-    /// reads the payload carrying none of them back as the absent value, so a source reached this
-    /// way writes two key sets and the merge owes it both. A `null` further down sits under a
-    /// choice serde matched a member on, where the same payload is one serde writes and then
-    /// matches no member for — the refusal a member position already carries.
     pub fn is_published_absence(&self) -> bool {
         self.branch.len() == 1 && self.non_object == Some("null")
     }
@@ -230,17 +184,6 @@ pub struct FlattenVariant {
 
 /// What a `#[model_schema()]` item publishes as a value, as the constrained-brand guard reads
 /// shapes.
-///
-/// One word cannot answer for a name that publishes a family. A generic item whose written target
-/// *is* one of its own parameters writes whatever the instantiation hands it, so the only flat
-/// answer available at its declaration is the opaque one every parameter describes as — and a
-/// brand written over `Later<String>` would then be refused for a shape the emission never
-/// composes, while the same declaration written above it is admitted for want of any record at
-/// all. So such a name records the position instead, and the reader fills it with the argument the
-/// reference carries.
-///
-/// A target with its own fixed shape — a `Vec<T>`, a map, a tuple — records that shape, which no
-/// filling changes.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum PublishedShape {
@@ -254,16 +197,6 @@ pub enum PublishedShape {
 
 /// A constrained brand's consult the registry had no record to answer with, kept until the named
 /// item registers and can answer it.
-///
-/// At the brand's own expansion a name declared below it and a name this crate never expands are
-/// one absence, and the argument the reference wrote proves nothing on its own — a publisher may
-/// write a string whatever its parameter is handed. So the admission stands at that moment, and
-/// what is recorded here is the question rather than a verdict. The registry is a compile-local
-/// recording the later expansion also writes to, so the item that finally registers under the name
-/// reads the questions naming it and answers them in its own output.
-///
-/// The arguments are kept as the shapes they resolve to rather than as the types they were written
-/// as, because the brand's expansion is the only one still holding those tokens.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[derive(Clone)]
 pub struct ShapeQuestion {
@@ -304,11 +237,6 @@ pub struct AliasInfo {
     /// What the value surface written under this name puts on the wire, one entry per leaf of it,
     /// and empty when nothing has been recorded at all. Filled by [`record_wire_leaves`] as each
     /// item registers.
-    ///
-    /// The shape above it answers the constrained-brand guard's question, which is what a check can
-    /// be appended to; this answers the merge's, which is whether an object can be joined to it —
-    /// two questions one word could not hold apart, an `integer` and a `number` being one shape and
-    /// two documents, and an array and a map one shape and opposite answers.
     #[cfg(all(feature = "serde", any(feature = "zod", feature = "typescript")))]
     pub wire: Vec<WireLeaf>,
     /// What an untagged enum's members are spelled as on the Zod surface, and empty for every other
@@ -320,23 +248,9 @@ pub struct AliasInfo {
 
 /// The walk over a parsed `pattern` that collects the rewrites its JavaScript spelling needs and
 /// the first construct that has no JavaScript spelling at all.
-///
-/// The AST walked is the one `regex::Regex::new` is itself built on, so the guard's reading of a
-/// pattern is the crate's own reading of it. A second grammar written here would answer for the
-/// crate's while drifting from it, and it would have to tell `[--/]`, three ordinary class members,
-/// from `[+--]`, a set difference — which the bytes alone do not say.
 #[derive(Default)]
 struct JsSpelling {
     /// The byte span of each construct that is rewritten, beside what it is rewritten to.
-    ///
-    /// Every rewrite is local — it replaces one construct's own span and leaves the bytes around
-    /// it alone — which is what makes it safe to apply them all in one pass: `(?P<name>` loses its
-    /// `P`, and a `\d`, `\w` or `\s` is replaced by the members it stands for. The `regex` crate
-    /// reads the results back exactly as it read the originals, so the one string that goes to all
-    /// three surfaces still means to the Rust validator what the guard decided it means.
-    ///
-    /// Escaping a class-opening `]` looks like the same kind of fix and is not — `[]-a]` is three
-    /// members and `[\]-a]` is a range — which is why that one is refused rather than rewritten.
     edits: Vec<(Range<usize>, &'static str)>,
     refusal: Option<Unportable>,
 }
@@ -416,17 +330,6 @@ impl JsSpelling {
     }
 
     /// Walks a `[...]` class, refusing it first if it is negated.
-    ///
-    /// A negated class is the last construct both grammars read and fill differently, and the
-    /// members cannot settle it: the complement is taken one code unit at a time there and one
-    /// character at a time here, so `[^0-9]` parts ways over an astral character exactly as the
-    /// `\D` above it does. Nothing is bought by admitting the bracketed spelling of a construct
-    /// already refused under its perl one.
-    ///
-    /// The one class whose `regex` reading does leave every astral character out has to name them
-    /// by astral bounds, and a flagless literal reads those as surrogate halves in descending
-    /// order and will not parse the class at all — so there is no admissible spelling to fall back
-    /// to, which is what makes refusal the whole verdict rather than a table of survivors.
     fn bracketed_class(&mut self, class: &ClassBracketed) {
         if class.negated {
             self.refuse_value_set(
@@ -597,12 +500,6 @@ impl JsSpelling {
     }
 
     /// Equalises a `\d`, `\w` or `\s` — or refuses its negation.
-    ///
-    /// The plain forms name a set each engine reads its own way, and the members they share can be
-    /// written out, so they are. The negated forms name a *complement*, and a complement taken one
-    /// code unit at a time is not the complement taken one character at a time however the members
-    /// are spelled: `[^0-9]` diverges over an astral character exactly as `\D` does. Nothing is
-    /// gained by rewriting them, so they are refused with the divergence named.
     fn perl_class(&mut self, perl: &ClassPerl, in_class: bool) {
         if perl.negated {
             self.refuse_value_set(
@@ -736,24 +633,6 @@ pub fn register_alias_info(
 
 /// Records what the value surface written under a name is, on the entry that name has just
 /// registered.
-///
-/// The question is the constrained-brand guard's: a brand appends `.min`/`.max`/a regex check to
-/// its inner's own schema binding, and a name is the one inner spelling whose binding this
-/// expansion cannot read off the declaration — the schema lives in the module the *named* item
-/// published. So each item answers for itself as it registers, and a brand over a name reads the
-/// answer back rather than guessing at it.
-///
-/// [`PublishedShape::Flat(None)`] is what an unanswered name and a string-checked one both leave,
-/// and the guard treats them alike: a name it cannot classify keeps the emission it has always
-/// had. That is the same regime the map-key registry already runs — `AliasKind::Unknown` is a name
-/// that was not registered before the type reading it — rather than a second one.
-///
-/// A name whose written target *is* one of its own parameters records that position instead of a
-/// word, because one word would have to stand for every instantiation and only the opaque one
-/// does — see [`PublishedShape`].
-///
-/// A chain resolves one link at a time and cannot cycle, because an entry is only ever built from
-/// entries registered before it.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 pub fn record_value_shape(rust_ident: &str, shape: PublishedShape) {
     ALIAS_INFO.with(|map| {
@@ -765,21 +644,6 @@ pub fn record_value_shape(rust_ident: &str, shape: PublishedShape) {
 
 /// Records what the value surface written under a name puts on the wire, on the entry that name has
 /// just registered.
-///
-/// The question is the flatten merge's: what serde writes for a member, named by the JSON type
-/// keyword the other surface writes for the same member, so the two refuse the same declaration in
-/// the same words. A name is the one member spelling the expansion reading it cannot answer for —
-/// the document lives in the module the *named* item published — so each item answers for itself as
-/// it registers.
-///
-/// Recorded as leaves rather than as one word because a published surface may be a choice: an item
-/// whose own surface is nullable publishes its value and a bare `null`, and the merge descending it
-/// names that `null` a level below the member. One word at the member's own position could not say
-/// where it sits, and naming it at the member's position would put the two merges into
-/// disagreement — the very thing the branch trail exists to prevent.
-///
-/// A chain resolves one link at a time and cannot cycle, because an entry is only ever built from
-/// entries registered before it.
 #[cfg(all(feature = "serde", any(feature = "zod", feature = "typescript")))]
 pub fn record_wire_leaves(rust_ident: &str, leaves: &[WireLeaf]) {
     ALIAS_INFO.with(|map| {
@@ -791,22 +655,6 @@ pub fn record_wire_leaves(rust_ident: &str, leaves: &[WireLeaf]) {
 
 /// Records what an untagged enum's members are spelled as on the Zod surface, on the entry that
 /// enum has already registered.
-///
-/// A merge that flattens the enum is a different macro invocation from the enum's own, so the
-/// members reach it through the registry or not at all — an intersection recognizes exactly the
-/// keys its operands name, and a `z.union` names none, so the merge joins one member per branch
-/// rather than the union as one operand.
-///
-/// What is recorded is already multiplied out: a member that is itself a recorded union contributes
-/// that union's members instead of its own name. That leaves the merge nothing to walk, and the
-/// walk is what could not be made to terminate — two unions naming each other is a shape a merge is
-/// free to reach. The recording cannot hold such a cycle, because an entry is only ever built from
-/// entries registered before it.
-///
-/// Each member carries where it sits and whether serde writes it as an object, because the merge is
-/// the position that has to answer for both and the spelling tells it neither. The member itself is
-/// left alone: an untagged enum may hold a scalar, and it is joining that scalar to an object that
-/// no value satisfies.
 #[cfg(feature = "zod")]
 pub fn record_zod_union_members(rust_ident: &str, members: &[ZodUnionMember]) {
     ALIAS_INFO.with(|map| {
@@ -818,15 +666,6 @@ pub fn record_zod_union_members(rust_ident: &str, members: &[ZodUnionMember]) {
 
 /// Records what an untagged enum's members are spelled as where an object flattens the enum itself,
 /// on the entry that enum has already registered.
-///
-/// The two spellings of one union part where an object is joined to it. Standing alone the union
-/// describes one member at a time, and the enum's own name is the whole of what it publishes;
-/// intersected with an open object each member is left satisfied by a payload carrying the other
-/// members' keys as well, which serde writes for no value. The members recorded here carry the
-/// exclusions that close them against one another, so the merge can spell them in the name's place.
-///
-/// Nothing is recorded where those exclusions come to nothing — a union of names proves no key an
-/// object could be told to leave out — and the merge then names the union as it always did.
 #[cfg(all(feature = "serde", feature = "typescript"))]
 pub fn record_ts_union_members(rust_ident: &str, members: &[String]) {
     ALIAS_INFO.with(|map| {
@@ -838,19 +677,6 @@ pub fn record_ts_union_members(rust_ident: &str, members: &[String]) {
 
 /// Records what an externally tagged enum's variants are spelled as where an object flattens the
 /// enum itself, on the entry that enum has already registered.
-///
-/// A variant standing alone and the same variant written into an object being merged are two
-/// spellings of one wire. serde writes a data-carrying variant as the single-key object its name
-/// tags, which is what the union already publishes; it writes a unit variant as that name alone
-/// standing on its own, and as that name holding `null` where the enum is flattened — a key set,
-/// where the union publishes a bare string no object joins. So the flatten-edge spelling is recorded
-/// beside the union's rather than read back off it.
-///
-/// Recorded for every externally tagged enum, and read by each surface wherever the enum is
-/// flattened directly. A Zod intersection recognizes exactly the keys its operands name, so it takes
-/// one operand per variant; TypeScript distributes over a union of objects on its own and takes the
-/// variants for what the union alone cannot say — the key set serde writes for a unit variant, and
-/// each variant's silence about the keys its siblings tag.
 #[cfg(all(feature = "serde", any(feature = "typescript", feature = "zod")))]
 pub fn record_flatten_variants(rust_ident: &str, variants: &[FlattenVariant]) {
     ALIAS_INFO.with(|map| {
@@ -861,22 +687,6 @@ pub fn record_flatten_variants(rust_ident: &str, variants: &[FlattenVariant]) {
 }
 
 /// Records which of the two Zod bindings a name publishes.
-///
-/// A reference reads this back rather than deciding for itself. The decision belongs to the named
-/// item — it turns on whether that item declares type parameters, nothing a reference can see — and
-/// is taken in one place, before the item is dispatched to its shape, so the binding an item
-/// publishes and every reference written to it move together whatever the reference was spelled
-/// with.
-///
-/// Held apart from the item's registry entry rather than on it, because a *self*-reference is
-/// written while the item's own expansion is still running: the entry is created as the item
-/// registers and its fields are rendered from it, so an answer stored on the entry would be read
-/// before the item that owns it had put one there — and the `false` a fresh entry carries reads as
-/// "publishes a `const`", which for a generic item names a binding nothing declares. Recorded here
-/// the answer stands from before the first field is rendered until after the last.
-///
-/// A name never recorded answers `false`, which is the right reading for every item that declares
-/// no parameters and for every name this expansion has not seen.
 #[cfg(feature = "zod")]
 pub fn record_zod_factory(rust_ident: &str, publishes: bool) {
     ZOD_FACTORY_PUBLISHERS.with(|names| {
@@ -898,14 +708,6 @@ pub fn publishes_zod_factory(rust_ident: &str) -> bool {
 /// Records `rust_ident`'s own `$SchemaDefault` fold-comparison keys — the plain [`FieldDef::zod_type`]
 /// rendering of each declared-default field, one per parameter in declaration order, computed
 /// before deferral and before a constrained brand's `.min`/`.max`/`.check` chain is appended.
-///
-/// This is a comparison key, not the text `$SchemaDefault` emits: the fold in
-/// [`default_zod_rendering`] renders a downstream reference's own arguments the same plain way, so
-/// the two must agree in form for the comparison to ever succeed. Recorded once as the item's
-/// `$SchemaDefault` is built, so a later item whose own declared default names this one at the
-/// identical arguments can read them back and fold onto this binding instead of composing a second
-/// call the memo cache does not share with it — two separately written `z.string()` calls are two
-/// different objects, and the cache keys on argument identity, not on what the argument says.
 #[cfg(feature = "zod")]
 pub fn record_zod_default_arguments(rust_ident: &str, arguments: Vec<String>) {
     ZOD_DEFAULT_ARGUMENTS.with(|map| {
@@ -922,16 +724,6 @@ pub fn zod_default_arguments(rust_ident: &str) -> Option<Vec<String>> {
 }
 
 /// The characters a `\d`, `\w` or `\s` covers in *both* engines, written out as a class body.
-///
-/// The `regex` crate reads the three as Unicode classes and a flagless JavaScript literal reads
-/// the narrower ASCII ones, so the reading the two share is the ASCII one, spelled out. For `\s`
-/// the two Unicode sets are not even nested — the `regex` crate spaces U+0085 and JavaScript does
-/// not, JavaScript spaces U+FEFF and the `regex` crate does not — which leaves the ASCII run as
-/// the only common ground rather than merely the safe one.
-///
-/// Returned as the bare body and the bracketed class, because where the construct sits decides
-/// which is written: a class nested inside a class is a construct the guard refuses, so a `\d`
-/// inside one contributes its members and not another `[...]`.
 const fn perl_class_equalised(kind: &ClassPerlKind) -> (&'static str, &'static str) {
     match *kind {
         ClassPerlKind::Digit => ("0-9", "[0-9]"),
@@ -955,19 +747,6 @@ pub fn lookup_alias_info(rust_ident: &str) -> Option<AliasInfo> {
 
 /// The type a spelling names, read through the invisible grouping a `macro_rules!` substitution
 /// arrives inside.
-///
-/// A type written through a `$t:ty` metavariable reaches the expansion wrapped in a
-/// `None`-delimited group — rustc's way of keeping the substituted type one unit whatever the
-/// expansion writes around it — which `syn` parses as [`Type::Group`]. The grouping is all it is:
-/// the type inside is the one the author wrote, at the spans they wrote it at, and it renders the
-/// same source text. What differs is the shape, and every reader below classifies by shape, so a
-/// substituted `String` handed over ungrouped is a type none of their arms answer for — it lands
-/// on the opaque value, silently, and the field comes to admit anything.
-///
-/// Substitutions nest — a metavariable passed on through a second `macro_rules!` arrives grouped
-/// twice — so the grouping is read all the way through rather than one layer off. A parenthesised
-/// type is left alone: `(String)` is a grouping the author wrote, and `syn` keeps it as
-/// [`Type::Paren`] precisely so it can be told from this one.
 pub fn written_type(ty: &Type) -> &Type {
     let mut current = ty;
     while let Type::Group(group) = current {
@@ -987,12 +766,6 @@ pub fn safe_type_name(key: &str) -> String {
 /// The schema module a `#[model_schema()]` item publishes — an alias, a struct, an enum, a branded
 /// newtype alike — which is also the module a reference assumes for a name the registry does not
 /// hold.
-///
-/// A reference written *before* the item expands has nothing but the Rust ident to name a module
-/// from — the registry is empty of the item, and the exported name is not recoverable from the
-/// ident once a `name = "…"` override is in play. So the module is named from the ident on both
-/// sides, and the two spellings agree in either declaration order. A rename moves what the item is
-/// exported as; it does not move where the item's schema lives.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 pub fn ident_schema_module_name(rust_ident: &str) -> String {
     format!("{}_schema", to_snake_case(&safe_type_name(rust_ident)))
@@ -1016,13 +789,6 @@ pub fn compute_alias_export_name(rust_ident: &str, override_name: Option<&str>) 
 /// cannot answer for it, which is what a reference standing *before* the item expanded has and
 /// nothing else — the ident with the `Json` suffix taken off, that being what the field walk
 /// records for a sibling and what [`ident_schema_module_name`] names the module from.
-///
-/// An item exported under this spelling already answers at it. One exported under any other — an
-/// alias, which is given the `Type` suffix, or anything carrying a `name = "…"` override — does
-/// not, so it publishes the ident as a name of its own on each nominal surface: the two
-/// declaration orders then spell the reference differently, and both spellings are defined by the
-/// same emission. The module seam settled the same question for the JSON surface, which addresses
-/// a Rust path rather than a name.
 #[cfg(any(feature = "typescript", feature = "zod"))]
 fn ident_reexport_name(rust_ident: &str, export_name: &str) -> Option<String> {
     let referenced = safe_type_name(rust_ident);
@@ -1030,18 +796,6 @@ fn ident_reexport_name(rust_ident: &str, export_name: &str) -> Option<String> {
 }
 
 /// The names an item's own declaration binds as type parameters.
-///
-/// This is the whole of what separates a name the expansion cannot resolve *because it is a
-/// parameter* from one it cannot resolve because the type lives elsewhere: the first is in scope
-/// at the declaration and names no type any emitted output can reference, the second names a type
-/// that publishes its own schema module. Every surface that has to draw that line draws it here —
-/// see [`crate::field_type::FieldDef::erase_type_parameters`] for what each of them then does with
-/// it.
-///
-/// Lifetimes and const parameters name no type a field position can be written out of, so they are
-/// left out. That is also why an emitted `impl` block is spelled from `split_for_impl` instead of
-/// from this list: the block has to carry every parameter the declaration binds, lifetimes and
-/// consts included, while only these can reach a schema.
 pub fn type_parameters_in_scope(generics: &Generics) -> Vec<String> {
     generics
         .params
@@ -1055,14 +809,6 @@ pub fn type_parameters_in_scope(generics: &Generics) -> Vec<String> {
 
 /// The parameter list a generic item's `TypeScript` declaration is written under — `<IdType>`,
 /// `<IdType, DateType>` — or the empty string for an item that binds none.
-///
-/// Spelled once for the alias, the struct and every enum shape, so the three cannot come to write
-/// the same declaration differently. The names are written as declared, which is what a field
-/// typed with one already renders as: the declaration and the fields it binds have to spell a
-/// parameter the same way or the type does not close.
-///
-/// A lifetime and a const parameter never reach here — they name no type `TypeScript` has a
-/// declaration slot for — so `struct Label<'a>` publishes a plain `export type Label`.
 #[cfg(feature = "typescript")]
 pub fn ts_generic_params(generics: &Generics) -> String {
     let parameters = type_parameters_in_scope(generics);
@@ -1086,10 +832,6 @@ pub fn ident_reexport_ts(rust_ident: &str, export_name: &str, ts_generics: &str)
 /// The zod counterpart of [`ident_reexport_ts`] — a binding, not a second schema, so the two names
 /// carry the one schema the item published. It is written unannotated because a zod-only build has
 /// no `ZodType` to annotate it with, and the binding's own type is the exported schema's.
-///
-/// `binding_suffix` is what the item's own binding is named with, and the two names have to agree
-/// on it: a generic type publishes a factory rather than a schema, so both spellings end in
-/// `$SchemaFactory` there and in `$Schema` everywhere else.
 #[cfg(feature = "zod")]
 pub fn ident_reexport_zod(rust_ident: &str, export_name: &str, binding_suffix: &str) -> String {
     ident_reexport_name(rust_ident, export_name).map_or_else(String::new, |referenced| {
@@ -1113,12 +855,6 @@ pub fn zod_factory_argument(parameter: &str) -> String {
 
 /// The local a JSON document binds one type parameter's argument document to — `_arg_id_type` for
 /// `IdType`.
-///
-/// The counterpart of [`zod_factory_argument`] on the surface that writes Rust rather than
-/// JavaScript, and named off the parameter for the same reason: the argument reads as the parameter
-/// it fills while staying a name of its own beside it. Snake case because that is what a Rust local
-/// is spelled in, and underscore-led because a declared parameter need not reach the document at
-/// all — the item is not owed a warning for one the wire does not carry.
 #[cfg(feature = "jsonschema")]
 pub fn json_argument_binding(parameter: &str) -> String {
     format!("_arg_{}", to_snake_case(parameter))
@@ -1127,26 +863,12 @@ pub fn json_argument_binding(parameter: &str) -> String {
 /// [`compute_alias_export_name`] for a declared item — a struct, an enum, a tuple struct, a branded
 /// newtype. Without an override the item keeps the name it is declared under, which is the one
 /// difference from an alias: an alias has no surface name of its own and is given the `Type` suffix.
-///
-/// This is the single seam every item path takes its exported name from, and the registry is keyed
-/// by the Rust ident and answers with it, so a sibling naming the type in Rust resolves to whatever
-/// it is exported as.
 pub fn compute_item_export_name(rust_ident: &str, override_name: Option<&str>) -> String {
     override_name.map_or_else(|| safe_type_name(rust_ident), ToOwned::to_owned)
 }
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 /// Extracts and concatenates documentation comments from a `syn::ItemStruct`.
-///
-/// # Arguments
-///
-/// * `item_struct` - A reference to the `syn::ItemStruct` to process.
-///
-/// # Returns
-///
-/// An `Option<String>` containing the concatenated documentation,
-/// or `None` if no doc comments are found. Returns an empty string
-/// if doc comments exist but are empty.
 pub fn get_struct_docs(item_struct: &ItemStruct) -> Option<Vec<String>> {
     collect_doc_lines(&item_struct.attrs)
 }
@@ -1249,7 +971,6 @@ pub fn extract_example_from_docs(docs: &[String]) -> Option<String> {
         // Strip leading asterisk from block-style comments
         let cleaned = trimmed.strip_prefix('*').unwrap_or(trimmed).trim();
 
-        // Check for opening fence
         if cleaned == "```rust example" {
             if !example_lines.is_empty() {
                 // Already found one example, return it
@@ -1259,7 +980,6 @@ pub fn extract_example_from_docs(docs: &[String]) -> Option<String> {
             continue;
         }
 
-        // Check for closing fence
         if in_example_block && cleaned == "```" {
             // Found complete example
             break;
@@ -1281,14 +1001,6 @@ pub fn extract_example_from_docs(docs: &[String]) -> Option<String> {
 }
 
 /// Transforms doctest-compatible example code to be suitable for `schema_example()`.
-///
-/// Applies regex transformations to convert code that returns () (for doctest)
-/// into code that returns the actual value (for schema serialization).
-///
-/// Current transformations:
-/// - Strips `use` statements (type is already in scope in impl block)
-/// - `println!("...", value);` → `value`
-/// - `let _: Type = value;` → `value`
 #[cfg(feature = "zod")]
 fn transform_example_code(code: &str) -> String {
     let mut result = code.to_owned();
@@ -1333,13 +1045,11 @@ pub fn strip_examples_from_docs(docs: &[String]) -> Vec<String> {
         // Strip leading asterisk from block-style comments
         let cleaned = trimmed.strip_prefix('*').unwrap_or(trimmed).trim();
 
-        // Check for opening fence
         if cleaned == "```rust example" {
             in_example_block = true;
             continue;
         }
 
-        // Check for closing fence
         if in_example_block && cleaned == "```" {
             in_example_block = false;
             continue;
@@ -1372,30 +1082,6 @@ const fn js_line_terminator_escape(ch: char) -> Option<&'static str> {
 
 /// A `pattern` attribute value in the spelling every surface it is spliced into reads the same
 /// way, or the rejection that keeps it off them, spanned on the literal the author wrote.
-///
-/// One string reaches three surfaces: the Rust validator's `regex::Regex::new(...).unwrap()`, the
-/// Zod schema's JavaScript regex literal, and the JSON Schema `pattern` keyword, which ECMA-262
-/// defines as a JavaScript regex. A pattern the `regex` crate cannot parse is a panic at the first
-/// validated value. A pattern only the `regex` crate can parse is quieter and worse: the derive
-/// expands clean and the generated JavaScript either throws where it loads or, where the two
-/// grammars disagree rather than collide, matches a different set of strings than the Rust
-/// validator it was written beside. Both verdicts are reached here, at expansion.
-///
-/// Where a construct has a spelling both grammars read alike, it is rewritten instead of refused,
-/// and the rewrite is what every surface receives — the Rust validator included, which is what
-/// keeps the three from validating different sets. There are two: `(?P<name>...)` becomes
-/// `(?<name>...)`, one group under two spellings; and `\d`, `\w` and `\s` become the members they
-/// stand for, the `regex` crate reading the three as Unicode classes where a flagless literal
-/// reads the narrower ASCII ones. The first changes nothing about what the pattern matches. The
-/// second narrows the Rust side on purpose, to the set the JavaScript side was going to enforce
-/// regardless.
-///
-/// What has no such spelling is refused with the construct named. That covers `.` and the negated
-/// `\D`, `\W` and `\S`: a flagless literal matches one UTF-16 code unit where the `regex` crate
-/// matches one character, so writing the members out settles which characters are named and never
-/// how many code units one of them is. A `]` opening a character class looks like a fixable
-/// spelling and is not — `[]-a]` is three members and `[\]-a]` is a range — so it too is refused
-/// rather than escaped.
 pub fn portable_pattern(lit: &LitStr) -> Result<String, syn::Error> {
     let pattern = lit.value();
     if let Err(err) = regex::Regex::new(&pattern) {
@@ -1459,28 +1145,6 @@ fn js_spelling(pattern: &str) -> Result<String, String> {
 
 /// The `pattern` handed back when it turns some value away, or the refusal it earns for admitting
 /// every value -- spanned on the literal the author wrote.
-///
-/// A `pattern` that matches at some position of every string is a constraint that constrains
-/// nothing. Nothing downstream can make it say anything: the generated validator would reject no
-/// value, and the Zod and JSON Schema surfaces would publish a check every payload passes. Taking
-/// it silently leaves the author holding a contract that says the value is checked when nothing
-/// checks it -- the same claim a bound written where no surface reads one is refused for, so it is
-/// refused the same way, where it is written.
-///
-/// It also settles what such a pattern would have been emitted as. The `str` call
-/// [`trivial_pattern`] names for a simple pattern does not exist here -- there is no call for "and
-/// then check nothing" -- and dropping the check from a validator whose only constraint is that
-/// pattern leaves `value` unread in the emitted `pub fn validate_..._value(value: &str)`, which is
-/// a fresh `-D warnings` failure in the consumer crate the validator is written into. Refusing at
-/// expansion means no such validator is ever emitted.
-///
-/// What stays on the regex path is every pattern that turns some value away, `\b` included. That
-/// one is the residual: `clippy::trivial_regex` flags it and names no replacement -- a probe of
-/// `#[model_schema_prop(pattern = r"\b")]` under `cargo clippy --all-targets -- -D warnings` in a
-/// crate denying `clippy::nursery` reports `trivial regex ... the regex is unlikely to be useful
-/// as it is` against the `#[model_schema]` attribute -- and it is left standing, because `\b` is a
-/// real constraint: the empty string holds no word boundary, so a value is turned away by it, and
-/// refusing it would drop a check the author is owed.
 pub fn constraining_pattern(lit: &LitStr, pattern: String) -> Result<String, syn::Error> {
     if admits_every_value(&pattern) {
         return Err(syn::Error::new_spanned(
@@ -1499,17 +1163,6 @@ pub fn constraining_pattern(lit: &LitStr, pattern: String) -> Result<String, syn
 /// Whether a search for `pattern` succeeds in every haystack, read off the HIR rather than off the
 /// pattern text: `^` and `(^)` and `^|a` are one verdict written three ways, and `^$` is written
 /// out of the same two anchors as `^` and `$` yet admits only the empty string.
-///
-/// The rule is one sentence with one exception. A pattern admits every value when nothing in it
-/// asks the haystack for anything -- when it matches the empty string wherever it is tried
-/// ([`matches_at_every_position`]) -- and the exception is that a single whole-text anchor asks
-/// for nothing either, since every haystack has a start and an end. Two of them do ask: `^$` pins
-/// both to one position, which only the empty string has.
-///
-/// It errs toward `false` everywhere the reading is not certain, and everything it declines keeps
-/// its `regex::Regex`, where being conservative costs nothing. `^^` and `(?:^)+` are both admit-
-/// everything shapes it does not classify, and a pattern the parser cannot read is not classified
-/// at all -- that one is [`portable_pattern`]'s refusal to make, ahead of this one.
 fn admits_every_value(pattern: &str) -> bool {
     regex_syntax::ParserBuilder::new()
         .unicode(true)
@@ -1549,11 +1202,6 @@ fn concat_matches_every_haystack(parts: &[hir::Hir]) -> bool {
 
 /// Whether this sub-expression matches the empty string at every position of every haystack, and
 /// so asks the haystack for nothing at all.
-///
-/// A repetition that may run zero times is such a match wherever it is tried, whatever it repeats;
-/// an alternation is one as soon as any single branch is. A literal or a class consumes a
-/// character, and a look-around holds only where the haystack has the property it names -- `^` at
-/// the start, `\b` at a word boundary — so neither asks for nothing.
 fn matches_at_every_position(hir: &hir::Hir) -> bool {
     match hir.kind() {
         hir::HirKind::Empty => true,
@@ -1579,30 +1227,6 @@ fn is_text_anchor(hir: &hir::Hir) -> bool {
 /// What a `pattern` accepts stated without a regex, for exactly the patterns
 /// `clippy::trivial_regex` proves one is unnecessary for -- and `None` for every other pattern,
 /// which keeps its `regex::Regex` and is the only thing that reads a pattern of any real shape.
-///
-/// The lint is right, and it is the consumer who pays for being wrong: the `Regex::new` it fires
-/// on is written by this crate into the consumer's crate, so the diagnostic lands on their
-/// `#[model_schema]` attribute with no edit available at that site. Answering it means emitting
-/// the call it asks for, and the emitted call has to accept and reject the same values the regex
-/// did, byte for byte, or a pattern would mean one thing in a consumer denying the lint and
-/// another in one that does not.
-///
-/// So the classification is clippy's own, read off `clippy_lints/src/regex.rs::is_trivial_regex`
-/// (rust-lang/rust-clippy) and mirrored arm for arm: a bare literal, and a concatenation whose
-/// only non-literal parts are a leading `^`, a trailing `$`, or both. It is deliberately no wider
-/// than that. A shape the lint does not name is left on the regex path, where it costs nothing;
-/// a shape misread as trivial would silently change which values a constraint admits.
-///
-/// Two of the shapes the lint calls trivial and offers no replacement for -- a pattern that
-/// matches everything (`""`, `^`, `$`), and one whose alternatives are all empty (`|`) -- never
-/// reach here at all: [`constraining_pattern`] refuses them where they are written, since there is
-/// no call to emit for them, only the absence of a check. The third, a bare `\b`, does reach here
-/// and keeps its regex, because it turns a value away and so has a check worth keeping.
-///
-/// The HIR walked is the one the lint reads, parsed with the options it parses with, so what is
-/// classified here is what it classifies. Anchors are the whole-haystack `Look::Start` and
-/// `Look::End` alone -- the line anchors `(?m)` turns those into never reach this crate, since
-/// [`portable_pattern`] refuses an inline flag before a pattern is ever emitted.
 #[cfg(feature = "serde")]
 pub fn trivial_pattern(pattern: &str) -> Option<TrivialPattern> {
     let parsed = regex_syntax::ParserBuilder::new()
@@ -1677,13 +1301,6 @@ fn literal_needle(parts: &[hir::Hir]) -> Option<String> {
 }
 
 /// Escapes a regex pattern for splicing between the `/` delimiters of a JavaScript regex literal.
-///
-/// The pattern is already a regex, so what needs work is what the literal syntax alone gives a
-/// meaning to: the `/` delimiter, which becomes `\/`, and a raw line terminator, which the literal
-/// cannot carry at all and so becomes its escape. A backslash escape is consumed whole, which keeps
-/// an authored `\/` from gaining a second backslash and keeps a literal `\\` from being read as the
-/// escape for the `/` that follows it. A backslash before a raw line terminator is an identity
-/// escape, and the escape form denotes that same character.
 #[cfg(feature = "zod")]
 pub fn escape_js_regex_literal(pattern: &str) -> String {
     let mut result = String::with_capacity(pattern.len());

--- a/src/utils/tests.rs
+++ b/src/utils/tests.rs
@@ -100,12 +100,6 @@ const CROSS_ENGINE_HAYSTACKS: [&str; 20] = [
 
 /// What a flagless JavaScript regex literal makes of each spelling the guard can hand one, over
 /// [`CROSS_ENGINE_HAYSTACKS`] in order.
-///
-/// Read off `new RegExp(source).test(haystack)` under node v26.2.0 (V8 14.6). The JavaScript side
-/// is recorded rather than executed because the crate's tests must not need a JavaScript runtime
-/// to run; what is asserted against it — the `regex` crate's verdict on the very string the guard
-/// emits — is executed. Both the authored spellings and the spellings they translate to are here,
-/// so the table shows the divergence and its closure side by side.
 const JAVASCRIPT_VERDICTS: [(&str, [bool; 20]); 22] = [
     (
         r"^\d$",
@@ -328,11 +322,6 @@ const UNCONSTRAINING_PATTERNS: [&str; 12] = [
 
 /// Patterns that turn some value away, kept beside [`UNCONSTRAINING_PATTERNS`] as the near misses
 /// that decide where the line sits.
-///
-/// `^$` and `^a*$` pin both ends of the value to one position, which is a constraint however
-/// little sits between them. `\b` and `\B` ask the value for a word boundary, or for the absence
-/// of one at every position, and the empty string has neither. `a+` and `(?:ab)+` demand the run
-/// they repeat at least once.
 const CONSTRAINING_PATTERNS: [&str; 8] = [
     "^$", "^a*$", r"\b", r"\B", "a+", "(?:ab)+", "^[a-z]+$", r"^\s*$",
 ];
@@ -879,12 +868,6 @@ fn test_the_emitted_pattern_picks_out_the_same_haystacks_in_both_engines() {
 
 /// Every regex this crate writes into a generated schema itself, rather than carrying over from an
 /// author's `pattern`.
-///
-/// Held to the guard the crate holds authors to, and held to it the strict way: admitted *and*
-/// handed back unchanged. A pattern the guard rewrites is one that was not written in the spelling
-/// both engines read the same way, and the crate is in a position to write it that way to begin
-/// with — so for these the rewrite is not a fix, it is the failure. That makes this the check a
-/// future emitted pattern has to pass before it can ship.
 #[test]
 #[cfg(feature = "object_id")]
 fn test_every_pattern_the_crate_emits_is_a_fixed_point_of_the_guard() {
@@ -954,14 +937,6 @@ fn test_portable_pattern_refuses_a_negated_class_whatever_its_members() {
 /// Held against the engines rather than restated, as the dot's verdict was: no spelling of a
 /// negated class agrees with JavaScript, so refusing every one of them is the verdict rather than
 /// an admission table of the ones that survive.
-///
-/// Each candidate below fills in the `regex` crate where a flagless literal cannot fill at all — a
-/// lone astral character is one character here and the two code units it is written from there, so
-/// no one-character class holds it. The one spelling whose `regex` reading does leave every astral
-/// character out has to name them by astral bounds, and that literal reads those bounds as
-/// surrogate halves in descending order: `new RegExp("^[^\u{10000}-\u{10FFFF}]$")` throws `Range
-/// out of order in character class` under node v26.2.0, so it is not a spelling that can be
-/// admitted either.
 #[test]
 fn test_no_spelling_of_a_negated_class_agrees_across_the_engines() {
     for candidate in NEGATED_CLASS_PATTERNS.into_iter().chain(["^[^\u{1f601}]$"]) {
@@ -1046,11 +1021,6 @@ fn test_portable_pattern_names_the_construct_javascript_cannot_carry() {
 
 /// Renaming a group is a change of spelling and not of meaning: what the pattern matched before
 /// it, it matches after — read off `regex::Regex` itself rather than restated here.
-///
-/// Equalising a perl class is the other kind of rewrite and deliberately does narrow what the
-/// `regex` crate accepts, down to the set JavaScript was going to enforce anyway. The haystacks
-/// here are ASCII, where the two engines already agree, so a `\d` sitting beside a renamed group
-/// still has to come through matching exactly what it matched.
 #[test]
 fn test_portable_pattern_rewrite_keeps_what_the_pattern_matched() {
     for pattern in [
@@ -1203,13 +1173,6 @@ fn test_a_pattern_admitting_every_value_is_refused() {
 }
 
 /// A pattern that turns some value away keeps its place, `\b` included.
-///
-/// `\b` is the one shape `clippy::trivial_regex` flags that this guard deliberately does not
-/// answer for. A probe run before this guard existed put `#[model_schema_prop(pattern = r"\b")]`
-/// through `cargo clippy --all-targets -- -D warnings` in a crate denying `clippy::nursery`, and
-/// the lint fired — `error: trivial regex ... the regex is unlikely to be useful as it is`, landing
-/// on the `#[model_schema()]` attribute. It fires anyway, and refusing `\b` here would be refusing
-/// a real constraint: the empty string holds no word boundary, so the pattern turns a value away.
 #[test]
 fn test_a_pattern_turning_some_value_away_clears_the_guard() {
     for pattern in CONSTRAINING_PATTERNS {

--- a/tests/advanced_tests/tests.rs
+++ b/tests/advanced_tests/tests.rs
@@ -13,11 +13,9 @@ struct Address {
     zip_code: String,
 }
 
-// Test complex nested structures (fixed to work with actual macro)
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct Company {
-    // Changed to string keys only - HashMap<String, Department> not supported
     department_names: Vec<String>,
     employees: Vec<Employee>,
     headquarters: Address,
@@ -38,7 +36,6 @@ struct CompanySettings {
     retirement_plan: Option<RetirementPlan>,
 }
 
-// Test discriminated union with complex fields
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(tag = "eventType", rename_all = "camelCase")]
@@ -77,7 +74,6 @@ struct ContactInfo {
     phone: Option<String>,
 }
 
-// Test with documentation comments
 /// A user account in the system.
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -95,7 +91,6 @@ struct DocumentedUser {
     name: String,
 }
 
-// Test edge cases with various field types (simplified)
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct EdgeCases {
@@ -103,7 +98,6 @@ struct EdgeCases {
     float_number: f32,
     medium_number: u32,
     nested_array: Vec<ContactInfo>,
-    // Nested optional structures
     #[serde(skip_serializing_if = "Option::is_none")]
     nested_optional: Option<ContactInfo>,
     numbers: Vec<u32>,
@@ -111,15 +105,11 @@ struct EdgeCases {
     optional_nested_array: Option<Vec<ContactInfo>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     optional_numbers: Option<Vec<u32>>,
-    // Optional collections
     #[serde(skip_serializing_if = "Option::is_none")]
     optional_strings: Option<Vec<String>>,
     small_number: u16,
-    // Simple maps (only string keys and values supported)
     string_map: HashMap<String, String>,
-    // Collections with different types
     strings: Vec<String>,
-    // Different numeric types
     tiny_number: u8,
 }
 
@@ -307,7 +297,6 @@ fn test_complex_nested_json_schema() {
     let settings_schema = CompanySettings::json_schema();
     let retirement_schema = RetirementPlan::json_schema();
 
-    // Verify all schemas are objects
     assert_eq!(company_schema["type"], "object");
     assert_eq!(employee_schema["type"], "object");
     assert_eq!(project_schema["type"], "object");
@@ -315,7 +304,6 @@ fn test_complex_nested_json_schema() {
     assert_eq!(settings_schema["type"], "object");
     assert_eq!(retirement_schema["type"], "object");
 
-    // Verify Company schema has all expected properties
     let company_properties = company_schema["properties"].as_object().unwrap();
     assert!(company_properties.contains_key("id"));
     assert!(company_properties.contains_key("name"));
@@ -324,7 +312,6 @@ fn test_complex_nested_json_schema() {
     assert!(company_properties.contains_key("headquarters"));
     assert!(company_properties.contains_key("settings"));
 
-    // Verify array properties are correctly typed
     assert_eq!(company_properties["employees"]["type"], "array");
     assert_eq!(company_properties["department_names"]["type"], "array");
     assert_eq!(
@@ -332,7 +319,6 @@ fn test_complex_nested_json_schema() {
         "string"
     );
 
-    // Verify RetirementPlan is a discriminated union
     assert!(retirement_schema.get("oneOf").is_some());
     let one_of = retirement_schema["oneOf"].as_array().unwrap();
     assert_eq!(one_of.len(), 3);
@@ -345,16 +331,13 @@ fn test_complex_nested_ts_definition() {
     let employee_definition = Employee::ts_definition();
     let retirement_definition = RetirementPlan::ts_definition();
 
-    // Check that nested types are properly referenced (without Json suffix)
     assert!(company_definition.contains("employees: Array<Employee>;"));
     assert!(company_definition.contains("department_names: Array<string>;"));
     assert!(company_definition.contains("headquarters: Address;"));
     assert!(company_definition.contains("settings: CompanySettings;"));
 
-    // Check optional fields in nested structures
     assert!(employee_definition.contains("manager?: string;"));
 
-    // Check discriminated union
     assert!(retirement_definition.contains("type: \"option401k\""));
     assert!(retirement_definition.contains("type: \"pension\""));
     assert!(retirement_definition.contains("type: \"roth\""));
@@ -362,7 +345,6 @@ fn test_complex_nested_ts_definition() {
     assert!(retirement_definition.contains("yearsOfServiceRequired: number;"));
     assert!(retirement_definition.contains("contributionLimit: number;"));
 
-    // Check Zod schema references (without Json suffix) - now in separate method
     let company_zod_schema = Company::zod_schema();
     let employee_zod_schema = Employee::zod_schema();
 
@@ -373,7 +355,6 @@ fn test_complex_nested_ts_definition() {
     assert!(employee_zod_schema.contains("manager: z.union([z.string(), z.undefined()])"));
 }
 
-// Test serialization consistency
 #[test]
 fn test_serialization_consistency() {
     let project = Project {
@@ -385,15 +366,12 @@ fn test_serialization_consistency() {
         budget: Some(50000),
     };
 
-    // Serialize to JSON
     let json_str = serde_json::to_string(&project).unwrap();
     let json_value: Value = serde_json::from_str(&json_str).unwrap();
 
-    // Deserialize back
     let deserialized: Project = serde_json::from_value(json_value.clone()).unwrap();
     assert_eq!(project, deserialized);
 
-    // Check that the JSON matches expected structure
     assert_eq!(json_value["id"], "proj_123");
     assert_eq!(json_value["name"], "New Website");
     assert_eq!(json_value["status"], "inProgress"); // Should be camelCase
@@ -408,13 +386,11 @@ fn test_edge_cases_json_schema() {
     let schema = EdgeCases::json_schema();
     let properties = schema["properties"].as_object().unwrap();
 
-    // Check numeric types
     assert_eq!(properties["tiny_number"]["type"], "integer");
     assert_eq!(properties["small_number"]["type"], "integer");
     assert_eq!(properties["medium_number"]["type"], "integer");
     assert_eq!(properties["float_number"]["type"], "number");
 
-    // Check array types
     assert_eq!(properties["strings"]["type"], "array");
     assert_eq!(properties["strings"]["items"]["type"], "string");
     assert_eq!(properties["numbers"]["type"], "array");
@@ -422,14 +398,12 @@ fn test_edge_cases_json_schema() {
     assert_eq!(properties["booleans"]["type"], "array");
     assert_eq!(properties["booleans"]["items"]["type"], "boolean");
 
-    // Check map types
     assert_eq!(properties["string_map"]["type"], "object");
     assert_eq!(
         properties["string_map"]["additionalProperties"]["type"],
         "string"
     );
 
-    // Check required vs optional fields
     let required = schema["required"].as_array().unwrap();
     assert!(required.contains(&Value::String("tiny_number".to_owned())));
     assert!(required.contains(&Value::String("strings".to_owned())));
@@ -444,7 +418,6 @@ fn test_edge_cases_json_schema() {
 fn test_edge_cases_ts_definition() {
     let ts_definition = EdgeCases::ts_definition();
 
-    // Check numeric types, arrays, optional arrays, maps, and nested types
     assert_ts_contains_fields(
         &ts_definition,
         &[
@@ -469,7 +442,6 @@ fn test_edge_cases_ts_definition() {
         ],
     );
 
-    // Check Zod schemas
     let zod_schema = EdgeCases::zod_schema();
     assert_zod_contains_fields(
         &zod_schema,
@@ -514,13 +486,11 @@ fn test_complex_discriminated_union() {
     let schema = ComplexEvent::json_schema();
     let ts_definition = ComplexEvent::ts_definition();
 
-    // Check that it's a discriminated union
     assert_eq!(schema["type"], "object");
     assert!(schema.get("oneOf").is_some());
     let one_of = schema["oneOf"].as_array().unwrap();
     assert_eq!(one_of.len(), 3);
 
-    // Check that each variant has the correct discriminator
     for variant in one_of {
         let properties = variant["properties"].as_object().unwrap();
         assert!(properties.contains_key("eventType"));
@@ -528,25 +498,21 @@ fn test_complex_discriminated_union() {
         assert!(properties["eventType"].get("const").is_some());
     }
 
-    // Check TypeScript definition
     assert!(ts_definition.contains("eventType: \"userRegistered\""));
     assert!(ts_definition.contains("eventType: \"purchaseCompleted\""));
     assert!(ts_definition.contains("eventType: \"systemMaintenance\""));
 
-    // Check that field names are converted to camelCase
     assert!(ts_definition.contains("userId: string;"));
     assert!(ts_definition.contains("registrationSource: string;"));
     assert!(ts_definition.contains("orderId: string;"));
     assert!(ts_definition.contains("totalAmount: number;"));
     assert!(ts_definition.contains("paymentMethod: string;"));
-    // Address type reference should not have Json suffix
     assert!(ts_definition.contains("shippingAddress?: Address;"));
     assert!(ts_definition.contains("scheduledStart: string;"));
     assert!(ts_definition.contains("estimatedDuration: number;"));
     assert!(ts_definition.contains("affectedServices: Array<string>;"));
     assert!(ts_definition.contains("notificationSent: boolean;"));
 
-    // Check Zod discriminated union - now in separate method
     let zod_schema = ComplexEvent::zod_schema();
     assert!(zod_schema.contains("z.discriminatedUnion(\"eventType\""));
 }
@@ -557,7 +523,6 @@ fn test_documented_struct() {
     let schema = DocumentedUser::json_schema();
     let ts_definition = DocumentedUser::ts_definition();
 
-    // Schema should still be valid
     assert_eq!(schema["type"], "object");
     let properties = schema["properties"].as_object().unwrap();
     assert!(properties.contains_key("id"));
@@ -566,7 +531,6 @@ fn test_documented_struct() {
     assert!(properties.contains_key("is_active"));
     assert!(properties.contains_key("metadata"));
 
-    // TypeScript definition should be generated (without Json suffix)
     assert!(ts_definition.contains("export type DocumentedUser = {"));
     assert!(ts_definition.contains("id: string;"));
     assert!(ts_definition.contains("name: string;"));
@@ -580,7 +544,6 @@ fn test_documented_struct() {
     );
 }
 
-// Test validation of generated JSON schemas
 #[test]
 #[cfg(feature = "jsonschema")]
 fn test_json_schema_validation() {
@@ -594,19 +557,15 @@ fn test_json_schema_validation() {
     ];
 
     for (name, schema) in schemas {
-        // All schemas should be objects
         assert!(schema.is_object(), "Schema for {name} should be an object");
 
-        // Should have required fields
         assert!(
             schema.get("type").is_some(),
             "Schema for {name} should have a type"
         );
 
-        // Object schemas should have properties
         if schema["type"] == "object" {
             if let Some(one_of) = schema.get("oneOf") {
-                // Discriminated union - check each variant
                 let variants = one_of.as_array().unwrap();
                 for variant in variants {
                     assert!(
@@ -615,7 +574,6 @@ fn test_json_schema_validation() {
                     );
                 }
             } else {
-                // Regular object - should have properties
                 assert!(
                     schema.get("properties").is_some(),
                     "Object schema for {name} should have properties"
@@ -623,13 +581,11 @@ fn test_json_schema_validation() {
             }
         }
 
-        // Should be valid JSON
         let json_str = serde_json::to_string(&schema).unwrap();
         let _: Value = serde_json::from_str(&json_str).unwrap();
     }
 }
 
-// Test actual serialization and deserialization roundtrip
 #[test]
 fn test_roundtrip_serialization() {
     let contact = ContactInfo {
@@ -652,15 +608,12 @@ fn test_roundtrip_serialization() {
         contact,
     };
 
-    // Test serialization
     let json_str = serde_json::to_string(&employee).unwrap();
     let json_value: Value = serde_json::from_str(&json_str).unwrap();
 
-    // Test deserialization
     let deserialized: Employee = serde_json::from_value(json_value).unwrap();
     assert_eq!(employee, deserialized);
 
-    // Test individual field serialization
     assert_eq!(deserialized.id, "emp_123");
     assert_eq!(deserialized.name, "Jane Smith");
     assert_eq!(deserialized.position, "Software Engineer");

--- a/tests/basic_tests/tests.rs
+++ b/tests/basic_tests/tests.rs
@@ -30,7 +30,6 @@ struct BasicUser {
     test,
     any(feature = "typescript", feature = "jsonschema", feature = "zod")
 ))]
-// Test empty struct.
 #[model_schema()]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq)]
@@ -40,7 +39,6 @@ struct EmptyStruct;
     test,
     any(feature = "typescript", feature = "jsonschema", feature = "zod")
 ))]
-// Test struct with optional fields.
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct UserWithOptionals {
@@ -85,11 +83,9 @@ fn test_basic_structs_constructible() {
 fn test_basic_struct_json_schema() {
     let schema = BasicUser::json_schema();
 
-    // Check that it's an object
     assert_eq!(schema["type"], "object");
     assert_eq!(schema["additionalProperties"], false);
 
-    // Check properties exist
     let properties = schema["properties"].as_object().unwrap();
     assert!(properties.contains_key("id"));
     assert!(properties.contains_key("name"));
@@ -97,14 +93,12 @@ fn test_basic_struct_json_schema() {
     assert!(properties.contains_key("height"));
     assert!(properties.contains_key("is_active"));
 
-    // Check property types
     assert_eq!(properties["id"]["type"], "string");
     assert_eq!(properties["name"]["type"], "string");
     assert_eq!(properties["age"]["type"], "integer");
     assert_eq!(properties["height"]["type"], "number");
     assert_eq!(properties["is_active"]["type"], "boolean");
 
-    // Check required fields
     let required = schema["required"].as_array().unwrap();
     assert_eq!(required.len(), 5);
     assert!(required.contains(&Value::String("id".to_owned())));
@@ -119,7 +113,6 @@ fn test_basic_struct_json_schema() {
 fn test_basic_struct_ts_definition() {
     let ts_definition = BasicUser::ts_definition();
 
-    // Check that it contains TypeScript type definition
     assert!(ts_definition.contains("export type BasicUser = {"));
     assert!(ts_definition.contains("id: string;"));
     assert!(ts_definition.contains("name: string;"));
@@ -127,7 +120,6 @@ fn test_basic_struct_ts_definition() {
     assert!(ts_definition.contains("height: number;"));
     assert!(ts_definition.contains("is_active: boolean;"));
 
-    // Should NOT contain Zod schema (now separated)
     assert!(!ts_definition.contains("export const BasicUser$Schema"));
     assert!(!ts_definition.contains("z.strictObject"));
     assert!(!ts_definition.contains("z.string()"));
@@ -140,7 +132,6 @@ fn test_basic_struct_ts_definition() {
 fn test_basic_struct_zod_schema() {
     let zod_schema = BasicUser::zod_schema();
 
-    // Check that it contains Zod schema
     assert!(zod_schema.contains("export const BasicUser$Schema"));
     assert!(zod_schema.contains("z.strictObject({"));
     assert!(zod_schema.contains("id: z.string()"));
@@ -149,7 +140,6 @@ fn test_basic_struct_zod_schema() {
     assert!(zod_schema.contains("height: z.number()"));
     assert!(zod_schema.contains("is_active: z.boolean()"));
 
-    // Should NOT contain TypeScript type definition
     assert!(!zod_schema.contains("export type BasicUser"));
     assert!(!zod_schema.contains("id: string;"));
     assert!(!zod_schema.contains("age: number;"));
@@ -160,7 +150,6 @@ fn test_basic_struct_zod_schema() {
 fn test_optional_fields_json_schema() {
     let schema = UserWithOptionals::json_schema();
 
-    // Check properties exist
     let properties = schema["properties"].as_object().unwrap();
     assert!(properties.contains_key("id"));
     assert!(properties.contains_key("name"));
@@ -168,7 +157,6 @@ fn test_optional_fields_json_schema() {
     assert!(properties.contains_key("age"));
     assert!(properties.contains_key("nickname"));
 
-    // Check required fields (only non-optional ones)
     let required = schema["required"].as_array().unwrap();
     assert_eq!(required.len(), 2);
     assert!(required.contains(&Value::String("id".to_owned())));
@@ -193,14 +181,12 @@ fn omitted_member(name: &str, ts_type: &str) -> String {
 fn test_optional_fields_ts_definition() {
     let ts_definition = UserWithOptionals::ts_definition();
 
-    // Check that optional fields are properly typed
     assert!(ts_definition.contains("id: string;"));
     assert!(ts_definition.contains("name: string;"));
     assert!(ts_definition.contains(&omitted_member("email", "string")));
     assert!(ts_definition.contains(&omitted_member("age", "number")));
     assert!(ts_definition.contains(&omitted_member("nickname", "string")));
 
-    // Should NOT contain Zod schema (now separated)
     assert!(!ts_definition.contains("z.union([z.string(), z.undefined()])"));
     assert!(!ts_definition.contains("z.union([z.number().int(), z.undefined()])"));
 }
@@ -210,12 +196,10 @@ fn test_optional_fields_ts_definition() {
 fn test_optional_fields_zod_schema() {
     let zod_schema = UserWithOptionals::zod_schema();
 
-    // Check Zod schema has optional fields
     assert!(zod_schema.contains("email: z.union([z.string(), z.undefined()])"));
     assert!(zod_schema.contains("age: z.union([z.number().int(), z.undefined()])"));
     assert!(zod_schema.contains("nickname: z.union([z.string(), z.undefined()])"));
 
-    // Should NOT contain TypeScript type definition
     assert!(!zod_schema.contains("email: string | undefined;"));
     assert!(!zod_schema.contains("age: number | undefined;"));
 }
@@ -240,6 +224,5 @@ fn test_empty_struct_json_schema() {
 fn test_empty_struct_ts_definition() {
     let ts_definition = EmptyStruct::ts_definition();
 
-    // Should generate Record<string, never> for empty structs
     assert!(ts_definition.contains("export type EmptyStruct = Record<string, never>;"));
 }

--- a/tests/branded_newtype_tests/tests.rs
+++ b/tests/branded_newtype_tests/tests.rs
@@ -1,4 +1,3 @@
-// Tests requiring both zod and typescript features
 #[cfg(all(feature = "zod", feature = "typescript"))]
 mod zod_ts_tests {
     use super::*;
@@ -8,14 +7,12 @@ mod zod_ts_tests {
     #[serde(transparent)]
     pub struct CorrelationId(pub String);
 
-    // Branded newtype with doc comment description
     /// A unique document identifier.
     #[model_schema()]
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     #[serde(transparent)]
     pub struct DocId(pub String);
 
-    // Generic branded newtype with doc comment and example
     /// Generic document identifier.
     ///
     /// - `DocumentId<String>` for API/HTTP layer.
@@ -34,7 +31,6 @@ mod zod_ts_tests {
     #[serde(transparent)]
     pub struct RoleId<IdType>(pub IdType);
 
-    // Integer inner type branded newtype
     #[model_schema()]
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     #[serde(transparent)]
@@ -49,16 +45,10 @@ mod zod_ts_tests {
         );
     }
 
-    /// The parameter is what the brand wraps, and a value surface reaches it through the argument
-    /// the enclosing factory binds for it — so the brand lands on the schema the caller supplied
-    /// rather than on a value that admits anything whatever it was filled with. The TypeScript
-    /// type beside it keeps `IdType`, its own declaration binding it for real.
-    ///
-    /// The builder itself carries no `$ZodBranded` — its own bound is the plain `IdType extends
-    /// ZodType`, unlike the non-generic const's own base schema, which names it directly. Only
-    /// `$SchemaDefault`, called at the declared default, has a concrete filling to annotate with
-    /// one (txsch-bpnj) — the shape `an_unconstrained_generic_brands_default_is_still_branded`
-    /// below pins.
+    /// The brand lands on the schema the caller supplied rather than on a value that admits
+    /// anything whatever it was filled with. Only `$SchemaDefault`, called at the declared
+    /// default, has a concrete filling to annotate with `$ZodBranded`; the builder's own bound
+    /// stays the plain `IdType extends ZodType`.
     #[test]
     fn test_branded_newtype_zod_schema() {
         let zod = RoleId::<String>::zod_schema();
@@ -73,13 +63,10 @@ mod zod_ts_tests {
         assert!(!zod[..builder_end].contains("$ZodBranded"), "Got: {zod}");
     }
 
-    /// Shape (b) from txsch-bpnj's capture: an *unconstrained* generic brand — no
-    /// `minLength`/`maxLength`/`pattern` at all — still has its `$SchemaDefault` annotated
-    /// `$ZodBranded<ZodString, "RoleId">` rather than `ZodType<RoleId<string>>`: the
-    /// factory's chain ends in `.brand()` whether or not there is a check to route, so the same
-    /// `_output` mismatch applies with or without one. Every class name is spelled off the `z`
-    /// namespace, since none resolves as a bare name under the documented `import { z } from
-    /// "zod";` (txsch-9rcw).
+    /// An *unconstrained* generic brand — no `minLength`/`maxLength`/`pattern` at all — still has
+    /// its `$SchemaDefault` annotated `$ZodBranded<ZodString, "RoleId">` rather than
+    /// `ZodType<RoleId<string>>`: the factory's chain ends in `.brand()` whether or not there is a
+    /// check to route.
     #[test]
     fn an_unconstrained_generic_brands_default_is_still_branded() {
         let zod = RoleId::<String>::zod_schema();
@@ -95,7 +82,6 @@ mod zod_ts_tests {
     #[test]
     fn test_branded_newtype_preserves_generic_param_name() {
         let ts = RoleId::<String>::ts_definition();
-        // Should contain IdType not T or any other name
         assert!(
             ts.contains("IdType"),
             "Should preserve generic param name. Got: {ts}"
@@ -124,12 +110,10 @@ mod zod_ts_tests {
     #[test]
     fn test_branded_newtype_non_generic_zod_schema_content() {
         let zod = CorrelationId::zod_schema();
-        // Should contain the raw schema definition
         assert!(
             zod.contains("const CorrelationId$RawSchema = z.string().brand"),
             "Should contain raw schema. Got: {zod}"
         );
-        // Should contain the exported typed schema
         assert!(
             zod.contains("export const CorrelationId$Schema: $ZodBranded<ZodString, \"CorrelationId\"> = CorrelationId$RawSchema"),
             "Should contain exported schema referencing raw schema. Got: {zod}"
@@ -139,14 +123,12 @@ mod zod_ts_tests {
     #[test]
     fn test_branded_newtype_integer_inner() {
         let ts = SequenceNum::ts_definition();
-        // Non-generic u64 maps to "number" in TypeScript
         assert!(
             ts.contains("export type SequenceNum = number & $brand<\"SequenceNum\">"),
             "Should have number branded type. Got: {ts}"
         );
 
         let zod = SequenceNum::zod_schema();
-        // Zod should use z.number().int() for u64
         assert!(
             zod.contains("z.number().int()"),
             "Should use z.number().int() for u64. Got: {zod}"
@@ -168,7 +150,6 @@ mod zod_ts_tests {
             zod.contains("A unique document identifier"),
             "Zod schema should contain doc comment text. Got:\n{zod}"
         );
-        // Must still have $Schema line after .meta()
         assert!(
             zod.contains("export const DocId$Schema:"),
             "Zod schema should have $Schema after .meta(). Got:\n{zod}"
@@ -190,8 +171,6 @@ mod zod_ts_tests {
             zod.contains("example:"),
             "Should contain example from doc comment. Got:\n{zod}"
         );
-        // The example lands inside the one `.meta({` the brand writes, and the binding the item
-        // publishes still stands after it.
         assert!(
             zod.contains("  example: \"64de3d95ff45b119e5b53a7e\",\n}).brand<\"DocumentId\">();"),
             "Should have the example inside the described block. Got:\n{zod}"
@@ -213,12 +192,10 @@ mod zod_ts_tests {
     }
 }
 
-// Tests for branded newtypes with string constraints
 #[cfg(all(feature = "zod", feature = "typescript", feature = "serde"))]
 mod constrained_branded_tests {
     use super::*;
 
-    // Pattern-only constraint
     #[model_schema(pattern = "^[0-9a-fA-F]{24}$")]
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     #[serde(transparent)]
@@ -294,7 +271,6 @@ mod constrained_branded_tests {
 
     #[test]
     fn test_constrained_branded_serde_rejects_invalid() {
-        // Serde should reject values that don't match constraints
         let too_short: Result<SlugId, _> = serde_json::from_str("\"ab\"");
         assert!(
             too_short.is_err(),
@@ -348,7 +324,6 @@ mod constrained_branded_tests {
             zod.contains(".check(z.regex(/^[0-9a-fA-F]{24}$/))"),
             "Should contain pattern. Got:\n{zod}"
         );
-        // Should not contain min/max
         assert!(!zod.contains(".min("), "Should not have min. Got:\n{zod}");
         assert!(!zod.contains(".max("), "Should not have max. Got:\n{zod}");
 
@@ -476,13 +451,10 @@ mod objectid_branded_surface_tests {
     }
 
     /// A brand's string constraints measure the inner's `Display` — the bare hex — which on the
-    /// wire is the `$oid` member, so both schema surfaces carry them there. Zod has no string
-    /// check to apply to the object itself.
-    ///
-    /// The brand's own `pattern` is layered rather than written over the hex the type always
-    /// holds: one JSON Schema string carries one `pattern`, and writing the brand's into that slot
-    /// dropped the type's — which is how a brand wider than the hex came to admit, on this surface
-    /// alone, strings an `ObjectId` can never hold.
+    /// wire is the `$oid` member, so both schema surfaces carry them there. The brand's own
+    /// `pattern` is layered rather than written over the hex the type always holds: one JSON
+    /// Schema string carries one `pattern`, and writing the brand's into that slot dropped the
+    /// type's.
     #[test]
     fn a_constrained_objectid_brand_carries_its_constraints_on_the_oid_member() {
         let zod = HexObjectId::zod_schema();
@@ -528,8 +500,7 @@ mod objectid_branded_surface_tests {
     }
 
     /// Every `pattern` the `$oid` member states, applied: the member's own and the one each `allOf`
-    /// branch adds. A payload has to match all of them, which is what a single `pattern` keyword
-    /// cannot say and so what tells a layered brand pattern from one written over the type's.
+    /// branch adds — which is what tells a layered brand pattern from one written over the type's.
     fn admits_oid(schema: &serde_json::Value, hex: &str) -> bool {
         let member = &schema["properties"]["$oid"];
         member["pattern"]
@@ -571,10 +542,8 @@ mod objectid_branded_surface_tests {
         }
     }
 
-    /// An arrayed `ObjectId` writes the array around the `$oid` object, which is a container and
-    /// so is described by the slot dispatch — the same rendering the unbranded tuple struct over
-    /// the same `Vec` publishes. Every position reads one builder, so the item here is the object
-    /// field position carries too.
+    /// An arrayed `ObjectId` writes the array around the `$oid` object, described by the slot
+    /// dispatch — the same rendering the unbranded tuple struct over the same `Vec` publishes.
     #[test]
     fn an_arrayed_objectid_brand_describes_the_array_of_oid_objects() {
         let zod = ObjectIdList::zod_schema();
@@ -607,7 +576,6 @@ mod objectid_branded_surface_tests {
     }
 }
 
-// Branded newtype referenced from a struct (all features enabled)
 #[cfg(all(feature = "zod", feature = "typescript", feature = "jsonschema"))]
 mod branded_in_struct_all_features_tests {
     use super::*;
@@ -695,7 +663,6 @@ mod branded_in_struct_all_features_tests {
     }
 }
 
-// Branded newtype referenced from a struct (zod+typescript, no jsonschema)
 #[cfg(all(feature = "zod", feature = "typescript", not(feature = "jsonschema")))]
 mod branded_in_struct_no_jsonschema_tests {
     use super::*;
@@ -742,7 +709,6 @@ mod branded_in_struct_no_jsonschema_tests {
     }
 }
 
-// Branded newtype referenced from a struct (jsonschema only, no zod/typescript)
 #[cfg(all(
     feature = "jsonschema",
     not(feature = "zod"),
@@ -798,7 +764,6 @@ mod branded_in_struct_jsonschema_only_tests {
     }
 }
 
-// Branded newtype referenced from a struct (typescript only, no zod/jsonschema)
 #[cfg(all(
     feature = "typescript",
     not(feature = "zod"),
@@ -839,7 +804,6 @@ mod branded_in_struct_typescript_only_tests {
     }
 }
 
-// Branded newtype with constraints — json_schema should include them
 #[cfg(feature = "jsonschema")]
 mod branded_constrained_json_schema_tests {
     use super::*;
@@ -907,7 +871,6 @@ mod branded_constrained_json_schema_tests {
         assert_eq!(schema["type"], "string", "Got: {schema}");
         assert_eq!(schema["minLength"], 3_i64, "Got: {schema}");
         assert_eq!(schema["maxLength"], 50_i64, "Got: {schema}");
-        // No pattern constraint — should not be present
         assert!(schema.get("pattern").is_none(), "Got: {schema}");
     }
 }
@@ -944,24 +907,17 @@ mod constrained_generic_branded_tests {
     }
 
     /// A declared default naming `StrictDocumentId` at exactly its own declared default — the
-    /// `ProDoctivity` `EcmDocument`/`DocumentId` shape the fold feature was motivated by. Before
-    /// the fix, the comparison read `StrictDocumentId$SchemaDefault`'s emitted text — the
-    /// `.min`/`.max`/`.check` chain and all — against the plain rendering this struct's own field
-    /// computes, so the two could never agree and the fold silently composed an unconstrained
-    /// `StrictDocumentId$SchemaFactory(z.string())` in its place.
+    /// shape the fold exists for.
     #[model_schema(default_types(HolderType = StrictDocumentId<String>))]
     #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct StrictDocumentIdHolder<HolderType> {
         pub id: HolderType,
     }
 
-    /// A SECOND constrained generic brand — itself carrying string constraints, unlike
-    /// `StrictDocumentIdHolder` above, which carries none — whose declared default names
-    /// `StrictDocumentId` at exactly its own declared default. The fold (txsch-qobf) resolves
-    /// `default_zod_rendering` to the deferred `z.lazy(() => StrictDocumentId$SchemaDefault)`
-    /// spelling, and `OuterId`'s own checks have to compose *inside* that thunk rather than after
-    /// it — the folded-generic-sibling half of txsch-euxz's bug, the non-generic half being
-    /// `constrained_default_names_a_sibling_tests::OuterBrand` below.
+    /// A second constrained generic brand whose declared default names `StrictDocumentId` at
+    /// exactly its own declared default, so the fold defers to
+    /// `z.lazy(() => StrictDocumentId$SchemaDefault)` and `OuterId`'s own checks have to compose
+    /// *inside* that thunk rather than after it.
     #[model_schema(minLength = 10, default_types(WrapType = StrictDocumentId<String>))]
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     #[serde(transparent)]
@@ -985,16 +941,7 @@ mod constrained_generic_branded_tests {
     }
 
     /// `$SchemaDefault` is the factory called at the declared default argument, with the checks
-    /// composed onto that argument — exactly the shape the design settled on.
-    ///
-    /// Annotated `$ZodBranded<ZodString, "StrictDocumentId">` rather than
-    /// `ZodType<StrictDocumentId<string>>`: the factory's own chain always ends in `.brand()`, and
-    /// strict tsc rejects the plain `ZodType<...>` spelling there — the classic interface's
-    /// deprecated `_output` field is computed at the pre-brand type and a brand intersection does
-    /// not refresh it (txsch-bpnj). `$ZodBranded` matches the spelling the non-generic const
-    /// already carries for the identical reason, and every class name is spelled off the `z`
-    /// namespace, since none resolves as a bare name under the documented `import { z } from
-    /// "zod";` (txsch-9rcw).
+    /// composed onto that argument.
     #[test]
     fn the_default_composes_the_factory_with_the_constrained_argument() {
         let zod = StrictDocumentId::<String>::zod_schema();
@@ -1035,20 +982,11 @@ mod constrained_generic_branded_tests {
         );
     }
 
-    /// `OuterId` is itself constrained, and its declared default folds onto `StrictDocumentId`'s
-    /// own `$SchemaDefault` — the deferred, checks-carrying binding, not a plain
-    /// `StrictDocumentId$SchemaFactory(z.string())` reconstruction. `OuterId`'s own `minLength`
-    /// check composes *inside* the `z.lazy(...)` thunk, over `.check(...)`'s base spelling rather
-    /// than `.min(...)`'s chain spelling — the deferred target's annotation is not guaranteed to
-    /// carry `ZodString`'s own chain methods, only the `.check(...)` every schema exposes. Before
-    /// the fix, this same check was appended after the thunk closed, landing on `ZodLazy`, which
-    /// has neither.
-    ///
-    /// Annotated `$ZodBranded<ZodLazy<typeof StrictDocumentId$SchemaDefault>, "OuterId">`
-    /// rather than `ZodType<OuterId<StrictDocumentId<string>>>` — the same `.brand()`-vs-`ZodType`
-    /// mismatch `the_default_composes_the_factory_with_the_constrained_argument` documents, with
-    /// the deferred target's own type spelled through `typeof` (txsch-bpnj), and every class name
-    /// spelled off the `z` namespace (txsch-9rcw).
+    /// `OuterId`'s declared default folds onto `StrictDocumentId$SchemaDefault` — the deferred,
+    /// checks-carrying binding — and `OuterId`'s own `minLength` composes *inside* the
+    /// `z.lazy(...)` thunk, over `.check(...)`'s base spelling: the deferred target's annotation is
+    /// not guaranteed to carry `ZodString`'s chain methods, only the `.check(...)` every schema
+    /// exposes.
     #[test]
     fn a_constrained_brands_default_naming_another_constrained_brands_default_composes_the_checks_inside_the_thunk()
      {
@@ -1093,8 +1031,8 @@ mod constrained_generic_branded_tests {
     }
 }
 
-/// The non-generic-sibling half of txsch-euxz's bug: a constrained generic brand whose declared
-/// default names an ordinary (non-generic) `#[model_schema]` sibling. Held apart from
+/// A constrained generic brand whose declared default names an ordinary (non-generic)
+/// `#[model_schema]` sibling. Held apart from
 /// `constrained_generic_branded_tests` above (whose fixtures all name a *generic* sibling) so each
 /// module pins one of the two spellings `default_zod_rendering` can defer to — a bare `$Schema`
 /// here, a folded `$SchemaDefault` there.
@@ -1113,21 +1051,18 @@ mod constrained_default_names_a_sibling_tests {
     /// A constrained generic brand whose declared default names `InnerString` — a non-generic
     /// sibling, so `default_zod_rendering` defers to its bare `$Schema` binding (never a
     /// `$SchemaDefault`, which only a generic sibling publishes) rather than reconstructing it
-    /// eagerly. This is the exact repro from txsch-euxz's own bug report.
+    /// eagerly.
     #[model_schema(minLength = 3, default_types(T = InnerString))]
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     #[serde(transparent)]
     pub struct OuterBrand<T>(pub T);
 
-    /// Before the fix: `OuterBrand$SchemaFactory(z.lazy(() => InnerString$Schema).min(3))` —
-    /// `.min` landing on `ZodLazy`, which does not have it. After: the check composes inside the
-    /// thunk, over `InnerString$Schema`'s own base `.check(...)` surface.
+    /// The check composes inside the thunk, over `InnerString$Schema`'s own base `.check(...)`
+    /// surface — `.min` after the thunk closed would land on `ZodLazy`, which does not have it.
     ///
-    /// Annotated `$ZodBranded<ZodLazy<typeof InnerString$Schema>, "OuterBrand">` rather
-    /// than `ZodType<OuterBrand<InnerString>>` — the same `.brand()`-vs-`ZodType` mismatch
-    /// `constrained_generic_branded_tests` documents for the primitive-default case, with the
-    /// deferred target's own type spelled through `typeof` (txsch-bpnj), and every class name
-    /// spelled off the `z` namespace (txsch-9rcw).
+    /// Annotated `$ZodBranded<ZodLazy<typeof InnerString$Schema>, "OuterBrand">` for the same
+    /// `.brand()`-vs-`ZodType` mismatch, with the deferred target's own type spelled through
+    /// `typeof`.
     #[test]
     fn a_constrained_brands_default_naming_a_non_generic_sibling_composes_the_check_inside_the_thunk()
      {
@@ -1171,7 +1106,6 @@ mod constrained_default_names_a_sibling_tests {
     }
 }
 
-// Display impl is generated for branded newtypes when any schema feature is enabled
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 mod branded_display_tests {
     use super::*;
@@ -1247,13 +1181,8 @@ mod branded_no_display_tests {
 }
 
 /// The four surfaces of a brand whose inner writes a container, pinned against what serde writes
-/// for it.
-///
-/// `#[serde(transparent)]` puts the inner on the wire by itself, so an array inner writes an
-/// array, a map inner an object, and a tuple inner the fixed-arity array — never a string. The
-/// TypeScript type and the Zod value already described those; the Zod type annotation and the JSON
-/// schema are pinned here beside them, so a consumer type-checking the exported binding and one
-/// validating a payload read the same shape.
+/// for it: `#[serde(transparent)]` puts the inner on the wire by itself, so an array inner writes
+/// an array, a map inner an object, and a tuple inner the fixed-arity array — never a string.
 #[cfg(all(
     feature = "jsonschema",
     feature = "serde",
@@ -1561,20 +1490,7 @@ mod branded_composite_inner_tests {
     }
 }
 
-/// The four surfaces of a brand whose inner is written out of the brand's own type parameters,
-/// pinned against what serde writes for it.
-///
-/// A parameter changes nothing about what `#[serde(transparent)]` puts on the wire: a `Vec` inner
-/// writes its array whether the elements are `String` or a parameter. So the shape around the
-/// parameter is described here exactly as the same shape is described where it is written without
-/// a brand — the generic alias beside each brand is that shape, and every surface is asserted to
-/// carry the same rendering it does.
-///
-/// The parameter itself carries what an uninstantiated parameter carries in every other position:
-/// its own name in TypeScript, where the declaration binds it for real; the argument the enclosing
-/// factory binds in Zod, where a schema is a value the caller has to fill before anything can
-/// validate; and the permissive empty schema in JSON, where the one document written covers every
-/// filling and so can describe none of them.
+/// The four surfaces of a brand whose inner is written out of the brand's own type parameters.
 #[cfg(all(
     feature = "jsonschema",
     feature = "serde",
@@ -1763,13 +1679,10 @@ mod branded_generic_inner_tests {
         }
     }
 
-    /// Zod publishes values, and a value-level surface has no generic a `const` can be declared
-    /// over: a parameter rendered as the `Name$Schema` binding every unresolved type is named
-    /// after would reference a binding no emitted module ever declares, and the consumer that
-    /// pastes the output gets a `ReferenceError` before any payload is read.
-    ///
-    /// Asserted over the brand and the alias together, because both compose their value from the
-    /// same rendering and so would drift apart one landing at a time.
+    /// A parameter rendered as the `Name$Schema` binding every unresolved type is named after
+    /// would reference a binding no emitted module declares, and the consumer that pastes the
+    /// output gets a `ReferenceError` before any payload is read. Asserted over the brand and the
+    /// alias together, since both compose their value from the same rendering.
     #[test]
     fn no_emitted_zod_value_references_a_binding_named_after_a_parameter() {
         for zod in [
@@ -1851,12 +1764,10 @@ mod branded_example_arity_tests {
     }
 }
 
-/// What a build emitting no TypeScript writes for a brand.
-///
-/// The name a brand carries is a *type* argument to `.brand`, and the binding's annotation is a
-/// type — neither of which a JavaScript parser reads, and a module carrying either stops at load
-/// rather than at a payload. Zod's runtime brand takes no argument at all, so the bare call is the
-/// same value under a spelling JavaScript does read.
+/// What a build emitting no TypeScript writes for a brand: the name a brand carries is a *type*
+/// argument to `.brand` and the binding's annotation is a type — neither of which a JavaScript
+/// parser reads. Zod's runtime brand takes no argument at all, so the bare call is the same value
+/// under a spelling JavaScript does read.
 #[cfg(all(feature = "zod", not(feature = "typescript")))]
 mod branded_javascript_flavour_tests {
     use super::*;
@@ -1889,13 +1800,8 @@ mod branded_javascript_flavour_tests {
     }
 }
 
-/// The four surfaces of a brand whose inner names another type, pinned against what serde writes
-/// for it.
-///
-/// `#[serde(transparent)]` puts the named type on the wire by itself, so an object inner writes
-/// that object — never a string. The TypeScript type and the Zod value already deferred to the
-/// name; the JSON schema and the Zod type annotation are pinned here beside them, so a consumer
-/// type-checking the exported binding and one validating a payload read the same shape.
+/// The four surfaces of a brand whose inner names another type: `#[serde(transparent)]` puts the
+/// named type on the wire by itself, so an object inner writes that object — never a string.
 #[cfg(all(
     feature = "jsonschema",
     feature = "serde",
@@ -1972,10 +1878,9 @@ mod branded_sibling_inner_tests {
     #[serde(transparent)]
     pub struct LateSlug(pub String);
 
-    // The same forward declaration with the inner's argument fixed where it is written, which is
-    // what the refusal for a parameterised inner does not reach. Written above `LateTag`, with
-    // `TrailingFixedTag` below it, so the one declaration stands here in both the orders it can be
-    // written in — the registry silent for the first and answering for the second.
+    // The same forward declaration with the inner's argument fixed where it is written. Written
+    // above `LateTag`, with `TrailingFixedTag` below it, so the one declaration stands in both the
+    // orders it can be written in — the registry silent for the first, answering for the second.
     #[model_schema(minLength = 3)]
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     #[serde(transparent)]
@@ -2103,16 +2008,10 @@ mod branded_sibling_inner_tests {
         );
     }
 
-    /// A brand reaching a name before the named item has expanded is asking a registry that has
-    /// nothing recorded for it, and the constrained brand keeps the emission it has always had
-    /// rather than being refused for where its inner happens to be written.
-    ///
-    /// That absence is the same one an unresolved user type leaves — a type this crate never
-    /// expands, whose schema the author supplies — so refusing on it would refuse the second for
-    /// the sake of the first. The consult is kept for the registration that follows instead, and
-    /// here that registration proves a string and settles it silently: what the author reads is the
-    /// same verdict wherever the two items are written. The `Display` assertion still bounds the
-    /// Rust surface either way.
+    /// A brand reaching a name before the named item has expanded asks a registry that has nothing
+    /// recorded for it, and keeps its emission rather than being refused for where its inner
+    /// happens to be written: that absence is the same one an unresolved user type leaves, so
+    /// refusing on it would refuse the second for the sake of the first.
     #[test]
     fn a_constrained_brand_over_a_forward_declared_sibling_keeps_its_emission() {
         assert_eq!(
@@ -2157,13 +2056,8 @@ mod branded_sibling_inner_tests {
     }
 
     /// The same declaration written after the item it names carries the same checks to the same
-    /// three surfaces, byte for byte.
-    ///
-    /// What `LateTag` records is a position rather than a word, so the registry answers with the
-    /// argument this brand wrote — a string, which is what the emission composes the checks onto.
-    /// One word could not have said that: it would have to stand for every filling, and the only
-    /// word that does is the opaque one, which refuses the very declaration the other order
-    /// admits. What the author reads is the same verdict wherever the two items are written.
+    /// three surfaces, byte for byte: what `LateTag` records is a position rather than a word, so
+    /// the registry answers with the argument this brand wrote.
     #[test]
     fn a_constrained_brand_over_a_fixed_instantiation_reads_the_same_in_either_order() {
         assert_eq!(TrailingFixedTag::json_schema(), FixedTag::json_schema());
@@ -2598,7 +2492,6 @@ mod constrained_no_display_tests {
     }
 }
 
-// zod=OFF, typescript=ON tests
 #[cfg(all(feature = "typescript", not(feature = "zod")))]
 mod no_zod_tests {
     use super::*;
@@ -2608,7 +2501,6 @@ mod no_zod_tests {
     #[serde(transparent)]
     pub struct RoleIdNoZod<IdType>(pub IdType);
 
-    // Non-generic branded newtype without Zod
     #[model_schema()]
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     #[serde(transparent)]
@@ -2632,12 +2524,10 @@ mod no_zod_tests {
     #[test]
     fn test_branded_newtype_non_generic_no_zod() {
         let ts = SessionToken::ts_definition();
-        // Should have unique symbol declaration
         assert!(
             ts.contains("declare const __brand_SessionToken: unique symbol"),
             "Should have unique symbol. Got: {ts}"
         );
-        // Should have non-generic type definition
         assert!(
             ts.contains(
                 "export type SessionToken = string & { readonly [__brand_SessionToken]: true }"
@@ -2647,7 +2537,6 @@ mod no_zod_tests {
     }
 }
 
-// Serde transparent test (always runs when serde is available)
 #[cfg(feature = "serde")]
 mod serde_tests {
     use super::*;
@@ -2664,28 +2553,23 @@ mod serde_tests {
 
     #[test]
     fn test_branded_newtype_serde_transparent() {
-        // WrappedString("abc") should serialize as "abc"
         let val = WrappedString("abc".to_owned());
         let json = serde_json::to_string(&val).unwrap();
         assert_eq!(json, "\"abc\"");
 
-        // "abc" should deserialize as WrappedString("abc")
         let deserialized: WrappedString = serde_json::from_str("\"abc\"").unwrap();
         assert_eq!(deserialized, WrappedString("abc".to_owned()));
     }
 
     #[test]
     fn test_branded_newtype_generic_serde_roundtrip() {
-        // Serialize a generic branded newtype with String inner type
         let original = GenericId::<String>("abc-123".to_owned());
         let json = serde_json::to_string(&original).unwrap();
         assert_eq!(json, "\"abc-123\"", "Should serialize transparently");
 
-        // Deserialize back
         let deserialized: GenericId<String> = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized, original, "Roundtrip should preserve equality");
 
-        // Also test with a numeric inner type
         let num_original = GenericId::<u64>(42);
         let num_json = serde_json::to_string(&num_original).unwrap();
         assert_eq!(num_json, "42", "Should serialize u64 transparently");
@@ -2698,14 +2582,10 @@ mod serde_tests {
     }
 }
 
-/// One value is one wire, and every spelling of that value publishes the one JSON type keyword the
-/// wire describes as.
-///
-/// `#[serde(transparent)]` puts the inner on the wire by itself, so a brand over a `u32` writes
-/// exactly what a field, a one-slot tuple struct and an alias of the same `u32` write. The four are
-/// pinned against each other because a keyword taken from the rendered TypeScript name instead of
-/// from the type spelled `integer` three times and `number` once — the same wire named twice, which
-/// the merge repeating the keyword cannot pick a side in.
+/// Every spelling of one value publishes the one JSON type keyword its wire describes as: a brand
+/// over a `u32` writes exactly what a field, a one-slot tuple struct and an alias of the same `u32`
+/// write. Pinned against each other because a keyword taken from the rendered TypeScript name
+/// instead of from the type spelled `integer` three times and `number` once.
 #[cfg(all(feature = "jsonschema", feature = "serde"))]
 mod branded_scalar_keyword_tests {
     use super::*;

--- a/tests/chrono_tests/tests.rs
+++ b/tests/chrono_tests/tests.rs
@@ -5,7 +5,6 @@ use serde::{Deserialize, Serialize};
 
 use tixschema::model_schema;
 
-// Test struct with all chrono types.
 #[model_schema()]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq)]
@@ -17,7 +16,6 @@ struct AllChronoTypes {
     utc_datetime: DateTime<Utc>,
 }
 
-// Test struct with Vec of dates.
 #[model_schema()]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq)]
@@ -26,7 +24,6 @@ struct DateList {
     name: String,
 }
 
-// Test struct with HashMap of DateTime.
 #[model_schema()]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq)]
@@ -78,7 +75,6 @@ struct NestedChronoMaps {
     window_batches: HashMap<String, Vec<HashMap<String, NaiveTime>>>,
 }
 
-// Test struct with NaiveDate field.
 #[model_schema()]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq)]
@@ -102,7 +98,6 @@ pub enum FixedValue {
     Time(NaiveTime),
 }
 
-// Test struct with NaiveDateTime field.
 #[model_schema()]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq)]
@@ -111,7 +106,6 @@ struct LocalEvent {
     title: String,
 }
 
-// Test struct with DateTime<Local> field.
 #[model_schema()]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq)]
@@ -120,7 +114,6 @@ struct LocalTimestamp {
     local_time: DateTime<Local>,
 }
 
-// Test struct with optional DateTime.
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct OptionalTimestamp {
@@ -129,7 +122,6 @@ struct OptionalTimestamp {
     updated_at: Option<DateTime<Utc>>,
 }
 
-// Test struct with NaiveTime field.
 #[model_schema()]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq)]
@@ -138,7 +130,6 @@ struct Schedule {
     task: String,
 }
 
-// Test struct with DateTime<Utc> field.
 #[model_schema()]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq)]
@@ -147,7 +138,6 @@ struct TimestampedRecord {
     id: String,
 }
 
-// Test struct mixing the default Date rendering with the `as_number` opt-out.
 #[model_schema()]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -158,8 +148,6 @@ struct Sample {
     start_time: NaiveTime,
 }
 
-// Test enum with a TupleSingle DateTime variant honoring the as_number opt-out. A `DateTime` is
-// written as a string, so it needs a content key of its own to sit under.
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "type", content = "value")]
@@ -257,8 +245,6 @@ fn test_chrono_types_constructible() {
     };
     assert!(optional_timestamp.updated_at.is_none());
 }
-
-// ========== TypeScript Type Tests ==========
 
 #[test]
 #[cfg(feature = "typescript")]
@@ -368,8 +354,6 @@ fn test_all_chrono_types_typescript() {
     );
 }
 
-// ========== Zod Schema Tests ==========
-
 #[test]
 #[cfg(feature = "zod")]
 fn test_naive_date_zod() {
@@ -453,8 +437,6 @@ fn test_hashmap_datetime_zod() {
         "HashMap<String, DateTime<Utc>> should use z.record(z.string(), z.coerce.date()). Got: {zod}"
     );
 }
-
-// ========== JSON Schema Tests ==========
 
 #[test]
 #[cfg(feature = "jsonschema")]
@@ -660,18 +642,14 @@ fn test_nested_string_keyed_chrono_map_typescript_and_zod() {
     }
 }
 
-// ========== Enum Tests (Original Use Case) ==========
-
 #[test]
 #[cfg(feature = "typescript")]
 fn test_enum_with_datetime_typescript() {
     let ts = FixedValue::ts_definition();
-    // The enum should compile and generate TypeScript.
     assert!(
         ts.contains("FixedValue"),
         "Should generate FixedValue type. Got: {ts}"
     );
-    // DateTime variant should be present.
     assert!(
         ts.contains("DateTime"),
         "Should contain DateTime variant. Got: {ts}"
@@ -682,18 +660,14 @@ fn test_enum_with_datetime_typescript() {
 #[cfg(feature = "zod")]
 fn test_enum_with_datetime_zod() {
     let zod = FixedValue::zod_schema();
-    // The enum should compile and generate Zod schema.
     assert!(
         zod.contains("FixedValue$Schema"),
         "Should generate FixedValue$Schema. Got: {zod}"
     );
 }
 
-// ========== Compilation Smoke Test ==========
-
 #[test]
 fn test_chrono_compilation_smoke_test() {
-    // This test ensures all chrono types compile without panics.
     let event = EventWithDate {
         name: "Test Event".to_owned(),
         date: NaiveDate::from_ymd_opt(2025, 11, 29).unwrap(),
@@ -709,13 +683,10 @@ fn test_chrono_compilation_smoke_test() {
         created_at: Utc::now(),
     };
 
-    // If we get here without panics, chrono support is working at compile time.
     assert_eq!(event.name, "Test Event");
     assert_eq!(schedule.task, "Meeting");
     assert!(!timestamp.id.is_empty());
 }
-
-// ========== as_number opt-out + native Date default ==========
 
 #[test]
 #[cfg(feature = "typescript")]
@@ -755,7 +726,6 @@ fn test_sample_zod_mixes_coerce_date_and_inline_number() {
         zod.contains("}, z.number()),"),
         "as_number coercer should validate with z.number(). Got: {zod}"
     );
-    // It must not fall back to the ISO datetime renderer or a named fn.
     assert!(
         !zod.contains("created_at: z.iso.datetime"),
         "as_number field must not use z.iso.datetime. Got: {zod}"

--- a/tests/collection_tests/tests.rs
+++ b/tests/collection_tests/tests.rs
@@ -20,7 +20,6 @@ const SEQUENCE_WRAPPERS: [&str; 5] = [
     "VecDeque",
 ];
 
-// Test comprehensive HashMap scenarios with various value types
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct ComprehensiveHashMapTest {
@@ -38,7 +37,6 @@ struct ComprehensiveHashMapTest {
     u64_value: HashMap<String, u64>,
 }
 
-// Test potential edge case with HashMap containing 64-bit integers
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct HashMapWith64Bit {
@@ -401,7 +399,6 @@ struct WrappedMapFields {
     wrapped_raw_keyed_counts: VecDeque<HashMap<u32, u64>>,
 }
 
-// Test struct with collections
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct UserWithCollections {
@@ -924,14 +921,12 @@ fn test_collections_json_schema() {
 
     let properties = schema["properties"].as_object().unwrap();
 
-    // Check array properties
     assert_eq!(properties["tags"]["type"], "array");
     assert_eq!(properties["tags"]["items"]["type"], "string");
 
     assert_eq!(properties["scores"]["type"], "array");
     assert_eq!(properties["scores"]["items"]["type"], "integer");
 
-    // Check map properties
     assert_eq!(properties["metadata"]["type"], "object");
     assert_eq!(
         properties["metadata"]["additionalProperties"]["type"],
@@ -944,13 +939,10 @@ fn test_collections_json_schema() {
 fn test_collections_ts_definition() {
     let ts_definition = UserWithCollections::ts_definition();
 
-    // Check TypeScript array types
     assert!(ts_definition.contains("tags: Array<string>;"));
     assert!(ts_definition.contains("scores: Array<number>;"));
-    // HashMap becomes Partial<Record<...>> in the generated output
     assert!(ts_definition.contains("metadata: Partial<Record<string, string>>;"));
 
-    // Check Zod schema - now in separate method
     let zod_schema = UserWithCollections::zod_schema();
     assert!(zod_schema.contains("tags: z.array(z.string())"));
     assert!(zod_schema.contains("scores: z.array(z.number().int())"));
@@ -963,14 +955,12 @@ fn test_comprehensive_hashmap_json_schema() {
     let schema = ComprehensiveHashMapTest::json_schema();
     let properties = schema["properties"].as_object().unwrap();
 
-    // Test simple primitive values
     assert_hashmap_primitive_type(properties, "string_value", "string");
     assert_hashmap_primitive_type(properties, "u64_value", "integer");
     assert_hashmap_primitive_type(properties, "i64_value", "integer");
     assert_hashmap_primitive_type(properties, "f64_value", "number");
     assert_hashmap_primitive_type(properties, "bool_value", "boolean");
 
-    // Test array values
     assert_hashmap_array_type(properties, "string_array", "string");
     assert_hashmap_array_type(properties, "u64_array", "integer");
     assert_hashmap_array_type(properties, "i64_array", "integer");
@@ -999,21 +989,18 @@ fn test_comprehensive_hashmap_json_schema() {
 fn test_comprehensive_hashmap_typescript_generation() {
     let ts_definition = ComprehensiveHashMapTest::ts_definition();
 
-    // Test TypeScript type generation for simple values
     assert!(ts_definition.contains("string_value: Partial<Record<string, string>>;"));
     assert!(ts_definition.contains("u64_value: Partial<Record<string, number>>;"));
     assert!(ts_definition.contains("i64_value: Partial<Record<string, number>>;"));
     assert!(ts_definition.contains("f64_value: Partial<Record<string, number>>;"));
     assert!(ts_definition.contains("bool_value: Partial<Record<string, boolean>>;"));
 
-    // Test TypeScript type generation for array values
     assert!(ts_definition.contains("string_array: Partial<Record<string, Array<string>>>;"));
     assert!(ts_definition.contains("u64_array: Partial<Record<string, Array<number>>>;"));
     assert!(ts_definition.contains("i64_array: Partial<Record<string, Array<number>>>;"));
     assert!(ts_definition.contains("f64_array: Partial<Record<string, Array<number>>>;"));
     assert!(ts_definition.contains("bool_array: Partial<Record<string, Array<boolean>>>;"));
 
-    // Test Zod schema generation for simple values - now in separate method
     let zod_schema = ComprehensiveHashMapTest::zod_schema();
     assert!(zod_schema.contains("string_value: z.record(z.string(), z.string())"));
     assert!(zod_schema.contains("u64_value: z.record(z.string(), z.number().int())"));
@@ -1021,7 +1008,6 @@ fn test_comprehensive_hashmap_typescript_generation() {
     assert!(zod_schema.contains("f64_value: z.record(z.string(), z.number())"));
     assert!(zod_schema.contains("bool_value: z.record(z.string(), z.boolean())"));
 
-    // Test Zod schema generation for array values
     assert!(zod_schema.contains("string_array: z.record(z.string(), z.array(z.string()))"));
     assert!(zod_schema.contains("u64_array: z.record(z.string(), z.array(z.number().int()))"));
     assert!(zod_schema.contains("i64_array: z.record(z.string(), z.array(z.number().int()))"));
@@ -2575,21 +2561,18 @@ fn test_hashmap_with_64bit_json_schema() {
 
     let properties = schema["properties"].as_object().unwrap();
 
-    // Check HashMap with u64 values
     assert_eq!(properties["u64_map"]["type"], "object");
     assert_eq!(
         properties["u64_map"]["additionalProperties"]["type"],
         "integer"
     );
 
-    // Check HashMap with i64 values
     assert_eq!(properties["i64_map"]["type"], "object");
     assert_eq!(
         properties["i64_map"]["additionalProperties"]["type"],
         "integer"
     );
 
-    // Check HashMap with Vec<u64> values
     assert_eq!(properties["mixed_map"]["type"], "object");
     assert_eq!(
         properties["mixed_map"]["additionalProperties"]["type"],
@@ -2606,12 +2589,10 @@ fn test_hashmap_with_64bit_json_schema() {
 fn test_hashmap_with_64bit_ts_definition() {
     let ts_definition = HashMapWith64Bit::ts_definition();
 
-    // Check TypeScript HashMap types
     assert!(ts_definition.contains("u64_map: Partial<Record<string, number>>;"));
     assert!(ts_definition.contains("i64_map: Partial<Record<string, number>>;"));
     assert!(ts_definition.contains("mixed_map: Partial<Record<string, Array<number>>>;"));
 
-    // Check Zod schema - now in separate method
     let zod_schema = HashMapWith64Bit::zod_schema();
     assert!(zod_schema.contains("u64_map: z.record(z.string(), z.number().int())"));
     assert!(zod_schema.contains("i64_map: z.record(z.string(), z.number().int())"));

--- a/tests/edge_cases_tests/tests.rs
+++ b/tests/edge_cases_tests/tests.rs
@@ -50,18 +50,14 @@ struct Address {
         feature = "serde"
     )
 ))]
-// Test the specific edge case that was originally failing
 #[model_schema()]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq)]
 struct OriginalBugReproduction {
-    // This was the original failing case
     problematic_map: HashMap<String, Vec<u64>>,
 
-    // Nested cases
     string_to_optional_vec_u64: HashMap<String, Option<Vec<u64>>>,
 
-    // Additional cases that might have similar issues
     string_to_vec_bool: HashMap<String, Vec<bool>>,
     string_to_vec_f64: HashMap<String, Vec<f64>>,
     string_to_vec_i64: HashMap<String, Vec<i64>>,
@@ -71,25 +67,20 @@ struct OriginalBugReproduction {
 // A named map value is rendered as the schema module its own `#[model_schema()]` expansion emits,
 // so an alias standing in a map value has to carry the attribute like any other referenced type.
 #[cfg(all(test, any(feature = "typescript", feature = "zod", feature = "serde")))]
-// Inner value type for the optional deeply nested map.
 #[model_schema()]
 type OptionalNestedValue = Vec<Option<HashMap<String, Option<Vec<i64>>>>>;
 
 #[cfg(all(test, any(feature = "typescript", feature = "zod", feature = "serde")))]
-// Inner value type for the quadruple nested map.
 #[model_schema()]
 type QuadrupleNestedValue = Vec<HashMap<String, Vec<HashMap<String, u64>>>>;
 
 #[cfg(all(test, any(feature = "typescript", feature = "zod", feature = "serde")))]
-// Now let's try the really complex case
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct ReallyComplexTest {
-    // Another challenging case with optional nested structures
     #[serde(skip_serializing_if = "Option::is_none")]
     optional_nested: Option<HashMap<String, OptionalNestedValue>>,
 
-    // The quadruple nested case that was causing issues
     quadruple_nested: HashMap<String, QuadrupleNestedValue>,
 }
 
@@ -102,12 +93,10 @@ struct ReallyComplexTest {
         feature = "serde"
     )
 ))]
-// Let's start with just one complex case to debug
 #[model_schema()]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq)]
 struct SimpleComplexTest {
-    // Start with just triple-nested to see what fails
     nested_map_of_arrays: HashMap<String, Vec<HashMap<String, u64>>>,
 }
 
@@ -231,14 +220,11 @@ fn test_nested_struct_json_schema() {
 
     let properties = user_schema["properties"].as_object().unwrap();
 
-    // Single nested object should reference the nested type
     assert!(properties.contains_key("address"));
 
-    // Array of nested objects should be an array with items referencing the nested type
     assert!(properties.contains_key("backup_addresses"));
     assert_eq!(properties["backup_addresses"]["type"], "array");
 
-    // Verify Address schema exists and is correct
     assert_eq!(address_schema["type"], "object");
     let address_properties = address_schema["properties"].as_object().unwrap();
     assert!(address_properties.contains_key("street"));
@@ -252,17 +238,14 @@ fn test_nested_struct_ts_definition() {
     let user_definition = UserWithAddress::ts_definition();
     let address_definition = Address::ts_definition();
 
-    // Check that nested types are referenced properly (without Json suffix)
     assert!(user_definition.contains("address: Address;"));
     assert!(user_definition.contains("backup_addresses: Array<Address>;"));
 
-    // Verify Address definition exists (without Json suffix in export type)
     assert!(address_definition.contains("export type Address = {"));
     assert!(address_definition.contains("street: string;"));
     assert!(address_definition.contains("city: string;"));
     assert!(address_definition.contains("zip_code: string;"));
 
-    // Check Zod schema references (without Json suffix) - now in separate method
     let user_zod_schema = UserWithAddress::zod_schema();
     assert!(user_zod_schema.contains("address: Address$Schema"));
     assert!(user_zod_schema.contains("backup_addresses: z.array(Address$Schema)"));
@@ -275,7 +258,6 @@ fn test_original_bug_reproduction_json_schema() {
 
     let properties = schema["properties"].as_object().unwrap();
 
-    // The original problematic case
     assert_eq!(properties["problematic_map"]["type"], "object");
     assert_eq!(
         properties["problematic_map"]["additionalProperties"]["type"],
@@ -286,7 +268,6 @@ fn test_original_bug_reproduction_json_schema() {
         "integer"
     );
 
-    // Similar cases
     assert_eq!(
         properties["string_to_vec_i64"]["additionalProperties"]["type"],
         "array"
@@ -329,7 +310,6 @@ fn test_original_bug_reproduction_json_schema() {
 fn test_original_bug_reproduction_typescript() {
     let ts_definition = OriginalBugReproduction::ts_definition();
 
-    // TypeScript should use Array<T> syntax for the HashMap values
     assert!(ts_definition.contains("problematic_map: Partial<Record<string, Array<number>>>;"));
     assert!(ts_definition.contains("string_to_vec_i64: Partial<Record<string, Array<number>>>;"));
     assert!(ts_definition.contains("string_to_vec_f64: Partial<Record<string, Array<number>>>;"));
@@ -338,7 +318,6 @@ fn test_original_bug_reproduction_typescript() {
         ts_definition.contains("string_to_vec_string: Partial<Record<string, Array<string>>>;")
     );
 
-    // Zod schemas should use z.array(...) for the HashMap values - now in separate method
     let zod_schema = OriginalBugReproduction::zod_schema();
     assert!(
         zod_schema.contains("problematic_map: z.record(z.string(), z.array(z.number().int()))")
@@ -357,8 +336,6 @@ fn test_complex_nested_maps_json_schema() {
     let schema = SimpleComplexTest::json_schema();
     let properties = schema["properties"].as_object().unwrap();
 
-    // Test the triple-nested structure: HashMap<String, Vec<HashMap<String, u64>>>
-    // Expected: object -> array -> object -> integer
     assert_eq!(properties["nested_map_of_arrays"]["type"], "object");
 
     let additional_props = properties["nested_map_of_arrays"]["additionalProperties"]
@@ -378,12 +355,10 @@ fn test_complex_nested_maps_json_schema() {
 fn test_complex_nested_maps_typescript() {
     let ts_definition = SimpleComplexTest::ts_definition();
 
-    // TypeScript should use the correct nested structure
     assert!(ts_definition.contains(
         "nested_map_of_arrays: Partial<Record<string, Array<Partial<Record<string, number>>>>>;"
     ));
 
-    // Zod schema should use the correct nested structure - now in separate method
     let zod_schema = SimpleComplexTest::zod_schema();
     assert!(zod_schema.contains("nested_map_of_arrays: z.record(z.string(), z.array(z.record(z.string(), z.number().int()))),"));
 }
@@ -391,19 +366,15 @@ fn test_complex_nested_maps_typescript() {
 #[test]
 #[cfg(all(feature = "jsonschema", feature = "typescript"))]
 fn test_quadruple_nested_maps_compilation() {
-    // If this compiles without panic, it's a huge success!
     let schema = ReallyComplexTest::json_schema();
     let ts_definition = ReallyComplexTest::ts_definition();
 
-    // Check that the schema contains our fields
     let properties = schema["properties"].as_object().unwrap();
     assert!(properties.contains_key("quadruple_nested"));
     assert!(properties.contains_key("optional_nested"));
 
-    // Basic structure checks
     assert_eq!(properties["quadruple_nested"]["type"], "object");
 
-    // Check TypeScript contains our fields (exact types may be complex)
     assert!(ts_definition.contains("quadruple_nested"));
     assert!(ts_definition.contains("optional_nested"));
 }
@@ -411,19 +382,15 @@ fn test_quadruple_nested_maps_compilation() {
 #[test]
 #[cfg(all(feature = "jsonschema", feature = "typescript", feature = "serde"))]
 fn test_quadruple_nested_maps_compilation_serde() {
-    // If this compiles without panic, it's a huge success!
     let schema = ReallyComplexTest::json_schema();
     let ts_definition = ReallyComplexTest::ts_definition();
 
-    // Check that the schema contains our fields
     let properties = schema["properties"].as_object().unwrap();
     assert!(properties.contains_key("quadruple_nested"));
     assert!(properties.contains_key("optional_nested"));
 
-    // Basic structure checks
     assert_eq!(properties["quadruple_nested"]["type"], "object");
 
-    // Check TypeScript contains our fields (exact types may be complex)
     assert!(ts_definition.contains("quadruple_nested"));
     assert!(ts_definition.contains("optional_nested"));
 }

--- a/tests/enum_tests/tests.rs
+++ b/tests/enum_tests/tests.rs
@@ -52,7 +52,6 @@ enum ActionTaggedWithNothingIgnored {
     Upload { value: String },
 }
 
-// Test single-value enum used as a field in a discriminated union.
 #[cfg(all(test, any(feature = "typescript", feature = "zod", feature = "serde")))]
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -100,7 +99,6 @@ pub enum CalculatedExpressionOperator {
     Subtract,
 }
 
-// Exact reproduction of user's DistributionValidMimeType enum.
 #[cfg(all(test, feature = "serde", any(feature = "typescript", feature = "zod")))]
 #[model_schema()]
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
@@ -121,7 +119,6 @@ enum DocumentLiteralValue {
     Document,
 }
 
-// Test plain enum with serde rename containing special characters (slashes, dots).
 #[cfg(all(test, feature = "serde", any(feature = "typescript", feature = "zod")))]
 #[model_schema()]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -138,7 +135,6 @@ pub enum MimeType {
     test,
     any(feature = "typescript", feature = "jsonschema", feature = "zod")
 ))]
-// Test discriminated union (tagged enum).
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(tag = "type", rename_all = "camelCase")]
@@ -253,14 +249,12 @@ fn test_plain_enum_json_schema() {
 fn test_plain_enum_ts_definition_serde_style() {
     let ts_definition = UserStatus::ts_definition();
 
-    // Check TypeScript union type
     assert!(ts_definition.contains("export type UserStatus"));
     assert!(ts_definition.contains("\"active\""));
     assert!(ts_definition.contains("\"inactive\""));
     assert!(ts_definition.contains("\"pending\""));
     assert!(ts_definition.contains("\"suspended\""));
 
-    // Check Zod schema - now in separate method
     let zod_schema = UserStatus::zod_schema();
     assert!(zod_schema.contains("export const UserStatus$Schema"));
     assert!(zod_schema.contains("z.enum([\"active\", \"inactive\", \"pending\", \"suspended\"])"));
@@ -271,14 +265,12 @@ fn test_plain_enum_ts_definition_serde_style() {
 fn test_plain_enum_ts_definition_not_serde_style() {
     let ts_definition = UserStatus::ts_definition();
 
-    // Check TypeScript union type
     assert!(ts_definition.contains("export type UserStatus"));
     assert!(ts_definition.contains("\"Active\""));
     assert!(ts_definition.contains("\"Inactive\""));
     assert!(ts_definition.contains("\"Pending\""));
     assert!(ts_definition.contains("\"Suspended\""));
 
-    // Check Zod schema - now in separate method
     let zod_schema = UserStatus::zod_schema();
     assert!(zod_schema.contains("export const UserStatus$Schema"));
     assert!(zod_schema.contains("z.enum([\"Active\", \"Inactive\", \"Pending\", \"Suspended\"])"));
@@ -309,7 +301,6 @@ fn test_discriminated_union_json_schema() {
     let one_of = schema["oneOf"].as_array().unwrap();
     assert_eq!(one_of.len(), 3);
 
-    // Check that each variant has the discriminator field
     for variant in one_of {
         let properties = variant["properties"].as_object().unwrap();
         assert!(properties.contains_key("type"));
@@ -345,19 +336,16 @@ fn test_payment_method_variants_json_schema() {
 fn test_discriminated_union_ts_definition() {
     let ts_definition = PaymentMethod::ts_definition();
 
-    // Check that it contains discriminated union syntax
     assert!(ts_definition.contains("export type PaymentMethod = "));
     assert!(ts_definition.contains("type: \"creditCard\""));
     assert!(ts_definition.contains("type: \"bankTransfer\""));
     assert!(ts_definition.contains("type: \"payPal\""));
 
-    // Check field names are converted to camelCase
     assert!(ts_definition.contains("cardNumber: string;"));
     assert!(ts_definition.contains("expiryDate: string;"));
     assert!(ts_definition.contains("accountNumber: string;"));
     assert!(ts_definition.contains("routingNumber: string;"));
 
-    // Check Zod discriminated union - now in separate method
     let zod_schema = PaymentMethod::zod_schema();
     assert!(zod_schema.contains("z.discriminatedUnion(\"type\""));
 }
@@ -426,7 +414,6 @@ fn test_tag_written_after_an_ignored_key_reaches_the_json_schema() {
 fn test_enum_with_docs() {
     let ts_definition = CalculatedExpressionOperator::ts_definition();
 
-    // Just make sure it compiles for now
     assert!(ts_definition.contains("export type CalculatedExpressionOperator"));
 }
 
@@ -435,7 +422,6 @@ fn test_enum_with_docs() {
 fn test_single_value_enum_ts_definition() {
     let ts_definition = DocumentLiteralValue::ts_definition();
 
-    // A single-value enum should generate a literal union type
     assert!(ts_definition.contains("export type DocumentLiteralValue"));
     assert!(ts_definition.contains("\"document\""));
 }
@@ -445,7 +431,6 @@ fn test_single_value_enum_ts_definition() {
 fn test_single_value_enum_zod_schema() {
     let zod_schema = DocumentLiteralValue::zod_schema();
 
-    // Should generate z.enum(["document"]) which is equivalent to z.literal("document")
     assert!(zod_schema.contains("export const DocumentLiteralValue$Schema"));
     assert!(zod_schema.contains("z.enum([\"document\"])"));
 }
@@ -455,9 +440,7 @@ fn test_single_value_enum_zod_schema() {
 fn test_single_value_enum_in_tagged_union_ts() {
     let ts_definition = ActionWithLiteralEnum::ts_definition();
 
-    // The generate variant should have value typed as DocumentLiteralValue
     assert!(ts_definition.contains("value: DocumentLiteralValue;"));
-    // The upload variant should have value typed as string
     assert!(ts_definition.contains("value: string;"));
 }
 
@@ -466,9 +449,7 @@ fn test_single_value_enum_in_tagged_union_ts() {
 fn test_single_value_enum_in_tagged_union_zod() {
     let zod_schema = ActionWithLiteralEnum::zod_schema();
 
-    // The generate variant should reference DocumentLiteralValue$Schema
     assert!(zod_schema.contains("DocumentLiteralValue$Schema"));
-    // The upload variant should use z.string()
     assert!(zod_schema.contains("z.string()"));
 }
 

--- a/tests/example_tests/tests.rs
+++ b/tests/example_tests/tests.rs
@@ -17,16 +17,13 @@ fn test_simple_enum_example() {
         Numeric,
     }
 
-    // Check that schema_example() method exists and returns correct value
     let example = DataType::schema_example();
     assert_eq!(example.as_str().unwrap(), "Numeric");
 
-    // Check that zod schema includes the example
     let zod = DataType::zod_schema();
     assert!(zod.contains("example:"));
     assert!(zod.contains("\"Numeric\""));
 
-    // Verify that example injection doesn't drop $Schema line
     #[cfg(feature = "typescript")]
     {
         assert!(
@@ -58,12 +55,10 @@ fn test_simple_struct_example() {
         pub name: String,
     }
 
-    // Check that schema_example() method exists
     let example = User::schema_example();
     assert_eq!(example["name"].as_str().unwrap(), "John Doe");
     assert_eq!(example["age"].as_u64().unwrap(), 25);
 
-    // Check that zod schema includes the example
     let zod = User::zod_schema();
     assert!(zod.contains("example:"));
     assert!(zod.contains("John Doe"));
@@ -92,14 +87,12 @@ fn test_complex_struct_with_logic() {
         pub tags: Vec<String>,
     }
 
-    // Check that schema_example() method exists and logic executed correctly
     let example = ComplexUser::schema_example();
     assert_eq!(example["id"].as_str().unwrap(), "usr_123");
     assert_eq!(example["tags"][0].as_str().unwrap(), "admin");
     assert_eq!(example["tags"][1].as_str().unwrap(), "active");
     assert_eq!(example["age"].as_u64().unwrap(), 30);
 
-    // Check that zod schema includes the example
     let zod = ComplexUser::zod_schema();
     assert!(zod.contains("example:"));
 }
@@ -127,13 +120,11 @@ fn test_nested_types_example() {
         pub tags: Vec<String>,
     }
 
-    // Check that schema_example() method exists
     let example = Profile::schema_example();
     assert_eq!(example["tags"][0].as_str().unwrap(), "tag1");
     assert_eq!(example["metadata"]["key1"].as_str().unwrap(), "value1");
     assert_eq!(example["optional_field"].as_str().unwrap(), "present");
 
-    // Check that zod schema includes the example
     let zod = Profile::zod_schema();
     assert!(zod.contains("example:"));
 }
@@ -157,13 +148,11 @@ fn test_discriminated_enum_example() {
         UserDeleted { user_id: String },
     }
 
-    // Check that schema_example() method exists
     let example = Event::schema_example();
     assert_eq!(example["type"].as_str().unwrap(), "UserCreated");
     assert_eq!(example["user_id"].as_str().unwrap(), "user_123");
     assert_eq!(example["timestamp"].as_str().unwrap(), "2024-01-01");
 
-    // Check that zod schema includes the example
     let zod = Event::zod_schema();
     assert!(zod.contains("example:"));
 }
@@ -185,7 +174,6 @@ fn test_multiple_examples_uses_first() {
         pub value: u32,
     }
 
-    // Check that only the first example is used
     let example = FirstExample::schema_example();
     assert_eq!(example["value"].as_u64().unwrap(), 1);
 }
@@ -204,10 +192,6 @@ fn test_no_example_no_method() {
     };
     assert!(no_example.value.is_empty());
 
-    // schema_example() should not exist, so we can't call it
-    // This test just verifies it compiles without the method
-
-    // However, zod schema should still be generated without example
     #[cfg(feature = "zod")]
     {
         let zod = NoExample::zod_schema();
@@ -230,7 +214,6 @@ fn test_typescript_zod_format() {
 
     let zod = Test::zod_schema();
 
-    // Should have TypeScript-style format with ZodType
     assert!(zod.contains("ZodType<"));
     assert!(zod.contains("$RawSchema"));
     assert!(zod.contains("example:"));
@@ -251,7 +234,6 @@ fn test_javascript_zod_format() {
 
     let zod = Test::zod_schema();
 
-    // Should have JavaScript-style format without ZodType
     assert!(!zod.contains("ZodType<"));
     assert!(zod.contains("example:"));
 }
@@ -276,9 +258,7 @@ fn test_serde_attributes_in_example() {
         pub user_id: String,
     }
 
-    // Check that example serializes with serde attributes
     let example = UserWithSerde::schema_example();
-    // The example should have camelCase keys
     assert!(example.get("userId").is_some());
     assert_eq!(
         example["emailAddress"].as_str().unwrap(),
@@ -310,10 +290,8 @@ fn test_objectid_example() {
         pub name: String,
     }
 
-    // Check that schema_example() method exists
     let example = Document::schema_example();
     assert_eq!(example["name"].as_str().unwrap(), "test");
-    // ObjectId should serialize to { "$oid": "..." } format
     assert!(example["id"].get("$oid").is_some());
 
     let zod = Document::zod_schema();
@@ -335,7 +313,6 @@ fn test_example_fence_must_be_exact() {
     let regular_fence = RegularFence { value: 0 };
     assert_eq!(regular_fence.value, 0_u32);
 
-    // schema_example() should not exist since fence is not "rust example"
     #[cfg(feature = "zod")]
     {
         let zod = RegularFence::zod_schema();
@@ -354,9 +331,6 @@ fn test_empty_example_block() {
         pub value: u32,
     }
 
-    // We test with a valid example instead
-    // An empty example block would cause a compilation error
-    // which is the desired behavior
     let zod = ValidExample::zod_schema();
     assert!(zod.contains("value"));
 }
@@ -377,7 +351,6 @@ fn test_regex_transform_println() {
         String,
     }
 
-    // Check that transformation worked - should extract the variable
     let example = DataType::schema_example();
     assert_eq!(example.as_str().unwrap(), "Integer");
 
@@ -400,7 +373,6 @@ fn test_regex_transform_let_underscore() {
         Inactive,
     }
 
-    // Check that transformation worked - should extract the value
     let example = Status::schema_example();
     assert_eq!(example.as_str().unwrap(), "Active");
 
@@ -425,7 +397,6 @@ fn test_description_strips_examples() {
     }
 
     let zod = DescriptionTest::zod_schema();
-    // Description should not contain the example code
     assert!(!zod.contains("DescriptionTest { value: 42 }"));
     // Note: Structs don't embed descriptions in .meta() currently (only enums do)
 }
@@ -445,9 +416,7 @@ fn test_description_escapes_quotes() {
     }
 
     let zod = QuoteTest::zod_schema();
-    // The generated code should have escaped quotes in description
     assert!(zod.contains("example:"));
-    // Check that the description is properly formatted with escaped quotes
     assert!(zod.contains("description:"));
     assert!(zod.contains(r#"\"quoted\""#));
 }

--- a/tests/flatten_tests/tests.rs
+++ b/tests/flatten_tests/tests.rs
@@ -993,10 +993,6 @@ struct OptUnionHolder {
 /// Whether `payload` is accepted by a document every leaf of which is an object closed by
 /// `additionalProperties: false`: a leaf accepts when it names every key the payload carries and
 /// requires no key it does not.
-///
-/// A union is read by the rule its spelling names — `oneOf` accepts on exactly one matching branch
-/// and `anyOf` on at least one — so a document that nests one union inside another is read the way
-/// a validator reads it, wrapper by wrapper.
 #[cfg(feature = "jsonschema")]
 fn closed_document_accepts(schema: &serde_json::Value, payload: &serde_json::Value) -> bool {
     if let Some(branches) = schema.get("oneOf") {
@@ -1057,10 +1053,6 @@ fn test_flatten_structs_constructible() {
     assert!(no_flatten.id.is_empty());
 }
 
-// ========================================================================
-// TypeScript
-// ========================================================================
-
 #[test]
 #[cfg(feature = "typescript")]
 fn test_flatten_typescript_intersection() {
@@ -1108,10 +1100,6 @@ fn test_flatten_variant_keeps_pascal_discriminator_and_camel_fields() {
     assert!(ts.contains("sampleValues:"));
     assert!(!ts.contains("sample_values"));
 }
-
-// ========================================================================
-// Zod
-// ========================================================================
 
 #[test]
 #[cfg(feature = "zod")]
@@ -1215,10 +1203,6 @@ fn test_a_flatten_cycle_through_a_variants_content_defers_both_sides() {
         "`CycleVariantContent$Schema` is read eagerly in: {host}"
     );
 }
-
-// ========================================================================
-// JSON Schema
-// ========================================================================
 
 #[test]
 #[cfg(feature = "jsonschema")]
@@ -1395,10 +1379,6 @@ fn test_the_deferred_flatten_document_is_byte_identical() {
         r##"{"$defs":{"FlatNode":{"type":"object","additionalProperties":false,"properties":{"children":{"type":"array","items":{"$ref":"#/$defs/FlatNode"}},"val":{"type":"string"}},"required":["children","val"]}},"type":"object","properties":{"extra":{"type":"string"},"children":{"type":"array","items":{"$ref":"#/$defs/FlatNode"}},"val":{"type":"string"}},"required":["extra","children","val"],"additionalProperties":false}"##
     );
 }
-
-// ========================================================================
-// Serialization round-trip
-// ========================================================================
 
 #[test]
 fn test_flatten_serialization_is_flat() {
@@ -2213,10 +2193,6 @@ fn test_an_optional_flattened_union_offers_every_member_and_their_absence() {
 /// the object's own beside none of them. `| undefined` said something else — that the whole value
 /// may be missing — and `&` binds tighter than `|`, so it admitted neither payload the object
 /// writes for an absent base.
-///
-/// The absent branch is the base's own keys mapped to `never` rather than `{}`. Both spell the same
-/// two payloads for a base written whole, and only the mapped one keeps a base written in part out:
-/// `{}` is every object, so a payload carrying one of the base's members passes through it.
 #[test]
 #[cfg(feature = "typescript")]
 fn test_the_optional_flatten_type_offers_the_base_and_its_absence() {
@@ -2272,10 +2248,6 @@ fn test_the_optional_flatten_schema_offers_the_base_and_its_absence() {
 /// And no branch of it admits a base written in part. The base joins a branch whole, under the name
 /// its own schema is bound to, or the branch is the object's own keys alone — so a payload carrying
 /// some of the base's members belongs to neither, and neither does a bare `undefined`.
-///
-/// Read off zod 4.4.3: this union accepts `{"left":"l","right":true,"own":"o"}` and `{"own":"o"}`,
-/// and rejects `{"left":"l","own":"o"}`, `{"right":true,"own":"o"}`, `undefined`, and any payload
-/// carrying a key neither the object nor the base names.
 #[test]
 #[cfg(feature = "zod")]
 fn test_the_optional_flatten_schema_admits_no_partial_base() {
@@ -2386,11 +2358,6 @@ fn test_the_named_nullable_flatten_document_admits_the_captured_payloads() {
 /// the name, or the object's own keys alone. The name is left spelled as the nullable binding it is
 /// — the null side of it carries no key an intersection could take, so the branch that names it
 /// admits exactly the payload the base writes.
-///
-/// Read off zod 4.4.3, the emitted spelling transcribed: this union accepts
-/// `{"left":"l","right":true,"own":"o"}` and `{"own":"o"}`, and rejects `{"left":"l","own":"o"}`,
-/// `{"right":true,"own":"o"}` and any payload carrying a key neither the object nor the base names
-/// — payload for payload what the `Option`-typed field's own schema answers.
 #[test]
 #[cfg(feature = "zod")]
 fn test_the_named_nullable_flatten_schema_offers_the_base_and_its_absence() {
@@ -2412,10 +2379,6 @@ fn test_the_named_nullable_flatten_schema_offers_the_base_and_its_absence() {
 /// value branch — an intersection distributes over the choice behind it and the `null` side takes no
 /// key, so that branch is already the base's — while the branch carrying none of the base's members
 /// reads them off the value side by name, a choice having no key of its own for `keyof` to find.
-///
-/// Read off tsc 7.0.2 under `--strict`, the emitted declarations compiled as written: this type
-/// accepts `{ own: "o", left: "l", right: true }` and `{ own: "o" }`, and rejects
-/// `{ own: "o", left: "l" }` — payload for payload what the `Option`-typed field's own type answers.
 #[test]
 #[cfg(feature = "typescript")]
 fn test_the_named_nullable_flatten_type_offers_the_base_and_its_absence() {
@@ -2558,14 +2521,6 @@ fn test_a_non_optional_flatten_schema_is_byte_identical() {
 /// What serde writes for a flattened untagged enum is one key set per member, and what Zod says
 /// about it is the object multiplied over those members: a union of intersections, not an
 /// intersection with a union.
-///
-/// Read off zod 4.4.3: named as one operand, this schema rejected both payloads serde writes —
-/// `{"own":"o","a":"x"}` and `{"own":"o","b":true}` each came back `invalid_union`, one branch
-/// calling `own` an unrecognized key and the other missing the member it names. An intersection
-/// recognizes exactly the keys its operands name and a `z.union` names none, so each branch was
-/// asked to validate the whole payload alone. Multiplied out, both are accepted, and the schema
-/// still rejects `{"own":"o"}`, `{"a":"x"}`, `{"own":"o","a":"x","b":true}` and any payload
-/// carrying a key neither the object nor the matched member names.
 #[test]
 #[cfg(feature = "zod")]
 fn test_the_untagged_flatten_schema_multiplies_the_object_over_the_unions_members() {
@@ -2602,10 +2557,6 @@ fn test_the_untagged_flatten_schema_names_no_union_as_an_operand() {
 /// The two choices multiply. An `Option` around the union offers the members or none of them, and
 /// the union offers one member or another, so the object writes one branch per member and one more
 /// for the absence — the same multiplication the JSON-schema document is written from.
-///
-/// Read off zod 4.4.3: this union accepts `{"own":"o","a":"x"}`, `{"own":"o","b":true}` and
-/// `{"own":"o"}`, and rejects `{"a":"x"}`, `{"own":"o","a":"x","b":true}`, `{"own":"o","extra":1}`
-/// and a bare `undefined`.
 #[test]
 #[cfg(feature = "zod")]
 fn test_an_optional_untagged_flatten_multiplies_the_members_and_the_absence() {
@@ -2690,14 +2641,6 @@ fn test_a_nested_untagged_flatten_multiplies_over_the_leaf_members() {
 
 /// A union declared below the object that flattens it is named as one operand — the spelling that
 /// rejects every payload the object writes, kept deliberately.
-///
-/// The members travel through the registry, and the registry holds what has already expanded, so a
-/// source declared below has none to offer. Nothing at the merge tells that source apart from a
-/// plain struct declared below, so a refusal would have to fire on every forward-declared base —
-/// including the two that flatten each other, which no declaration order puts both above the other
-/// and which this crate compiles today. The merge falls back instead: a union flattened by an
-/// object must be declared above that object, which is the ordering the deferred operands already
-/// document the other half of.
 #[test]
 #[cfg(feature = "zod")]
 fn test_a_union_declared_below_the_object_is_named_as_one_operand() {
@@ -2804,9 +2747,6 @@ fn test_the_unions_declared_below_the_object_are_still_named_as_one_operand() {
 /// written for the scalar member was the object intersected with it, which no payload satisfies and
 /// which nothing reported. The declaration that would carry it does not exist under this feature,
 /// so what the refusal is pinned against is the field it names.
-///
-/// The reach is the recording's: a union declared below the object records nothing for the merge to
-/// read, so that one is still named as the one operand it is.
 #[test]
 #[cfg(feature = "zod")]
 fn test_a_union_with_a_scalar_member_declared_below_is_still_named_as_one_operand() {
@@ -3159,11 +3099,6 @@ fn test_the_direct_tagged_flatten_document_admits_the_captured_payloads() {
 /// And Zod multiplies the object over the same variants, each written in the spelling a merge joins
 /// rather than the one the union publishes: the unit variant is the key serde writes for it, not the
 /// literal the enum's own schema names.
-///
-/// Read off zod 4.4.3, the emitted spelling transcribed: this union accepts `{"own":"o","Bare":null}`
-/// and `{"own":"o","Wrapped":{"b":true}}`, and rejects `{"own":"o"}`, `{"own":"o","Bare":"Bare"}`,
-/// `{"own":"o","Bare":null,"Wrapped":{"b":true}}`, `{"Bare":null}` and any payload carrying a key
-/// neither the object nor the matched variant names.
 #[test]
 #[cfg(feature = "zod")]
 fn test_the_direct_tagged_flatten_schema_multiplies_the_object_over_the_variants() {
@@ -3183,17 +3118,6 @@ fn test_the_direct_tagged_flatten_schema_multiplies_the_object_over_the_variants
 /// And TypeScript spells the same two key sets, because it cannot reach them by distributing: the
 /// bare string a unit variant publishes standing alone intersects the object to `never`, and the
 /// payload serde writes for that variant belongs to no branch of the result.
-///
-/// Each key set also says it does not carry the other's tag, which is what keeps the type on the one
-/// variant at a time serde writes. Without it the excess-property check reads the union of both key
-/// sets and either branch is satisfied by a payload carrying both.
-///
-/// Read off tsc 7.0.2 under `--strict`, the emitted declarations compiled as written: this type
-/// accepts `{ own: "o", Bare: null }` and `{ own: "o", Wrapped: { b: true } }`, and rejects
-/// `{ own: "o" }`, `{ own: "o", Bare: "Bare" }`, `{ Bare: null }` and
-/// `{ own: "o", Bare: null, Wrapped: { b: true } }`. Named as the enum's own union, the first of
-/// those was `TS2353: 'Bare' does not exist in type '{ own: string; } & { Wrapped: FlatSecond; }'`;
-/// without the exclusions the last one was accepted.
 #[test]
 #[cfg(feature = "typescript")]
 fn test_the_direct_tagged_flatten_type_spells_the_key_set_serde_writes() {
@@ -3240,12 +3164,6 @@ fn test_a_directly_flattened_all_object_tagged_enum_round_trips_every_variant() 
 /// So Zod multiplies the object over those variants too. Nothing about them has to be proved: an
 /// intersection recognizes exactly the keys its operands name and a `z.union` names none, so the
 /// object joined to the union as one operand describes a payload set no value inhabits.
-///
-/// Read off zod 4.4.3, the emitted spelling transcribed: named as one operand, this schema rejected
-/// both payloads serde writes — `{"own":"o","One":{"a":"x"}}` and `{"own":"o","Two":{"b":true}}`.
-/// Multiplied out, both are accepted, and the schema still rejects `{"own":"o"}`,
-/// `{"One":{"a":"x"}}`, `{"own":"o","One":{"a":"x"},"Two":{"b":true}}` and any payload carrying a
-/// key neither the object nor the matched variant names.
 #[test]
 #[cfg(feature = "zod")]
 fn test_the_all_object_tagged_direct_flatten_schema_multiplies_the_object_over_the_variants() {
@@ -3267,12 +3185,6 @@ fn test_the_all_object_tagged_direct_flatten_schema_multiplies_the_object_over_t
 /// about the other: the excess-property check reads the union of both key sets, so a payload
 /// carrying both tags satisfies either branch structurally — a payload serde writes for no value and
 /// the other three surfaces refuse. Spelling the variants is what carries that.
-///
-/// Read off tsc 7.0.2 under `--strict`, the emitted declarations compiled as written: this type
-/// accepts `{ own: "o", One: { a: "x" } }` and `{ own: "o", Two: { b: true } }`, and rejects
-/// `{ own: "o" }`, `{ One: { a: "x" } }` and
-/// `{ own: "o", One: { a: "x" }, Two: { b: true } }`. Named as the enum's own union, that last one
-/// was accepted.
 #[test]
 #[cfg(feature = "typescript")]
 fn test_an_all_object_tagged_direct_flatten_type_closes_each_variant_against_the_other() {
@@ -3297,10 +3209,6 @@ fn test_an_all_object_tagged_direct_flatten_document_is_byte_identical() {
 /// read: `keyof` a union is the keys its branches share, so before the exclusions the branch was an
 /// empty mapped type — `{}`, which every object passes through, including one carrying part of a
 /// variant's key set.
-///
-/// Read off tsc 7.0.2 under `--strict`, the emitted declarations compiled as written: this type
-/// accepts `{ own: "o" }`, `{ own: "o", One: { a: "x" } }` and `{ own: "o", Two: { b: true } }`, and
-/// rejects `{ own: "o", One: { a: "x" }, Two: { b: true } }`.
 #[test]
 #[cfg(feature = "typescript")]
 fn test_the_optional_all_object_tagged_flatten_type_names_the_keys_its_absence_leaves_out() {
@@ -3364,11 +3272,6 @@ fn test_a_directly_flattened_inline_untagged_union_round_trips_every_member() {
 
 /// So the merged type spells the members in the union's name's place, each closed against the keys
 /// the other names.
-///
-/// Read off tsc 7.0.2 under `--strict`, the emitted declarations compiled as written: this type
-/// accepts `{ own: "o", left: "l" }` and `{ own: "o", right: true }`, and rejects `{ own: "o" }`,
-/// `{ left: "l" }` and `{ own: "o", left: "l", right: true }`. Named as the enum's own union, that
-/// last one was accepted.
 #[test]
 #[cfg(feature = "typescript")]
 fn test_an_inline_untagged_direct_flatten_type_closes_each_member_against_the_other() {

--- a/tests/generic_types_tests/tests.rs
+++ b/tests/generic_types_tests/tests.rs
@@ -515,11 +515,6 @@ mod zod {
     /// own default folds the argument onto that item's own `$SchemaDefault`, so the checks and
     /// brand it declared are carried in by reference instead of rebuilt under a `z.string()` the
     /// memo would not share with it.
-    ///
-    /// The folded reference is deferred through `z.lazy` — `Tagged$SchemaDefault` is a module-scope
-    /// `const` like `EchoedDefault$SchemaDefault` itself, and a generated module concatenates one
-    /// string per type in whatever order the consuming project's entity list produces, so nothing
-    /// here can know whether `Tagged`'s `const` is written above this one or below it.
     #[test]
     fn a_default_naming_a_siblings_own_default_folds_onto_its_binding() {
         let zod = EchoedDefault::<String>::zod_schema();

--- a/tests/item_jsdoc_example_tests/tests.rs
+++ b/tests/item_jsdoc_example_tests/tests.rs
@@ -420,10 +420,6 @@ fn an_example_only_item_and_member_name_themselves() {
 /// The `description` a shape publishes is spelled from the lines its `JSDoc` body is spelled from,
 /// so the fallback fires on the same reading at both. The two shapes that publish one are covered:
 /// a plain enum writes it beside a header of its own, and a brand writes it instead of one.
-///
-/// Only the description is held against the twin's. The Zod surface is where an example is *kept* —
-/// it is published as the schema's own `example`, which is the one thing an example-only shape has
-/// that an undocumented one does not.
 #[cfg(feature = "zod")]
 #[test]
 fn an_example_only_shape_describes_itself_as_its_undocumented_twin_does() {

--- a/tests/jsonschema_tests/tests.rs
+++ b/tests/jsonschema_tests/tests.rs
@@ -130,24 +130,20 @@ enum Status {
 fn test_basic_struct_json_schema() {
     let schema = BasicStruct::json_schema();
 
-    // Check top-level schema properties
     assert_eq!(schema["type"], "object");
     assert_eq!(schema["additionalProperties"], false);
 
-    // Check properties exist
     let properties = schema["properties"].as_object().unwrap();
     assert!(properties.contains_key("name"));
     assert!(properties.contains_key("age"));
     assert!(properties.contains_key("score"));
     assert!(properties.contains_key("active"));
 
-    // Check property types
     assert_eq!(properties["name"]["type"], "string");
     assert_eq!(properties["age"]["type"], "integer");
     assert_eq!(properties["score"]["type"], "number");
     assert_eq!(properties["active"]["type"], "boolean");
 
-    // Check required fields
     let required = schema["required"].as_array().unwrap();
     assert_eq!(required.len(), 4);
     assert!(required.contains(&Value::String("name".to_owned())));
@@ -166,12 +162,10 @@ fn test_optional_fields_not_in_required() {
     assert!(properties.contains_key("optional_number"));
     assert!(properties.contains_key("optional_bool"));
 
-    // Check that optional fields have correct types
     assert_eq!(properties["optional_string"]["type"], "string");
     assert_eq!(properties["optional_number"]["type"], "integer");
     assert_eq!(properties["optional_bool"]["type"], "boolean");
 
-    // Check required array only contains required field
     let required = schema["required"].as_array().unwrap();
     assert_eq!(required.len(), 1);
     assert!(required.contains(&Value::String("required".to_owned())));
@@ -186,19 +180,15 @@ fn test_vec_fields_generate_array_schemas() {
 
     let properties = schema["properties"].as_object().unwrap();
 
-    // Check tags array
     assert_eq!(properties["tags"]["type"], "array");
     assert_eq!(properties["tags"]["items"]["type"], "string");
 
-    // Check numbers array
     assert_eq!(properties["numbers"]["type"], "array");
     assert_eq!(properties["numbers"]["items"]["type"], "integer");
 
-    // Check optional array
     assert_eq!(properties["optional_array"]["type"], "array");
     assert_eq!(properties["optional_array"]["items"]["type"], "string");
 
-    // Check required fields
     let required = schema["required"].as_array().unwrap();
     assert!(required.contains(&Value::String("tags".to_owned())));
     assert!(required.contains(&Value::String("numbers".to_owned())));
@@ -211,14 +201,12 @@ fn test_hashmap_generates_object_with_additional_properties() {
 
     let properties = schema["properties"].as_object().unwrap();
 
-    // Check metadata map
     assert_eq!(properties["metadata"]["type"], "object");
     assert_eq!(
         properties["metadata"]["additionalProperties"]["type"],
         "string"
     );
 
-    // Check counts map
     assert_eq!(properties["counts"]["type"], "object");
     assert_eq!(
         properties["counts"]["additionalProperties"]["type"],
@@ -272,14 +260,11 @@ fn test_nested_structs_present_in_schema() {
 
     let properties = schema["properties"].as_object().unwrap();
 
-    // Single nested object should have the address property
     assert!(properties.contains_key("address"));
 
-    // Array of nested objects should be an array
     assert!(properties.contains_key("previous_addresses"));
     assert_eq!(properties["previous_addresses"]["type"], "array");
 
-    // Verify Address schema exists and is correct
     assert_eq!(address_schema["type"], "object");
     let address_properties = address_schema["properties"].as_object().unwrap();
     assert!(address_properties.contains_key("street"));
@@ -305,7 +290,6 @@ fn test_integer_types_use_integer_schema() {
 
     let properties = schema["properties"].as_object().unwrap();
 
-    // All integer types should have type "integer"
     assert_eq!(properties["u8"]["type"], "integer");
     assert_eq!(properties["u16"]["type"], "integer");
     assert_eq!(properties["u32"]["type"], "integer");
@@ -324,7 +308,6 @@ fn test_float_types_use_number_schema() {
 
     let properties = schema["properties"].as_object().unwrap();
 
-    // Float types should have type "number"
     assert_eq!(properties["f32"]["type"], "number");
     assert_eq!(properties["f64"]["type"], "number");
 }
@@ -336,15 +319,12 @@ fn test_serde_rename_all_affects_property_names() {
 
     let properties = schema["properties"].as_object().unwrap();
 
-    // Should use camelCase names
     assert!(properties.contains_key("userName"));
     assert!(properties.contains_key("userEmail"));
 
-    // Should not contain original snake_case names
     assert!(!properties.contains_key("user_name"));
     assert!(!properties.contains_key("user_email"));
 
-    // Check required array uses renamed fields
     let required = schema["required"].as_array().unwrap();
     assert!(required.contains(&Value::String("userName".to_owned())));
     assert!(required.contains(&Value::String("userEmail".to_owned())));
@@ -370,7 +350,6 @@ fn test_complex_nested_collections() {
 
     let properties = schema["properties"].as_object().unwrap();
 
-    // HashMap<String, Vec<String>>
     assert_eq!(properties["map_of_arrays"]["type"], "object");
     let map_of_arrays_additional = properties["map_of_arrays"]["additionalProperties"]
         .as_object()
@@ -385,7 +364,6 @@ fn test_complex_nested_collections() {
         "integer"
     );
 
-    // Check required fields
     let required = schema["required"].as_array().unwrap();
     assert!(required.contains(&Value::String("map_of_arrays".to_owned())));
     assert!(!required.contains(&Value::String("optional_map".to_owned())));
@@ -409,14 +387,12 @@ fn test_objectid_generates_proper_schema() {
 
     let properties = schema["properties"].as_object().unwrap();
 
-    // ObjectId should be object with $oid field
     let id_prop = &properties["id"];
     assert_eq!(id_prop["type"], "object");
     assert_eq!(id_prop["properties"]["$oid"]["type"], "string");
     assert_eq!(id_prop["required"][0], "$oid");
     assert_eq!(id_prop["additionalProperties"], false);
 
-    // Optional ObjectId
     let author_prop = &properties["author_id"];
     assert_eq!(author_prop["type"], "object");
     assert_eq!(author_prop["properties"]["$oid"]["type"], "string");
@@ -455,10 +431,8 @@ fn test_schema_has_required_structure() {
 
     let schema = Test::json_schema();
 
-    // Should be a JSON object
     assert!(schema.is_object());
 
-    // Should have required keys
     assert!(schema.get("type").is_some());
     assert!(schema.get("properties").is_some());
     assert!(schema.get("required").is_some());

--- a/tests/model_schema_prop_tests/tests.rs
+++ b/tests/model_schema_prop_tests/tests.rs
@@ -19,7 +19,6 @@ use serde::{Deserialize, Serialize};
 ))]
 use tixschema::model_schema;
 
-// Test the example from the user request.
 #[cfg(all(
     test,
     any(
@@ -45,7 +44,6 @@ struct AccountContext {
     pub sub: String,
 }
 
-// Test array of literals.
 #[cfg(all(
     test,
     any(
@@ -64,7 +62,6 @@ struct ArrayLiteral {
     pub literal_array: Vec<String>,
 }
 
-// Test combining literal and minLength (should prioritize literal).
 #[cfg(all(
     test,
     any(
@@ -84,7 +81,6 @@ struct CombinedTest {
     pub normal_field: String,
 }
 
-// Test struct with comprehensive minLength configurations.
 #[cfg(all(
     test,
     any(
@@ -97,24 +93,20 @@ struct CombinedTest {
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct MinLengthTest {
-    // Regular string without minLength
     pub description: String,
     #[model_schema_prop(as = String, minLength = 1)]
     pub name: String,
-    // Optional string with minLength
     #[model_schema_prop(as = String, minLength = 3)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nickname: Option<String>,
     #[model_schema_prop(as = String, minLength = 10)]
     pub password: String,
-    // Array of strings with minLength on the items
     #[model_schema_prop(as = String, minLength = 2)]
     pub tags: Vec<String>,
     #[model_schema_prop(as = String, minLength = 5)]
     pub username: String,
 }
 
-// Test multiple literal values in one struct.
 #[cfg(all(
     test,
     any(
@@ -136,7 +128,6 @@ struct MultipleLiterals {
     pub version: String,
 }
 
-// Test optional literal fields.
 #[cfg(all(
     test,
     any(
@@ -297,20 +288,16 @@ fn test_ts_optional_variant_constructible() {
 fn test_string_literal_typescript() {
     let ts_definition = AccountContext::ts_definition();
 
-    // Check that the literal field generates the correct TypeScript type
     assert!(ts_definition.contains("iss: \"Tixena\";"));
 
-    // Check that other fields are still normal string types
     assert!(ts_definition.contains("aud: string;"));
     assert!(ts_definition.contains("sub: string;"));
     assert!(ts_definition.contains("jti: string;"));
 
-    // Check that numeric fields are still numbers
     assert!(ts_definition.contains("exp: number;"));
     assert!(ts_definition.contains("iat: number;"));
     assert!(ts_definition.contains("nbf: number;"));
 
-    // Check that minLength fields have documentation
     assert!(ts_definition.contains("Minimum length: 1"));
 }
 
@@ -319,17 +306,13 @@ fn test_string_literal_typescript() {
 fn test_string_literal_zod() {
     let zod_schema = AccountContext::zod_schema();
 
-    // Check that the literal field generates the correct Zod schema
     assert!(zod_schema.contains("iss: z.literal(\"Tixena\")"));
 
-    // Check that other fields are still normal string schemas
     assert!(zod_schema.contains("aud: z.string()"));
 
-    // Check that minLength fields have the correct validation
     assert!(zod_schema.contains("sub: z.string().min(1)"));
     assert!(zod_schema.contains("jti: z.string().min(1)"));
 
-    // Check that numeric fields use correct Zod types
     assert!(zod_schema.contains("exp: z.number().int()"));
     assert!(zod_schema.contains("iat: z.number().int()"));
     assert!(zod_schema.contains("nbf: z.number().int()"));
@@ -341,18 +324,15 @@ fn test_string_literal_json_schema() {
     let schema = AccountContext::json_schema();
     let properties = schema["properties"].as_object().unwrap();
 
-    // Check that the literal field has the correct JSON schema
     let iss_prop = &properties["iss"];
     assert_eq!(iss_prop["type"], "string");
     assert_eq!(iss_prop["const"], "Tixena");
 
-    // Check that other string fields are normal strings without const
     let aud_prop = &properties["aud"];
     assert_eq!(aud_prop["type"], "string");
     assert!(aud_prop.get("const").is_none());
     assert!(aud_prop.get("minLength").is_none());
 
-    // Check that minLength fields have the correct validation
     let sub_prop = &properties["sub"];
     assert_eq!(sub_prop["type"], "string");
     assert!(sub_prop.get("const").is_none());
@@ -369,11 +349,9 @@ fn test_string_literal_json_schema() {
 fn test_multiple_literals_typescript() {
     let ts_definition = MultipleLiterals::ts_definition();
 
-    // Check multiple literals
     assert!(ts_definition.contains("type_field: \"fixed_type\";"));
     assert!(ts_definition.contains("version: \"v1.0\";"));
 
-    // Check normal fields
     assert!(ts_definition.contains("id: string;"));
     assert!(ts_definition.contains("name: string;"));
 }
@@ -383,11 +361,9 @@ fn test_multiple_literals_typescript() {
 fn test_multiple_literals_zod() {
     let zod_schema = MultipleLiterals::zod_schema();
 
-    // Check multiple literals
     assert!(zod_schema.contains("type_field: z.literal(\"fixed_type\")"));
     assert!(zod_schema.contains("version: z.literal(\"v1.0\")"));
 
-    // Check normal fields
     assert!(zod_schema.contains("id: z.string()"));
     assert!(zod_schema.contains("name: z.string()"));
 }
@@ -397,7 +373,6 @@ fn test_multiple_literals_zod() {
 fn test_optional_literal_typescript() {
     let ts_definition = OptionalLiteral::ts_definition();
 
-    // Check that optional literal works correctly
     assert!(ts_definition.contains(&omitted_member("optional_type", "\"optional_literal\"")));
     assert!(ts_definition.contains("id: string;"));
 }
@@ -407,7 +382,6 @@ fn test_optional_literal_typescript() {
 fn test_optional_literal_zod() {
     let zod_schema = OptionalLiteral::zod_schema();
 
-    // Check that optional literal works correctly
     assert!(
         zod_schema
             .contains("optional_type: z.union([z.literal(\"optional_literal\"), z.undefined()])")
@@ -420,7 +394,6 @@ fn test_optional_literal_zod() {
 fn test_array_literal_typescript() {
     let ts_definition = ArrayLiteral::ts_definition();
 
-    // Check that array of literals works correctly
     assert!(ts_definition.contains("literal_array: Array<\"array_item\">;"));
     assert!(ts_definition.contains("id: string;"));
 }
@@ -430,7 +403,6 @@ fn test_array_literal_typescript() {
 fn test_array_literal_zod() {
     let zod_schema = ArrayLiteral::zod_schema();
 
-    // Check that array of literals works correctly
     assert!(zod_schema.contains("literal_array: z.array(z.literal(\"array_item\"))"));
     assert!(zod_schema.contains("id: z.string()"));
 }
@@ -441,7 +413,6 @@ fn test_array_literal_json_schema() {
     let schema = ArrayLiteral::json_schema();
     let properties = schema["properties"].as_object().unwrap();
 
-    // Check that array of literals has correct JSON schema
     let literal_array_prop = &properties["literal_array"];
     assert_eq!(literal_array_prop["type"], "array");
     assert_eq!(literal_array_prop["items"]["type"], "string");
@@ -453,7 +424,6 @@ fn test_array_literal_json_schema() {
 fn test_min_length_typescript() {
     let ts_definition = MinLengthTest::ts_definition();
 
-    // Check that all fields have correct TypeScript types
     assert!(ts_definition.contains("name: string;"));
     assert!(ts_definition.contains("username: string;"));
     assert!(ts_definition.contains("password: string;"));
@@ -461,7 +431,6 @@ fn test_min_length_typescript() {
     assert!(ts_definition.contains(&omitted_member("nickname", "string")));
     assert!(ts_definition.contains("tags: Array<string>;"));
 
-    // Check that minLength documentation is present
     assert!(ts_definition.contains("Minimum length: 1"));
     assert!(ts_definition.contains("Minimum length: 5"));
     assert!(ts_definition.contains("Minimum length: 10"));
@@ -474,16 +443,13 @@ fn test_min_length_typescript() {
 fn test_min_length_zod() {
     let zod_schema = MinLengthTest::zod_schema();
 
-    // Check that minLength fields have correct validation
     assert!(zod_schema.contains("name: z.string().min(1)"));
     assert!(zod_schema.contains("username: z.string().min(5)"));
     assert!(zod_schema.contains("password: z.string().min(10)"));
     assert!(zod_schema.contains("tags: z.array(z.string().min(2))"));
 
-    // Check that regular string field doesn't have minLength
     assert!(zod_schema.contains("description: z.string(),"));
 
-    // Check that optional string with minLength works correctly
     assert!(zod_schema.contains("nickname: z.union([z.string().min(3), z.undefined()])"));
 }
 
@@ -493,7 +459,6 @@ fn test_min_length_json_schema() {
     let schema = MinLengthTest::json_schema();
     let properties = schema["properties"].as_object().unwrap();
 
-    // Check that minLength fields have the correct JSON schema
     let name_prop = &properties["name"];
     assert_eq!(name_prop["type"], "string");
     assert_eq!(name_prop["minLength"], 1_i32);
@@ -510,12 +475,10 @@ fn test_min_length_json_schema() {
     assert_eq!(nickname_prop["type"], "string");
     assert_eq!(nickname_prop["minLength"], 3_i32);
 
-    // Check that regular string field doesn't have minLength
     let description_prop = &properties["description"];
     assert_eq!(description_prop["type"], "string");
     assert!(description_prop.get("minLength").is_none());
 
-    // Check that array field has minLength on items
     let tags_prop = &properties["tags"];
     assert_eq!(tags_prop["type"], "array");
     assert_eq!(tags_prop["items"]["type"], "string");
@@ -527,11 +490,9 @@ fn test_min_length_json_schema() {
 fn test_combined_literal_minlength_typescript() {
     let ts_definition = CombinedTest::ts_definition();
 
-    // Literal should take precedence - should be a literal type, not a string with minLength
     assert!(ts_definition.contains("fixed_field: \"fixed\";"));
     assert!(ts_definition.contains("normal_field: string;"));
 
-    // Should still have minLength documentation for the normal field
     assert!(ts_definition.contains("Minimum length: 1"));
 }
 
@@ -540,7 +501,6 @@ fn test_combined_literal_minlength_typescript() {
 fn test_combined_literal_minlength_zod() {
     let zod_schema = CombinedTest::zod_schema();
 
-    // Literal should take precedence - should be a literal, not a string with minLength
     assert!(zod_schema.contains("fixed_field: z.literal(\"fixed\")"));
     assert!(zod_schema.contains("normal_field: z.string().min(1)"));
 }
@@ -551,13 +511,11 @@ fn test_combined_literal_minlength_json_schema() {
     let schema = CombinedTest::json_schema();
     let properties = schema["properties"].as_object().unwrap();
 
-    // Literal should take precedence
     let fixed_prop = &properties["fixed_field"];
     assert_eq!(fixed_prop["type"], "string");
     assert_eq!(fixed_prop["const"], "fixed");
     assert!(fixed_prop.get("minLength").is_none()); // Should not have minLength when literal
 
-    // Normal field should have minLength
     let normal_prop = &properties["normal_field"];
     assert_eq!(normal_prop["type"], "string");
     assert_eq!(normal_prop["minLength"], 1_i32);

--- a/tests/mongodb_real_tests/tests.rs
+++ b/tests/mongodb_real_tests/tests.rs
@@ -67,7 +67,6 @@ struct EveryOidPosition {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct OidSlot(ObjectId);
 
-// Basic struct with real ObjectId
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct RealUser {
@@ -82,12 +81,10 @@ struct RealUser {
 fn test_real_objectid_basic_types() {
     let ts_definition = RealUser::ts_definition();
 
-    // TypeScript should use ObjectId type
     assert!(ts_definition.contains("id: ObjectId;"));
     assert!(ts_definition.contains("name: string;"));
     assert!(ts_definition.contains("email?: string;"));
 
-    // Zod schema should use the MongoDB ObjectId structure with regex validation - now in separate method
     let zod_schema = RealUser::zod_schema();
     assert!(zod_schema.contains("id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: \"Invalid ObjectId\" }) }),"));
     assert!(zod_schema.contains("name: z.string(),"));
@@ -99,20 +96,17 @@ fn test_real_objectid_basic_types() {
 #[test]
 #[cfg(all(feature = "object_id", feature = "jsonschema", feature = "typescript"))]
 fn test_real_objectid_compilation_smoke_test() {
-    // This test ensures all ObjectId types compile without panics with real MongoDB ObjectIds
     let user_schema = RealUser::json_schema();
     let _document_schema = RealDocument::json_schema();
 
     let _user_ts = RealUser::ts_definition();
     let _document_ts = RealDocument::ts_definition();
 
-    // If we get here without panics, real MongoDB ObjectId support is working
     assert!(!user_schema.is_null());
 }
 
 #[test]
 fn test_real_objectid_complex_serialization() {
-    // Create real ObjectIds
     let doc_id = ObjectId::new();
     let author_id = ObjectId::new();
     let ref1 = ObjectId::new();
@@ -140,13 +134,11 @@ fn test_real_objectid_complex_serialization() {
         },
     };
 
-    // Test serialization
     let serialized = serde_json::to_string_pretty(&document).unwrap();
 
     // println!("=== REAL MONGODB OBJECTID SERIALIZATION ===");
     // println!("{serialized}");
 
-    // Should contain all the ObjectId hex values in $oid format
     assert!(serialized.contains(&doc_id.to_hex()));
     assert!(serialized.contains(&author_id.to_hex()));
     assert!(serialized.contains(&ref1.to_hex()));
@@ -156,10 +148,8 @@ fn test_real_objectid_complex_serialization() {
     assert!(serialized.contains(&nested_oid1.to_hex()));
     assert!(serialized.contains(&nested_oid2.to_hex()));
 
-    // Should use proper MongoDB structure
     assert!(serialized.contains("\"$oid\""));
 
-    // Test round-trip deserialization
     let deserialized: RealDocument = serde_json::from_str(&serialized).unwrap();
     assert_eq!(deserialized.id, doc_id);
     assert_eq!(deserialized.author_id, author_id);
@@ -172,7 +162,6 @@ fn test_real_objectid_complex_serialization() {
 fn test_real_objectid_complex_structures() {
     let ts_definition = RealDocument::ts_definition();
 
-    // TypeScript should handle all ObjectId variations
     assert!(ts_definition.contains("id: ObjectId;"));
     assert!(ts_definition.contains("author_id: ObjectId;"));
     assert!(ts_definition.contains("references: Array<ObjectId>;"));
@@ -180,7 +169,6 @@ fn test_real_objectid_complex_structures() {
     assert!(ts_definition.contains("parent_id?: ObjectId;"));
     assert!(ts_definition.contains("nested_refs: Partial<Record<string, Array<ObjectId>>>;"));
 
-    // Zod schema should handle all ObjectId variations with regex validation - now in separate method
     let zod_schema = RealDocument::zod_schema();
     let regex_pattern = "z.string().regex(/^[a-f0-9]{24}$/, { message: \"Invalid ObjectId\" })";
     assert!(zod_schema.contains(&format!("id: z.object({{ $oid: {regex_pattern} }}),")));
@@ -207,14 +195,12 @@ fn test_real_objectid_json_schema() {
     let schema = RealUser::json_schema();
     let properties = schema["properties"].as_object().unwrap();
 
-    // Check basic ObjectId field
     let id_prop = &properties["id"];
     assert_eq!(id_prop["type"], "object");
     assert_eq!(id_prop["properties"]["$oid"]["type"], "string");
     assert_eq!(id_prop["required"][0], "$oid");
     assert_eq!(id_prop["additionalProperties"], false);
 
-    // Check other fields are unaffected
     assert_eq!(properties["name"]["type"], "string");
 }
 
@@ -224,7 +210,6 @@ fn test_real_objectid_json_schema_structure() {
     let schema = RealDocument::json_schema();
     let properties = schema["properties"].as_object().unwrap();
 
-    // Test nested_refs: HashMap<String, Vec<ObjectId>>
     let nested_refs_prop = &properties["nested_refs"];
     assert_eq!(nested_refs_prop["type"], "object");
     let additional_props = &nested_refs_prop["additionalProperties"];
@@ -235,7 +220,6 @@ fn test_real_objectid_json_schema_structure() {
     assert_eq!(items["required"][0], "$oid");
     assert_eq!(items["additionalProperties"], false);
 
-    // Test metadata: HashMap<String, ObjectId>
     let metadata_prop = &properties["metadata"];
     assert_eq!(metadata_prop["type"], "object");
     let meta_additional_props = &metadata_prop["additionalProperties"];
@@ -453,7 +437,6 @@ fn every_serde_written_oid_payload_satisfies_the_unified_spelling() {
 
 #[test]
 fn test_real_objectid_serialization() {
-    // Create a real ObjectId
     let real_oid = ObjectId::new();
 
     let user = RealUser {
@@ -462,14 +445,11 @@ fn test_real_objectid_serialization() {
         email: Some("test@example.com".to_owned()),
     };
 
-    // Test serialization
     let serialized = serde_json::to_string(&user).unwrap();
 
-    // Should contain the MongoDB $oid structure
     assert!(serialized.contains("\"$oid\""));
     assert!(serialized.contains(&real_oid.to_hex()));
 
-    // Test deserialization
     let deserialized: RealUser = serde_json::from_str(&serialized).unwrap();
     assert_eq!(deserialized.id, real_oid);
     assert_eq!(deserialized.name, "Test User");
@@ -528,21 +508,17 @@ fn a_real_object_id_hex_satisfies_the_zod_literal_and_the_json_schema_pattern_al
 
 #[test]
 fn test_real_objectid_validation_compatibility() {
-    // Test that real ObjectIds produce valid hex strings that match our regex
     let real_oid = ObjectId::new();
     let hex_string = real_oid.to_hex();
 
-    // Should be exactly 24 characters
     assert_eq!(hex_string.len(), 24);
 
-    // Should match our regex pattern: /^[a-f0-9]{24}$/
     let regex = regex::Regex::new("^[a-f0-9]{24}$").unwrap();
     assert!(
         regex.is_match(&hex_string),
         "Real ObjectId hex '{hex_string}' should match our validation regex"
     );
 
-    // Test with multiple ObjectIds to ensure consistency
     for _ in 0_u32..10_u32 {
         let oid = ObjectId::new();
         let hex = oid.to_hex();

--- a/tests/mongodb_tests/tests.rs
+++ b/tests/mongodb_tests/tests.rs
@@ -4,7 +4,6 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::HashMap;
 use tixschema::model_schema;
 
-// Test struct with more complex ObjectId nesting
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct ComplexDocument {
@@ -18,7 +17,6 @@ struct ComplexDocument {
     title: String,
 }
 
-// Test struct with complex ObjectId usage
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct Document {
@@ -38,7 +36,6 @@ struct Document {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ObjectId(String);
 
-// Test struct with optional nested ObjectId
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct Post {
@@ -49,7 +46,6 @@ struct Post {
     title: String,
 }
 
-// Test struct with ObjectId field
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct User {
@@ -59,7 +55,6 @@ struct User {
     name: String,
 }
 
-// Test struct with HashMap<String, ObjectId>
 #[model_schema()]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq)]
@@ -69,7 +64,6 @@ struct UserWithHashMapObjectId {
     relationships: HashMap<String, ObjectId>,
 }
 
-// Test struct with ObjectId array
 #[model_schema()]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq)]
@@ -79,7 +73,6 @@ struct UserWithObjectIdArray {
     name: String,
 }
 
-// Test struct with ObjectId in HashMap
 #[model_schema()]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq)]
@@ -89,7 +82,6 @@ struct UserWithObjectIdMap {
     relationships: HashMap<String, ObjectId>,
 }
 
-// Test struct with optional ObjectId field
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct UserWithOptionalId {
@@ -99,7 +91,6 @@ struct UserWithOptionalId {
     name: String,
 }
 
-// Test struct with HashMap<String, ObjectId>
 #[model_schema()]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq)]
@@ -235,12 +226,10 @@ fn test_mongodb_structs_constructible() {
 fn test_basic_object_id_types() {
     let ts_definition = User::ts_definition();
 
-    // TypeScript should use ObjectId type
     assert!(ts_definition.contains("id: ObjectId;"));
     assert!(ts_definition.contains("name: string;"));
     assert!(ts_definition.contains("email?: string;"));
 
-    // Zod schema should use the MongoDB ObjectId structure with regex validation - now in separate method
     let zod_schema = User::zod_schema();
     assert!(zod_schema.contains("id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: \"Invalid ObjectId\" }) }),"));
     assert!(zod_schema.contains("name: z.string(),"));
@@ -254,7 +243,6 @@ fn test_basic_object_id_types() {
 fn test_complex_nested_object_id_structures() {
     let ts_definition = ComplexDocument::ts_definition();
 
-    // TypeScript should handle all ObjectId variations
     assert!(ts_definition.contains("id: ObjectId;"));
     assert!(ts_definition.contains("author_id: ObjectId;"));
     assert!(ts_definition.contains("references: Array<ObjectId>;"));
@@ -262,7 +250,6 @@ fn test_complex_nested_object_id_structures() {
     assert!(ts_definition.contains("parent_id?: ObjectId;"));
     assert!(ts_definition.contains("nested_refs: Partial<Record<string, Array<ObjectId>>>;"));
 
-    // Zod schema should handle all ObjectId variations with regex validation - now in separate method
     let zod_schema = ComplexDocument::zod_schema();
     let regex_pattern = "z.string().regex(/^[a-f0-9]{24}$/, { message: \"Invalid ObjectId\" })";
     assert!(zod_schema.contains(&format!("id: z.object({{ $oid: {regex_pattern} }}),")));
@@ -289,7 +276,6 @@ fn test_complex_object_id_json_schema() {
     let schema = ComplexDocument::json_schema();
     let properties = schema["properties"].as_object().unwrap();
 
-    // Test nested_refs: HashMap<String, Vec<ObjectId>>
     let nested_refs_prop = &properties["nested_refs"];
     assert_eq!(nested_refs_prop["type"], "object");
     let additional_props = &nested_refs_prop["additionalProperties"];
@@ -306,14 +292,12 @@ fn test_complex_object_id_json_schema() {
 fn test_complex_object_id_zod_schema() {
     let zod_schema = ComplexDocument::zod_schema();
 
-    // Test that complex nested ObjectId structures work
     let regex_pattern = "z.string().regex(/^[a-f0-9]{24}$/, { message: \"Invalid ObjectId\" })";
     assert!(zod_schema.contains(&format!(
         "nested_refs: z.record(z.string(), z.array(z.object({{ $oid: {regex_pattern} }}))),"
     )));
 }
 
-// Test that includes Document
 #[test]
 #[cfg(feature = "jsonschema")]
 fn test_document_json() {
@@ -334,7 +318,6 @@ fn test_hashmap_object_id_json_schema() {
     let schema = UserWithObjectIdMap::json_schema();
     let properties = schema["properties"].as_object().unwrap();
 
-    // Check HashMap<String, ObjectId>
     let relationships_prop = &properties["relationships"];
     assert_eq!(relationships_prop["type"], "object");
 
@@ -350,7 +333,6 @@ fn test_hashmap_object_id_json_schema() {
 fn test_hashmap_object_id_zod_schema() {
     let zod_schema = UserWithObjectIdMap::zod_schema();
 
-    // Should handle HashMap<String, ObjectId> correctly
     assert!(zod_schema.contains("relationships: z.record(z.string(), z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: \"Invalid ObjectId\" }) })),"));
 }
 
@@ -359,12 +341,10 @@ fn test_hashmap_object_id_zod_schema() {
 fn test_hashmap_with_object_id_values() {
     let ts_definition = UserWithObjectIdMap::ts_definition();
 
-    // TypeScript should use ObjectId type
     assert!(ts_definition.contains("id: ObjectId;"));
     assert!(ts_definition.contains("name: string;"));
     assert!(ts_definition.contains("relationships: Partial<Record<string, ObjectId>>;"));
 
-    // Zod schema should use the MongoDB ObjectId structure with regex validation - now in separate method
     let zod_schema = UserWithObjectIdMap::zod_schema();
     assert!(zod_schema.contains("id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: \"Invalid ObjectId\" }) }),"));
     assert!(zod_schema.contains("name: z.string(),"));
@@ -377,11 +357,9 @@ fn test_json_schema_optional_parent() {
     let schema = Post::json_schema();
     let properties = schema["properties"].as_object().unwrap();
 
-    // parent_id should be optional
     let required = schema["required"].as_array().unwrap();
     assert!(!required.contains(&serde_json::Value::String("parent_id".to_owned())));
 
-    // But still should have the ObjectId structure
     let parent_id_prop = &properties["parent_id"];
     assert_eq!(parent_id_prop["type"], "object");
     assert_eq!(parent_id_prop["properties"]["$oid"]["type"], "string");
@@ -394,12 +372,10 @@ fn test_json_schema_optional_parent() {
 fn test_object_id_arrays() {
     let ts_definition = UserWithObjectIdArray::ts_definition();
 
-    // TypeScript should use ObjectId type
     assert!(ts_definition.contains("id: ObjectId;"));
     assert!(ts_definition.contains("name: string;"));
     assert!(ts_definition.contains("friend_ids: Array<ObjectId>;"));
 
-    // Zod schema should use the MongoDB ObjectId structure with regex validation - now in separate method
     let zod_schema = UserWithObjectIdArray::zod_schema();
     assert!(zod_schema.contains("id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: \"Invalid ObjectId\" }) }),"));
     assert!(zod_schema.contains("name: z.string(),"));
@@ -412,7 +388,6 @@ fn test_object_id_arrays_json_schema() {
     let schema = UserWithObjectIdArray::json_schema();
     let properties = schema["properties"].as_object().unwrap();
 
-    // Check array of ObjectId
     let friend_ids_prop = &properties["friend_ids"];
     assert_eq!(friend_ids_prop["type"], "array");
 
@@ -428,20 +403,17 @@ fn test_object_id_arrays_json_schema() {
 fn test_object_id_arrays_zod_schema() {
     let zod_schema = UserWithObjectIdArray::zod_schema();
 
-    // Should handle array of ObjectId correctly
     assert!(zod_schema.contains("friend_ids: z.array(z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: \"Invalid ObjectId\" }) })),"));
 }
 
 #[test]
 fn test_object_id_compilation_smoke_test() {
-    // This test ensures all ObjectId types compile without panics
     let user = User {
         id: ObjectId::new(),
         name: "Test User".to_owned(),
         email: Some("test@example.com".to_owned()),
     };
 
-    // If we get here without panics, ObjectId support is working at compile time
     assert_eq!(user.name, "Test User");
 }
 
@@ -451,14 +423,12 @@ fn test_object_id_json_schema() {
     let schema = User::json_schema();
     let properties = schema["properties"].as_object().unwrap();
 
-    // Check basic ObjectId field
     let id_prop = &properties["id"];
     assert_eq!(id_prop["type"], "object");
     assert_eq!(id_prop["properties"]["$oid"]["type"], "string");
     assert_eq!(id_prop["required"][0], "$oid");
     assert_eq!(id_prop["additionalProperties"], false);
 
-    // Check other fields are unaffected
     assert_eq!(properties["name"]["type"], "string");
 }
 
@@ -467,7 +437,6 @@ fn test_object_id_json_schema() {
 fn test_object_id_zod_schema() {
     let zod_schema = Post::zod_schema();
 
-    // Should handle optional ObjectId correctly
     assert!(zod_schema.contains("parent_id: z.union([z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: \"Invalid ObjectId\" }) }), z.undefined()]).prefault(undefined),"));
 }
 
@@ -476,12 +445,10 @@ fn test_object_id_zod_schema() {
 fn test_optional_object_id() {
     let ts_definition = UserWithOptionalId::ts_definition();
 
-    // TypeScript should use ObjectId type
     assert!(ts_definition.contains("id?: ObjectId;"));
     assert!(ts_definition.contains("name: string;"));
     assert!(ts_definition.contains("email: string;"));
 
-    // Zod schema should use the MongoDB ObjectId structure with regex validation - now in separate method
     let zod_schema = UserWithOptionalId::zod_schema();
     assert!(zod_schema.contains("id: z.union([z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: \"Invalid ObjectId\" }) }), z.undefined()]).prefault(undefined),"));
     assert!(zod_schema.contains("name: z.string(),"));
@@ -493,13 +460,11 @@ fn test_optional_object_id() {
 fn test_optional_object_id_zod_schema() {
     let zod_schema = UserWithOptionalId::zod_schema();
 
-    // Should handle optional ObjectId correctly
     assert!(zod_schema.contains("id: z.union([z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: \"Invalid ObjectId\" }) }), z.undefined()]).prefault(undefined),"));
     assert!(zod_schema.contains("name: z.string(),"));
     assert!(zod_schema.contains("email: z.string(),"));
 }
 
-// Test that includes UserWithHashMapObjectId
 #[test]
 #[cfg(feature = "jsonschema")]
 fn test_user_with_hashmap_object_id_json() {
@@ -514,7 +479,6 @@ fn test_user_with_hashmap_object_id_json() {
     );
 }
 
-// Test that includes UserWithOtherHashMapObjectId
 #[test]
 #[cfg(feature = "jsonschema")]
 fn test_user_with_other_hashmap_object_id_json() {

--- a/tests/pattern_preprocess_tests/tests.rs
+++ b/tests/pattern_preprocess_tests/tests.rs
@@ -51,7 +51,6 @@ fn test_pattern_ts_type_unaffected() {
     }
 
     let ts = PatternTsTest::ts_definition();
-    // TypeScript type should just be string, no regex info in the type body
     assert!(ts.contains("data_element_id: string"), "TS: {ts}");
     assert!(!ts.contains("regex"), "TS should not contain regex: {ts}");
     // The type body itself (after the JSDoc comment) should not have pattern syntax
@@ -194,7 +193,6 @@ fn test_preprocess_json_schema_unaffected() {
     }
 
     let schema = PreprocessJsonSchema::json_schema();
-    // JSON schema should be same as without preprocess - just string type
     let properties = schema["properties"].as_object().unwrap();
     let date_schema = &properties["date_value"];
     assert_eq!(date_schema["type"], "string");
@@ -213,15 +211,12 @@ fn test_pattern_and_preprocess_same_field() {
     }
 
     let schema = PatternAndPreprocess::zod_schema();
-    // Should have preprocess wrapping the string with pattern check
     assert!(schema.contains("z.preprocess(trim,"), "Schema: {schema}");
     assert!(
         schema.contains(".check(z.regex(/^[0-9a-fA-F]{24}$/))"),
         "Schema: {schema}"
     );
 }
-
-// ==================== Pattern with optional field ====================
 
 #[cfg(feature = "zod")]
 #[test]
@@ -235,14 +230,11 @@ fn test_pattern_optional_field_zod() {
     }
 
     let schema = PatternOptional::zod_schema();
-    // Optional field with pattern: z.union([z.string().check(z.regex(...)), z.undefined()])
     assert!(
         schema.contains("z.union([z.string().check(z.regex(/^[0-9]+$/)), z.undefined()])"),
         "Expected optional pattern union in Zod schema: {schema}"
     );
 }
-
-// ==================== Pattern combined with minLength/maxLength ====================
 
 #[cfg(feature = "zod")]
 #[test]
@@ -291,8 +283,6 @@ fn test_pattern_with_min_length_json_schema() {
     );
 }
 
-// ==================== Preprocess with optional field ====================
-
 #[cfg(feature = "zod")]
 #[test]
 fn test_preprocess_optional_field_zod() {
@@ -311,8 +301,6 @@ fn test_preprocess_optional_field_zod() {
         "Expected preprocess inside optional union in Zod schema: {schema}"
     );
 }
-
-// ==================== Preprocess with multiple fields ====================
 
 #[cfg(feature = "zod")]
 #[test]
@@ -337,8 +325,6 @@ fn test_preprocess_different_fields() {
     );
 }
 
-// ==================== Pattern with special regex characters ====================
-
 #[cfg(feature = "zod")]
 #[test]
 fn test_pattern_special_regex_chars() {
@@ -359,8 +345,6 @@ fn test_pattern_special_regex_chars() {
     );
 }
 
-// ==================== Preprocess ordering with three functions ====================
-
 #[cfg(feature = "zod")]
 #[test]
 fn test_preprocess_ordering_three_fns() {
@@ -378,8 +362,6 @@ fn test_preprocess_ordering_three_fns() {
         "Expected correct nesting order a(b(c(inner))): {schema}"
     );
 }
-
-// ==================== Pattern on enum variant combined with minLength ====================
 
 #[cfg(all(feature = "zod", feature = "serde"))]
 #[test]
@@ -404,8 +386,6 @@ fn test_pattern_enum_variant_with_min_length() {
         "Expected .check(z.regex(...)) in Zod enum schema: {schema}"
     );
 }
-
-// ==================== Serde validation for pattern with enum variant ====================
 
 #[cfg(all(
     feature = "serde",
@@ -445,8 +425,6 @@ fn test_pattern_enum_variant_serde_validation() {
         "Error should mention pattern mismatch: {err_str}"
     );
 }
-
-// ==================== Forward slash inside the Zod regex literal ====================
 
 // The Zod surface splices a pattern into a JS regex literal, where `/` is the delimiter: an
 // unescaped one closes the literal early and the emitted TypeScript stops parsing. That escaping
@@ -567,8 +545,6 @@ fn test_the_escaped_zod_pattern_matches_the_value_set_the_validator_enforces() {
         );
     }
 }
-
-// ==================== Line terminators inside the Zod regex literal ====================
 
 // A JS regex literal cannot carry a raw line terminator: the literal ends at the line break and
 // the emitted TypeScript stops parsing, exactly as an unescaped delimiter did. The escape form

--- a/tests/primitive_types_tests/tests.rs
+++ b/tests/primitive_types_tests/tests.rs
@@ -53,7 +53,6 @@ struct LargeNumbers {
     test,
     any(feature = "typescript", feature = "jsonschema", feature = "zod")
 ))]
-// Test edge cases with mixed integer types
 #[model_schema()]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq)]
@@ -74,7 +73,6 @@ struct MixedIntegers {
     test,
     any(feature = "typescript", feature = "jsonschema", feature = "zod")
 ))]
-// Test edge cases with all primitive integer types in various contexts
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct PrimitiveTypesShowcase {
@@ -402,32 +400,26 @@ fn test_64bit_integers_json_schema() {
 
     let properties = schema["properties"].as_object().unwrap();
 
-    // Check that u64 and i64 are properly typed
     assert!(properties.contains_key("large_unsigned"));
     assert!(properties.contains_key("large_signed"));
 
-    // These should be integer type
     assert_eq!(properties["large_unsigned"]["type"], "integer");
     assert_eq!(properties["large_signed"]["type"], "integer");
 
-    // Check optional fields
     assert!(properties.contains_key("optional_large_unsigned"));
     assert!(properties.contains_key("optional_large_signed"));
 
-    // Check arrays
     assert_eq!(properties["array_of_u64"]["type"], "array");
     assert_eq!(properties["array_of_u64"]["items"]["type"], "integer");
     assert_eq!(properties["array_of_i64"]["type"], "array");
     assert_eq!(properties["array_of_i64"]["items"]["type"], "integer");
 
-    // Check required fields
     let required = schema["required"].as_array().unwrap();
     assert!(required.contains(&Value::String("large_unsigned".to_owned())));
     assert!(required.contains(&Value::String("large_signed".to_owned())));
     assert!(required.contains(&Value::String("array_of_u64".to_owned())));
     assert!(required.contains(&Value::String("array_of_i64".to_owned())));
 
-    // Optional fields should NOT be in required
     assert!(!required.contains(&Value::String("optional_large_unsigned".to_owned())));
     assert!(!required.contains(&Value::String("optional_large_signed".to_owned())));
 }
@@ -437,7 +429,6 @@ fn test_64bit_integers_json_schema() {
 fn test_64bit_integers_ts_definition() {
     let ts_definition = LargeNumbers::ts_definition();
 
-    // Check TypeScript type mapping - should be number
     assert!(ts_definition.contains("large_unsigned: number;"));
     assert!(ts_definition.contains("large_signed: number;"));
     assert_ts_omitted_fields_contain(
@@ -448,7 +439,6 @@ fn test_64bit_integers_ts_definition() {
     assert!(ts_definition.contains("array_of_u64: Array<number>;"));
     assert!(ts_definition.contains("array_of_i64: Array<number>;"));
 
-    // Check Zod schema - now in separate method
     let zod_schema = LargeNumbers::zod_schema();
     assert!(zod_schema.contains("large_unsigned: z.number().int()"));
     assert!(zod_schema.contains("large_signed: z.number().int()"));
@@ -469,7 +459,6 @@ fn test_mixed_integers_json_schema() {
 
     let properties = schema["properties"].as_object().unwrap();
 
-    // All integer types should map to "integer" in JSON schema
     assert_eq!(properties["small_u8"]["type"], "integer");
     assert_eq!(properties["small_i8"]["type"], "integer");
     assert_eq!(properties["medium_u16"]["type"], "integer");
@@ -487,7 +476,6 @@ fn test_mixed_integers_json_schema() {
 fn test_mixed_integers_ts_definition() {
     let ts_definition = MixedIntegers::ts_definition();
 
-    // All integer types should map to number in TypeScript
     assert!(ts_definition.contains("small_u8: number;"));
     assert!(ts_definition.contains("small_i8: number;"));
     assert!(ts_definition.contains("medium_u16: number;"));
@@ -499,7 +487,6 @@ fn test_mixed_integers_ts_definition() {
     assert!(ts_definition.contains("size_type: number;"));
     assert!(ts_definition.contains("isize_type: number;"));
 
-    // All should use z.number().int() in Zod - now in separate method
     let zod_schema = MixedIntegers::zod_schema();
     assert!(zod_schema.contains("small_u8: z.number().int()"));
     assert!(zod_schema.contains("small_i8: z.number().int()"));
@@ -519,7 +506,6 @@ fn test_primitive_types_json_schema_details() {
     let schema = PrimitiveTypesShowcase::json_schema();
     let properties = schema["properties"].as_object().unwrap();
 
-    // All integer types should map to "integer" in JSON Schema
     let integer_fields = [
         "tiny_signed",
         "tiny_unsigned",
@@ -536,27 +522,22 @@ fn test_primitive_types_json_schema_details() {
         assert_property_type(properties, field, "integer");
     }
 
-    // Float types should map to "number" in JSON Schema
     assert_property_type(properties, "float_single", "number");
     assert_property_type(properties, "float_double", "number");
 
-    // Optional fields should not be in required array
     let required = schema["required"].as_array().unwrap();
     for opt_field in &["opt_i8", "opt_u64", "opt_f64"] {
         assert!(!required.contains(&serde_json::Value::String((*opt_field).to_owned())));
     }
 
-    // Arrays should have proper structure
     assert_array_property(properties, "array_i8", "integer");
     assert_array_property(properties, "array_u64", "integer");
     assert_array_property(properties, "array_f64", "number");
 
-    // HashMap with primitive values
     assert_hashmap_property(properties, "map_to_i8", "integer");
     assert_hashmap_property(properties, "map_to_u64", "integer");
     assert_hashmap_property(properties, "map_to_f64", "number");
 
-    // HashMap with array values
     assert_hashmap_array_property(properties, "map_to_i8_array", "integer");
     assert_hashmap_array_property(properties, "map_to_u64_array", "integer");
     assert_hashmap_array_property(properties, "map_to_f64_array", "number");
@@ -567,7 +548,6 @@ fn test_primitive_types_json_schema_details() {
 fn test_primitive_types_typescript_generation_details() {
     let ts_definition = PrimitiveTypesShowcase::ts_definition();
 
-    // All integer and float types should map to "number" in TypeScript
     let numeric_fields = [
         "tiny_signed",
         "tiny_unsigned",
@@ -584,41 +564,34 @@ fn test_primitive_types_typescript_generation_details() {
     ];
     assert_ts_fields_contain(&ts_definition, &numeric_fields, "number");
 
-    // Optional types carry the key serde may drop
     assert_ts_omitted_fields_contain(&ts_definition, &["opt_i8", "opt_u64", "opt_f64"], "number");
 
-    // Arrays should use Array<number> syntax
     assert_ts_fields_contain(
         &ts_definition,
         &["array_i8", "array_u64", "array_f64"],
         "Array<number>",
     );
 
-    // Optional arrays carry the key serde may drop
     assert_ts_omitted_fields_contain(
         &ts_definition,
         &["opt_array_i8", "opt_array_u64", "opt_array_f64"],
         "Array<number>",
     );
 
-    // HashMap with primitive values
     assert_ts_fields_contain(
         &ts_definition,
         &["map_to_i8", "map_to_u64", "map_to_f64"],
         "Partial<Record<string, number>>",
     );
 
-    // HashMap with array values
     assert_ts_fields_contain(
         &ts_definition,
         &["map_to_i8_array", "map_to_u64_array", "map_to_f64_array"],
         "Partial<Record<string, Array<number>>>",
     );
 
-    // Check Zod schema - now in separate method
     let zod_schema = PrimitiveTypesShowcase::zod_schema();
 
-    // Integer Zod schemas
     assert_zod_fields_contain(
         &zod_schema,
         &[
@@ -630,10 +603,8 @@ fn test_primitive_types_typescript_generation_details() {
         "z.number().int()",
     );
 
-    // Float Zod schemas (no .int())
     assert_zod_fields_contain(&zod_schema, &["float_single", "float_double"], "z.number()");
 
-    // Optional Zod schemas
     assert_zod_fields_contain(
         &zod_schema,
         &["opt_i8", "opt_u64"],
@@ -641,7 +612,6 @@ fn test_primitive_types_typescript_generation_details() {
     );
     assert!(zod_schema.contains("opt_f64: z.union([z.number(), z.undefined()])"));
 
-    // Array Zod schemas
     assert_zod_fields_contain(
         &zod_schema,
         &["array_i8", "array_u64"],
@@ -649,7 +619,6 @@ fn test_primitive_types_typescript_generation_details() {
     );
     assert!(zod_schema.contains("array_f64: z.array(z.number())"));
 
-    // HashMap Zod schemas
     assert_zod_fields_contain(
         &zod_schema,
         &["map_to_i8", "map_to_u64"],
@@ -657,7 +626,6 @@ fn test_primitive_types_typescript_generation_details() {
     );
     assert!(zod_schema.contains("map_to_f64: z.record(z.string(), z.number())"));
 
-    // HashMap with array Zod schemas
     assert_zod_fields_contain(
         &zod_schema,
         &["map_to_i8_array", "map_to_u64_array"],

--- a/tests/readme_example_tests/tests.rs
+++ b/tests/readme_example_tests/tests.rs
@@ -131,12 +131,6 @@ fn test_the_optional_fields_example_is_declarable_and_shows_what_it_emits() {
 
 /// A bullet from the "Supported Serde attributes" list, held to what it claims the generator
 /// writes.
-///
-/// Three things have to agree: the README still carries the bullet as its own line, the bullet
-/// still quotes each spelling, and the generator still writes it. A bullet summarising an attribute
-/// it no longer describes correctly is what this catches — the list stated for a long time that
-/// `skip_serializing_if` did not affect the generated types, which the omitted-key contract had
-/// already made false.
 fn assert_readme_bullet_shows(bullet: &str, emission: &str, spellings: &[&str]) {
     assert!(
         readme().lines().any(|line| line == bullet),

--- a/tests/recursive_type_tests/tests.rs
+++ b/tests/recursive_type_tests/tests.rs
@@ -341,8 +341,6 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use tixschema::model_schema;
 
-// ========== Type definitions at module level ==========
-
 /// Recursive struct holding at most one of itself.
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -536,20 +534,16 @@ pub struct TreeNode {
     pub val: String,
 }
 
-// ========== Tests ==========
-
 /// Test 1: Recursive enum with `Vec` of self.
 #[test]
 fn test_recursive_enum_with_vec() {
     let zod = RecursiveVecEnum::zod_schema();
 
-    // Should contain getter syntax for Array variant (recursive)
     assert!(
         zod.contains("get value()"),
         "Recursive Array variant should use getter syntax. Got: {zod}"
     );
 
-    // Text variant should NOT use getter (not recursive)
     assert!(
         zod.contains("value: z.string()"),
         "Non-recursive Text variant should use normal property syntax. Got: {zod}"
@@ -561,13 +555,11 @@ fn test_recursive_enum_with_vec() {
 fn test_recursive_enum_with_hashmap() {
     let zod = RecursiveMapEnum::zod_schema();
 
-    // Should contain getter syntax for Object variant (recursive)
     assert!(
         zod.contains("get value()"),
         "Recursive Object variant should use getter syntax. Got: {zod}"
     );
 
-    // Number variant should NOT use getter (not recursive)
     assert!(
         zod.contains("value: z.number()"),
         "Non-recursive Number variant should use normal property syntax. Got: {zod}"
@@ -579,13 +571,11 @@ fn test_recursive_enum_with_hashmap() {
 fn test_recursive_struct() {
     let zod = TreeNode::zod_schema();
 
-    // Should contain getter syntax for children (recursive)
     assert!(
         zod.contains("get children()"),
         "Recursive children field should use getter syntax. Got: {zod}"
     );
 
-    // val field should NOT use getter (not recursive)
     assert!(
         zod.contains("val: z.string()"),
         "Non-recursive val field should use normal property syntax. Got: {zod}"
@@ -597,14 +587,12 @@ fn test_recursive_struct() {
 fn test_complex_dynamic_value() {
     let zod = DynamicValueTest::zod_schema();
 
-    // Count getter occurrences - should have exactly 2 (array and object)
     let getter_count = zod.matches("get value()").count();
     assert_eq!(
         getter_count, 2,
         "Should have exactly 2 getter properties (array and object). Got: {getter_count}. Schema: {zod}"
     );
 
-    // Verify non-recursive variants use normal syntax
     assert!(
         zod.contains("value: z.string()"),
         "String variant should use normal syntax"
@@ -624,7 +612,6 @@ fn test_complex_dynamic_value() {
 fn test_non_recursive_enum_no_getter() {
     let zod = SimpleEnum::zod_schema();
 
-    // Should NOT contain getter syntax
     assert!(
         !zod.contains("get "),
         "Non-recursive enum should not use getter syntax. Got: {zod}"
@@ -636,7 +623,6 @@ fn test_non_recursive_enum_no_getter() {
 fn test_non_recursive_struct_no_getter() {
     let zod = SimpleStruct::zod_schema();
 
-    // Should NOT contain getter syntax
     assert!(
         !zod.contains("get "),
         "Non-recursive struct should not use getter syntax. Got: {zod}"
@@ -648,7 +634,6 @@ fn test_non_recursive_struct_no_getter() {
 fn test_struct_with_sibling_type_no_getter() {
     let zod = Person::zod_schema();
 
-    // Should NOT contain getter syntax (Address is a different type, not self)
     assert!(
         !zod.contains("get "),
         "Struct with sibling type reference should not use getter syntax. Got: {zod}"
@@ -660,13 +645,11 @@ fn test_struct_with_sibling_type_no_getter() {
 fn test_recursive_named_struct_variant() {
     let zod = TreeEnum::zod_schema();
 
-    // Should contain getter syntax for nodes field in Branch variant
     assert!(
         zod.contains("get nodes()"),
         "Recursive nodes field in named variant should use getter syntax. Got: {zod}"
     );
 
-    // Leaf variant should NOT use getter
     assert!(
         zod.contains("text: z.string()"),
         "Non-recursive text field should use normal syntax. Got: {zod}"

--- a/tests/semantic_types_tests/tests.rs
+++ b/tests/semantic_types_tests/tests.rs
@@ -6,10 +6,6 @@ use serde::{Deserialize, Serialize};
 #[cfg(all(test, feature = "typescript"))]
 use tixschema::model_schema;
 
-// ========================================================================
-// Type Alias Definitions
-// ========================================================================
-
 #[cfg(all(test, feature = "typescript"))]
 #[model_schema(name = "AuditId")]
 pub type AuditId = OrderId;
@@ -129,10 +125,6 @@ struct NestedAliasStruct {
     owner: DocumentId,
 }
 
-// ========================================================================
-// Basic Type Alias Tests - TypeScript Generation
-// ========================================================================
-
 #[test]
 #[cfg(feature = "typescript")]
 fn test_string_alias_typescript() {
@@ -230,10 +222,6 @@ fn test_tuple_alias_typescript() {
     );
 }
 
-// ========================================================================
-// Generic Type Alias Tests
-// ========================================================================
-
 #[test]
 #[cfg(feature = "typescript")]
 fn test_single_generic_alias_typescript() {
@@ -270,10 +258,6 @@ fn test_double_generic_alias_typescript() {
     );
 }
 
-// ========================================================================
-// Nested Type Alias Tests
-// ========================================================================
-
 #[test]
 #[cfg(feature = "typescript")]
 fn test_nested_alias_typescript() {
@@ -291,10 +275,6 @@ fn test_nested_alias_typescript() {
         "Should reference OrderId type. Got: {ts}"
     );
 }
-
-// ========================================================================
-// Type Aliases Used in Struct Fields
-// ========================================================================
 
 #[test]
 #[cfg(all(feature = "typescript", feature = "serde"))]
@@ -342,10 +322,6 @@ fn test_struct_with_nested_alias_fields() {
     );
 }
 
-// ========================================================================
-// Type Aliases in Collections
-// ========================================================================
-
 #[test]
 #[cfg(all(feature = "typescript", feature = "serde"))]
 fn test_alias_in_vec() {
@@ -371,10 +347,6 @@ fn test_alias_in_hashmap() {
         "Should use DocumentId in HashMap. Got: {ts}"
     );
 }
-
-// ========================================================================
-// Zod Schema Tests
-// ========================================================================
 
 #[test]
 #[cfg(all(feature = "zod", feature = "typescript"))]
@@ -443,16 +415,11 @@ fn test_vec_of_alias_references_schema() {
 fn test_struct_with_alias_zod_schema() {
     let zod = DocumentRecord::zod_schema();
 
-    // The struct should generate a proper Zod schema
     assert!(
         zod.contains("z.strictObject"),
         "Should contain Zod object schema. Got: {zod}"
     );
 }
-
-// ========================================================================
-// JSON Schema Tests
-// ========================================================================
 
 /// An alias publishes the schema of the type it names, so a slot filled by the alias validates
 /// exactly what the aliased type validates — the scalar mapping being the same one a field written
@@ -569,7 +536,6 @@ fn test_generic_alias_json_schema() {
 fn test_struct_with_alias_json_schema() {
     let schema = DocumentRecord::json_schema();
 
-    // The struct should generate a proper JSON schema
     assert_eq!(
         schema["type"], "object",
         "Should be an object schema. Got: {schema:?}"
@@ -595,25 +561,17 @@ fn test_struct_with_alias_json_schema() {
     }
 }
 
-// ========================================================================
-// Module Structure Tests
-// ========================================================================
-
 #[test]
 #[cfg(feature = "typescript")]
 fn test_alias_generates_module() {
-    // Verify that the alias generates the expected module structure
-    // The module should be accessible as `document_id_schema`
     let ts = document_id_schema::Schema::ts_definition();
 
-    // If we can call this method, the module was generated correctly
     assert!(!ts.is_empty(), "Module should be accessible");
 }
 
 #[test]
 #[cfg(feature = "typescript")]
 fn test_multiple_aliases_generate_separate_modules() {
-    // Each alias should generate its own module
     let doc_ts = document_id_schema::Schema::ts_definition();
     let rev_ts = revision_schema::Schema::ts_definition();
     let score_ts = score_schema::Schema::ts_definition();
@@ -622,14 +580,9 @@ fn test_multiple_aliases_generate_separate_modules() {
     assert!(rev_ts.contains("Revision"));
     assert!(score_ts.contains("Score"));
 
-    // They should be different
     assert_ne!(doc_ts, rev_ts);
     assert_ne!(rev_ts, score_ts);
 }
-
-// ========================================================================
-// Edge Cases and Complex Scenarios
-// ========================================================================
 
 #[test]
 #[cfg(all(feature = "typescript", feature = "serde"))]
@@ -650,10 +603,6 @@ fn test_complex_alias_usage() {
         "Should handle HashMap<String, Vec<Alias>>. Got: {ts}"
     );
 }
-
-// ========================================================================
-// Name Override Tests
-// ========================================================================
 
 #[test]
 #[cfg(feature = "typescript")]
@@ -678,10 +627,6 @@ fn test_name_override() {
         "Original type name should reach nothing but the re-export. Got: {ts}"
     );
 }
-
-// ========================================================================
-// Documentation Tests
-// ========================================================================
 
 #[test]
 #[cfg(feature = "typescript")]

--- a/tests/serde_tests/tests.rs
+++ b/tests/serde_tests/tests.rs
@@ -10,10 +10,6 @@ enum Color {
     Red,
 }
 
-// ========================================================================
-// Discriminated Union with Serde
-// ========================================================================
-
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(tag = "type", rename_all = "camelCase")]
@@ -30,12 +26,6 @@ enum Event {
     },
 }
 
-// ========================================================================
-// Different rename_all Conventions
-// Note: Currently only camelCase and lowercase are fully implemented
-// lowercase converts field names to lowercase while keeping underscores
-// ========================================================================
-
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "lowercase")]
@@ -43,10 +33,6 @@ struct Lowercase {
     field_one: String,
     field_two: String,
 }
-
-// ========================================================================
-// Serde with Optional Fields
-// ========================================================================
 
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -60,10 +46,6 @@ struct OptionalFields {
     required_field: String,
 }
 
-// ========================================================================
-// Option Fields That Satisfy the None-Serialization Guard
-// ========================================================================
-
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct CompliantOptionals {
@@ -75,10 +57,6 @@ struct CompliantOptionals {
     tag: Option<String>,
 }
 
-// ========================================================================
-// Enum Serde Tests
-// ========================================================================
-
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "lowercase")]
@@ -87,10 +65,6 @@ enum Status {
     Inactive,
     Pending,
 }
-
-// ========================================================================
-// Basic Serde Rename Tests
-// ========================================================================
 
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -104,10 +78,6 @@ struct UserWithSerde {
     last_name: String,
     user_id: String,
 }
-
-// ========================================================================
-// Wire Names That No Identifier Can Hold
-// ========================================================================
 
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -213,7 +183,6 @@ fn test_serde_rename_all_camel_case_json_schema() {
 
     let properties = schema["properties"].as_object().unwrap();
 
-    // Check that serde rename attributes are applied
     assert!(properties.contains_key("userId")); // user_id -> userId
     assert!(properties.contains_key("firstName")); // first_name -> firstName
     assert!(properties.contains_key("lastName")); // last_name -> lastName
@@ -221,7 +190,6 @@ fn test_serde_rename_all_camel_case_json_schema() {
     assert!(properties.contains_key("createdAt")); // created_at -> createdAt
     assert!(properties.contains_key("isVerified")); // is_verified -> isVerified
 
-    // Check that original field names are NOT present
     assert!(!properties.contains_key("user_id"));
     assert!(!properties.contains_key("first_name"));
     assert!(!properties.contains_key("last_name"));
@@ -229,7 +197,6 @@ fn test_serde_rename_all_camel_case_json_schema() {
     assert!(!properties.contains_key("created_at"));
     assert!(!properties.contains_key("is_verified"));
 
-    // Verify field types
     assert_eq!(properties["userId"]["type"], "string");
     assert_eq!(properties["firstName"]["type"], "string");
     assert_eq!(properties["lastName"]["type"], "string");
@@ -243,7 +210,6 @@ fn test_serde_rename_all_camel_case_json_schema() {
 fn test_serde_rename_all_camel_case_typescript() {
     let ts_definition = UserWithSerde::ts_definition();
 
-    // Check that field names are converted in TypeScript
     assert!(ts_definition.contains("userId: string;"));
     assert!(ts_definition.contains("firstName: string;"));
     assert!(ts_definition.contains("lastName: string;"));
@@ -347,12 +313,10 @@ fn test_enum_field_rename() {
 fn test_discriminated_union_with_serde_typescript() {
     let ts = Event::ts_definition();
 
-    // Check discriminator field with camelCase applied to variant names
     assert!(ts.contains("type: \"userCreated\""));
     assert!(ts.contains("type: \"userDeleted\""));
     assert!(ts.contains("type: \"userUpdated\""));
 
-    // Check renamed fields
     assert!(ts.contains("userId: string;"));
     assert!(ts.contains("userName: string;"));
     assert!(ts.contains("newEmail: string;"));

--- a/tests/skipped_field_tests/tests.rs
+++ b/tests/skipped_field_tests/tests.rs
@@ -265,9 +265,6 @@ fn the_json_schema_drops_the_variant_member_too() {
         tagged["oneOf"][0]["properties"]["internal"].is_null(),
         "Got: {tagged}"
     );
-    // The discriminator's own name is the `serde` feature's business, so what is read here is the
-    // membership rather than the whole list: the dropped member is out of `required` and the one
-    // beside it is in.
     let required = tagged["oneOf"][0]["required"].as_array().unwrap().clone();
     assert!(
         !required.contains(&serde_json::json!("internal")),

--- a/tests/tuple_field_tests/tests.rs
+++ b/tests/tuple_field_tests/tests.rs
@@ -78,7 +78,6 @@ fn test_string_pair_tuple_field_zod() {
         zod.contains("values: z.tuple([z.string(), z.string()])"),
         "Expected z.tuple in Zod schema. Got: {zod}"
     );
-    // Must not emit the malformed bare-object-literal form.
     assert!(
         !zod.contains("element_0"),
         "Should not emit element_N keys in Zod. Got: {zod}"

--- a/tests/tuple_variant_tests/tests.rs
+++ b/tests/tuple_variant_tests/tests.rs
@@ -416,7 +416,6 @@ fn test_multi_tuple_variant_zod() {
 
     let zod = MultiTupleZod::zod_schema();
 
-    // Verify z.tuple() is used
     assert!(zod.contains("z.tuple("), "Missing z.tuple");
     assert!(
         zod.contains("z.tuple([z.string(), z.number().int()])"),
@@ -444,15 +443,12 @@ fn test_plain_enum_string_union() {
 
     let ts = DataType::ts_definition();
 
-    // Should be a string union, not discriminated union
     assert!(ts.contains("\"Alphanumeric\""), "Missing Alphanumeric");
     assert!(ts.contains("\"Image\""), "Missing Image");
     assert!(ts.contains("\"Decimal\""), "Missing Decimal");
     assert!(ts.contains("\"Integer\""), "Missing Integer");
     assert!(ts.contains("\"Boolean\""), "Missing Boolean");
 
-    // Should NOT have type/value fields (it's a plain string union)
-    // The format should be: type DataType = "Alphanumeric" | "Image" | ...
     assert!(
         !ts.contains("type:") || ts.contains("export type"),
         "Should not have type discriminator field"
@@ -473,7 +469,6 @@ fn test_plain_enum_zod() {
 
     let zod = PlainEnumZod::zod_schema();
 
-    // Should use z.enum, not z.discriminatedUnion
     assert!(zod.contains("z.enum("), "Should use z.enum for plain enums");
     assert!(
         !zod.contains("z.discriminatedUnion"),
@@ -494,7 +489,6 @@ fn test_mixed_variants_typescript() {
         Named { field_a: String, field_b: bool },
         // Multi tuple
         Pair(String, i64),
-        // Single tuple
         Text(String),
     }
 
@@ -618,11 +612,9 @@ fn test_custom_content_field() {
 
     let ts = CustomContent::ts_definition();
 
-    // Should use "kind" instead of "type"
     assert!(ts.contains("kind: \"Text\""), "Should use 'kind' as tag");
     assert!(ts.contains("kind: \"Number\""), "Should use 'kind' as tag");
 
-    // Should use "data" instead of "value"
     assert!(
         ts.contains("data: string"),
         "Should use 'data' as content field"
@@ -647,13 +639,11 @@ fn test_custom_content_field_zod() {
 
     let zod = CustomContentZod::zod_schema();
 
-    // Should use "kind" in discriminatedUnion
     assert!(
         zod.contains("z.discriminatedUnion(\"kind\""),
         "Should use 'kind' as discriminator"
     );
 
-    // Should use "data" as field name
     assert!(
         zod.contains("data: z.string()"),
         "Should use 'data' as content field"
@@ -671,7 +661,6 @@ fn test_tuple_with_vec() {
     #[derive(Serialize, Deserialize, Debug, Clone)]
     pub enum TupleWithVec {
         Data(Vec<String>),
-        // This was the original problem case: Image(String, Vec<u8>)
         Image(String, Vec<u8>),
     }
 
@@ -784,7 +773,6 @@ fn test_optional_in_tuple() {
 fn test_tuple_with_custom_type() {
     let ts = Outer::ts_definition();
 
-    // Should reference the inner type
     assert!(
         ts.contains("\"Wrapped\": Inner"),
         "Wrapped should reference Inner type. Got: {ts}"
@@ -821,7 +809,6 @@ fn test_serde_serialization_compatibility() {
         Text(String),
     }
 
-    // Test serialization produces expected format
     let text = SerdeCompat::Text("hello".to_owned());
     let text_json = serde_json::to_value(&text).unwrap();
     assert_eq!(text_json["type"], "Text");
@@ -856,8 +843,6 @@ fn test_fixed_value_original_issue() {
 
     let ts = FixedValue::ts_definition();
 
-    // Verify NO empty field names (the original bug)
-    // Empty field names would look like "  : string;" (space before colon, no field name)
     assert!(
         !ts.contains("\n  : "),
         "Should not have empty field name (found line starting with colon)"
@@ -909,7 +894,6 @@ fn test_fixed_value_ext_comprehensive() {
 
     let ts = FixedValueExt::ts_definition();
 
-    // Single tuple variants
     assert!(
         ts.contains("\"Alphanumeric\": string"),
         "Missing Alphanumeric. Got: {ts}"
@@ -1016,7 +1000,6 @@ fn test_jsdoc_comments() {
 
     let ts = JsDoc::ts_definition();
 
-    // Should have JSDoc comments
     assert!(ts.contains("/**"), "Should have JSDoc comments");
     assert!(ts.contains("*/"), "Should have JSDoc end");
 

--- a/tests/typescript_feature_tests/tests.rs
+++ b/tests/typescript_feature_tests/tests.rs
@@ -1,7 +1,6 @@
 use serde::{Deserialize, Serialize};
 use tixschema::model_schema;
 
-// Test discriminated union for typescript feature testing
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(tag = "type", rename_all = "camelCase")]
@@ -10,7 +9,6 @@ enum TypeScriptTestPayment {
     PayPal { email: String },
 }
 
-// Test enum for typescript feature testing
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "lowercase")]
@@ -20,7 +18,6 @@ enum TypeScriptTestStatus {
     Pending,
 }
 
-// Test simple struct for typescript feature testing
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct TypeScriptTestUser {
@@ -47,20 +44,17 @@ fn test_typescript_feature_types_constructible() {
     assert!(user.id.is_empty());
 }
 
-// Tests for when typescript feature is ENABLED (default configuration)
 #[test]
 #[cfg(feature = "typescript")]
 fn test_typescript_enabled_struct_ts_definition() {
     let ts_definition = TypeScriptTestUser::ts_definition();
 
-    // Should contain TypeScript type definition
     assert!(ts_definition.contains("export type TypeScriptTestUser = {"));
     assert!(ts_definition.contains("id: string;"));
     assert!(ts_definition.contains("name: string;"));
     assert!(ts_definition.contains("age: number;"));
     assert!(ts_definition.contains("active: boolean;"));
 
-    // Should NOT contain Zod schema
     assert!(!ts_definition.contains("z.strictObject"));
     assert!(!ts_definition.contains("z.string()"));
 }
@@ -70,14 +64,12 @@ fn test_typescript_enabled_struct_ts_definition() {
 fn test_typescript_enabled_struct_zod_schema() {
     let zod_schema = TypeScriptTestUser::zod_schema();
 
-    // Should contain TypeScript-style Zod schema with type annotations
     assert!(zod_schema.contains("const TypeScriptTestUser$RawSchema = z.strictObject({"));
     assert!(zod_schema.contains("id: z.string()"));
     assert!(zod_schema.contains("name: z.string()"));
     assert!(zod_schema.contains("age: z.number().int()"));
     assert!(zod_schema.contains("active: z.boolean()"));
 
-    // Should NOT contain TypeScript type definition
     assert!(!zod_schema.contains("export type TypeScriptTestUser"));
 }
 
@@ -86,13 +78,11 @@ fn test_typescript_enabled_struct_zod_schema() {
 fn test_typescript_enabled_plain_enum_ts_definition() {
     let ts_definition = TypeScriptTestStatus::ts_definition();
 
-    // Should contain TypeScript union type with serde transformations applied
     assert!(ts_definition.contains("export type TypeScriptTestStatus"));
     assert!(ts_definition.contains("\"active\""));
     assert!(ts_definition.contains("\"inactive\""));
     assert!(ts_definition.contains("\"pending\""));
 
-    // Should NOT contain Zod schema
     assert!(!ts_definition.contains("z.enum"));
 }
 
@@ -101,16 +91,12 @@ fn test_typescript_enabled_plain_enum_ts_definition() {
 fn test_typescript_enabled_plain_enum_zod_schema() {
     let zod_schema = TypeScriptTestStatus::zod_schema();
 
-    // Should contain $RawSchema definition with z.enum
     assert!(zod_schema.contains(
         "const TypeScriptTestStatus$RawSchema = z.enum([\"active\", \"inactive\", \"pending\"])"
     ));
-    // Should contain typed $Schema referencing $RawSchema
     assert!(zod_schema.contains("export const TypeScriptTestStatus$Schema: ZodType<TypeScriptTestStatus> = TypeScriptTestStatus$RawSchema;"));
-    // Now includes .meta() with description
     assert!(zod_schema.contains(".meta({"));
 
-    // Should NOT contain TypeScript type definition
     assert!(!zod_schema.contains("export type TypeScriptTestStatus"));
 }
 
@@ -119,12 +105,10 @@ fn test_typescript_enabled_plain_enum_zod_schema() {
 fn test_typescript_enabled_discriminated_enum_ts_definition() {
     let ts_definition = TypeScriptTestPayment::ts_definition();
 
-    // Should contain TypeScript discriminated union with serde transformations applied
     assert!(ts_definition.contains("export type TypeScriptTestPayment = "));
     assert!(ts_definition.contains("type: \"creditCard\""));
     assert!(ts_definition.contains("type: \"payPal\""));
 
-    // Should NOT contain Zod schema
     assert!(!ts_definition.contains("z.discriminatedUnion"));
 }
 
@@ -133,17 +117,13 @@ fn test_typescript_enabled_discriminated_enum_ts_definition() {
 fn test_typescript_enabled_discriminated_enum_zod_schema() {
     let zod_schema = TypeScriptTestPayment::zod_schema();
 
-    // Should contain $RawSchema definition with z.discriminatedUnion
     assert!(zod_schema.contains("const TypeScriptTestPayment$RawSchema = "));
     assert!(zod_schema.contains("z.discriminatedUnion"));
-    // Should contain typed $Schema referencing $RawSchema
     assert!(zod_schema.contains("export const TypeScriptTestPayment$Schema: ZodType<TypeScriptTestPayment> = TypeScriptTestPayment$RawSchema;"));
 
-    // Should NOT contain TypeScript type definition
     assert!(!zod_schema.contains("export type TypeScriptTestPayment"));
 }
 
-// Tests for when typescript feature is DISABLED
 #[test]
 #[cfg(not(feature = "typescript"))]
 fn test_typescript_disabled_struct_ts_definition_not_available() {
@@ -151,9 +131,6 @@ fn test_typescript_disabled_struct_ts_definition_not_available() {
     // This would cause a compile error if we tried to call TypeScriptTestUser::ts_definition().
     // We can't test the compilation failure directly, but we can verify the method doesn't exist
     // by checking that our code compiles without calling it.
-
-    // This test mainly serves as documentation that ts_definition() is not available
-    // when typescript feature is disabled.
 }
 
 #[test]
@@ -161,14 +138,12 @@ fn test_typescript_disabled_struct_ts_definition_not_available() {
 fn test_typescript_disabled_struct_zod_schema_javascript_style() {
     let zod_schema = TypeScriptTestUser::zod_schema();
 
-    // Should contain JavaScript-style Zod schema WITHOUT type annotations
     assert!(zod_schema.contains("export const TypeScriptTestUser$Schema = z.strictObject({"));
     assert!(zod_schema.contains("id: z.string()"));
     assert!(zod_schema.contains("name: z.string()"));
     assert!(zod_schema.contains("age: z.number().int()"));
     assert!(zod_schema.contains("active: z.boolean()"));
 
-    // Should NOT contain TypeScript type annotations
     assert!(!zod_schema.contains(": ZodType<TypeScriptTestUser>"));
     assert!(!zod_schema.contains("export type TypeScriptTestUser"));
 }
@@ -217,7 +192,6 @@ fn test_typescript_disabled_plain_enum_zod_schema_javascript_serde_style() {
     ));
     assert!(zod_schema.contains(".meta({"));
 
-    // Should NOT contain TypeScript type annotations
     assert!(!zod_schema.contains(": ZodType<TypeScriptTestStatus>"));
     assert!(!zod_schema.contains("export type TypeScriptTestStatus"));
 }
@@ -234,7 +208,6 @@ fn test_typescript_disabled_plain_enum_zod_schema_javascript_not_serde_style() {
     ));
     assert!(zod_schema.contains(".meta({"));
 
-    // Should NOT contain TypeScript type annotations
     assert!(!zod_schema.contains(": ZodType<TypeScriptTestStatus>"));
     assert!(!zod_schema.contains("export type TypeScriptTestStatus"));
 }
@@ -244,11 +217,9 @@ fn test_typescript_disabled_plain_enum_zod_schema_javascript_not_serde_style() {
 fn test_typescript_disabled_discriminated_enum_zod_schema_javascript_style() {
     let zod_schema = TypeScriptTestPayment::zod_schema();
 
-    // Should contain JavaScript-style Zod schema WITHOUT type annotations
     assert!(zod_schema.contains("export const TypeScriptTestPayment$Schema = "));
     assert!(zod_schema.contains("z.discriminatedUnion"));
 
-    // Should NOT contain TypeScript type annotations
     assert!(!zod_schema.contains(": ZodType<TypeScriptTestPayment>"));
     assert!(!zod_schema.contains("export type TypeScriptTestPayment"));
 }
@@ -260,11 +231,9 @@ fn test_typescript_and_zod_both_enabled() {
     let ts_definition = TypeScriptTestUser::ts_definition();
     let zod_schema = TypeScriptTestUser::zod_schema();
 
-    // TypeScript definition should be available and contain only TypeScript types
     assert!(ts_definition.contains("export type TypeScriptTestUser = {"));
     assert!(!ts_definition.contains("z.strictObject"));
 
-    // Zod schema should be available and contain TypeScript-style type annotations
     assert!(
         zod_schema.contains("export const TypeScriptTestUser$Schema: ZodType<TypeScriptTestUser>")
     );
@@ -276,12 +245,8 @@ fn test_typescript_and_zod_both_enabled() {
 fn test_typescript_disabled_zod_enabled() {
     let zod_schema = TypeScriptTestUser::zod_schema();
 
-    // Zod schema should be available but in JavaScript style (no type annotations)
     assert!(zod_schema.contains("export const TypeScriptTestUser$Schema = z.strictObject({"));
     assert!(!zod_schema.contains(": ZodType<TypeScriptTestUser>"));
-
-    // TypeScript definition should NOT be available
-    // (We can't test the compilation failure directly, but the method shouldn't exist)
 }
 
 #[test]
@@ -289,9 +254,5 @@ fn test_typescript_disabled_zod_enabled() {
 fn test_typescript_enabled_zod_disabled() {
     let ts_definition = TypeScriptTestUser::ts_definition();
 
-    // TypeScript definition should be available
     assert!(ts_definition.contains("export type TypeScriptTestUser = {"));
-
-    // Zod schema should NOT be available
-    // (We can't test the compilation failure directly, but the method shouldn't exist)
 }

--- a/tests/untagged_tests/tests.rs
+++ b/tests/untagged_tests/tests.rs
@@ -277,10 +277,6 @@ fn test_untagged_entry_constructible() {
     assert!(entry.data_element_id.is_empty());
 }
 
-// ========================================================================
-// TypeScript
-// ========================================================================
-
 #[test]
 #[cfg(feature = "typescript")]
 fn test_tuple_single_union_typescript() {
@@ -325,10 +321,6 @@ fn test_flatten_end_to_end_typescript() {
         "Got:\n{variant_ts}"
     );
 }
-
-// ========================================================================
-// Zod
-// ========================================================================
 
 #[test]
 #[cfg(feature = "zod")]
@@ -396,10 +388,6 @@ fn test_flatten_end_to_end_zod() {
     );
 }
 
-// ========================================================================
-// JSON Schema
-// ========================================================================
-
 #[test]
 #[cfg(feature = "jsonschema")]
 fn test_tuple_single_union_json_schema() {
@@ -455,10 +443,6 @@ fn test_flatten_end_to_end_json_schema() {
     assert_eq!(any_of[1]["pattern"], "^[0-9]{4}-[0-9]{2}-[0-9]{2}$");
 }
 
-// ========================================================================
-// Serde round-trip
-// ========================================================================
-
 #[test]
 fn test_serde_round_trip_string_member() {
     let value = DateValue::S(DateString("2026-06-26".to_owned()));
@@ -490,10 +474,6 @@ fn test_serde_round_trip_number_member() {
     let back: DateValue = serde_json::from_str(&json).unwrap();
     assert_eq!(back, value);
 }
-
-// ========================================================================
-// Untagged newtype variant holding an `Option` — the slot the three surfaces read against
-// ========================================================================
 
 /// What serde writes for an untagged newtype variant whose content is `None` — the capture the
 /// three surface assertions below are read against.
@@ -549,10 +529,6 @@ fn test_untagged_newtype_option_content_json_schema_null_flavor() {
     );
     assert_eq!(any_of[1], serde_json::json!({ "type": "string" }));
 }
-
-// ========================================================================
-// Untagged member holding a map — the key the guard reads off the written type
-// ========================================================================
 
 /// A key that enumerates its members, and an open one, both render the map their written type
 /// earns: the guard is a filter over keys the registry rules out, never a rewrite of the ones it

--- a/tests/validation_tests/tests.rs
+++ b/tests/validation_tests/tests.rs
@@ -32,8 +32,6 @@ trait UnpublishedValidate {
     }
 }
 
-// ==================== String constraint: maxLength ====================
-
 #[cfg(all(feature = "serde", feature = "zod"))]
 #[test]
 fn test_max_length_zod() {
@@ -89,8 +87,6 @@ fn test_min_and_max_length_zod() {
     );
 }
 
-// ==================== String constraint: maxLength — JSON Schema ====================
-
 #[cfg(all(feature = "serde", feature = "jsonschema"))]
 #[test]
 fn test_max_length_json_schema() {
@@ -130,8 +126,6 @@ fn test_min_and_max_length_json_schema() {
         "Expected maxLength:50 in JSON schema: {schema_str}"
     );
 }
-
-// ==================== String constraint: maxLength — Rust validation ====================
 
 #[cfg(all(
     feature = "serde",
@@ -178,8 +172,6 @@ fn test_max_length_rust_invalid() {
     );
 }
 
-// ==================== String constraint: minLength — Rust validation ====================
-
 #[cfg(all(
     feature = "serde",
     any(feature = "typescript", feature = "zod", feature = "jsonschema")
@@ -224,8 +216,6 @@ fn test_min_length_rust_invalid() {
         "Error should mention 'too short': {err_str}"
     );
 }
-
-// ==================== Combined string constraints ====================
 
 #[cfg(all(
     feature = "serde",
@@ -284,8 +274,6 @@ fn test_combined_string_constraints_pattern_fail() {
     let result: Result<CombinedStringPattern, _> = serde_json::from_str(invalid);
     assert!(result.is_err(), "Value failing pattern should fail");
 }
-
-// ==================== validate() method — string ====================
 
 #[cfg(all(
     feature = "serde",
@@ -369,8 +357,6 @@ fn test_validate_method_multiple_errors() {
     assert_eq!(errors.len(), 2, "Should have 2 errors, got: {errors:?}");
 }
 
-// ==================== Numeric constraints: minimum/maximum — Zod ====================
-
 #[cfg(all(feature = "serde", feature = "zod"))]
 #[test]
 fn test_minimum_zod() {
@@ -426,8 +412,6 @@ fn test_float_minimum_maximum_zod() {
     );
 }
 
-// ==================== Numeric constraints: minimum/maximum — JSON Schema ====================
-
 #[cfg(all(feature = "serde", feature = "jsonschema"))]
 #[test]
 fn test_minimum_json_schema() {
@@ -463,8 +447,6 @@ fn test_maximum_json_schema() {
         "Expected 'maximum' in JSON schema: {schema_str}"
     );
 }
-
-// ==================== Numeric constraints: minimum/maximum — Rust validation ====================
 
 #[cfg(all(
     feature = "serde",
@@ -569,7 +551,6 @@ fn test_minimum_at_boundary() {
         pub count: i32,
     }
 
-    // Exactly at minimum should pass
     let valid = r#"{"count": 5}"#;
     let result: Result<MinBoundary, _> = serde_json::from_str(valid);
     assert!(
@@ -592,7 +573,6 @@ fn test_maximum_at_boundary() {
         pub count: i32,
     }
 
-    // Exactly at maximum should pass
     let valid = r#"{"count": 5}"#;
     let result: Result<MaxBoundary, _> = serde_json::from_str(valid);
     assert!(
@@ -601,8 +581,6 @@ fn test_maximum_at_boundary() {
         result.err()
     );
 }
-
-// ==================== validate() method — numeric ====================
 
 #[cfg(all(
     feature = "serde",
@@ -652,8 +630,6 @@ fn test_validate_method_numeric_err() {
         "Error message should mention 'too small': {errors:?}"
     );
 }
-
-// ==================== validate() method — pattern ====================
 
 #[cfg(all(
     feature = "serde",
@@ -760,8 +736,6 @@ fn test_validate_method_pattern_and_length() {
     );
 }
 
-// ==================== validate() method — maxLength ====================
-
 #[cfg(all(
     feature = "serde",
     any(feature = "typescript", feature = "zod", feature = "jsonschema")
@@ -815,8 +789,6 @@ fn test_validate_method_max_length_err() {
     );
 }
 
-// ==================== validate() method — mixed string and numeric ====================
-
 #[cfg(all(
     feature = "serde",
     any(feature = "typescript", feature = "zod", feature = "jsonschema")
@@ -857,8 +829,6 @@ fn test_validate_method_mixed_string_numeric() {
         "Should contain numeric 'too small' error: {errors:?}"
     );
 }
-
-// ==================== Float numeric validation — Rust (serde) ====================
 
 #[cfg(all(
     feature = "serde",
@@ -950,8 +920,6 @@ fn test_maximum_float_rust_invalid() {
     );
 }
 
-// ==================== validate() method — float ====================
-
 #[cfg(all(
     feature = "serde",
     any(feature = "typescript", feature = "zod", feature = "jsonschema")
@@ -979,8 +947,6 @@ fn test_validate_method_float_err() {
     );
 }
 
-// ==================== Combined minimum+maximum — Zod ====================
-
 #[cfg(all(feature = "serde", feature = "zod"))]
 #[test]
 fn test_min_max_numeric_zod() {
@@ -1001,8 +967,6 @@ fn test_min_max_numeric_zod() {
         "Expected .max() in Zod schema: {schema}"
     );
 }
-
-// ==================== Combined minimum+maximum — JSON Schema ====================
 
 #[cfg(all(feature = "serde", feature = "jsonschema"))]
 #[test]
@@ -1025,8 +989,6 @@ fn test_min_max_numeric_json_schema() {
         "Expected 'maximum' in JSON schema: {schema_str}"
     );
 }
-
-// ==================== TypeScript unaffected by constraints ====================
 
 #[cfg(all(feature = "serde", feature = "typescript"))]
 #[test]
@@ -1074,7 +1036,6 @@ fn test_constraints_dont_affect_typescript() {
         !type_section.contains("z.number"),
         "TypeScript type should not contain z.number: {type_section}"
     );
-    // Type fields should still be plain `string` and `number`
     assert!(
         type_section.contains("username: string"),
         "TypeScript should have 'username: string': {type_section}"
@@ -1084,8 +1045,6 @@ fn test_constraints_dont_affect_typescript() {
         "TypeScript should have 'age: number': {type_section}"
     );
 }
-
-// ==================== Edge cases ====================
 
 #[cfg(all(
     feature = "serde",
@@ -1100,7 +1059,6 @@ fn test_boundary_min_length_zero() {
         pub tag: String,
     }
 
-    // Empty string should pass with minLength = 0
     let instance = MinLenZero { tag: String::new() };
     let validate_result = instance.validate();
     assert!(
@@ -1109,7 +1067,6 @@ fn test_boundary_min_length_zero() {
         validate_result.err()
     );
 
-    // Also test via serde
     let valid = r#"{"tag": ""}"#;
     let serde_result: Result<MinLenZero, _> = serde_json::from_str(valid);
     assert!(
@@ -1132,7 +1089,6 @@ fn test_pattern_empty_string_match() {
         pub empty_field: String,
     }
 
-    // Empty string should match "^\s*$"
     let valid_instance = PatternEmpty {
         empty_field: String::new(),
     };
@@ -1143,7 +1099,6 @@ fn test_pattern_empty_string_match() {
         valid_result.err()
     );
 
-    // Non-empty string should NOT match "^\s*$"
     let invalid_instance = PatternEmpty {
         empty_field: "not empty".to_owned(),
     };
@@ -1230,8 +1185,6 @@ fn test_pattern_pinning_both_ends_to_one_position() {
         "Rejection should read exactly as the regex path words it: {errors:?}"
     );
 }
-
-// ==================== Constraints under Option / wrappers / sequences ====================
 
 #[cfg(all(
     feature = "serde",
@@ -1482,8 +1435,6 @@ fn test_validate_boxed_option_string() {
         "A None under a Box still writes nothing to constrain"
     );
 }
-
-// ==================== Constraints on the wire, under Option / wrappers / sequences ====================
 
 /// The gate every consumer reaches first. A constraint describes the value the field puts on the
 /// wire, so a payload carrying a value the constraint rejects is rejected as it is read — at the
@@ -1844,8 +1795,6 @@ fn test_two_variants_naming_one_field_keep_their_own_constraints() {
         "A value Upload admits is not held to Delete's minimum"
     );
 }
-
-// ==================== validate() method — enum members ====================
 
 /// The struct and its single-variant tagged twin carry the same constraint on the same member, so
 /// an author who changes the one declaration into the other reads the identical sentence back.
@@ -2230,8 +2179,6 @@ fn test_every_variant_shape_reaches_the_accessor() {
         .unwrap();
     EveryShape::Nothing.validate().unwrap();
 }
-
-// ==================== The error strings the README prints ====================
 
 /// The README's `validate()` example prints the errors a caller reads back, and a reader who greps
 /// for one of those sentences, or writes an assertion against it, is holding the crate to it. So

--- a/tests/zod_tests/tests.rs
+++ b/tests/zod_tests/tests.rs
@@ -284,7 +284,6 @@ fn test_discriminated_union_uses_z_discriminated_union() {
 fn test_integer_types_use_int_modifier() {
     let zod = AllNumericTypes::zod_schema();
 
-    // All integer types should use .int()
     assert!(
         zod.contains("u8: z.number().int()"),
         "u8 should use .int(). Got: {zod}"
@@ -307,7 +306,6 @@ fn test_integer_types_use_int_modifier() {
 fn test_float_types_do_not_use_int_modifier() {
     let zod = AllNumericTypes::zod_schema();
 
-    // Float types should not use .int()
     assert!(
         zod.contains("f32: z.number()") && !zod.contains("f32: z.number().int()"),
         "f32 should not use .int(). Got: {zod}"


### PR DESCRIPTION
Two passes over every `.rs` file.

**Tracker references.** Every `txsch-*` id is gone from doc comments in `src/model_schema.rs`, `src/field_type/tests.rs` and `tests/branded_newtype_tests/tests.rs`. An id names a tracker row a reader of this repository cannot open, so each sentence now carries its reason on its own. Four of them also still argued for the `z`-qualified spelling the previous change replaced; they now state the bare rule.

**Commentary.** Around a thousand line comments narrated the statement underneath them (`// Check that it's an object` over an assertion on `schema["type"]`, `// Deserialize back` over a `from_str`, the `// ===== JSON Schema Tests =====` banners). Those are gone. Comments explaining what the code cannot say — what serde puts on the wire, why a check composes inside a `z.lazy` thunk rather than after it — are kept where they were.

Doc comments on internal items were multi-paragraph essays; each is now its leading paragraph, which was already the summary and stands alone. The public rustdoc in `src/lib.rs` and on `ModelSchemaPropMeta` is untouched — it documents the macro surface and carries the doctests.

3,840 comment lines removed, no code line touched. `just lint-all` and `just test` (32 feature combinations) green; rustdoc builds warning-free.