### PR TITLE
let ts_optional alone decide which of the two spellings an optional member is written with

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ pub struct UserProfile {
 
 `Option<T>` fields validate as `z.union([type, z.undefined()]).prefault(undefined)` in Zod v4 and are left out of the JSON Schema's `required` list. The `.prefault(undefined)` makes the field default to `undefined` when omitted from the input.
 
-What TypeScript writes follows the wire. A field carrying `#[serde(skip_serializing_if = "Option::is_none")]` or `#[serde(skip_serializing)]` has no key at all in the payload serde writes for a `None`, so the member is written with an optional key — `field?: T`, which the absent-key payload satisfies. Every other `Option<T>` field keeps its key and carries `T | undefined`.
+TypeScript writes every `Option<T>` field as `field: T | undefined`. The one thing that writes the other spelling, `field?: T`, is [`#[model_schema_prop(ts_optional)]`](#ts_optional) on the author's word. A serde attribute that drops the key decides what reaches the wire — the JSON Schema's `required` list and the Zod schema both read it — and never which of the two TypeScript spellings is written.
 
 A bare `#[serde(skip)]` is not that. serde writes the key into no payload *and* throws it away out of every payload that supplies one, so there is nothing on the wire for any surface to describe: TypeScript writes no member, Zod no key, and the JSON Schema neither a `properties` entry nor a `required` one. `#[serde(skip_serializing, skip_deserializing)]` is the same wire spelled out and is answered the same way. Note what this costs on the way in — a `z.strictObject` and an `additionalProperties: false` both *reject* a payload carrying that key, while serde accepts such a payload and discards the value. The schemas describe the payload serde writes, and that key appears in none of them; a member under an optional key would instead claim the key is sometimes written, and would describe a value nothing ever reads.
 
@@ -125,9 +125,9 @@ Generated TypeScript:
 export type UserWithOptionals = {
   id: string;
   name: string;
-  email?: string;
-  phone?: string;
-  avatar_url?: string;
+  email: string | undefined;
+  phone: string | undefined;
+  avatar_url: string | undefined;
 };
 ```
 
@@ -1674,7 +1674,7 @@ pub struct Event {
 
 ### Optional TypeScript Keys (`ts_optional`)
 
-The bare `ts_optional` flag asks for the optional key (`field?: T` rather than `field: T | undefined`) on the author's word, for a field whose key nothing else says may be absent.
+The bare `ts_optional` flag asks for the optional key (`field?: T` rather than `field: T | undefined`) on the author's word. It is the only thing that writes that spelling.
 
 **Read the condition before reaching for it.** An `Option<T>` field whose serde attributes drop the key for a `None` already renders as an optional key, off the wire and in every build ([Optional Fields](#optional-fields)) — on such a field the flag changes nothing, because the attribute has already said it. What is left over is an `Option<T>` carrying no key-dropping attribute at all, and with the `serde` feature on that field does not compile: serde writes its `None` as a `null`, the generated schema admits only the absent key, and the guard refuses the declaration and names the attribute to add. So the flag decides the key in exactly one place — a build with the `serde` feature **off**, where no attribute is read and no such guard runs:
 
@@ -1817,7 +1817,7 @@ export type Document = {
   author_id: ObjectId;
   tags: Array<ObjectId>;
   metadata: Partial<Record<string, ObjectId>>;
-  parent_id?: ObjectId;
+  parent_id: ObjectId | undefined;
   related_docs: Partial<Record<string, Array<ObjectId>>>;
 };
 
@@ -1907,7 +1907,7 @@ export type Event = {
   local_datetime: string;
   created_at: Date;
   epoch_ms: number;
-  updated_at?: Date;
+  updated_at: Date | undefined;
 };
 ```
 
@@ -2069,9 +2069,9 @@ Supported Serde attributes:
 - `#[serde(untagged)]` -- untagged enums generate a union (`A | B`) / Zod `z.union([...])` / JSON Schema `anyOf`
 - `#[serde(flatten)]` -- flatten a field into the parent as an intersection type (`A & B`) / Zod `.and(...)`
 - `#[serde(transparent)]` -- transparent wrappers (used for branded newtypes)
-- `#[serde(skip_serializing_if = "...")]` -- the key is left out of the payload when the predicate fires, so the member is described under an optional key: `roles?: Array<string>;` in TypeScript, `roles: z.array(z.string()).optional(),` in Zod, and no `required` entry in the JSON Schema
+- `#[serde(skip_serializing_if = "...")]` -- the key is left out of the payload when the predicate fires: `roles: z.array(z.string()).optional(),` in Zod and no `required` entry in the JSON Schema. On a field that is not an `Option` the TypeScript member takes the optional key too, `roles?: Array<string>;`, there being no second spelling for it; an `Option` field keeps `T | undefined` unless [`ts_optional`](#ts_optional) asks otherwise
 - `#[serde(skip)]` -- the key is written into no payload and read out of none, so no surface describes the member at all: no TypeScript member, no Zod key, and neither a `properties` nor a `required` entry. On a tuple-struct or tuple-variant slot it takes the slot out of the described tuple, which shortens the arity -- and a variant declaring one slot becomes a unit variant, which is what serde writes for it
-- `#[serde(skip_serializing)]` -- the write half of `skip`: the key is left out of every payload while a supplied one is still read, so the member is described under an optional key, as `skip_serializing_if` is
+- `#[serde(skip_serializing)]` -- the write half of `skip`: the key is left out of every payload while a supplied one is still read, and every surface answers as it does for `skip_serializing_if`
 - `#[serde(skip_deserializing)]` -- the read half: the key is written into every payload while a supplied one is discarded, so the member keeps a required key
 
 The three `skip` spellings are three different wires, and [Optional Fields](#optional-fields) reads each one in both directions, positional slots included.
@@ -2088,7 +2088,7 @@ If the `serde` feature is disabled but serde attributes are present, you will se
 
 4. **Array Types**: `Vec<T>` becomes `Array<T>` in TypeScript, one `Array<...>` per level written — `Vec<Vec<T>>` is `Array<Array<T>>`.
 
-5. **Optional Fields**: `Option<T>` becomes `field?: T` in TypeScript where a serde attribute drops the key for a `None` and `field: T | undefined` where it does not, and `z.union([type, z.undefined()]).prefault(undefined)` in Zod v4 either way.
+5. **Optional Fields**: `Option<T>` becomes `field: T | undefined` in TypeScript unless `#[model_schema_prop(ts_optional)]` asks for `field?: T`, and `z.union([type, z.undefined()]).prefault(undefined)` in Zod v4 either way.
 
 6. **Complex Nesting**: The crate supports deeply nested structures including `HashMap<String, Vec<HashMap<String, T>>>` and similar patterns.
 

--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -440,13 +440,23 @@ impl FieldDef {
     /// Whether the object key this field writes may be absent, which is the question the two
     /// spellings of an optional member answer differently — `field?: T` admits the payload with no
     /// such key, `field: T | undefined` demands the key and lets its value be `undefined`.
+    ///
+    /// For an `Option` field the answer is `ts_optional` and nothing else. The serde attribute that
+    /// drops the key decides what reaches the wire — `required` on the JSON surface, `.optional()`
+    /// on the Zod one — but not which of the two TypeScript spellings is written, or the flag whose
+    /// whole purpose is to ask for one of them would be inert on every field that carries it: the
+    /// `Option`-null guard requires that same attribute of every named `Option` field.
+    ///
+    /// A field that is not an `Option` has no second spelling to choose between, so the attribute
+    /// is the only thing left that can absent its key.
     fn key_may_be_absent(&self) -> bool {
-        self.omits_value
-            || (self.is_optional()
-                && self
-                    .model_schema_prop_meta
-                    .as_ref()
-                    .is_some_and(|m| m.ts_optional))
+        if self.is_optional() {
+            self.model_schema_prop_meta
+                .as_ref()
+                .is_some_and(|m| m.ts_optional)
+        } else {
+            self.omits_value
+        }
     }
 
     fn mark_fixed_length_at(&mut self, level: u8, length: usize) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,7 @@ export type User = {
    * age
    * 
    */
-  age?: number;
+  age: number | undefined;
   /**
    * firstName
    * 
@@ -280,7 +280,7 @@ export type Event = {
    * reason
    * 
    */
-  reason?: string;
+  reason: string | undefined;
   /**
    * userId
    * 
@@ -449,7 +449,7 @@ export type Document = {
    * parent_id
    * 
    */
-  parent_id?: ObjectId;
+  parent_id: ObjectId | undefined;
   /**
    * tags
    * 

--- a/tests/advanced_tests/tests.rs
+++ b/tests/advanced_tests/tests.rs
@@ -265,13 +265,13 @@ fn assert_ts_contains_fields(ts_definition: &str, assertions: &[(&str, &str)]) {
     }
 }
 
-/// Holds the members whose key serde drops for a `None` to the spelling that admits the payload
-/// without the key. One spelling under every toggle: the attribute that drops the key is on the
-/// field whether or not the `serde` feature is on.
+/// Holds the members whose key serde drops for a `None` to the `T | undefined` spelling. The
+/// attribute that drops the key decides what reaches the wire, never which of the two TypeScript
+/// spellings is written — only `ts_optional` asks for `field?: T`, and none of these carries it.
 #[cfg(all(feature = "typescript", feature = "zod"))]
 fn assert_ts_contains_omitted_fields(ts_definition: &str, assertions: &[(&str, &str)]) {
     for (field, expected_type) in assertions {
-        let expected = format!("{field}?: {expected_type};");
+        let expected = format!("{field}: {expected_type} | undefined;");
         assert!(
             ts_definition.contains(&expected),
             "missing {expected}, got: {ts_definition}"
@@ -336,7 +336,7 @@ fn test_complex_nested_ts_definition() {
     assert!(company_definition.contains("headquarters: Address;"));
     assert!(company_definition.contains("settings: CompanySettings;"));
 
-    assert!(employee_definition.contains("manager?: string;"));
+    assert!(employee_definition.contains("manager: string | undefined;"));
 
     assert!(retirement_definition.contains("type: \"option401k\""));
     assert!(retirement_definition.contains("type: \"pension\""));
@@ -507,7 +507,7 @@ fn test_complex_discriminated_union() {
     assert!(ts_definition.contains("orderId: string;"));
     assert!(ts_definition.contains("totalAmount: number;"));
     assert!(ts_definition.contains("paymentMethod: string;"));
-    assert!(ts_definition.contains("shippingAddress?: Address;"));
+    assert!(ts_definition.contains("shippingAddress: Address | undefined;"));
     assert!(ts_definition.contains("scheduledStart: string;"));
     assert!(ts_definition.contains("estimatedDuration: number;"));
     assert!(ts_definition.contains("affectedServices: Array<string>;"));
@@ -537,9 +537,10 @@ fn test_documented_struct() {
     assert!(ts_definition.contains("email: string;"));
     assert!(ts_definition.contains("is_active: boolean;"));
     // HashMap becomes Partial<Record<...>>
-    // The key serde drops for a `None`, which every build reads off the attribute on the field.
+    // An `Option` carrying no `ts_optional` writes `T | undefined`, whatever the attribute that
+    // drops its key from the wire says.
     assert!(
-        ts_definition.contains("metadata?: Partial<Record<string, string>>;"),
+        ts_definition.contains("metadata: Partial<Record<string, string>> | undefined;"),
         "Got: {ts_definition}"
     );
 }

--- a/tests/basic_tests/tests.rs
+++ b/tests/basic_tests/tests.rs
@@ -168,12 +168,11 @@ fn test_optional_fields_json_schema() {
 
 /// The member spelling an `Option` field written with a `skip_serializing_if` renders as.
 ///
-/// serde drops the key for a `None`, so the payload has no such key and the member is written with
-/// an optional one. The attribute is on the field under every toggle, so this is one spelling and
-/// not two.
+/// The attribute drops the key from the wire, which the JSON `required` list and the Zod schema
+/// say; the TypeScript spelling is `ts_optional`'s to decide, and none of these fields carries it.
 #[cfg(feature = "typescript")]
 fn omitted_member(name: &str, ts_type: &str) -> String {
-    format!("{name}?: {ts_type};")
+    format!("{name}: {ts_type} | undefined;")
 }
 
 #[test]

--- a/tests/chrono_tests/tests.rs
+++ b/tests/chrono_tests/tests.rs
@@ -300,8 +300,7 @@ fn test_datetime_local_typescript() {
 #[cfg(feature = "typescript")]
 fn test_optional_datetime_typescript() {
     let ts = OptionalTimestamp::ts_definition();
-    // serde drops the key for a `None`, which every build reads off the attribute on the field.
-    let expected = "updated_at?: Date;";
+    let expected = "updated_at: Date | undefined;";
     assert!(
         ts.contains(expected),
         "Option<DateTime<Utc>> should map to {expected}. Got: {ts}"

--- a/tests/collection_tests/tests.rs
+++ b/tests/collection_tests/tests.rs
@@ -642,12 +642,11 @@ struct DocumentedSequenceFields {
 
 /// The member spelling an `Option` field written with a `skip_serializing_if` renders as.
 ///
-/// serde drops the key for a `None`, so the payload has no such key and the member is written with
-/// an optional one. The attribute is on the field under every toggle, so this is one spelling and
-/// not two.
+/// The attribute drops the key from the wire, which the JSON `required` list and the Zod schema
+/// say; the TypeScript spelling is `ts_optional`'s to decide, and none of these fields carries it.
 #[cfg(feature = "typescript")]
 fn omitted_member(name: &str, ts_type: &str) -> String {
-    format!("{name}?: {ts_type};")
+    format!("{name}: {ts_type} | undefined;")
 }
 
 fn one<T, C>(item: T) -> C

--- a/tests/fixed_array_tests/tests.rs
+++ b/tests/fixed_array_tests/tests.rs
@@ -34,12 +34,11 @@ struct FixedArraySlots {
 
 /// The member spelling an `Option` field written with a `skip_serializing_if` renders as.
 ///
-/// serde drops the key for a `None`, so the payload has no such key and the member is written with
-/// an optional one. The attribute is on the field under every toggle, so this is one spelling and
-/// not two.
+/// The attribute drops the key from the wire, which the JSON `required` list and the Zod schema
+/// say; the TypeScript spelling is `ts_optional`'s to decide, and none of these fields carries it.
 #[cfg(feature = "typescript")]
 fn omitted_member(name: &str, ts_type: &str) -> String {
-    format!("{name}?: {ts_type};")
+    format!("{name}: {ts_type} | undefined;")
 }
 
 fn fixed_array_fields() -> FixedArrayFields {

--- a/tests/generic_types_tests/tests.rs
+++ b/tests/generic_types_tests/tests.rs
@@ -119,9 +119,9 @@ mod typescript {
             ts.contains("  by_key: Partial<Record<string, ValueType>>;"),
             "Got: {ts}"
         );
-        // serde drops the key for a `None`, which every build reads off the attribute on the
-        // field.
-        assert!(ts.contains("  maybe?: ValueType;"), "Got: {ts}");
+        // An `Option` carrying no `ts_optional` writes `T | undefined`, whatever the attribute
+        // that drops its key from the wire says.
+        assert!(ts.contains("  maybe: ValueType | undefined;"), "Got: {ts}");
         assert!(ts.contains("  tuple: [KeyType, ValueType];"), "Got: {ts}");
     }
 

--- a/tests/generic_types_tests/whole_type_tests.rs
+++ b/tests/generic_types_tests/whole_type_tests.rs
@@ -44,7 +44,10 @@ mod typescript {
         assert!(ts.contains("  stamp: ArchiveStamp<IdType>;"), "Got: {ts}");
         assert!(ts.contains("  createdAt: DateType;"), "Got: {ts}");
         assert!(ts.contains("  tags: Array<TagType>;"), "Got: {ts}");
-        assert!(ts.contains("  byteSize?: SizeType;"), "Got: {ts}");
+        assert!(
+            ts.contains("  byteSize: SizeType | undefined;"),
+            "Got: {ts}"
+        );
         assert!(
             ts.contains("  ownersByRole: Partial<Record<string, OwnerType>>;"),
             "Got: {ts}"

--- a/tests/model_schema_prop_tests/tests.rs
+++ b/tests/model_schema_prop_tests/tests.rs
@@ -201,12 +201,11 @@ enum TsOptionalVariant {
 
 /// The member spelling an `Option` field written with a `skip_serializing_if` renders as.
 ///
-/// serde drops the key for a `None`, so the payload has no such key and the member is written with
-/// an optional one. The attribute is on the field under every toggle, so this is one spelling and
-/// not two.
+/// The attribute drops the key from the wire, which the JSON `required` list and the Zod schema
+/// say; the TypeScript spelling is `ts_optional`'s to decide, and none of these fields carries it.
 #[cfg(feature = "typescript")]
 fn omitted_member(name: &str, ts_type: &str) -> String {
-    format!("{name}?: {ts_type};")
+    format!("{name}: {ts_type} | undefined;")
 }
 
 #[cfg(all(
@@ -533,7 +532,7 @@ fn test_ts_optional_struct_typescript() {
         "did not expect required-key form for `f` in:\n{ts}"
     );
 
-    // `g` carries no `ts_optional`, so its key is optional only where the serde omission says so.
+    // `g` carries no `ts_optional`, so it keeps the `T | undefined` spelling.
     let g = omitted_member("g", "Inner");
     assert!(ts.contains(&g), "expected control `{g}` in:\n{ts}");
 

--- a/tests/mongodb_real_tests/tests.rs
+++ b/tests/mongodb_real_tests/tests.rs
@@ -83,7 +83,7 @@ fn test_real_objectid_basic_types() {
 
     assert!(ts_definition.contains("id: ObjectId;"));
     assert!(ts_definition.contains("name: string;"));
-    assert!(ts_definition.contains("email?: string;"));
+    assert!(ts_definition.contains("email: string | undefined;"));
 
     let zod_schema = RealUser::zod_schema();
     assert!(zod_schema.contains("id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: \"Invalid ObjectId\" }) }),"));
@@ -166,7 +166,7 @@ fn test_real_objectid_complex_structures() {
     assert!(ts_definition.contains("author_id: ObjectId;"));
     assert!(ts_definition.contains("references: Array<ObjectId>;"));
     assert!(ts_definition.contains("metadata: Partial<Record<string, ObjectId>>;"));
-    assert!(ts_definition.contains("parent_id?: ObjectId;"));
+    assert!(ts_definition.contains("parent_id: ObjectId | undefined;"));
     assert!(ts_definition.contains("nested_refs: Partial<Record<string, Array<ObjectId>>>;"));
 
     let zod_schema = RealDocument::zod_schema();

--- a/tests/mongodb_tests/tests.rs
+++ b/tests/mongodb_tests/tests.rs
@@ -228,7 +228,7 @@ fn test_basic_object_id_types() {
 
     assert!(ts_definition.contains("id: ObjectId;"));
     assert!(ts_definition.contains("name: string;"));
-    assert!(ts_definition.contains("email?: string;"));
+    assert!(ts_definition.contains("email: string | undefined;"));
 
     let zod_schema = User::zod_schema();
     assert!(zod_schema.contains("id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: \"Invalid ObjectId\" }) }),"));
@@ -247,7 +247,7 @@ fn test_complex_nested_object_id_structures() {
     assert!(ts_definition.contains("author_id: ObjectId;"));
     assert!(ts_definition.contains("references: Array<ObjectId>;"));
     assert!(ts_definition.contains("metadata: Partial<Record<string, ObjectId>>;"));
-    assert!(ts_definition.contains("parent_id?: ObjectId;"));
+    assert!(ts_definition.contains("parent_id: ObjectId | undefined;"));
     assert!(ts_definition.contains("nested_refs: Partial<Record<string, Array<ObjectId>>>;"));
 
     let zod_schema = ComplexDocument::zod_schema();
@@ -445,7 +445,7 @@ fn test_object_id_zod_schema() {
 fn test_optional_object_id() {
     let ts_definition = UserWithOptionalId::ts_definition();
 
-    assert!(ts_definition.contains("id?: ObjectId;"));
+    assert!(ts_definition.contains("id: ObjectId | undefined;"));
     assert!(ts_definition.contains("name: string;"));
     assert!(ts_definition.contains("email: string;"));
 

--- a/tests/omitted_key_tests/tests.rs
+++ b/tests/omitted_key_tests/tests.rs
@@ -102,15 +102,16 @@ fn the_predicate_omitted_key_is_absent_from_the_payload_serde_writes() {
     );
 }
 
-/// `age: number | undefined` would demand the key the absent-key payload does not carry, so the
-/// member is written with an optional key instead. The members serde always writes keep theirs.
+/// An `Option` writes `T | undefined` whatever drops its key from the wire; only `ts_optional`
+/// asks for the optional-key spelling, and this field carries none. The members serde always
+/// writes are unaffected either way.
 #[test]
 #[cfg(feature = "typescript")]
-fn typescript_writes_the_omitted_key_as_optional() {
+fn typescript_writes_the_option_as_undefined_valued() {
     let ts = OmittedKeyFields::ts_definition();
 
-    assert!(ts.contains("age?: number;"), "Got: {ts}");
-    assert!(!ts.contains("age: number"), "Got: {ts}");
+    assert!(ts.contains("age: number | undefined;"), "Got: {ts}");
+    assert!(!ts.contains("age?:"), "Got: {ts}");
     assert!(ts.contains("id: string;"), "Got: {ts}");
     assert!(ts.contains("roles: Array<string>;"), "Got: {ts}");
 }

--- a/tests/optional_key_flag_tests/tests.rs
+++ b/tests/optional_key_flag_tests/tests.rs
@@ -1,18 +1,15 @@
-//! `ts_optional` writes the optional key for the one field nothing else says may be absent.
+//! `ts_optional` is the whole of what decides between the two spellings of an optional member.
 //!
-//! An `Option<T>` whose serde attributes drop its key already renders `field?: T` off the wire, so
-//! on such a field the flag decides nothing — every shape below carries a flagged member beside an
-//! unflagged control of the same type and the same attributes, and the two render the same line.
-//! What is left is the `Option<T>` carrying no key-dropping attribute at all, and that is exactly
-//! the field the `serde` feature's `Option`-null guard refuses, because serde writes its `None` as
-//! `null` while the generated schema admits only the absent key. So the flag has one live shape and
-//! it is a build with the `serde` feature off, where no attribute is read and no such guard runs.
+//! An `Option<T>` renders `field: T | undefined` unless the flag asks for `field?: T`. The serde
+//! attribute that drops the key decides what reaches the wire — the JSON `required` list and the
+//! Zod schema read it — and never which spelling TypeScript is written with, so a flagged member
+//! and an unflagged control carrying the same attributes render two different lines.
 //!
-//! That is what makes this a two-flavour question rather than a TypeScript one, and both halves are
-//! held here so neither can drift into claiming the other's ground.
+//! Both feature flavours are held here: under the `serde` feature, where an attribute is read and
+//! the `Option`-null guard requires one, and without it, where neither happens.
 
 #[cfg(feature = "serde")]
-mod already_decided {
+mod under_the_serde_feature {
     use super::member;
     use serde::{Deserialize, Serialize};
     use tixschema::model_schema;
@@ -52,12 +49,16 @@ mod already_decided {
         id: String,
     }
 
-    /// On every shape the `serde` feature accepts, the flagged member and its control are one line.
+    /// On every shape the `serde` feature accepts, the flag is the whole of the difference between
+    /// the flagged member and its control — the attribute both carry writes neither line.
     #[test]
-    fn the_flag_writes_nothing_the_omission_attribute_has_not_written() {
+    fn the_flag_decides_the_spelling_the_omission_attribute_leaves_open() {
         let predicate = UnderAPredicate::ts_definition();
         assert!(member(&predicate, "a?: string;"), "Got: {predicate}");
-        assert!(member(&predicate, "b?: string;"), "Got: {predicate}");
+        assert!(
+            member(&predicate, "b: string | undefined;"),
+            "Got: {predicate}"
+        );
 
         let skip_serializing = UnderSkipSerializing::ts_definition();
         assert!(
@@ -65,7 +66,7 @@ mod already_decided {
             "Got: {skip_serializing}"
         );
         assert!(
-            member(&skip_serializing, "b?: string;"),
+            member(&skip_serializing, "b: string | undefined;"),
             "Got: {skip_serializing}"
         );
     }
@@ -83,12 +84,12 @@ mod already_decided {
 }
 
 #[cfg(not(feature = "serde"))]
-mod the_flag_decides {
+mod without_the_serde_feature {
     use super::member;
     use tixschema::model_schema;
 
-    /// The shape the flag is for: an `Option<T>` no attribute says anything about. Declarable only
-    /// here — under the `serde` feature the `Option`-null guard refuses both of these fields.
+    /// An `Option<T>` no attribute says anything about. Declarable only here — under the `serde`
+    /// feature the `Option`-null guard refuses both of these fields.
     ///
     /// Declared with its fields alphabetically, as this crate's lints require of Rust source; the
     /// README orders the same three for reading. Only the written order differs, so each member is

--- a/tests/optional_nesting_tests/tests.rs
+++ b/tests/optional_nesting_tests/tests.rs
@@ -52,12 +52,11 @@ struct NullNestingSlots {
 
 /// The member spelling an `Option` field written with a `skip_serializing_if` renders as.
 ///
-/// serde drops the key for a `None`, so the payload has no such key and the member is written with
-/// an optional one. The attribute is on the field under every toggle, so this is one spelling and
-/// not two.
+/// The attribute drops the key from the wire, which the JSON `required` list and the Zod schema
+/// say; the TypeScript spelling is `ts_optional`'s to decide, and none of these fields carries it.
 #[cfg(feature = "typescript")]
 fn omitted_member(name: &str, ts_type: &str) -> String {
-    format!("{name}?: {ts_type};")
+    format!("{name}: {ts_type} | undefined;")
 }
 
 fn element_null_fields() -> ElementNullFields {

--- a/tests/primitive_types_tests/tests.rs
+++ b/tests/primitive_types_tests/tests.rs
@@ -335,12 +335,11 @@ fn assert_ts_fields_contain(ts_definition: &str, fields: &[&str], expected_suffi
 
 /// The member spelling an `Option` field written with a `skip_serializing_if` renders as.
 ///
-/// serde drops the key for a `None`, so the payload has no such key and the member is written with
-/// an optional one. The attribute is on the field under every toggle, so this is one spelling and
-/// not two.
+/// The attribute drops the key from the wire, which the JSON `required` list and the Zod schema
+/// say; the TypeScript spelling is `ts_optional`'s to decide, and none of these fields carries it.
 #[cfg(all(feature = "typescript", feature = "zod"))]
 fn omitted_member(name: &str, ts_type: &str) -> String {
-    format!("{name}?: {ts_type};")
+    format!("{name}: {ts_type} | undefined;")
 }
 
 #[cfg(all(feature = "typescript", feature = "zod"))]

--- a/tests/readme_example_tests/tests.rs
+++ b/tests/readme_example_tests/tests.rs
@@ -26,13 +26,13 @@ use tixschema::model_schema;
 
 /// The predicate bullet: the key goes missing when the predicate fires, so the member is described
 /// under an optional key rather than left untouched.
-const PREDICATE_BULLET: &str = "- `#[serde(skip_serializing_if = \"...\")]` -- the key is left out of the payload when the predicate fires, so the member is described under an optional key: `roles?: Array<string>;` in TypeScript, `roles: z.array(z.string()).optional(),` in Zod, and no `required` entry in the JSON Schema";
+const PREDICATE_BULLET: &str = "- `#[serde(skip_serializing_if = \"...\")]` -- the key is left out of the payload when the predicate fires: `roles: z.array(z.string()).optional(),` in Zod and no `required` entry in the JSON Schema. On a field that is not an `Option` the TypeScript member takes the optional key too, `roles?: Array<string>;`, there being no second spelling for it; an `Option` field keeps `T | undefined` unless [`ts_optional`](#ts_optional) asks otherwise";
 
 /// The bare-`skip` bullet, whose claim is an absence on every surface.
 const SKIP_BULLET: &str = "- `#[serde(skip)]` -- the key is written into no payload and read out of none, so no surface describes the member at all: no TypeScript member, no Zod key, and neither a `properties` nor a `required` entry. On a tuple-struct or tuple-variant slot it takes the slot out of the described tuple, which shortens the arity -- and a variant declaring one slot becomes a unit variant, which is what serde writes for it";
 
 /// The write-half bullet, which lands where the predicate bullet does.
-const WRITE_HALF_BULLET: &str = "- `#[serde(skip_serializing)]` -- the write half of `skip`: the key is left out of every payload while a supplied one is still read, so the member is described under an optional key, as `skip_serializing_if` is";
+const WRITE_HALF_BULLET: &str = "- `#[serde(skip_serializing)]` -- the write half of `skip`: the key is left out of every payload while a supplied one is still read, and every surface answers as it does for `skip_serializing_if`";
 
 /// The read-half bullet, the one spelling of the three that keeps a required key.
 const READ_HALF_BULLET: &str = "- `#[serde(skip_deserializing)]` -- the read half: the key is written into every payload while a supplied one is discarded, so the member keeps a required key";
@@ -121,9 +121,9 @@ fn test_the_optional_fields_example_is_declarable_and_shows_what_it_emits() {
             "export type UserWithOptionals = {",
             "  id: string;",
             "  name: string;",
-            "  email?: string;",
-            "  phone?: string;",
-            "  avatar_url?: string;",
+            "  email: string | undefined;",
+            "  phone: string | undefined;",
+            "  avatar_url: string | undefined;",
             "};",
         ],
     );
@@ -284,7 +284,7 @@ fn test_the_object_id_example_is_declarable_and_shows_what_it_emits() {
             "  author_id: ObjectId;",
             "  tags: Array<ObjectId>;",
             "  metadata: Partial<Record<string, ObjectId>>;",
-            "  parent_id?: ObjectId;",
+            "  parent_id: ObjectId | undefined;",
             "  related_docs: Partial<Record<string, Array<ObjectId>>>;",
             "};",
         ],
@@ -332,7 +332,7 @@ fn test_the_chrono_example_is_declarable_and_shows_what_it_emits() {
             "  local_datetime: string;",
             "  created_at: Date;",
             "  epoch_ms: number;",
-            "  updated_at?: Date;",
+            "  updated_at: Date | undefined;",
             "};",
         ],
     );

--- a/tests/recursive_type_tests/tests.rs
+++ b/tests/recursive_type_tests/tests.rs
@@ -313,9 +313,7 @@ mod describes {
         );
 
         let boxed_self = produced("boxed_self_ts");
-        // serde drops the key for a `None`, which every build reads off the attribute on the
-        // field.
-        let next = "next?: ChainNode;";
+        let next = "next: ChainNode | undefined;";
         assert!(
             boxed_self.contains(next),
             "an optional box of self is the type's own name: {boxed_self}"

--- a/tests/semantic_types_tests/tests.rs
+++ b/tests/semantic_types_tests/tests.rs
@@ -590,7 +590,7 @@ fn test_complex_alias_usage() {
     let ts = ComplexAliasStruct::ts_definition();
 
     assert!(
-        ts.contains("optional_id?: DocumentId;"),
+        ts.contains("optional_id: DocumentId | undefined;"),
         "Should handle Optional<Alias>. Got: {ts}"
     );
     // A `Vec<Vec<T>>` writes an array of arrays, so it types as one: a level per level written.

--- a/tests/serde_tests/tests.rs
+++ b/tests/serde_tests/tests.rs
@@ -247,8 +247,8 @@ fn test_serde_with_optional_fields_typescript() {
     let ts = OptionalFields::ts_definition();
 
     assert!(ts.contains("requiredField: string;"));
-    assert!(ts.contains("optionalField?: string;"));
-    assert!(ts.contains("customOptional?: number;"));
+    assert!(ts.contains("optionalField: string | undefined;"));
+    assert!(ts.contains("customOptional: number | undefined;"));
 }
 
 #[test]
@@ -339,19 +339,15 @@ fn test_discriminated_union_with_serde_zod() {
 fn test_compliant_optionals_typescript() {
     let ts = CompliantOptionals::ts_definition();
 
-    // The `skip_serializing_if` is what makes the key optional; `ts_optional` on `tag` asks for the
-    // same spelling and so adds nothing on top of it.
+    // `ts_optional` on `tag` is the whole of why it is spelled with an optional key; `note`
+    // carries the same `skip_serializing_if` and none of the flag, so it keeps `T | undefined`.
     assert!(
         ts.contains("tag?: string;"),
         "expected `tag?: string;`:\n{ts}"
     );
     assert!(
-        ts.contains("note?: string;"),
-        "expected `note?: string;`:\n{ts}"
-    );
-    assert!(
-        !ts.contains(" | undefined"),
-        "no member of this type keeps a key serde may drop:\n{ts}"
+        ts.contains("note: string | undefined;"),
+        "expected `note: string | undefined;`:\n{ts}"
     );
 }
 
@@ -398,7 +394,8 @@ fn test_a_hyphenated_field_key_is_written_as_a_string() {
     let ts = Message::ts_definition();
 
     assert!(
-        ts.lines().any(|line| line == r#"  "reply-to"?: string;"#),
+        ts.lines()
+            .any(|line| line == r#"  "reply-to": string | undefined;"#),
         "expected the key as a string member:\n{ts}"
     );
     assert!(

--- a/tests/untagged_tests/tests.rs
+++ b/tests/untagged_tests/tests.rs
@@ -302,7 +302,7 @@ fn test_named_union_typescript() {
 fn test_compliant_union_typescript() {
     let ts = CompliantUnion::ts_definition();
     assert!(
-        ts.contains("number | { id: string; note?: string };"),
+        ts.contains("number | { id: string; note: string | undefined };"),
         "Got:\n{ts}"
     );
 }


### PR DESCRIPTION
`Option<T>` is documented — in CLAUDE.md, in the README and on the flag itself — as rendering `field: T | undefined`, with `#[model_schema_prop(ts_optional)]` asking for `field?: T`. It has not behaved that way: every named `Option` field rendered `field?: T`, and the flag could not change a line of output.

Two rules landed apart and closed the door between them. `check_optional_field_serialization` requires an omission attribute of every named `Option` field. `key_may_be_absent` was later taught to read that same attribute:

```rust
self.omits_value
    || (self.is_optional() && ...ts_optional)
```

The first operand is true on every named `Option` field the first rule admits, so the second could never contribute.

The predicate now asks what the position actually poses: for an `Option` field, `ts_optional` and nothing else; for a field that is not an `Option`, there is no second spelling, so the attribute still absents its key (`#[serde(skip_serializing_if = "Vec::is_empty")] roles: Vec<String>` keeps `roles?: Array<string>`).

What reaches the wire is untouched — `key_is_required` still reads `omits_value` for JSON `required`, `zod_type` still writes `.optional()` for a non-`Option` droppable key, and the `Option`-null guard is where it was.

Pinned expectations across sixteen suites, the crate rustdoc and the README are updated from real output. `optional_key_flag_tests` was written around the collapsed behaviour and now holds a flagged member against an unflagged control carrying identical attributes.

`just lint-all` and `just test` (32 feature combinations) green.