### PR TITLE
hold the new comments to the standard the rest of the file was cut back to

### DIFF
--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -437,18 +437,12 @@ impl FieldDef {
         !self.is_optional() && !self.omits_value
     }
 
-    /// Whether the object key this field writes may be absent, which is the question the two
-    /// spellings of an optional member answer differently — `field?: T` admits the payload with no
-    /// such key, `field: T | undefined` demands the key and lets its value be `undefined`.
+    /// Whether the object key this field writes may be absent — `field?: T` admits the payload
+    /// with no such key, `field: T | undefined` demands it.
     ///
-    /// For an `Option` field the answer is `ts_optional` and nothing else. The serde attribute that
-    /// drops the key decides what reaches the wire — `required` on the JSON surface, `.optional()`
-    /// on the Zod one — but not which of the two TypeScript spellings is written, or the flag whose
-    /// whole purpose is to ask for one of them would be inert on every field that carries it: the
-    /// `Option`-null guard requires that same attribute of every named `Option` field.
-    ///
-    /// A field that is not an `Option` has no second spelling to choose between, so the attribute
-    /// is the only thing left that can absent its key.
+    /// The key-dropping serde attribute is deliberately not read for an `Option`: the
+    /// `Option`-null guard requires one of every named `Option` field, so reading it here would
+    /// leave `ts_optional` inert on every field that carries it.
     fn key_may_be_absent(&self) -> bool {
         if self.is_optional() {
             self.model_schema_prop_meta
@@ -472,13 +466,10 @@ impl FieldDef {
     }
 
     /// Whether this field's rendering reads any other item's own module-scope Zod binding — a
-    /// factory call or a bare `$Schema` const — at any depth, wrapped in a `Vec`/`Option`/`Map`/
-    /// `Tuple` or named directly. [`default_zod_rendering`](crate::model_schema) asks this once its
-    /// own direct-sibling fold gate declines, since that gate answers a narrower question (can this
-    /// argument fold onto a bare `$SchemaDefault`) than deferral needs (does the rendered tree name
-    /// a sibling's binding at all) — `Tagged$SchemaFactory` inside
-    /// `z.array(Tagged$SchemaFactory(z.string()))` is exactly as much a module-scope `const` read as
-    /// a bare `Tagged$SchemaFactory(z.string())` is.
+    /// factory call or a bare `$Schema` const — at any depth, wrapped or named directly. Deferral
+    /// asks a wider question than the direct-sibling fold gate does:
+    /// `z.array(Tagged$SchemaFactory(z.string()))` reads a sibling `const` exactly as much as a
+    /// bare `Tagged$SchemaFactory(z.string())` does.
     #[cfg(feature = "zod")]
     pub fn names_a_sibling_binding(&self) -> bool {
         match &self.field_type {

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -1258,12 +1258,8 @@ fn has_serde_transparent(attrs: &[syn::Attribute]) -> bool {
 /// `build_item_docs_and_description`; a member publishes no second surface.
 ///
 /// The no-docs fallback names what is documented as it is exported, not as it is declared in Rust,
-/// so a `JSDoc` header never contradicts the line under it.
-///
-/// A ` ```rust example ` block is dropped before its lines reach the body, the way
-/// `item_plain_doc_lines` drops it: the block is Rust source, and nothing reads it as such once it
-/// is sitting in a `TypeScript` comment. A consumer after the example reads the Rust docs. What is
-/// left reaches the body as written — this is the one surface that publishes docs unflattened.
+/// so a `JSDoc` header never contradicts the line under it. A ` ```rust example ` block is dropped
+/// on the way in — it is Rust source, unreadable as such from a `TypeScript` comment.
 fn build_jsdoc_body(docs_vec: Option<&[String]>, fallback_name: &str) -> String {
     item_jsdoc_body(&item_lines_or_name(docs_vec, fallback_name, |doc_lines| {
         strip_examples_from_docs(doc_lines)
@@ -2359,23 +2355,10 @@ fn with_prefixed_tokens(expanded: TokenStream, prefix: &[proc_macro2::TokenStrea
 /// declaring a const parameter, or none where it carries no example and none where it declares no
 /// const.
 ///
-/// A doc example is Rust the expansion has to compile, so its value is annotated with the item's
-/// own name at one instantiation — every parameter filled in, a type parameter taking the type
-/// `default_types` declares for it or `String` where it declares none. A const takes no filling
-/// from that convention: both spellings name a type, and a const is a value. Nor can one be read
-/// off the item, since `default_types` declares types and no value is the one every
-/// const-parameterised example is written at, so one picked here would render the example at a
-/// length the author never wrote. So the example is refused where it was written, rather than
-/// expanded into an annotation that fails `E0107` before anything runs.
-///
-/// Answered at the one seam every expanded shape is dispatched from, so a struct and an enum cannot
-/// come to answer differently, and a branded newtype is answered before the struct path splits it
-/// off. An alias reaches here too and is deliberately left out: it publishes no `schema_example()`
-/// at all, so its example is already unread and a const on it costs nothing.
-///
-/// Only a build that reads an example owes the refusal, which is why this is `zod`-gated: without
-/// it no `schema_example()` is emitted and an example on a const-declaring item is exactly as
-/// unread as an example on any other item.
+/// A doc example is annotated with the item's own name at one instantiation, and a const takes no
+/// filling from that convention — both spellings name a type, and a const is a value. So the
+/// example is refused where it was written rather than expanded into an `E0107`. An alias is left
+/// out deliberately: it publishes no `schema_example()`, so its example is already unread.
 #[cfg(feature = "zod")]
 fn const_parameter_example_errors(item: &Item) -> Vec<proc_macro2::TokenStream> {
     let (generics, attrs) = if let Item::Struct(item_struct) = item {
@@ -5258,15 +5241,9 @@ fn item_plain_doc_lines(doc_lines: &[String]) -> Vec<String> {
 /// so a `JSDoc` header never contradicts the `export type` one line beneath it and a description
 /// never names an item something no surface exports.
 ///
-/// Whether anything was said is read off the flattened lines rather than off the attribute, because
-/// the flattening is what decides: a ` ```rust example ` block is Rust source and is dropped, so an
-/// item documented with nothing else has an attribute and still says nothing, and is left naming
-/// itself the way an undocumented one is.
-///
-/// Every item shape and member reaches that fallback through here, so no path can drift from the
-/// rest by spelling it separately. What a caller brings of its own is `flatten` — how its docs
-/// reach the surface, not what it says when it has none. Ungated because the member call sites
-/// are: a field's docs are read whatever features are on.
+/// Whether anything was said is read off the flattened lines rather than off the attribute: a
+/// ` ```rust example ` block is Rust source and is dropped, so an item documented with nothing else
+/// has an attribute and still says nothing.
 fn item_lines_or_name(
     docs_vec: Option<&[String]>,
     item_name: &str,
@@ -11061,15 +11038,11 @@ fn zod_default_block(
     )
 }
 
-/// The `$SchemaDefault` annotation [`zod_default_block`] writes: the plain `ZodType<Name<...>>`
-/// spelling for an ordinary generic item — tsc already accepts a factory's return type there, since
-/// nothing in the chain calls `.brand()`, so nothing narrows the classic `ZodType` interface's own
-/// deprecated `_output` field out from under it. A branded newtype's factory always ends its chain
-/// in `.brand()` (see [`branded_zod_expression`]), so its return type is always some
-/// `$ZodBranded<Argument, Name>` — never the plain `Name<...>` instantiation `ZodType`
-/// names — and the annotation has to read the same way, exactly as [`branded_zod_const_block`]
-/// already annotates the non-generic case. The class is written bare throughout, per
-/// [`branded_zod_type_name`].
+/// The `$SchemaDefault` annotation [`zod_default_block`] writes: plain `ZodType<Name<...>>` for an
+/// ordinary generic item, and `$ZodBranded<Argument, Name>` for a branded newtype, whose factory
+/// always ends its chain in `.brand()` — a return type strict tsc will not accept under the plain
+/// spelling, the classic `ZodType` interface's deprecated `_output` field being computed at the
+/// pre-brand type. Classes are written bare, per [`branded_zod_type_name`].
 #[cfg(all(feature = "zod", feature = "typescript"))]
 fn branded_default_annotation(
     item_name: &str,
@@ -11108,13 +11081,9 @@ fn branded_default_annotation(
 }
 
 /// The class a bare-parameter brand's own declared-default argument is annotated with, for
-/// [`branded_default_annotation`]: the eager expression's own class from [`branded_zod_type_name`]
-/// bare, or that same class wrapped in `ZodLazy<...>` for a deferred one — `typeof {schema}` when
-/// the deferred target is a plain binding name, which is every deferred shape
-/// [`default_zod_rendering`] folds or defers to a sibling's own `$Schema`/`$SchemaDefault`; the
-/// widened class otherwise, for the one shape it is not — a declared default naming a generic
-/// sibling at some filling other than that sibling's own, whose un-folded reference is a factory
-/// call rather than a name `typeof` can read.
+/// [`branded_default_annotation`]: the eager expression's class bare, or that class inside
+/// `ZodLazy<...>` for a deferred one — spelled `typeof {schema}` where the deferred target is a
+/// binding name, and widened where it is a factory call `typeof` cannot read.
 #[cfg(all(feature = "zod", feature = "typescript"))]
 fn branded_default_argument_class(field: &FieldDef, rendering: &DefaultZodRendering) -> String {
     match rendering {

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -2623,14 +2623,10 @@ fn a_string_filling_annotates_the_example_as_no_filling_does() {
     assert_eq!(render(&filled), render(&super::ModelSchemaArgs::default()));
 }
 
-/// The three shapes a declared default renders as: a primitive's ordinary Zod expression, another
-/// primitive's, and a reference to a generic sibling read back through [`super::default_zod_rendering`]
-/// rather than reconstructed. The third row is the one that matters — `DocumentId` is registered as
-/// a factory publisher whose own `$SchemaDefault` was recorded at exactly `z.string()`, and
-/// `IdType = DocumentId<String>` names it at that identical argument, so the render folds onto
-/// `DocumentId$SchemaDefault` instead of composing `DocumentId$SchemaFactory(z.string())` a second
-/// time — deferred, since `DocumentId$SchemaDefault` is a module-scope `const` this one's own
-/// `const` cannot be known to be written above or below.
+/// The three shapes a declared default renders as. The third row is the one that matters:
+/// `IdType = DocumentId<String>` names that sibling at exactly the argument its own
+/// `$SchemaDefault` was recorded at, so the render folds onto that binding — deferred, two
+/// module-scope `const`s having no knowable order between them.
 #[cfg(feature = "zod")]
 #[test]
 fn declared_default_renders_each_shape_the_table_describes() {
@@ -2666,13 +2662,9 @@ fn declared_default_renders_each_shape_the_table_describes() {
     }
 }
 
-/// The direct-sibling fold gate (`array_depth == 0 && !is_optional()`) scopes the fold correctly —
-/// a wrapped default has no bare `DocumentId$SchemaDefault` binding to fold onto — but is not the
-/// deferral boundary: [`super::default_zod_rendering`] falls through to
-/// [`crate::field_type::FieldDef::names_a_sibling_binding`] for everything the fold gate declines,
-/// which asks whether the rendered tree names a sibling *anywhere*, `Vec`/`Option`/`Map`/`Tuple`
-/// wrapped or not. The `Vec<String>` row is the control: nothing inside it names a sibling, so it
-/// stays eager exactly as the bare-primitive rows above do.
+/// The direct-sibling fold gate scopes the fold but is not the deferral boundary: a wrapped default
+/// has no bare binding to fold onto, yet still names a sibling and still defers. The `Vec<String>`
+/// row is the control, naming none and staying eager.
 #[cfg(feature = "zod")]
 #[test]
 fn declared_default_renders_each_wrapped_shape_the_table_describes() {
@@ -3800,14 +3792,10 @@ fn a_tuple_struct_records_the_value_surface_its_slots_publish() {
     }
 }
 
-/// A brand constraining one of its own type parameters no longer has nothing to hang the checks
-/// on: it consults the parameter's *declared default* instead of the parameter itself, the same
-/// way a concrete argument is consulted through the registry. A `String` default carries the
-/// checks fine, and an entry the declaration left out falls back to `String` —
-/// [`super::declared_default_field`]'s own fallback, [`super::schema_example_value_type`]'s for the
-/// identical gap — so `pattern_args()`, which declares no `default_types` at all, is admitted here
-/// too: this guard alone requires nothing, and `jsonschema` is what actually requires an entry,
-/// through the unrelated `default_types_guard_errors`.
+/// A brand constraining one of its own type parameters consults that parameter's *declared
+/// default* rather than the parameter itself. An entry the declaration left out falls back to
+/// `String`, so this guard alone requires no `default_types`; `jsonschema` is what requires an
+/// entry, through the unrelated `default_types_guard_errors`.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
 fn string_constraints_over_the_brands_own_type_parameter_consult_the_declared_default() {
@@ -4441,13 +4429,9 @@ fn a_default_types_refusal_is_spanned_on_what_earned_it() {
     }
 }
 
-/// A filling is rendered through the dispatch a field's type is, and that dispatch takes a name it
-/// has no arm for to be another `#[model_schema]` item — right for `Foo`, gibberish for a reserved
-/// primitive name the dispatch has no arm for, which emitted a call into a module nothing publishes
-/// and left the author reading an `E0433` about a module they never wrote plus two `E0425`s about
-/// the generated body's own bindings. Refused at the entry instead, in words that name the type and
-/// the limitation. `char` is no longer among them: it gained `FieldDefType::Char` and is asserted
-/// admitted in `a_renderable_or_sibling_named_filling_is_left_alone` instead.
+/// The field-type dispatch takes a name it has no arm for to be another `#[model_schema]` item —
+/// right for `Foo`, gibberish for a reserved primitive, which emitted a call into a module nothing
+/// publishes. Refused at the entry instead, in words that name the type.
 #[cfg(feature = "jsonschema")]
 #[test]
 fn a_filling_no_document_can_be_built_from_is_refused_at_the_entry() {
@@ -5735,13 +5719,9 @@ fn a_required_map_value_carries_no_nullable_wrap() {
     }
 }
 
-/// The kind an alias registers is its *target's* answer, because a type path resolves through the
-/// alias — the same four verdicts a brand carries up from its inner, and for the same reason. A
-/// target serde writes as a bare string makes the alias one too, whatever spelling that target
-/// wears; a target serde stringifies for the author makes the alias key the open object that bare
-/// target keys; a target serde writes as no key at all leaves the alias refused, under its own name.
-/// `Vec<Slot>` is the collection, not the enum it holds; a target this expansion has not seen
-/// registered is `Unknown`, which is not a negative.
+/// The kind an alias registers is its *target's* answer, a type path resolving through the alias —
+/// the same four verdicts a brand carries up from its inner. `Vec<Slot>` is the collection, not the
+/// enum it holds; a target this expansion has not seen is `Unknown`, which is not a negative.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
 fn an_alias_registers_the_kind_of_what_it_targets() {
@@ -6910,13 +6890,10 @@ fn brand_json_schema_over(inner_ty: &syn::Type) -> String {
     .to_string()
 }
 
-/// A named type resolves to one schema module wherever it is written, and a brand is one of those
-/// places: it carries its inner by the same reference a field carries it by, so what the module
-/// name is derived from cannot differ between the two. A name the registry knows resolves through
-/// the registry in both, and a name it does not know assumes the module that name's own
-/// `#[model_schema()]` would publish — which for a type declared without the attribute is a module
-/// nothing emits, and rustc reports the `E0433` in either position. Nothing the expansion holds can
-/// tell those two apart, so that report is the whole contract, and it has to be one contract.
+/// A named type resolves to one schema module wherever it is written, a brand carrying its inner by
+/// the same reference a field does. A name the registry does not know assumes the module that
+/// name's own `#[model_schema()]` would publish, and rustc reports the `E0433` in either position —
+/// which is the whole contract, since nothing the expansion holds can tell the two cases apart.
 #[cfg(feature = "jsonschema")]
 #[test]
 fn a_named_type_resolves_to_the_same_module_in_field_and_brand_position() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -947,20 +947,8 @@ pub fn to_snake_case(name: &str) -> String {
     result
 }
 
-/// Extracts the first Rust code example from documentation comments.
-///
-/// Looks for a code fence with the format ` ```rust example` and extracts
-/// all code until the closing ` ``` `. If multiple examples are found,
-/// only the first one is returned.
-///
-/// # Arguments
-///
-/// * `docs` - A slice of documentation comment lines.
-///
-/// # Returns
-///
-/// An `Option<String>` containing the example code if found, or `None` if
-/// no example fence is present.
+/// The code inside the first ` ```rust example ` fence in these doc lines, or `None` where there is
+/// no such fence. Later fences are ignored.
 #[cfg(feature = "zod")]
 pub fn extract_example_from_docs(docs: &[String]) -> Option<String> {
     let mut in_example_block = false;

--- a/tests/advanced_tests/tests.rs
+++ b/tests/advanced_tests/tests.rs
@@ -265,9 +265,8 @@ fn assert_ts_contains_fields(ts_definition: &str, assertions: &[(&str, &str)]) {
     }
 }
 
-/// Holds the members whose key serde drops for a `None` to the `T | undefined` spelling. The
-/// attribute that drops the key decides what reaches the wire, never which of the two TypeScript
-/// spellings is written — only `ts_optional` asks for `field?: T`, and none of these carries it.
+/// Holds each member to `T | undefined`; none of these fields carries the `ts_optional` that would
+/// ask for the other spelling.
 #[cfg(all(feature = "typescript", feature = "zod"))]
 fn assert_ts_contains_omitted_fields(ts_definition: &str, assertions: &[(&str, &str)]) {
     for (field, expected_type) in assertions {
@@ -536,9 +535,6 @@ fn test_documented_struct() {
     assert!(ts_definition.contains("name: string;"));
     assert!(ts_definition.contains("email: string;"));
     assert!(ts_definition.contains("is_active: boolean;"));
-    // HashMap becomes Partial<Record<...>>
-    // An `Option` carrying no `ts_optional` writes `T | undefined`, whatever the attribute that
-    // drops its key from the wire says.
     assert!(
         ts_definition.contains("metadata: Partial<Record<string, string>> | undefined;"),
         "Got: {ts_definition}"

--- a/tests/basic_tests/tests.rs
+++ b/tests/basic_tests/tests.rs
@@ -166,10 +166,8 @@ fn test_optional_fields_json_schema() {
     assert!(!required.contains(&Value::String("nickname".to_owned())));
 }
 
-/// The member spelling an `Option` field written with a `skip_serializing_if` renders as.
-///
-/// The attribute drops the key from the wire, which the JSON `required` list and the Zod schema
-/// say; the TypeScript spelling is `ts_optional`'s to decide, and none of these fields carries it.
+/// The member an `Option` field written with a `skip_serializing_if` renders as. The attribute
+/// decides the wire, not the spelling, and none of these fields carries `ts_optional`.
 #[cfg(feature = "typescript")]
 fn omitted_member(name: &str, ts_type: &str) -> String {
     format!("{name}: {ts_type} | undefined;")

--- a/tests/collection_tests/tests.rs
+++ b/tests/collection_tests/tests.rs
@@ -640,10 +640,8 @@ struct DocumentedSequenceFields {
     undocumented_vec: Vec<String>,
 }
 
-/// The member spelling an `Option` field written with a `skip_serializing_if` renders as.
-///
-/// The attribute drops the key from the wire, which the JSON `required` list and the Zod schema
-/// say; the TypeScript spelling is `ts_optional`'s to decide, and none of these fields carries it.
+/// The member an `Option` field written with a `skip_serializing_if` renders as. The attribute
+/// decides the wire, not the spelling, and none of these fields carries `ts_optional`.
 #[cfg(feature = "typescript")]
 fn omitted_member(name: &str, ts_type: &str) -> String {
     format!("{name}: {ts_type} | undefined;")

--- a/tests/fixed_array_tests/tests.rs
+++ b/tests/fixed_array_tests/tests.rs
@@ -32,10 +32,8 @@ struct FixedArraySlots {
     entry: (String, [u32; 3]),
 }
 
-/// The member spelling an `Option` field written with a `skip_serializing_if` renders as.
-///
-/// The attribute drops the key from the wire, which the JSON `required` list and the Zod schema
-/// say; the TypeScript spelling is `ts_optional`'s to decide, and none of these fields carries it.
+/// The member an `Option` field written with a `skip_serializing_if` renders as. The attribute
+/// decides the wire, not the spelling, and none of these fields carries `ts_optional`.
 #[cfg(feature = "typescript")]
 fn omitted_member(name: &str, ts_type: &str) -> String {
     format!("{name}: {ts_type} | undefined;")

--- a/tests/generic_types_tests/tests.rs
+++ b/tests/generic_types_tests/tests.rs
@@ -119,8 +119,6 @@ mod typescript {
             ts.contains("  by_key: Partial<Record<string, ValueType>>;"),
             "Got: {ts}"
         );
-        // An `Option` carrying no `ts_optional` writes `T | undefined`, whatever the attribute
-        // that drops its key from the wire says.
         assert!(ts.contains("  maybe: ValueType | undefined;"), "Got: {ts}");
         assert!(ts.contains("  tuple: [KeyType, ValueType];"), "Got: {ts}");
     }
@@ -246,14 +244,9 @@ mod zod {
     #[cfg(all(feature = "typescript", feature = "serde"))]
     use super::{ConstrainedEchoedDefault, ConstrainedId, DeepEchoedDefault};
 
-    /// Two generic items whose declared defaults name each other: `CycleLeader`'s names
-    /// `CycleFollower` and `CycleFollower`'s names `CycleLeader` back, at arguments neither can have
-    /// registered yet when the other is expanded — one macro invocation sees one type, so neither
-    /// side can know at expansion time that the other's declared default will turn out to name it
-    /// back. Nothing folds, both sides call the other's factory, and both calls are deferred exactly
-    /// as an unfolded reference to any other sibling's factory already is: the module loads and
-    /// resolves each side's read only once something asks the resulting schema to validate, so
-    /// which of the two names is written first in the generated module is never asked.
+    /// Two generic items whose declared defaults name each other. Neither has registered the
+    /// other's arguments when it expands, so neither folds; both calls are deferred, and which of
+    /// the two names is written first in the generated module is never asked.
     #[test]
     fn a_cycle_between_two_defaults_is_deferred_on_both_sides() {
         let leader = CycleLeader::<u32>::zod_schema();

--- a/tests/model_schema_prop_tests/tests.rs
+++ b/tests/model_schema_prop_tests/tests.rs
@@ -199,10 +199,8 @@ enum TsOptionalVariant {
     },
 }
 
-/// The member spelling an `Option` field written with a `skip_serializing_if` renders as.
-///
-/// The attribute drops the key from the wire, which the JSON `required` list and the Zod schema
-/// say; the TypeScript spelling is `ts_optional`'s to decide, and none of these fields carries it.
+/// The member an `Option` field written with a `skip_serializing_if` renders as. The attribute
+/// decides the wire, not the spelling, and none of these fields carries `ts_optional`.
 #[cfg(feature = "typescript")]
 fn omitted_member(name: &str, ts_type: &str) -> String {
     format!("{name}: {ts_type} | undefined;")
@@ -532,7 +530,6 @@ fn test_ts_optional_struct_typescript() {
         "did not expect required-key form for `f` in:\n{ts}"
     );
 
-    // `g` carries no `ts_optional`, so it keeps the `T | undefined` spelling.
     let g = omitted_member("g", "Inner");
     assert!(ts.contains(&g), "expected control `{g}` in:\n{ts}");
 

--- a/tests/omitted_key_tests/tests.rs
+++ b/tests/omitted_key_tests/tests.rs
@@ -102,9 +102,7 @@ fn the_predicate_omitted_key_is_absent_from_the_payload_serde_writes() {
     );
 }
 
-/// An `Option` writes `T | undefined` whatever drops its key from the wire; only `ts_optional`
-/// asks for the optional-key spelling, and this field carries none. The members serde always
-/// writes are unaffected either way.
+/// `age` carries no `ts_optional`, so the attribute that drops its key leaves the spelling alone.
 #[test]
 #[cfg(feature = "typescript")]
 fn typescript_writes_the_option_as_undefined_valued() {

--- a/tests/optional_key_flag_tests/tests.rs
+++ b/tests/optional_key_flag_tests/tests.rs
@@ -1,12 +1,8 @@
-//! `ts_optional` is the whole of what decides between the two spellings of an optional member.
+//! `ts_optional` is the whole of what decides between `field?: T` and `field: T | undefined`.
 //!
-//! An `Option<T>` renders `field: T | undefined` unless the flag asks for `field?: T`. The serde
-//! attribute that drops the key decides what reaches the wire — the JSON `required` list and the
-//! Zod schema read it — and never which spelling TypeScript is written with, so a flagged member
-//! and an unflagged control carrying the same attributes render two different lines.
-//!
-//! Both feature flavours are held here: under the `serde` feature, where an attribute is read and
-//! the `Option`-null guard requires one, and without it, where neither happens.
+//! Every shape below carries a flagged member beside an unflagged control of the same type and the
+//! same serde attributes, so the flag is the only difference the two lines can come from. Held
+//! under both feature flavours, since only one of them reads an attribute at all.
 
 #[cfg(feature = "serde")]
 mod under_the_serde_feature {
@@ -49,8 +45,6 @@ mod under_the_serde_feature {
         id: String,
     }
 
-    /// On every shape the `serde` feature accepts, the flag is the whole of the difference between
-    /// the flagged member and its control — the attribute both carry writes neither line.
     #[test]
     fn the_flag_decides_the_spelling_the_omission_attribute_leaves_open() {
         let predicate = UnderAPredicate::ts_definition();

--- a/tests/optional_nesting_tests/tests.rs
+++ b/tests/optional_nesting_tests/tests.rs
@@ -50,10 +50,8 @@ struct NullNestingSlots {
     tuple_vec_slot: (String, Option<Vec<u32>>),
 }
 
-/// The member spelling an `Option` field written with a `skip_serializing_if` renders as.
-///
-/// The attribute drops the key from the wire, which the JSON `required` list and the Zod schema
-/// say; the TypeScript spelling is `ts_optional`'s to decide, and none of these fields carries it.
+/// The member an `Option` field written with a `skip_serializing_if` renders as. The attribute
+/// decides the wire, not the spelling, and none of these fields carries `ts_optional`.
 #[cfg(feature = "typescript")]
 fn omitted_member(name: &str, ts_type: &str) -> String {
     format!("{name}: {ts_type} | undefined;")

--- a/tests/primitive_types_tests/tests.rs
+++ b/tests/primitive_types_tests/tests.rs
@@ -333,10 +333,8 @@ fn assert_ts_fields_contain(ts_definition: &str, fields: &[&str], expected_suffi
     }
 }
 
-/// The member spelling an `Option` field written with a `skip_serializing_if` renders as.
-///
-/// The attribute drops the key from the wire, which the JSON `required` list and the Zod schema
-/// say; the TypeScript spelling is `ts_optional`'s to decide, and none of these fields carries it.
+/// The member an `Option` field written with a `skip_serializing_if` renders as. The attribute
+/// decides the wire, not the spelling, and none of these fields carries `ts_optional`.
 #[cfg(all(feature = "typescript", feature = "zod"))]
 fn omitted_member(name: &str, ts_type: &str) -> String {
     format!("{name}: {ts_type} | undefined;")

--- a/tests/serde_tests/tests.rs
+++ b/tests/serde_tests/tests.rs
@@ -339,8 +339,7 @@ fn test_discriminated_union_with_serde_zod() {
 fn test_compliant_optionals_typescript() {
     let ts = CompliantOptionals::ts_definition();
 
-    // `ts_optional` on `tag` is the whole of why it is spelled with an optional key; `note`
-    // carries the same `skip_serializing_if` and none of the flag, so it keeps `T | undefined`.
+    // Same `skip_serializing_if` on both; the flag on `tag` is the only difference.
     assert!(
         ts.contains("tag?: string;"),
         "expected `tag?: string;`:\n{ts}"


### PR DESCRIPTION
The optional-key change (#192) wrote its commentary in the style the pass before it (#191) had just removed: a ten-line essay on `key_may_be_absent`, a three-line preamble on each of six copies of `omitted_member`, an eight-line module header on `optional_key_flag_tests`, and inline notes restating the assertion below them. Cut to the operative fact.

A second sweep catches what #191 missed. Its doc trimmer skipped any block containing a fenced-code marker, which excluded every doc that merely mentions ` ```rust example ` in prose — `const_parameter_example_errors`, `extract_example_from_docs`, `item_lines_or_name`, `build_jsdoc_body` — and `extract_example_from_docs` still carried `# Arguments`/`# Returns` sections restating its own signature. Long single-paragraph blocks were never in scope either, so `branded_default_annotation`, `branded_default_argument_class`, `names_a_sibling_binding` and five test docs are cut here too.

One narrating line, `// HashMap becomes Partial<Record<...>>`, was left standing alone when the comment beneath it was replaced.

Every remaining block was checked for an ending that trails off into text no longer there; none does. `just lint-all` and `just test` (32 combinations) green, rustdoc warning-free, no code line touched.