### PR TITLE
Give an optional key two wire shapes, coerced null and explicit null

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,7 +219,7 @@ pub struct BadConfig {
 - `String` → `string`
 - `bool` → `boolean`
 - Numeric types → `number`
-- `Option<T>` → `T | undefined` (Zod: `z.union([T, z.undefined()]).prefault(undefined)`); with `#[model_schema_prop(ts_optional)]` the TypeScript key becomes optional instead: `field?: T`
+- `Option<T>` → `T | undefined` (Zod: `z.union([z.null().transform(() => undefined), T, z.undefined()]).prefault(undefined)`, accepting an explicit `null` and coercing it to `undefined`; JSON Schema `anyOf: [T, {"type": "null"}]`, key left out of `required`); with `#[model_schema_prop(ts_optional)]` the TypeScript key becomes optional instead: `field?: T`; with `#[model_schema_prop(nullable)]` all three surfaces render `T | null` with the key **required** instead: Zod `z.union([T, z.null()])`, JSON Schema `anyOf: [T, {"type": "null"}]` with the key in `required`
 - `Vec<T>` → `Array<T>`
 - `HashMap<String, T>` → `Partial<Record<string, T>>`
 - Custom types → Reference by name (Json suffix stripped if present)
@@ -246,8 +246,8 @@ Generated schemas use Zod v4's modern syntax:
 export const User$Schema = z.strictObject({
   id: z.string(),
   name: z.string(),
-  email: z.union([z.string(), z.undefined()]).prefault(undefined),      // Modern v4 syntax
-  age: z.union([z.number().int(), z.undefined()]).prefault(undefined),  // Works with JSON schema generation
+  email: z.union([z.null().transform(() => undefined), z.string(), z.undefined()]).prefault(undefined),      // Modern v4 syntax, null coerced to undefined
+  age: z.union([z.null().transform(() => undefined), z.number().int(), z.undefined()]).prefault(undefined),  // Works with JSON schema generation
 });
 
 // ❌ OLD FORMAT (no longer generated)
@@ -297,6 +297,7 @@ All validation constraints generate checks in **Zod (frontend), JSON Schema, and
 | `preprocess = ["fn"]` | any | `z.preprocess(fn, ...)` | — | — (Zod-only) |
 | `ts_optional` | `Option<T>` | — | — | — (TypeScript-only) |
 | `as_number` | `DateTime<Tz>` | inline `z.preprocess(..., z.number())` | — | — (TS+Zod) |
+| `nullable` | `Option<T>` | `z.union([T, z.null()])`, key required | `anyOf: [T, {"type":"null"}]`, key required | guard: refuses a key-dropping serde attr |
 
 Multiple constraints on one field are combined. Multiple `preprocess` functions nest:
 `z.preprocess(fn1, z.preprocess(fn2, innerSchema))`.
@@ -304,6 +305,8 @@ Multiple constraints on one field are combined. Multiple `preprocess` functions 
 `ts_optional` is a bare flag (no value): it renders an `Option<T>` field as the optional TypeScript key `field?: T` instead of the default `field: T | undefined`. Zod and JSON Schema output are unchanged. It is only valid on `Option<T>` fields (non-`Option` is a compile error) and composes with `as = Type`.
 
 `as_number` is a bare flag (no value): it renders a `DateTime<Tz>` field as a `number` (epoch milliseconds) with an inline self-contained Zod coercer, instead of the default native `Date` (`z.coerce.date()`). It is only valid on `DateTime<Tz>` fields (anything else is a compile error) and is honored on a tuple-variant `DateTime<Tz>` enum payload.
+
+`nullable` is a bare flag (no value): on an `Option<T>` field it renders `T | null` with the key **required** on TypeScript, Zod and JSON Schema, instead of the default coercing `T | undefined` with the key left optional. It is only valid on `Option<T>` fields (non-`Option` is a compile error), is refused together with `ts_optional` (the two disagree about the key), and composes with `preprocess` — the preprocess wrap goes around the whole nullable union. With the `serde` feature on, it is also refused together with a key-dropping serde attribute (`skip_serializing_if`, `skip_serializing`, `skip`) — the flag declares the key always written, so dropping it would let serde write a payload the generated schema does not admit. The mirror guard, `check_optional_field_serialization`, requires that same attribute on a bare `Option<T>` field carrying no `nullable`.
 
 ```rust
 #[model_schema()]
@@ -650,7 +653,7 @@ The macro transforms Rust types to TypeScript following these rules:
 
 1. **Type Name Transformation**: If the Rust type name ends with `Json`, the suffix is stripped (e.g., `UserJson` → `User`). Otherwise, the name is used as-is (e.g., `User` → `User`).
 2. **Field Names**: Respect serde rename attributes (`#[serde(rename = "...")]`, `#[serde(rename_all = "...")]`)
-3. **Optional Fields**: `Option<T>` becomes `T | undefined` in TypeScript and `z.union([type, z.undefined()]).prefault(undefined)` in Zod
+3. **Optional Fields**: `Option<T>` becomes `T | undefined` in TypeScript and `z.union([z.null().transform(() => undefined), type, z.undefined()]).prefault(undefined)` in Zod, accepting both an absent key and an explicit `null`
 4. **Arrays**: `Vec<T>` becomes `Array<T>` in TypeScript
 5. **Maps**: `HashMap<String, T>` becomes `Partial<Record<string, T>>` in TypeScript
 6. **Nested Types**: Reference other types by name (Json suffix stripped if present)
@@ -805,7 +808,7 @@ export const Document$Schema = z.strictObject({
   author_id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) }),
   tags: z.array(z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) })),
   metadata: z.record(z.string(), z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) })),
-  parent_id: z.union([z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) }), z.undefined()]).prefault(undefined),
+  parent_id: z.union([z.null().transform(() => undefined), z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) }), z.undefined()]).prefault(undefined),
   related: z.record(z.string(), z.array(z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) }))),
 });
 ```

--- a/README.md
+++ b/README.md
@@ -86,9 +86,11 @@ pub struct UserProfile {
 
 ### Optional Fields
 
-`Option<T>` fields validate as `z.union([type, z.undefined()]).prefault(undefined)` in Zod v4 and are left out of the JSON Schema's `required` list. The `.prefault(undefined)` makes the field default to `undefined` when omitted from the input.
+`Option<T>` fields validate as `z.union([z.null().transform(() => undefined), type, z.undefined()]).prefault(undefined)` in Zod v4 and are left out of the JSON Schema's `required` list, whose `anyOf: [type, { "type": "null" }]` describes the same two spellings serde reads into `None`. The `.prefault(undefined)` makes the field default to `undefined` when omitted from the input, and the leading `z.null()` arm coerces an explicit `null` to the same `undefined`.
 
-TypeScript writes every `Option<T>` field as `field: T | undefined`. The one thing that writes the other spelling, `field?: T`, is [`#[model_schema_prop(ts_optional)]`](#ts_optional) on the author's word. A serde attribute that drops the key decides what reaches the wire — the JSON Schema's `required` list and the Zod schema both read it — and never which of the two TypeScript spellings is written.
+TypeScript writes every `Option<T>` field as `field: T | undefined`. The one thing that writes the other spelling, `field?: T`, is [`#[model_schema_prop(ts_optional)]`](#ts_optional) on the author's word. A serde attribute that drops the key decides what reaches the wire — the JSON Schema's `required` list and the Zod schema both read it — and never which of the two TypeScript spellings is written. [`#[model_schema_prop(nullable)]`](#nullable-object-keys-nullable) writes a third spelling, `field: T | null`, for the field whose `None` reaches the wire as an explicit `null` rather than an absent key.
+
+Each flavor is pinned to the one shape its declared type describes, and the `serde` feature enforces the pin. A bare `Option<T>` field is a compile error unless it carries a key-dropping attribute (`skip_serializing_if`, `skip_serializing`, or `skip`) — its declared shape is `T | undefined`, so a `None` has to leave the key out, not reach the wire as `null`. `nullable` is refused the opposite way: pairing it with a key-dropping attribute is a compile error too, since the flag declares the key always written. Either violation names the field and the attribute to add or remove. Deserialization does not enforce either pin: `{}` and `{"a":null}` both read into `None` under both flavors, so an optional key accepts an explicit `null` on input even on a field whose own serializer never writes one.
 
 A bare `#[serde(skip)]` is not that. serde writes the key into no payload *and* throws it away out of every payload that supplies one, so there is nothing on the wire for any surface to describe: TypeScript writes no member, Zod no key, and the JSON Schema neither a `properties` entry nor a `required` one. `#[serde(skip_serializing, skip_deserializing)]` is the same wire spelled out and is answered the same way. Note what this costs on the way in — a `z.strictObject` and an `additionalProperties: false` both *reject* a payload carrying that key, while serde accepts such a payload and discards the value. The schemas describe the payload serde writes, and that key appears in none of them; a member under an optional key would instead claim the key is sometimes written, and would describe a value nothing ever reads.
 
@@ -1679,7 +1681,7 @@ pub struct Event {
 
 The bare `ts_optional` flag asks for the optional key (`field?: T` rather than `field: T | undefined`) on the author's word. It is the only thing that writes that spelling.
 
-**Read the condition before reaching for it.** An `Option<T>` field whose serde attributes drop the key for a `None` already renders as an optional key, off the wire and in every build ([Optional Fields](#optional-fields)) — on such a field the flag changes nothing, because the attribute has already said it. What is left over is an `Option<T>` carrying no key-dropping attribute at all, and with the `serde` feature on that field does not compile: serde writes its `None` as a `null`, the generated schema admits only the absent key, and the guard refuses the declaration and names the attribute to add. So the flag decides the key in exactly one place — a build with the `serde` feature **off**, where no attribute is read and no such guard runs:
+**Read the condition before reaching for it.** An `Option<T>` field whose serde attributes drop the key for a `None` already renders as an optional key, off the wire and in every build ([Optional Fields](#optional-fields)) — on such a field the flag changes nothing, because the attribute has already said it. What is left over is an `Option<T>` carrying no key-dropping attribute at all, and with the `serde` feature on that field does not compile: the field's declared shape is `T | undefined`, so its key has to be dropped for a `None`, not written as `null` the way serde writes it absent an attribute saying otherwise — and the guard refuses the declaration and names the attribute to add (or, if the wire really does carry `null` here, points at [`nullable`](#nullable-object-keys-nullable) instead). So the flag decides the key in exactly one place — a build with the `serde` feature **off**, where no attribute is read and no such guard runs:
 
 ```rust
 #[model_schema()]
@@ -1704,6 +1706,37 @@ export type Profile = {
 `nick_handle` is the same field without the flag, so the flag is the whole of the difference between those two lines.
 
 This is a TypeScript-only knob -- the Zod schema and JSON Schema are unchanged (the field is already optional in both, flagged or not). The flag is only valid on `Option<T>` fields; applying it to a non-`Option` field is a compile error. It composes with `as = Type`, which names the type the field already renders. On a field the flag has no say over — one already carrying an omission attribute, or a positional slot, which has no key to make optional — writing it is accepted and inert.
+
+### Nullable Object Keys (`nullable`)
+
+The bare `nullable` flag is for the `Option<T>` field whose empty state genuinely *is* `null` on the wire — the key is always written and `null` is its value, not the absence of one. Where the default coerces an incoming `null` away to `undefined` and leaves the key optional, `nullable` renders the field as `T | null` with the key **required** on all three surfaces:
+
+```rust
+#[model_schema()]
+#[derive(Serialize, Deserialize)]
+pub struct DocumentMetadata {
+    pub name: String,
+    #[model_schema_prop(nullable)]
+    pub template_id: Option<String>,
+}
+```
+
+Generated TypeScript:
+
+```typescript
+export type DocumentMetadata = {
+  name: string;
+  templateId: string | null;
+};
+```
+
+Generated Zod: `templateId: z.union([z.string(), z.null()])` -- no `.prefault`, no coercing arm. Parsing `{ name: "invoice.pdf", templateId: null }` succeeds; parsing `{ name: "invoice.pdf" }` fails, because the flag declares the key required.
+
+Generated JSON Schema: `"templateId": { "anyOf": [{ "type": "string" }, { "type": "null" }] }`, with `templateId` in `required`.
+
+`nullable` is only valid on `Option<T>` fields; applying it to a non-`Option` field is a compile error. It is refused together with `ts_optional` -- the two disagree about the key (`nullable` keeps it, `ts_optional` drops it), and writing both would spell `field?: T | null`, a third state neither flag models. It composes with `preprocess`: the preprocess wrap goes around the whole nullable union, coercing the raw value before it is checked against `T | null`.
+
+With the `serde` feature on, `nullable` is also refused together with any key-dropping serde attribute -- `skip_serializing_if`, `skip_serializing`, or `skip` -- because the flag declares the key always written and one of those would drop it instead, leaving serde write a payload the generated schema does not admit. The guard names the field and the flag. Deserialization needs no such guard: a `nullable` field reads both `{"templateId":null}` and `{"templateId":"invoice.pdf"}` the same way it always did, `{}` included, since nothing about `nullable` changes what serde accepts on the way in.
 
 ## Compiler-Validated Examples
 
@@ -1830,7 +1863,7 @@ export const Document$Schema = z.strictObject({
   author_id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) }),
   tags: z.array(z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) })),
   metadata: z.record(z.string(), z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) })),
-  parent_id: z.union([z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) }), z.undefined()]).prefault(undefined),
+  parent_id: z.union([z.null().transform(() => undefined), z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) }), z.undefined()]).prefault(undefined),
   related_docs: z.record(z.string(), z.array(z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) }))),
 });
 ```
@@ -1924,7 +1957,7 @@ export const Event$Schema: ZodType<Event> = z.strictObject({
   local_datetime: z.iso.datetime({ local: true }),
   created_at: z.coerce.date(),
   epoch_ms: z.preprocess((arg) => { if (arg instanceof Date) return arg.getTime(); if (typeof arg === "string") return Date.parse(arg); return arg; }, z.number()),
-  updated_at: z.union([z.coerce.date(), z.undefined()]).prefault(undefined),
+  updated_at: z.union([z.null().transform(() => undefined), z.coerce.date(), z.undefined()]).prefault(undefined),
 });
 ```
 
@@ -2091,7 +2124,7 @@ If the `serde` feature is disabled but serde attributes are present, you will se
 
 4. **Array Types**: `Vec<T>` becomes `Array<T>` in TypeScript, one `Array<...>` per level written — `Vec<Vec<T>>` is `Array<Array<T>>`.
 
-5. **Optional Fields**: `Option<T>` becomes `field: T | undefined` in TypeScript unless `#[model_schema_prop(ts_optional)]` asks for `field?: T`, and `z.union([type, z.undefined()]).prefault(undefined)` in Zod v4 either way.
+5. **Optional Fields**: `Option<T>` becomes `field: T | undefined` in TypeScript unless `#[model_schema_prop(ts_optional)]` asks for `field?: T`, and `z.union([z.null().transform(() => undefined), type, z.undefined()]).prefault(undefined)` in Zod v4 either way.
 
 6. **Complex Nesting**: The crate supports deeply nested structures including `HashMap<String, Vec<HashMap<String, T>>>` and similar patterns.
 
@@ -2368,8 +2401,8 @@ Zod v4 (generated by this library):
 export const User$Schema = z.strictObject({
   id: z.string(),
   name: z.string(),
-  email: z.union([z.string(), z.undefined()]).prefault(undefined),
-  age: z.union([z.number().int(), z.undefined()]).prefault(undefined),
+  email: z.union([z.null().transform(() => undefined), z.string(), z.undefined()]).prefault(undefined),
+  age: z.union([z.null().transform(() => undefined), z.number().int(), z.undefined()]).prefault(undefined),
 });
 ```
 

--- a/src/features/model_schema_prop.rs
+++ b/src/features/model_schema_prop.rs
@@ -23,6 +23,7 @@ const KNOWN_KEYS: &[&str] = &[
     "preprocess",
     "ts_optional",
     "as_number",
+    "nullable",
 ];
 
 /// Metadata for `model_schema_prop` attributes applied to a field.
@@ -118,6 +119,7 @@ pub struct ModelSchemaPropMeta {
     pub maximum: Option<f64>,    // e.g., 100.0 from maximum = 100
     pub min_length: Option<usize>, // e.g., 1 from minLength = 1
     pub minimum: Option<f64>,    // e.g., 0.0 from minimum = 0
+    pub nullable: bool, // Option<T> at object-key position renders `T | null` with the key required
     /// `pattern` in the spelling every surface reads the same way, or as it was written when it
     /// earned a [`Self::pattern_rejection`].
     pub pattern: Option<String>, // e.g., "^[0-9a-fA-F]{24}$" from pattern = "^[0-9a-fA-F]{24}$"
@@ -187,6 +189,8 @@ fn parse_prop_key(nested: &ParseNestedMeta, meta: &mut ModelSchemaPropMeta) -> s
         meta.ts_optional = true;
     } else if nested.path.is_ident("as_number") {
         meta.as_number = true;
+    } else if nested.path.is_ident("nullable") {
+        meta.nullable = true;
     } else {
         return Err(unknown_key_rejection(nested));
     }

--- a/src/features/model_schema_prop/tests.rs
+++ b/src/features/model_schema_prop/tests.rs
@@ -88,6 +88,22 @@ fn test_parse_no_ts_optional_by_default() {
 }
 
 #[test]
+fn test_parse_nullable() {
+    let attr: Attribute = parse_quote! { #[model_schema_prop(nullable)] };
+    let meta = parse_model_schema_prop_attributes(&[attr]);
+    assert!(meta.nullable);
+    assert!(meta.as_type.is_none());
+    assert!(meta.literal.is_none());
+}
+
+#[test]
+fn test_parse_no_nullable_by_default() {
+    let attr: Attribute = parse_quote! { #[model_schema_prop(minLength = 1)] };
+    let meta = parse_model_schema_prop_attributes(&[attr]);
+    assert!(!meta.nullable);
+}
+
+#[test]
 fn test_parse_all_attributes() {
     let attr: Attribute =
         parse_quote! { #[model_schema_prop(as = String, literal = "test", minLength = 3)] };
@@ -129,7 +145,7 @@ fn a_misspelled_length_constraint_key_is_refused_by_the_name_as_written() {
 /// one it actually reads — the list and the arms cannot drift apart while both hold.
 #[test]
 fn no_key_the_parser_reads_is_rejected() {
-    let attrs: [Attribute; 10] = [
+    let attrs: [Attribute; 11] = [
         parse_quote! { #[model_schema_prop(as = String)] },
         parse_quote! { #[model_schema_prop(literal = "Tixena")] },
         parse_quote! { #[model_schema_prop(minLength = 1)] },
@@ -140,6 +156,7 @@ fn no_key_the_parser_reads_is_rejected() {
         parse_quote! { #[model_schema_prop(preprocess = ["trim"])] },
         parse_quote! { #[model_schema_prop(ts_optional)] },
         parse_quote! { #[model_schema_prop(as_number)] },
+        parse_quote! { #[model_schema_prop(nullable)] },
     ];
     assert_eq!(attrs.len(), KNOWN_KEYS.len());
 

--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -406,6 +406,16 @@ impl FieldDef {
             .is_some_and(|m| m.as_number)
     }
 
+    /// Whether `#[model_schema_prop(nullable)]` was written on this field — an `Option<T>` at
+    /// object-key position rendering `T | null` with the key required, instead of the coercing
+    /// default. Validated elsewhere to sit only on an `Option<T>` field, so a caller reading it
+    /// under [`Self::is_optional`] never needs to ask twice.
+    fn has_nullable(&self) -> bool {
+        self.model_schema_prop_meta
+            .as_ref()
+            .is_some_and(|m| m.nullable)
+    }
+
     /// Whether the field describes an array at all — the question every surface asked of the
     /// boolean this depth replaced. Asked only where a schema is generated.
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
@@ -431,10 +441,15 @@ impl FieldDef {
 
     /// Whether every payload serde writes carries a key for this field — what the JSON surface's
     /// `required` names, and the one question there that a field's `Option`-ness alone cannot
-    /// answer.
+    /// answer. A `nullable` `Option<T>` is the one case where both hold at once: the key is always
+    /// written and `null` is its empty value.
     #[cfg(feature = "jsonschema")]
     pub fn key_is_required(&self) -> bool {
-        !self.is_optional() && !self.omits_value
+        if self.is_optional() {
+            self.has_nullable()
+        } else {
+            !self.omits_value
+        }
     }
 
     /// Whether the object key this field writes may be absent — `field?: T` admits the payload
@@ -895,10 +910,12 @@ impl FieldDef {
     pub fn typescript_typename(&self) -> String {
         let pre_result = self.typescript_base();
         if self.is_optional() {
-            // An absent-able key renders as `field?: T`, so the `| undefined` is redundant — and
-            // under `exactOptionalPropertyTypes` it would claim an explicit `undefined` the key's
-            // omission is exactly what serde writes instead.
-            if self.key_may_be_absent() {
+            if self.has_nullable() {
+                format!("{pre_result} | null")
+            } else if self.key_may_be_absent() {
+                // An absent-able key renders as `field?: T`, so the `| undefined` is redundant —
+                // and under `exactOptionalPropertyTypes` it would claim an explicit `undefined`
+                // the key's omission is exactly what serde writes instead.
                 pre_result
             } else {
                 format!("{pre_result} | undefined")
@@ -1021,20 +1038,7 @@ impl FieldDef {
     /// `z.union([…, z.undefined()]).prefault(undefined)` wrap lives in `zod_type`.
     #[cfg(feature = "zod")]
     fn zod_base(&self) -> String {
-        let array_result = self.zod_array_base();
-
-        // Wrap with preprocess if specified
-        if let Some(meta) = &self.model_schema_prop_meta
-            && !meta.preprocess.is_empty()
-        {
-            let mut wrapped = array_result;
-            for fn_name in meta.preprocess.iter().rev() {
-                wrapped = format!("z.preprocess({fn_name}, {wrapped})");
-            }
-            wrapped
-        } else {
-            array_result
-        }
+        self.zod_preprocess_wrap(self.zod_array_base())
     }
 
     /// The key schema a `z.record(…)` is written with: the key's own, except where the key is one
@@ -1068,6 +1072,23 @@ impl FieldDef {
             }
         }
         result
+    }
+
+    /// Wraps `schema` in one `z.preprocess(fn, …)` per function named by `preprocess`, innermost
+    /// function first, or returns it unwrapped where none was written. Held apart from
+    /// [`Self::zod_base`] so [`Self::zod_type`] can also wrap the whole `nullable` union rather
+    /// than only the type match beneath it — coerce, then validate.
+    #[cfg(feature = "zod")]
+    fn zod_preprocess_wrap(&self, schema: String) -> String {
+        let Some(meta) = &self.model_schema_prop_meta else {
+            return schema;
+        };
+        meta.preprocess
+            .iter()
+            .rev()
+            .fold(schema, |wrapped, fn_name| {
+                format!("z.preprocess({fn_name}, {wrapped})")
+            })
     }
 
     /// The Zod schema for a value in a slot that cannot be dropped — a tuple element, a map entry,
@@ -1111,13 +1132,23 @@ impl FieldDef {
     #[cfg(feature = "zod")]
     /// Generates the Zod schema string for this field (requires "zod" feature).
     pub fn zod_type(&self) -> String {
-        let pre_result = self.zod_base();
         if self.is_optional() {
-            format!("z.union([{pre_result}, z.undefined()]).prefault(undefined)")
-        } else if self.key_may_be_absent() {
-            format!("{pre_result}.optional()")
+            if self.has_nullable() {
+                let union = format!("z.union([{}, z.null()])", self.zod_array_base());
+                self.zod_preprocess_wrap(union)
+            } else {
+                let pre_result = self.zod_base();
+                format!(
+                    "z.union([z.null().transform(() => undefined), {pre_result}, z.undefined()]).prefault(undefined)"
+                )
+            }
         } else {
-            pre_result
+            let pre_result = self.zod_base();
+            if self.key_may_be_absent() {
+                format!("{pre_result}.optional()")
+            } else {
+                pre_result
+            }
         }
     }
 

--- a/src/field_type/tests.rs
+++ b/src/field_type/tests.rs
@@ -163,7 +163,7 @@ fn test_optional_sequence_field_keeps_the_field_level_optionality() {
     #[cfg(feature = "zod")]
     assert_eq!(
         optional.zod_type(),
-        "z.union([z.array(z.string()), z.undefined()]).prefault(undefined)"
+        "z.union([z.null().transform(() => undefined), z.array(z.string()), z.undefined()]).prefault(undefined)"
     );
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,14 @@ use proc_macro::TokenStream;
  *   "additionalProperties": false,
  *   "properties": {
  *     "age": {
- *       "type": "integer"
+ *       "anyOf": [
+ *         {
+ *           "type": "integer"
+ *         },
+ *         {
+ *           "type": "null"
+ *         }
+ *       ]
  *     },
  *     "firstName": {
  *       "type": "string"
@@ -120,7 +127,7 @@ export type User = {
 ///
 #[doc = "```typescript
 const User$RawSchema = z.strictObject({
-  age: z.union([z.number().int(), z.undefined()]).prefault(undefined),
+  age: z.union([z.null().transform(() => undefined), z.number().int(), z.undefined()]).prefault(undefined),
   firstName: z.string(),
   id: z.string(),
   lastName: z.string(),
@@ -240,7 +247,14 @@ export const Status$Schema: ZodType<Status> = Status$RawSchema;
  *           "const": "userDeleted"
  *         },
  *         "reason": {
- *           "type": "string"
+ *           "anyOf": [
+ *             {
+ *               "type": "string"
+ *             },
+ *             {
+ *               "type": "null"
+ *             }
+ *           ]
  *         },
  *         "userId": {
  *           "type": "string"
@@ -298,7 +312,7 @@ const Event$RawSchema = z.discriminatedUnion("type", [z.strictObject({
   userId: z.string(),
 }), z.strictObject({
   type: z.literal("userDeleted"),
-  reason: z.union([z.string(), z.undefined()]).prefault(undefined),
+  reason: z.union([z.null().transform(() => undefined), z.string(), z.undefined()]).prefault(undefined),
   userId: z.string(),
 })]);
 
@@ -388,17 +402,24 @@ pub struct Document {
  *       }
  *     },
  *     "parent_id": {
- *       "type": "object",
- *       "properties": {
- *         "$oid": {
- *           "type": "string",
- *           "pattern": "^[a-f0-9]{24}$"
+ *       "anyOf": [
+ *         {
+ *           "type": "object",
+ *           "properties": {
+ *             "$oid": {
+ *               "type": "string",
+ *               "pattern": "^[a-f0-9]{24}$"
+ *             }
+ *           },
+ *           "required": [
+ *             "$oid"
+ *           ],
+ *           "additionalProperties": false
+ *         },
+ *         {
+ *           "type": "null"
  *         }
- *       },
- *       "required": [
- *         "$oid"
- *       ],
- *       "additionalProperties": false
+ *       ]
  *     },
  *     "tags": {
  *       "type": "array",
@@ -470,7 +491,7 @@ const Document$RawSchema = z.strictObject({
   author_id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) }),
   id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) }),
   metadata: z.record(z.string(), z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) })),
-  parent_id: z.union([z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) }), z.undefined()]).prefault(undefined),
+  parent_id: z.union([z.null().transform(() => undefined), z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) }), z.undefined()]).prefault(undefined),
   tags: z.array(z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: "Invalid ObjectId" }) })),
   title: z.string(),
 });
@@ -749,6 +770,25 @@ pub fn model_schema(args: TokenStream, input: TokenStream) -> TokenStream {
 ///     pub name: String,
 /// }
 /// ```
+///
+/// ## Flags
+///
+/// These take no value, and each is only valid on the field shape it names — applying one
+/// elsewhere is a compile error.
+///
+/// - `ts_optional` — on an `Option<T>` field, writes the optional TypeScript key `field?: T`
+///   instead of the default `field: T | undefined`. TypeScript-only; Zod and JSON Schema are
+///   unchanged.
+/// - `as_number` — on a `DateTime<Tz>` field, renders an epoch-millisecond `number` with an
+///   inline Zod coercer instead of the default `Date`.
+/// - `nullable` — on an `Option<T>` field, renders `T | null` with the key **required** on
+///   TypeScript, Zod and JSON Schema, instead of the default `T | undefined` with the key
+///   dropped for a `None`. Refused together with `ts_optional` — the two disagree about the key.
+///   With the `serde` feature on, the field must never carry a key-dropping serde attribute
+///   (`skip_serializing_if`, `skip_serializing`, `skip`): `nullable` declares the key always
+///   written, so serde has to write `null` for a `None` rather than omit the key, and the guard
+///   naming that pairing is the mirror of the one that requires such an attribute on a bare
+///   `Option<T>` field with no `nullable`.
 #[proc_macro_attribute]
 pub fn model_schema_prop(_args: TokenStream, input: TokenStream) -> TokenStream {
     // For now, simply pass through the input

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -7027,7 +7027,7 @@ fn close_untagged_flatten_member(member: &str, excluded: &[String]) -> String {
 fn untagged_named_json_value(field_defs: &[FieldDef]) -> proc_macro2::TokenStream {
     let property_inserts = field_defs.iter().map(|fld| {
         let name_str = fld.name.clone();
-        let value = field_json_schema_value(fld);
+        let value = nullable_slot_json_schema_value(fld, field_json_schema_value(fld));
         let required_insert = if fld.key_is_required() {
             quote! {
                 required.push(serde_json::Value::String(#name_str.to_string()));
@@ -7249,6 +7249,7 @@ fn untagged_member_field_def(
         field,
         field_name,
         field_def.is_optional(),
+        prop_meta.nullable,
         serde_field_meta,
         ctx.container_defaulted,
         positional_constraint_error,
@@ -7802,7 +7803,10 @@ fn generate_type_schema(
     field_name_str: &str,
     type_json_schema: &proc_macro2::TokenStream,
 ) -> proc_macro2::TokenStream {
-    let schema = arrayed_json_schema_value(fld, type_json_schema.clone());
+    let schema = nullable_slot_json_schema_value(
+        fld,
+        arrayed_json_schema_value(fld, type_json_schema.clone()),
+    );
     quote! {
         properties.insert(#field_name_str.to_string(), #schema);
     }
@@ -8310,10 +8314,10 @@ fn build_tuple_element_base_json_schema(
     Ok(arrayed_json_schema_value(&value, item.into_value()))
 }
 
-/// The `anyOf [<base>, null]` form for a value in a slot that cannot be dropped — a tuple element
-/// or a map entry — or `None` when the value is not an `Option`. Only an object key can be
-/// omitted; in either of these positions serde writes a `None` as JSON `null`, so the schema has
-/// to admit it.
+/// The `anyOf [<base>, null]` form for a value that is an `Option`, or `None` when it is not. A
+/// slot that cannot be dropped — a tuple element or a map entry — needs it because there is no
+/// other way to write a `None` there; an object key needs it too, because serde reads an explicit
+/// `null` into `None` exactly as readily as an absent key.
 #[cfg(feature = "jsonschema")]
 fn nullable_slot_json_schema(
     fld: &FieldDef,
@@ -9002,7 +9006,8 @@ fn build_map_field_schema(
 
     match map_json_schema_value(key, value) {
         Ok(map_schema) => {
-            let field_schema = arrayed_json_schema_value(fld, map_schema);
+            let field_schema =
+                nullable_slot_json_schema_value(fld, arrayed_json_schema_value(fld, map_schema));
             quote! {
                 properties.insert(#field_name_str.to_string(), #field_schema);
             }
@@ -9038,7 +9043,10 @@ fn build_string_field_schema(fld: &FieldDef, field_name_str: &str) -> proc_macro
         quote! { schema_obj.insert("pattern".to_string(), serde_json::json!(#pattern)); }
     });
 
-    let schema = arrayed_json_schema_value(fld, quote! { serde_json::Value::Object(schema_obj) });
+    let schema = nullable_slot_json_schema_value(
+        fld,
+        arrayed_json_schema_value(fld, quote! { serde_json::Value::Object(schema_obj) }),
+    );
     quote! {
         properties.insert(#field_name_str.to_string(), {
             let mut schema_obj = serde_json::Map::new();
@@ -9058,9 +9066,12 @@ fn build_string_literal_field_schema(
     field_name_str: &str,
     literal: &str,
 ) -> proc_macro2::TokenStream {
-    let schema = arrayed_json_schema_value(
+    let schema = nullable_slot_json_schema_value(
         fld,
-        quote! { serde_json::json!({ "type": "string", "const": #literal }) },
+        arrayed_json_schema_value(
+            fld,
+            quote! { serde_json::json!({ "type": "string", "const": #literal }) },
+        ),
     );
     quote! {
         properties.insert(#field_name_str.to_string(), { #schema });
@@ -9083,7 +9094,10 @@ fn build_numeric_field_schema(
         quote! { schema_obj.insert("maximum".to_string(), serde_json::json!(#max)); }
     });
 
-    let schema = arrayed_json_schema_value(fld, quote! { serde_json::Value::Object(schema_obj) });
+    let schema = nullable_slot_json_schema_value(
+        fld,
+        arrayed_json_schema_value(fld, quote! { serde_json::Value::Object(schema_obj) }),
+    );
     quote! {
         properties.insert(#field_name_str.to_string(), {
             let mut schema_obj = serde_json::Map::new();
@@ -9098,8 +9112,10 @@ fn build_numeric_field_schema(
 /// Builds the JSON schema for a `bool` field.
 #[cfg(feature = "jsonschema")]
 fn build_boolean_field_schema(fld: &FieldDef, field_name_str: &str) -> proc_macro2::TokenStream {
-    let schema =
-        arrayed_json_schema_value(fld, quote! { serde_json::json!({ "type": "boolean" }) });
+    let schema = nullable_slot_json_schema_value(
+        fld,
+        arrayed_json_schema_value(fld, quote! { serde_json::json!({ "type": "boolean" }) }),
+    );
     quote! {
         properties.insert(#field_name_str.to_string(), { #schema });
     }
@@ -9110,9 +9126,12 @@ fn build_boolean_field_schema(fld: &FieldDef, field_name_str: &str) -> proc_macr
 /// carries none of those constraints.
 #[cfg(feature = "jsonschema")]
 fn build_char_field_schema(fld: &FieldDef, field_name_str: &str) -> proc_macro2::TokenStream {
-    let schema = arrayed_json_schema_value(
+    let schema = nullable_slot_json_schema_value(
         fld,
-        quote! { serde_json::json!({ "type": "string", "minLength": 1, "maxLength": 1 }) },
+        arrayed_json_schema_value(
+            fld,
+            quote! { serde_json::json!({ "type": "string", "minLength": 1, "maxLength": 1 }) },
+        ),
     );
     quote! {
         properties.insert(#field_name_str.to_string(), { #schema });
@@ -9181,9 +9200,12 @@ fn object_id_hex_json_schema() -> proc_macro2::TokenStream {
 /// Builds the JSON schema for a `MongoDB` `ObjectId` field (`{ "$oid": string }`).
 #[cfg(all(feature = "jsonschema", feature = "object_id"))]
 fn build_object_id_field_schema(fld: &FieldDef, field_name_str: &str) -> proc_macro2::TokenStream {
-    let schema = arrayed_json_schema_value(
+    let schema = nullable_slot_json_schema_value(
         fld,
-        object_id_json_schema_value(&object_id_hex_json_schema()),
+        arrayed_json_schema_value(
+            fld,
+            object_id_json_schema_value(&object_id_hex_json_schema()),
+        ),
     );
     quote! {
         properties.insert(#field_name_str.to_string(), { #schema });
@@ -9197,9 +9219,12 @@ fn build_string_format_field_schema(
     field_name_str: &str,
     format: &str,
 ) -> proc_macro2::TokenStream {
-    let schema = arrayed_json_schema_value(
+    let schema = nullable_slot_json_schema_value(
         fld,
-        quote! { serde_json::json!({ "type": "string", "format": #format }) },
+        arrayed_json_schema_value(
+            fld,
+            quote! { serde_json::json!({ "type": "string", "format": #format }) },
+        ),
     );
     quote! {
         properties.insert(#field_name_str.to_string(), { #schema });
@@ -9218,7 +9243,7 @@ fn build_tuple_field_schema(
         Err(rejection) => return map_member_rejection_error(field_name_str, &rejection),
     };
 
-    let schema = arrayed_json_schema_value(fld, tuple_schema);
+    let schema = nullable_slot_json_schema_value(fld, arrayed_json_schema_value(fld, tuple_schema));
     quote! {
         properties.insert(#field_name_str.to_string(), #schema);
     }
@@ -9231,7 +9256,10 @@ fn build_tuple_field_schema(
 fn build_unknown_field_schema(fld: &FieldDef, field_name_str: &str) -> proc_macro2::TokenStream {
     log::trace!("Unknown => field_name: {field_name_str}, fld: {fld:?}");
 
-    let schema = arrayed_json_schema_value(fld, opaque_json_schema_value(fld));
+    let schema = nullable_slot_json_schema_value(
+        fld,
+        arrayed_json_schema_value(fld, opaque_json_schema_value(fld)),
+    );
     quote! {
         properties.insert(#field_name_str.to_string(), #schema);
     }
@@ -9941,6 +9969,28 @@ fn validate_ts_optional_flag(field_optional: bool, flag_set: bool) -> Result<(),
     Ok(())
 }
 
+fn validate_nullable_flag(field_optional: bool, flag_set: bool) -> Result<(), String> {
+    if flag_set && !field_optional {
+        return Err("#[model_schema_prop(nullable)] requires an Option<T> field".into());
+    }
+    Ok(())
+}
+
+/// Rejects `nullable` written beside `ts_optional`: the two disagree about the key.
+/// `nullable` keeps it and writes `null` for a `None`; `ts_optional` drops it entirely. Together
+/// they would spell `field?: T | null`, a third state neither flag models.
+fn check_nullable_ts_optional_conflict(flags: &ModelSchemaPropMeta) -> Result<(), String> {
+    if flags.nullable && flags.ts_optional {
+        return Err(
+            "#[model_schema_prop(nullable)] and ts_optional cannot be written together: nullable \
+             keeps the key and writes `null` for a `None`, ts_optional drops the key entirely. \
+             Pick the one the wire actually carries."
+                .into(),
+        );
+    }
+    Ok(())
+}
+
 /// The field's ident as a string, empty for a positional slot that has none.
 fn field_ident_string(field: &Field) -> String {
     field
@@ -9967,22 +10017,49 @@ fn push_described_field(field_defs: &mut Vec<FieldDef>, field_def: FieldDef) {
     }
 }
 
-/// Rejects a named `Option` field whose serde attributes let a `None` reach the wire as `null`.
+/// Rejects a named `Option` field whose serde attributes let a `None` reach the wire as `null`,
+/// unless `nullable` already declares that shape on the author's word.
 #[cfg(feature = "serde")]
-fn check_optional_field_serialization(field: &Field, is_optional: bool) -> Result<(), syn::Error> {
+fn check_optional_field_serialization(
+    field: &Field,
+    is_optional: bool,
+    is_nullable: bool,
+) -> Result<(), syn::Error> {
     let Some(ident) = field.ident.as_ref() else {
         return Ok(());
     };
-    if !is_optional || parse_serde_key_omission(&field.attrs).omits_key {
+    if !is_optional || is_nullable || parse_serde_key_omission(&field.attrs).omits_key {
         return Ok(());
     }
     Err(syn::Error::new_spanned(
         field,
         format!(
-            "model_schema: field `{ident}` is `Option` but is serialized as `null` when `None`, \
-             while the generated schema only accepts the key being absent. Add \
-             #[serde(skip_serializing_if = \"Option::is_none\")] (plus `default` if the type \
-             derives Deserialize), or `skip` / `skip_serializing`."
+            "model_schema: field `{ident}` is `Option`, so its declared shape is `{ident}: T | \
+             undefined` — the key is dropped for a `None`, not written as `null`. serde writes \
+             `null` unless told otherwise. Add #[serde(skip_serializing_if = \"Option::is_none\")] \
+             (plus `default` if the type derives Deserialize), or `skip` / `skip_serializing` — or \
+             declare #[model_schema_prop(nullable)] if the wire really does carry `null` here."
+        ),
+    ))
+}
+
+/// Rejects a `nullable` field whose serde attributes drop the key the flag says is always
+/// written.
+#[cfg(feature = "serde")]
+fn check_nullable_field_serialization(field: &Field, is_nullable: bool) -> Result<(), syn::Error> {
+    let Some(ident) = field.ident.as_ref() else {
+        return Ok(());
+    };
+    if !is_nullable || !parse_serde_key_omission(&field.attrs).omits_key {
+        return Ok(());
+    }
+    Err(syn::Error::new_spanned(
+        field,
+        format!(
+            "model_schema: field `{ident}` is declared #[model_schema_prop(nullable)], so its key \
+             is always written and a `None` reaches the wire as `null` — but its serde attribute \
+             drops the key instead, and the generated schema requires it. Remove the key-dropping \
+             attribute, or drop the `nullable` flag."
         ),
     ))
 }
@@ -10020,14 +10097,16 @@ fn check_omitted_key_is_readable(
 
 /// The serde-read guard errors the field violates.
 ///
-/// A hidden serde attribute leaves every serde-read diagnostic unreliable — the `Option`-null guard
-/// included, since the wrapper is exactly what kept its evidence out of the meta. The
-/// positional-constraint guard reads no serde attribute, so it stands whatever the wrapper hid.
+/// A hidden serde attribute leaves every serde-read diagnostic unreliable — the `Option`-null and
+/// `nullable`-key guards included, since the wrapper is exactly what kept its evidence out of the
+/// meta. The positional-constraint guard reads no serde attribute, so it stands whatever the
+/// wrapper hid.
 #[cfg(feature = "serde")]
 fn field_guard_errors(
     field: &Field,
     raw_field_ident: &str,
     is_optional: bool,
+    is_nullable: bool,
     serde_field_meta: &SerdeFieldMeta,
     container_defaulted: bool,
     positional_constraint_error: Option<proc_macro2::TokenStream>,
@@ -10036,7 +10115,8 @@ fn field_guard_errors(
         .into_iter()
         .chain(serde_field_meta.cfg_attr_rejection.as_ref().map_or_else(
             || {
-                check_optional_field_serialization(field, is_optional)
+                check_optional_field_serialization(field, is_optional, is_nullable)
+                    .and_then(|()| check_nullable_field_serialization(field, is_nullable))
                     .and_then(|()| {
                         check_omitted_key_is_readable(field, is_optional, container_defaulted)
                     })
@@ -10091,7 +10171,7 @@ fn collect_field_guard_errors(
 
 /// Every guard the field's `model_schema_prop` attribute earns: what the parser refused, then an
 /// unparseable `pattern`, then a bound written where the type renders none, an `as` naming a type
-/// the field is not written as, and the three misuses the flag validators answer for.
+/// the field is not written as, and the misuses the flag validators answer for.
 fn model_schema_prop_guard_errors(
     field: &Field,
     field_def: &FieldDef,
@@ -10113,6 +10193,12 @@ fn model_schema_prop_guard_errors(
             label,
             validate_as_number_flag(&field_def.field_type, prop_meta.as_number),
         ),
+        flag_guard_error(
+            field,
+            label,
+            validate_nullable_flag(field_def.is_optional(), prop_meta.nullable),
+        ),
+        flag_guard_error(field, label, check_nullable_ts_optional_conflict(prop_meta)),
     ];
 
     prop_meta
@@ -10379,6 +10465,7 @@ fn process_field(
         field,
         &raw_field_ident,
         field_def.is_optional(),
+        model_schema_prop_meta.nullable,
         &serde_field_meta,
         ctx.container_defaulted,
         positional_constraint_error,
@@ -10540,6 +10627,7 @@ fn apply_model_schema_prop_meta(
         || prop_meta.maximum.is_some()
         || prop_meta.ts_optional
         || prop_meta.as_number
+        || prop_meta.nullable
         || !prop_meta.preprocess.is_empty())
     .then_some(prop_meta);
 

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -1,13 +1,13 @@
 use super::{
-    FieldDefType, check_os_string_field, collect_discriminated_variants, field_label,
-    get_field_def, render_discriminated_variants, validate_as_number_flag,
-    validate_ts_optional_flag,
+    FieldDefType, ModelSchemaPropMeta, check_nullable_ts_optional_conflict, check_os_string_field,
+    collect_discriminated_variants, field_label, get_field_def, render_discriminated_variants,
+    validate_as_number_flag, validate_nullable_flag, validate_ts_optional_flag,
 };
 
 #[cfg(feature = "serde")]
 use super::{
-    ConstraintLeaf, MemberAccess, ModelSchemaPropMeta, adjacent_collapsed_slot_guard_errors,
-    build_field_validation, cfg_attr_guard_error, check_omitted_key_is_readable,
+    ConstraintLeaf, MemberAccess, adjacent_collapsed_slot_guard_errors, build_field_validation,
+    cfg_attr_guard_error, check_nullable_field_serialization, check_omitted_key_is_readable,
     check_optional_field_serialization, collect_untagged_members, constrained_shape,
     enum_cfg_attr_guard_errors, generate_field_validation, generate_numeric_validation_code,
     generate_string_validation_code, has_serde_default, helper_name_stem,
@@ -152,8 +152,53 @@ fn as_number_err_on_non_datetime_field() {
     assert!(err.contains("DateTime<Tz>"));
 }
 
-/// Runs the guard over the sole field of `item`, deriving `is_optional` the way the generator
-/// does rather than re-sniffing the type.
+#[test]
+fn nullable_ok_on_option_field() {
+    validate_nullable_flag(true, true).unwrap();
+}
+
+#[test]
+fn nullable_ok_when_flag_unset() {
+    validate_nullable_flag(true, false).unwrap();
+    validate_nullable_flag(false, false).unwrap();
+}
+
+#[test]
+fn nullable_err_on_non_option_field() {
+    let err = validate_nullable_flag(false, true).unwrap_err();
+    assert!(err.contains("nullable"));
+    assert!(err.contains("Option<T>"));
+}
+
+#[test]
+fn nullable_ts_optional_conflict_err_when_both_set() {
+    let flags = ModelSchemaPropMeta {
+        nullable: true,
+        ts_optional: true,
+        ..ModelSchemaPropMeta::default()
+    };
+    let err = check_nullable_ts_optional_conflict(&flags).unwrap_err();
+    assert!(err.contains("nullable"));
+    assert!(err.contains("ts_optional"));
+}
+
+#[test]
+fn nullable_ts_optional_conflict_ok_when_only_one_set() {
+    check_nullable_ts_optional_conflict(&ModelSchemaPropMeta {
+        nullable: true,
+        ..ModelSchemaPropMeta::default()
+    })
+    .unwrap();
+    check_nullable_ts_optional_conflict(&ModelSchemaPropMeta {
+        ts_optional: true,
+        ..ModelSchemaPropMeta::default()
+    })
+    .unwrap();
+    check_nullable_ts_optional_conflict(&ModelSchemaPropMeta::default()).unwrap();
+}
+
+/// Runs the guard over the sole field of `item`, deriving `is_optional` and `is_nullable` the way
+/// the generator does rather than re-sniffing the type.
 #[cfg(feature = "serde")]
 fn guard_result(item: &syn::ItemStruct) -> Result<(), syn::Error> {
     let field = item.fields.iter().next().unwrap();
@@ -163,7 +208,17 @@ fn guard_result(item: &syn::ItemStruct) -> Result<(), syn::Error> {
         .map(ToString::to_string)
         .unwrap_or_default();
     let field_def = get_field_def(&field_name, &field.ty, "");
-    check_optional_field_serialization(field, field_def.is_optional())
+    let is_nullable = super::parse_model_schema_prop_attributes(&field.attrs).nullable;
+    check_optional_field_serialization(field, field_def.is_optional(), is_nullable)
+}
+
+/// Runs the `nullable`-key guard over the sole field of `item`, reading the flag off its
+/// `model_schema_prop` attribute the way the generator does.
+#[cfg(feature = "serde")]
+fn nullable_guard_result(item: &syn::ItemStruct) -> Result<(), syn::Error> {
+    let field = item.fields.iter().next().unwrap();
+    let is_nullable = super::parse_model_schema_prop_attributes(&field.attrs).nullable;
+    check_nullable_field_serialization(field, is_nullable)
 }
 
 /// Runs the omitted-key readability guard over the sole field of `item`, with the container's own
@@ -194,7 +249,69 @@ fn bare_option_field_is_rejected() {
     };
     let message = guard_result(&item).unwrap_err().to_string();
     assert!(message.contains("note"));
+    assert!(message.contains("T | undefined"));
     assert!(message.contains("skip_serializing_if = \"Option::is_none\""));
+    assert!(message.contains("nullable"));
+    assert!(!message.contains("only accepts the key being absent"));
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn bare_nullable_option_field_is_accepted() {
+    let item: syn::ItemStruct = syn::parse_quote! {
+        struct Report {
+            #[model_schema_prop(nullable)]
+            note: Option<String>,
+        }
+    };
+    guard_result(&item).unwrap();
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn nullable_field_with_a_key_dropping_attribute_is_rejected() {
+    for spelling in [
+        "skip_serializing_if = \"Option::is_none\"",
+        "skip_serializing",
+        "skip",
+    ] {
+        let item: syn::ItemStruct = syn::parse_str(&format!(
+            "struct Report {{ #[model_schema_prop(nullable)] #[serde({spelling})] note: \
+             Option<String> }}"
+        ))
+        .unwrap();
+        let message = nullable_guard_result(&item).unwrap_err().to_string();
+        assert!(message.contains("note"), "{spelling}: {message}");
+        assert!(message.contains("nullable"), "{spelling}: {message}");
+        assert!(
+            message.contains("key-dropping attribute"),
+            "{spelling}: {message}"
+        );
+    }
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn nullable_field_with_no_key_dropping_attribute_is_accepted() {
+    let item: syn::ItemStruct = syn::parse_quote! {
+        struct Report {
+            #[model_schema_prop(nullable)]
+            note: Option<String>,
+        }
+    };
+    nullable_guard_result(&item).unwrap();
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn non_nullable_field_with_a_key_dropping_attribute_passes_the_nullable_guard() {
+    let item: syn::ItemStruct = syn::parse_quote! {
+        struct Report {
+            #[serde(skip_serializing_if = "Option::is_none")]
+            note: Option<String>,
+        }
+    };
+    nullable_guard_result(&item).unwrap();
 }
 
 /// Read off serde itself: a `Vec` behind a `skip_serializing_if` and nothing else serializes to
@@ -2687,7 +2804,7 @@ fn declared_default_renders_each_wrapped_shape_the_table_describes() {
             "IdType",
             quote::quote! { Option<DocumentId<String>> },
             "z.lazy(() => \
-             z.union([DocumentId$SchemaFactory(z.string()), z.undefined()]).prefault(undefined))",
+             z.union([z.null().transform(() => undefined), DocumentId$SchemaFactory(z.string()), z.undefined()]).prefault(undefined))",
         ),
         (
             "IdType",
@@ -7063,7 +7180,6 @@ fn a_sequence_wrapped_map_field_describes_as_the_array_of_the_map_it_holds() {
     for (map_type, wrapped_type) in [
         ("HashMap<String, u64>", "Vec<HashMap<String, u64>>"),
         ("HashMap<String, u64>", "VecDeque<HashMap<String, u64>>"),
-        ("HashMap<String, u64>", "Option<Vec<HashMap<String, u64>>>"),
         ("HashMap<Slot, u64>", "Vec<HashMap<Slot, u64>>"),
         (
             "HashMap<Slot, Vec<u64>>",
@@ -7084,6 +7200,22 @@ fn a_sequence_wrapped_map_field_describes_as_the_array_of_the_map_it_holds() {
     }
 }
 
+/// An `Option` around the wrapper is the field's own key-position optionality, which now widens the
+/// array with the same `anyOf [<base>, null]` every other optional key gets, on top of the wrap this
+/// test's unwrapped cases already prove.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn an_optional_sequence_wrapped_map_field_widens_the_array_with_null() {
+    let array = format!(
+        r#"serde_json :: json ! ({{ "type" : "array" , "items" : {} }})"#,
+        inserted_field_value("HashMap<String, u64>")
+    );
+    assert_eq!(
+        inserted_field_value("Option<Vec<HashMap<String, u64>>>"),
+        format!(r#"serde_json :: json ! ({{ "anyOf" : [{array} , {{ "type" : "null" }}] }})"#)
+    );
+}
+
 /// An `Option` the sequence holds is not the field's: the array is written either way, and the
 /// `None` lands among its items — so the map's own rendering is what admits the `null`, one level
 /// inside the array wrap rather than around it.
@@ -7100,8 +7232,6 @@ fn a_sequence_of_optional_maps_admits_the_null_among_its_items() {
 }
 
 /// A map named without a sequence wrapper describes exactly as it always has, on every key path.
-/// An `Option` around one is not such a wrapper: field position spells optionality by leaving the
-/// name out of `required`, as it does for every other field type, so the map itself is untouched.
 #[cfg(feature = "jsonschema")]
 #[test]
 fn an_unwrapped_map_field_keeps_the_object_it_has_always_described_as() {
@@ -7109,21 +7239,43 @@ fn an_unwrapped_map_field_keeps_the_object_it_has_always_described_as() {
     for (map_type, expected) in [
         ("HashMap<String, u64>", string_keyed),
         ("BTreeMap<String, u64>", string_keyed),
-        ("Option<HashMap<String, u64>>", string_keyed),
         (
             "HashMap<u32, u64>",
             r#"serde_json :: json ! ({ "type" : "object" , "additionalProperties" : true })"#,
+        ),
+    ] {
+        assert_eq!(inserted_field_value(map_type), expected, "for {map_type}");
+    }
+}
+
+/// An `Option` around an unwrapped map is not a sequence wrapper, but it is still the field's own
+/// key-position optionality — so, like every other optional key, it widens the map's own rendering
+/// with `anyOf [<base>, null]` rather than leaving it untouched.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn an_optional_unwrapped_map_field_widens_the_object_with_null() {
+    for (map_type, base) in [
+        (
+            "Option<HashMap<String, u64>>",
+            r#"serde_json :: json ! ({ "type" : "object" , "additionalProperties" : { "type" : "integer" } })"#,
         ),
         (
             "Option<HashMap<u32, u64>>",
             r#"serde_json :: json ! ({ "type" : "object" , "additionalProperties" : true })"#,
         ),
     ] {
-        assert_eq!(inserted_field_value(map_type), expected, "for {map_type}");
+        assert_eq!(
+            inserted_field_value(map_type),
+            format!(r#"serde_json :: json ! ({{ "anyOf" : [{base} , {{ "type" : "null" }}] }})"#),
+            "for {map_type}"
+        );
     }
     assert_eq!(
         inserted_field_value("Option<HashMap<Slot, u64>>"),
-        inserted_field_value("HashMap<Slot, u64>")
+        format!(
+            r#"serde_json :: json ! ({{ "anyOf" : [{} , {{ "type" : "null" }}] }})"#,
+            inserted_field_value("HashMap<Slot, u64>")
+        )
     );
 }
 

--- a/tests/advanced_tests/tests.rs
+++ b/tests/advanced_tests/tests.rs
@@ -351,7 +351,9 @@ fn test_complex_nested_ts_definition() {
     assert!(company_zod_schema.contains("department_names: z.array(z.string())"));
     assert!(company_zod_schema.contains("headquarters: Address$Schema"));
     assert!(company_zod_schema.contains("get settings() { return CompanySettings$Schema; },"));
-    assert!(employee_zod_schema.contains("manager: z.union([z.string(), z.undefined()])"));
+    assert!(employee_zod_schema.contains(
+        "manager: z.union([z.null().transform(() => undefined), z.string(), z.undefined()])"
+    ));
 }
 
 #[test]
@@ -454,21 +456,21 @@ fn test_edge_cases_ts_definition() {
             ("booleans", "z.array(z.boolean())"),
             (
                 "optional_strings",
-                "z.union([z.array(z.string()), z.undefined()])",
+                "z.union([z.null().transform(() => undefined), z.array(z.string()), z.undefined()])",
             ),
             (
                 "optional_numbers",
-                "z.union([z.array(z.number().int()), z.undefined()])",
+                "z.union([z.null().transform(() => undefined), z.array(z.number().int()), z.undefined()])",
             ),
             ("string_map", "z.record(z.string(), z.string())"),
             (
                 "nested_optional",
-                "z.union([ContactInfo$Schema, z.undefined()])",
+                "z.union([z.null().transform(() => undefined), ContactInfo$Schema, z.undefined()])",
             ),
             ("nested_array", "z.array(ContactInfo$Schema)"),
             (
                 "optional_nested_array",
-                "z.union([z.array(ContactInfo$Schema), z.undefined()])",
+                "z.union([z.null().transform(() => undefined), z.array(ContactInfo$Schema), z.undefined()])",
             ),
         ],
     );

--- a/tests/basic_tests/tests.rs
+++ b/tests/basic_tests/tests.rs
@@ -193,9 +193,15 @@ fn test_optional_fields_ts_definition() {
 fn test_optional_fields_zod_schema() {
     let zod_schema = UserWithOptionals::zod_schema();
 
-    assert!(zod_schema.contains("email: z.union([z.string(), z.undefined()])"));
-    assert!(zod_schema.contains("age: z.union([z.number().int(), z.undefined()])"));
-    assert!(zod_schema.contains("nickname: z.union([z.string(), z.undefined()])"));
+    assert!(zod_schema.contains(
+        "email: z.union([z.null().transform(() => undefined), z.string(), z.undefined()])"
+    ));
+    assert!(zod_schema.contains(
+        "age: z.union([z.null().transform(() => undefined), z.number().int(), z.undefined()])"
+    ));
+    assert!(zod_schema.contains(
+        "nickname: z.union([z.null().transform(() => undefined), z.string(), z.undefined()])"
+    ));
 
     assert!(!zod_schema.contains("email: string | undefined;"));
     assert!(!zod_schema.contains("age: number | undefined;"));

--- a/tests/branded_newtype_tests/tests.rs
+++ b/tests/branded_newtype_tests/tests.rs
@@ -1976,7 +1976,9 @@ mod branded_sibling_inner_tests {
                         "additionalProperties": false,
                         "properties": {
                             "name": { "type": "string" },
-                            "next": { "$ref": "#/$defs/ChainRef" }
+                            "next": {
+                                "anyOf": [{ "$ref": "#/$defs/ChainRef" }, { "type": "null" }]
+                            }
                         },
                         "required": ["name"]
                     }

--- a/tests/chrono_tests/tests.rs
+++ b/tests/chrono_tests/tests.rs
@@ -412,8 +412,11 @@ fn test_datetime_local_zod() {
 fn test_optional_datetime_zod() {
     let zod = OptionalTimestamp::zod_schema();
     assert!(
-        zod.contains("updated_at: z.union([z.coerce.date(), z.undefined()]).prefault(undefined),"),
-        "Option<DateTime<Utc>> should use z.union([z.coerce.date(), z.undefined()]). Got: {zod}"
+        zod.contains(
+            "updated_at: z.union([z.null().transform(() => undefined), z.coerce.date(), z.undefined()]).prefault(undefined),"
+        ),
+        "Option<DateTime<Utc>> should use z.union([z.null().transform(() => undefined), \
+         z.coerce.date(), z.undefined()]). Got: {zod}"
     );
 }
 

--- a/tests/collection_tests/tests.rs
+++ b/tests/collection_tests/tests.rs
@@ -2465,7 +2465,6 @@ fn test_wrapped_map_fields_write_arrays_of_their_map() {
 fn test_wrapped_map_fields_describe_as_arrays_of_their_map() {
     let properties = wrapped_map_fields_properties();
     for (wrapped, unwrapped) in [
-        ("optional_wrapped_labels", "labels"),
         ("wrapped_bucket_counts", "bucket_counts"),
         ("wrapped_labels", "labels"),
         ("wrapped_raw_keyed_counts", "raw_keyed_counts"),
@@ -2477,11 +2476,24 @@ fn test_wrapped_map_fields_describe_as_arrays_of_their_map() {
             properties[wrapped]
         );
     }
+    // The field's own `Option` widens the key position with `null`, on top of the array wrap the
+    // loop above already proves.
+    assert_eq!(
+        properties["optional_wrapped_labels"],
+        serde_json::json!({
+            "anyOf": [
+                { "type": "array", "items": properties["labels"] },
+                { "type": "null" }
+            ]
+        }),
+        "for optional_wrapped_labels, got: {}",
+        properties["optional_wrapped_labels"]
+    );
 }
 
 /// A map named without a sequence wrapper keeps the object it has always described as, on every key
-/// path — including behind an `Option`, which field position spells by leaving the name out of
-/// `required` rather than by admitting a `null`.
+/// path — including behind an `Option`, which field position now widens with `anyOf [<base>, null]`
+/// just as every other optional key does, on top of the name staying out of `required`.
 #[test]
 #[cfg(feature = "jsonschema")]
 fn test_unwrapped_map_fields_keep_the_object_they_describe_as() {
@@ -2495,7 +2507,10 @@ fn test_unwrapped_map_fields_keep_the_object_they_describe_as() {
         serde_json::json!({ "type": "object", "additionalProperties": true })
     );
     assert_eq!(properties["bucket_counts"], bucket_keyed_count_map());
-    assert_eq!(properties["optional_labels"], properties["labels"]);
+    assert_eq!(
+        properties["optional_labels"],
+        serde_json::json!({ "anyOf": [properties["labels"], { "type": "null" }] })
+    );
 
     let required = WrappedMapFields::json_schema()["required"]
         .as_array()
@@ -3182,10 +3197,16 @@ fn test_nested_sequences_describe_at_the_depth_they_are_written() {
         "items": { "type": "array", "items": { "type": "integer" } }
     });
 
-    for field in ["optional_rows", "set_of_rows", "small_ids"] {
+    for field in ["set_of_rows", "small_ids"] {
         assert_eq!(properties[field], integer_rows, "for: {field}");
     }
     assert_eq!(properties["vec_of_sets"], integer_rows);
+    // The field's own `Option` widens the key position with the null the outer wrap now admits, on
+    // top of the array nesting every other field in this loop shares.
+    assert_eq!(
+        properties["optional_rows"],
+        serde_json::json!({ "anyOf": [integer_rows, { "type": "null" }] })
+    );
     // Every level of a fixed-size array is the same array of arrays, bounded at each level by the
     // length it was written with.
     assert_eq!(

--- a/tests/fixed_array_tests/tests.rs
+++ b/tests/fixed_array_tests/tests.rs
@@ -103,9 +103,12 @@ fn test_a_fixed_array_describes_its_length_at_the_level_it_bounds() {
     });
     let open_integers = serde_json::json!({ "type": "array", "items": { "type": "integer" } });
 
-    for field in ["ids", "optional_ids"] {
-        assert_eq!(properties[field], three_integers, "for: {field}");
-    }
+    assert_eq!(properties["ids"], three_integers);
+    // The field's own `Option` widens the bounded array with `null` rather than replacing its bound.
+    assert_eq!(
+        properties["optional_ids"],
+        serde_json::json!({ "anyOf": [three_integers, { "type": "null" }] })
+    );
     for field in ["const_ids", "slice_ids"] {
         assert_eq!(properties[field], open_integers, "for: {field}");
     }
@@ -187,7 +190,8 @@ fn test_a_fixed_array_validates_its_length_in_zod() {
     // The field's own optionality wraps the bounded array rather than replacing its bound.
     assert!(
         zod_schema.contains(
-            "optional_ids: z.union([z.array(z.number().int()).length(3), z.undefined()])"
+            "optional_ids: z.union([z.null().transform(() => undefined), \
+             z.array(z.number().int()).length(3), z.undefined()])"
         ),
         "Got: {zod_schema}"
     );

--- a/tests/flatten_tests/tests.rs
+++ b/tests/flatten_tests/tests.rs
@@ -1866,7 +1866,7 @@ fn test_the_overlapping_payload_is_admitted_by_two_branches() {
 fn test_an_overlapping_untagged_flatten_keeps_the_any_of_spelling() {
     assert_eq!(
         serde_json::to_string(&FlatOverOverlap::json_schema()).unwrap(),
-        r#"{"type":"object","anyOf":[{"type":"object","properties":{"own":{"type":"string"},"a":{"type":"string"}},"required":["own","a"],"additionalProperties":false},{"type":"object","properties":{"own":{"type":"string"},"a":{"type":"string"},"b":{"type":"string"}},"required":["own","a"],"additionalProperties":false}]}"#
+        r#"{"type":"object","anyOf":[{"type":"object","properties":{"own":{"type":"string"},"a":{"type":"string"}},"required":["own","a"],"additionalProperties":false},{"type":"object","properties":{"own":{"type":"string"},"a":{"type":"string"},"b":{"anyOf":[{"type":"string"},{"type":"null"}]}},"required":["own","a"],"additionalProperties":false}]}"#
     );
 }
 

--- a/tests/generic_types_tests/tests.rs
+++ b/tests/generic_types_tests/tests.rs
@@ -559,7 +559,8 @@ mod zod {
         assert!(
             zod.contains(
                 "= SlottedDefault$SchemaFactory(z.lazy(() => \
-                 z.union([Tagged$SchemaFactory(z.string()), z.undefined()]).prefault(undefined)));"
+                 z.union([z.null().transform(() => undefined), Tagged$SchemaFactory(z.string()), \
+                 z.undefined()]).prefault(undefined)));"
             ),
             "Got: {zod}"
         );
@@ -1352,7 +1353,8 @@ mod jsonschema {
         assert_eq!(
             serde_json::to_string(&super::Recurring::<String>::json_schema()).unwrap(),
             "{\"$defs\":{\"Recurring\":{\"type\":\"object\",\"additionalProperties\":false,\
-             \"properties\":{\"next\":{\"$ref\":\"#/$defs/Recurring\"},\
+             \"properties\":{\"next\":{\"anyOf\":[{\"$ref\":\"#/$defs/Recurring\"},\
+             {\"type\":\"null\"}]},\
              \"value\":{\"type\":\"string\"}},\"required\":[\"value\"]}},\
              \"$ref\":\"#/$defs/Recurring\"}"
         );

--- a/tests/generic_types_tests/whole_type_tests.rs
+++ b/tests/generic_types_tests/whole_type_tests.rs
@@ -157,7 +157,10 @@ mod zod {
         assert!(zod.contains("  createdAt: dateType,"), "Got: {zod}");
         assert!(zod.contains("  tags: z.array(tagType),"), "Got: {zod}");
         assert!(
-            zod.contains("  byteSize: z.union([sizeType, z.undefined()]).prefault(undefined),"),
+            zod.contains(
+                "  byteSize: z.union([z.null().transform(() => undefined), sizeType, \
+                 z.undefined()]).prefault(undefined),"
+            ),
             "Got: {zod}"
         );
         assert!(
@@ -294,8 +297,9 @@ mod json_schema {
         assert_eq!(
             serde_json::to_string(&ArchiveEntry::<String, f64, String, u32, String>::json_schema())
                 .unwrap(),
-            "{\"type\":\"object\",\"additionalProperties\":false,\"properties\":{\"byteSize\":{\"ty\
-             pe\":\"integer\"},\"createdAt\":{\"type\":\"number\"},\"ownersByRole\":{\"type\":\"obj\
+            "{\"type\":\"object\",\"additionalProperties\":false,\"properties\":{\"byteSize\":{\"an\
+             yOf\":[{\"type\":\"integer\"},{\"type\":\"null\"}]},\"createdAt\":{\"type\":\"number\"\
+             },\"ownersByRole\":{\"type\":\"obj\
              ect\",\"additionalProperties\":{\"type\":\"string\"}},\"stamp\":{\"type\":\"object\",\
              \"additionalProperties\":false,\"properties\":{\"archiveId\":{\"type\":\"string\"}},\"\
              required\":[\"archiveId\"]},\"tags\":{\"type\":\"array\",\"items\":{\"type\":\"string\

--- a/tests/jsonschema_tests/tests.rs
+++ b/tests/jsonschema_tests/tests.rs
@@ -162,9 +162,18 @@ fn test_optional_fields_not_in_required() {
     assert!(properties.contains_key("optional_number"));
     assert!(properties.contains_key("optional_bool"));
 
-    assert_eq!(properties["optional_string"]["type"], "string");
-    assert_eq!(properties["optional_number"]["type"], "integer");
-    assert_eq!(properties["optional_bool"]["type"], "boolean");
+    assert_eq!(
+        properties["optional_string"],
+        serde_json::json!({ "anyOf": [{ "type": "string" }, { "type": "null" }] })
+    );
+    assert_eq!(
+        properties["optional_number"],
+        serde_json::json!({ "anyOf": [{ "type": "integer" }, { "type": "null" }] })
+    );
+    assert_eq!(
+        properties["optional_bool"],
+        serde_json::json!({ "anyOf": [{ "type": "boolean" }, { "type": "null" }] })
+    );
 
     let required = schema["required"].as_array().unwrap();
     assert_eq!(required.len(), 1);
@@ -186,8 +195,15 @@ fn test_vec_fields_generate_array_schemas() {
     assert_eq!(properties["numbers"]["type"], "array");
     assert_eq!(properties["numbers"]["items"]["type"], "integer");
 
-    assert_eq!(properties["optional_array"]["type"], "array");
-    assert_eq!(properties["optional_array"]["items"]["type"], "string");
+    assert_eq!(
+        properties["optional_array"],
+        serde_json::json!({
+            "anyOf": [
+                { "type": "array", "items": { "type": "string" } },
+                { "type": "null" }
+            ]
+        })
+    );
 
     let required = schema["required"].as_array().unwrap();
     assert!(required.contains(&Value::String("tags".to_owned())));
@@ -222,7 +238,10 @@ fn test_opaque_value_fields_generate_permissive_schemas() {
 
     // An opaque field carries no type name, so it admits any value.
     assert_eq!(properties["payload"], serde_json::json!({}));
-    assert_eq!(properties["optional_payload"], serde_json::json!({}));
+    assert_eq!(
+        properties["optional_payload"],
+        serde_json::json!({ "anyOf": [{}, { "type": "null" }] })
+    );
 
     assert_eq!(properties["payloads"]["type"], "array");
     assert_eq!(properties["payloads"]["items"], serde_json::json!({}));
@@ -358,11 +377,12 @@ fn test_complex_nested_collections() {
     assert_eq!(map_of_arrays_additional["items"]["type"], "string");
 
     // Option<HashMap<String, i32>>
-    assert_eq!(properties["optional_map"]["type"], "object");
+    assert_eq!(properties["optional_map"]["anyOf"][0]["type"], "object");
     assert_eq!(
-        properties["optional_map"]["additionalProperties"]["type"],
+        properties["optional_map"]["anyOf"][0]["additionalProperties"]["type"],
         "integer"
     );
+    assert_eq!(properties["optional_map"]["anyOf"][1]["type"], "null");
 
     let required = schema["required"].as_array().unwrap();
     assert!(required.contains(&Value::String("map_of_arrays".to_owned())));
@@ -394,8 +414,12 @@ fn test_objectid_generates_proper_schema() {
     assert_eq!(id_prop["additionalProperties"], false);
 
     let author_prop = &properties["author_id"];
-    assert_eq!(author_prop["type"], "object");
-    assert_eq!(author_prop["properties"]["$oid"]["type"], "string");
+    assert_eq!(author_prop["anyOf"][0]["type"], "object");
+    assert_eq!(
+        author_prop["anyOf"][0]["properties"]["$oid"]["type"],
+        "string"
+    );
+    assert_eq!(author_prop["anyOf"][1]["type"], "null");
 
     // Vec<ObjectId>
     let tags_prop = &properties["tag_ids"];

--- a/tests/model_schema_prop_tests/tests.rs
+++ b/tests/model_schema_prop_tests/tests.rs
@@ -199,6 +199,46 @@ enum TsOptionalVariant {
     },
 }
 
+/// `f` and `h` carry no key-dropping serde attribute: `nullable` requires the key always be
+/// written, so serde writes `null` for a `None` rather than omitting the key. `g` is the control,
+/// left in the default flavor with the key-dropping attribute the default guard requires.
+#[cfg(all(
+    test,
+    any(
+        feature = "typescript",
+        feature = "jsonschema",
+        feature = "zod",
+        feature = "serde"
+    )
+))]
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct NullableStruct {
+    #[model_schema_prop(nullable)]
+    pub f: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub g: Option<String>,
+    #[model_schema_prop(nullable, preprocess = ["trim"])]
+    pub h: Option<String>,
+}
+
+#[cfg(all(
+    test,
+    any(
+        feature = "typescript",
+        feature = "jsonschema",
+        feature = "zod",
+        feature = "serde"
+    )
+))]
+#[model_schema(default_types(IdType = String))]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct NullableGeneric<IdType> {
+    #[model_schema_prop(nullable)]
+    pub id: Option<IdType>,
+    pub name: String,
+}
+
 /// The member an `Option` field written with a `skip_serializing_if` renders as. The attribute
 /// decides the wire, not the spelling, and none of these fields carries `ts_optional`.
 #[cfg(feature = "typescript")]
@@ -268,6 +308,17 @@ fn test_model_schema_prop_structs_constructible() {
         h: None,
     };
     assert!(ts_optional.f.is_none());
+    let nullable = NullableStruct {
+        f: None,
+        g: None,
+        h: None,
+    };
+    assert!(nullable.f.is_none());
+    let nullable_generic = NullableGeneric {
+        name: String::new(),
+        id: None::<String>,
+    };
+    assert!(nullable_generic.id.is_none());
 }
 
 #[cfg(all(
@@ -379,10 +430,10 @@ fn test_optional_literal_typescript() {
 fn test_optional_literal_zod() {
     let zod_schema = OptionalLiteral::zod_schema();
 
-    assert!(
-        zod_schema
-            .contains("optional_type: z.union([z.literal(\"optional_literal\"), z.undefined()])")
-    );
+    assert!(zod_schema.contains(
+        "optional_type: z.union([z.null().transform(() => undefined), \
+         z.literal(\"optional_literal\"), z.undefined()])"
+    ));
     assert!(zod_schema.contains("id: z.string()"));
 }
 
@@ -447,7 +498,9 @@ fn test_min_length_zod() {
 
     assert!(zod_schema.contains("description: z.string(),"));
 
-    assert!(zod_schema.contains("nickname: z.union([z.string().min(3), z.undefined()])"));
+    assert!(zod_schema.contains(
+        "nickname: z.union([z.null().transform(() => undefined), z.string().min(3), z.undefined()])"
+    ));
 }
 
 #[test]
@@ -469,8 +522,9 @@ fn test_min_length_json_schema() {
     assert_eq!(password_prop["minLength"], 10_i32);
 
     let nickname_prop = &properties["nickname"];
-    assert_eq!(nickname_prop["type"], "string");
-    assert_eq!(nickname_prop["minLength"], 3_i32);
+    assert_eq!(nickname_prop["anyOf"][0]["type"], "string");
+    assert_eq!(nickname_prop["anyOf"][0]["minLength"], 3_i32);
+    assert_eq!(nickname_prop["anyOf"][1]["type"], "null");
 
     let description_prop = &properties["description"];
     assert_eq!(description_prop["type"], "string");
@@ -542,11 +596,15 @@ fn test_ts_optional_struct_zod_unchanged() {
     let zod = TsOptionalStruct::zod_schema();
 
     assert!(
-        zod.contains("f: z.union([Inner$Schema, z.undefined()]).prefault(undefined)"),
+        zod.contains(
+            "f: z.union([z.null().transform(() => undefined), Inner$Schema, z.undefined()]).prefault(undefined)"
+        ),
         "expected unchanged Zod for `f` in:\n{zod}"
     );
     assert!(
-        zod.contains("g: z.union([Inner$Schema, z.undefined()]).prefault(undefined)"),
+        zod.contains(
+            "g: z.union([z.null().transform(() => undefined), Inner$Schema, z.undefined()]).prefault(undefined)"
+        ),
         "expected unchanged Zod for `g` in:\n{zod}"
     );
 }
@@ -581,5 +639,100 @@ fn test_ts_optional_variant_typescript() {
     assert!(
         !ts.contains("filter: Inner | undefined"),
         "did not expect required-key form for variant `filter` in:\n{ts}"
+    );
+}
+
+#[test]
+#[cfg(feature = "typescript")]
+fn test_nullable_struct_typescript() {
+    let ts = NullableStruct::ts_definition();
+
+    assert!(ts.contains("f: string | null;"), "Got: {ts}");
+    assert!(
+        !ts.contains("f: string | undefined"),
+        "nullable should not fall back to the coercing spelling: {ts}"
+    );
+
+    let g = omitted_member("g", "string");
+    assert!(ts.contains(&g), "expected control `{g}` in:\n{ts}");
+
+    assert!(
+        ts.contains("h: string | null;"),
+        "preprocess should not change the TypeScript type: {ts}"
+    );
+}
+
+#[test]
+#[cfg(feature = "zod")]
+fn test_nullable_struct_zod() {
+    let zod = NullableStruct::zod_schema();
+
+    assert!(
+        zod.contains("f: z.union([z.string(), z.null()])"),
+        "Got: {zod}"
+    );
+    assert!(
+        !zod.contains("f: z.union([z.null().transform"),
+        "nullable should not coerce null away: {zod}"
+    );
+
+    assert!(
+        zod.contains(
+            "g: z.union([z.null().transform(() => undefined), z.string(), z.undefined()]).prefault(undefined)"
+        ),
+        "expected unchanged Zod for control field `g` in:\n{zod}"
+    );
+
+    assert!(
+        zod.contains("h: z.preprocess(trim, z.union([z.string(), z.null()]))"),
+        "preprocess should wrap the whole nullable union: {zod}"
+    );
+}
+
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_nullable_struct_json_schema() {
+    let schema = NullableStruct::json_schema();
+    let required_arr = schema["required"].as_array().unwrap();
+    let required: Vec<&str> = required_arr.iter().filter_map(|v| v.as_str()).collect();
+
+    assert!(
+        required.contains(&"f"),
+        "`f` should be required: {required:?}"
+    );
+    assert!(
+        !required.contains(&"g"),
+        "`g` should not be required: {required:?}"
+    );
+    assert!(
+        required.contains(&"h"),
+        "`h` should be required: {required:?}"
+    );
+
+    let properties = schema["properties"].as_object().unwrap();
+    let f_prop = &properties["f"];
+    assert_eq!(f_prop["anyOf"][0]["type"], "string");
+    assert_eq!(f_prop["anyOf"][1]["type"], "null");
+}
+
+#[test]
+#[cfg(feature = "typescript")]
+fn test_nullable_generic_typescript() {
+    let ts = NullableGeneric::<String>::ts_definition();
+    assert!(ts.contains("id: IdType | null;"), "Got: {ts}");
+}
+
+#[test]
+#[cfg(feature = "zod")]
+fn test_nullable_generic_zod() {
+    let zod = NullableGeneric::<String>::zod_schema();
+
+    assert!(
+        zod.contains("export function NullableGeneric$SchemaFactory"),
+        "expected a factory for a generic type: {zod}"
+    );
+    assert!(
+        zod.contains("id: z.union([idType, z.null()])"),
+        "nullable should compose with the factory argument: {zod}"
     );
 }

--- a/tests/mongodb_real_tests/tests.rs
+++ b/tests/mongodb_real_tests/tests.rs
@@ -88,9 +88,9 @@ fn test_real_objectid_basic_types() {
     let zod_schema = RealUser::zod_schema();
     assert!(zod_schema.contains("id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: \"Invalid ObjectId\" }) }),"));
     assert!(zod_schema.contains("name: z.string(),"));
-    assert!(
-        zod_schema.contains("email: z.union([z.string(), z.undefined()]).prefault(undefined),")
-    );
+    assert!(zod_schema.contains(
+        "email: z.union([z.null().transform(() => undefined), z.string(), z.undefined()]).prefault(undefined),"
+    ));
 }
 
 #[test]
@@ -182,7 +182,7 @@ fn test_real_objectid_complex_structures() {
         "metadata: z.record(z.string(), z.object({{ $oid: {regex_pattern} }})),"
     )));
     assert!(zod_schema.contains(&format!(
-        "parent_id: z.union([z.object({{ $oid: {regex_pattern} }}), z.undefined()]).prefault(undefined),"
+        "parent_id: z.union([z.null().transform(() => undefined), z.object({{ $oid: {regex_pattern} }}), z.undefined()]).prefault(undefined),"
     )));
     assert!(zod_schema.contains(&format!(
         "nested_refs: z.record(z.string(), z.array(z.object({{ $oid: {regex_pattern} }}))),"

--- a/tests/mongodb_tests/tests.rs
+++ b/tests/mongodb_tests/tests.rs
@@ -233,9 +233,9 @@ fn test_basic_object_id_types() {
     let zod_schema = User::zod_schema();
     assert!(zod_schema.contains("id: z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: \"Invalid ObjectId\" }) }),"));
     assert!(zod_schema.contains("name: z.string(),"));
-    assert!(
-        zod_schema.contains("email: z.union([z.string(), z.undefined()]).prefault(undefined),")
-    );
+    assert!(zod_schema.contains(
+        "email: z.union([z.null().transform(() => undefined), z.string(), z.undefined()]).prefault(undefined),"
+    ));
 }
 
 #[test]
@@ -263,7 +263,7 @@ fn test_complex_nested_object_id_structures() {
         "metadata: z.record(z.string(), z.object({{ $oid: {regex_pattern} }})),"
     )));
     assert!(zod_schema.contains(&format!(
-        "parent_id: z.union([z.object({{ $oid: {regex_pattern} }}), z.undefined()]).prefault(undefined),"
+        "parent_id: z.union([z.null().transform(() => undefined), z.object({{ $oid: {regex_pattern} }}), z.undefined()]).prefault(undefined),"
     )));
     assert!(zod_schema.contains(&format!(
         "nested_refs: z.record(z.string(), z.array(z.object({{ $oid: {regex_pattern} }}))),"
@@ -361,10 +361,12 @@ fn test_json_schema_optional_parent() {
     assert!(!required.contains(&serde_json::Value::String("parent_id".to_owned())));
 
     let parent_id_prop = &properties["parent_id"];
-    assert_eq!(parent_id_prop["type"], "object");
-    assert_eq!(parent_id_prop["properties"]["$oid"]["type"], "string");
-    assert_eq!(parent_id_prop["required"][0], "$oid");
-    assert_eq!(parent_id_prop["additionalProperties"], false);
+    let parent_id_base = &parent_id_prop["anyOf"][0];
+    assert_eq!(parent_id_base["type"], "object");
+    assert_eq!(parent_id_base["properties"]["$oid"]["type"], "string");
+    assert_eq!(parent_id_base["required"][0], "$oid");
+    assert_eq!(parent_id_base["additionalProperties"], false);
+    assert_eq!(parent_id_prop["anyOf"][1]["type"], "null");
 }
 
 #[test]
@@ -437,7 +439,7 @@ fn test_object_id_json_schema() {
 fn test_object_id_zod_schema() {
     let zod_schema = Post::zod_schema();
 
-    assert!(zod_schema.contains("parent_id: z.union([z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: \"Invalid ObjectId\" }) }), z.undefined()]).prefault(undefined),"));
+    assert!(zod_schema.contains("parent_id: z.union([z.null().transform(() => undefined), z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: \"Invalid ObjectId\" }) }), z.undefined()]).prefault(undefined),"));
 }
 
 #[test]
@@ -450,7 +452,7 @@ fn test_optional_object_id() {
     assert!(ts_definition.contains("email: string;"));
 
     let zod_schema = UserWithOptionalId::zod_schema();
-    assert!(zod_schema.contains("id: z.union([z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: \"Invalid ObjectId\" }) }), z.undefined()]).prefault(undefined),"));
+    assert!(zod_schema.contains("id: z.union([z.null().transform(() => undefined), z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: \"Invalid ObjectId\" }) }), z.undefined()]).prefault(undefined),"));
     assert!(zod_schema.contains("name: z.string(),"));
     assert!(zod_schema.contains("email: z.string(),"));
 }
@@ -460,7 +462,7 @@ fn test_optional_object_id() {
 fn test_optional_object_id_zod_schema() {
     let zod_schema = UserWithOptionalId::zod_schema();
 
-    assert!(zod_schema.contains("id: z.union([z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: \"Invalid ObjectId\" }) }), z.undefined()]).prefault(undefined),"));
+    assert!(zod_schema.contains("id: z.union([z.null().transform(() => undefined), z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: \"Invalid ObjectId\" }) }), z.undefined()]).prefault(undefined),"));
     assert!(zod_schema.contains("name: z.string(),"));
     assert!(zod_schema.contains("email: z.string(),"));
 }

--- a/tests/omitted_key_tests/tests.rs
+++ b/tests/omitted_key_tests/tests.rs
@@ -135,7 +135,9 @@ fn zod_keeps_the_undefined_union_that_already_admits_the_absent_key() {
     let zod = OmittedKeyFields::zod_schema();
 
     assert!(
-        zod.contains("age: z.union([z.number().int(), z.undefined()]).prefault(undefined),"),
+        zod.contains(
+            "age: z.union([z.null().transform(() => undefined), z.number().int(), z.undefined()]).prefault(undefined),"
+        ),
         "Got: {zod}"
     );
     assert!(zod.contains("id: z.string(),"), "Got: {zod}");

--- a/tests/optional_key_flag_tests/tests.rs
+++ b/tests/optional_key_flag_tests/tests.rs
@@ -137,11 +137,15 @@ mod without_the_serde_feature {
         let zod = Profile::zod_schema();
 
         assert!(
-            zod.contains("nickname: z.union([z.string(), z.undefined()]).prefault(undefined),"),
+            zod.contains(
+                "nickname: z.union([z.null().transform(() => undefined), z.string(), z.undefined()]).prefault(undefined),"
+            ),
             "Got: {zod}"
         );
         assert!(
-            zod.contains("nick_handle: z.union([z.string(), z.undefined()]).prefault(undefined),"),
+            zod.contains(
+                "nick_handle: z.union([z.null().transform(() => undefined), z.string(), z.undefined()]).prefault(undefined),"
+            ),
             "Got: {zod}"
         );
     }

--- a/tests/optional_nesting_tests/tests.rs
+++ b/tests/optional_nesting_tests/tests.rs
@@ -20,9 +20,9 @@ struct ElementNullFields {
     vec_items: Vec<Option<u32>>,
 }
 
-/// The `Option` around the wrapper. In field position a `None` writes a bare `null` under the key,
-/// which the generated contract does not admit — so this shape carries the omission the guard
-/// demands, and the key is dropped instead.
+/// The `Option` around the wrapper. In field position a `None` writes either an absent key or a bare
+/// `null` under it, and the generated contract now admits both — dropping the key still satisfies the
+/// guard, so this shape keeps the omission.
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct SlotNullFields {
@@ -162,13 +162,14 @@ fn test_an_element_null_field_describes_as_an_array_of_nullable_items() {
     }
 }
 
-/// The key is dropped rather than written `null`, so the field describes as the plain array and
-/// says nothing about `null` at all — it is the absence that the schema admits, by not requiring it.
+/// The key's own `Option` widens the plain array with `null`, the same as every other optional key,
+/// on top of the absence the schema already admits by leaving the key out of `required`.
 #[test]
 #[cfg(feature = "jsonschema")]
 fn test_a_slot_null_field_describes_as_the_array_it_writes_when_present() {
     let schema = SlotNullFields::json_schema();
-    let expected = array_of(&serde_json::json!({ "type": "integer" }));
+    let array = array_of(&serde_json::json!({ "type": "integer" }));
+    let expected = or_null(&array);
     for field in ["set_items", "vec_items"] {
         assert_eq!(schema["properties"][field], expected, "{field}");
         assert!(
@@ -285,8 +286,10 @@ fn test_the_zod_surface_puts_the_nullable_at_the_level_it_was_written() {
     }
     let slot_null = SlotNullFields::zod_schema();
     for spelling in [
-        "set_items: z.union([z.array(z.number().int()), z.undefined()]).prefault(undefined),",
-        "vec_items: z.union([z.array(z.number().int()), z.undefined()]).prefault(undefined),",
+        "set_items: z.union([z.null().transform(() => undefined), z.array(z.number().int()), \
+         z.undefined()]).prefault(undefined),",
+        "vec_items: z.union([z.null().transform(() => undefined), z.array(z.number().int()), \
+         z.undefined()]).prefault(undefined),",
     ] {
         assert!(slot_null.contains(spelling), "Got: {slot_null}");
     }

--- a/tests/pattern_preprocess_tests/tests.rs
+++ b/tests/pattern_preprocess_tests/tests.rs
@@ -231,7 +231,9 @@ fn test_pattern_optional_field_zod() {
 
     let schema = PatternOptional::zod_schema();
     assert!(
-        schema.contains("z.union([z.string().check(z.regex(/^[0-9]+$/)), z.undefined()])"),
+        schema.contains(
+            "z.union([z.null().transform(() => undefined), z.string().check(z.regex(/^[0-9]+$/)), z.undefined()])"
+        ),
         "Expected optional pattern union in Zod schema: {schema}"
     );
 }
@@ -295,9 +297,11 @@ fn test_preprocess_optional_field_zod() {
     }
 
     let schema = PreprocessOptional::zod_schema();
-    // Preprocess wraps the inner schema, then union with undefined wraps that
+    // Preprocess wraps the inner schema, then union with null/undefined wraps that
     assert!(
-        schema.contains("z.union([z.preprocess(trim, z.string()), z.undefined()])"),
+        schema.contains(
+            "z.union([z.null().transform(() => undefined), z.preprocess(trim, z.string()), z.undefined()])"
+        ),
         "Expected preprocess inside optional union in Zod schema: {schema}"
     );
 }

--- a/tests/primitive_types_tests/tests.rs
+++ b/tests/primitive_types_tests/tests.rs
@@ -264,7 +264,9 @@ fn test_char_types_typescript_and_zod() {
         "Got: {zod_schema}"
     );
     assert!(
-        zod_schema.contains("opt_char: z.union([z.string().length(1), z.undefined()])"),
+        zod_schema.contains(
+            "opt_char: z.union([z.null().transform(() => undefined), z.string().length(1), z.undefined()])"
+        ),
         "Got: {zod_schema}"
     );
     assert!(
@@ -290,7 +292,10 @@ fn test_char_types_json_schema() {
         properties["map_to_char"],
         serde_json::json!({ "type": "object", "additionalProperties": one_character_string })
     );
-    assert_eq!(properties["opt_char"], one_character_string);
+    assert_eq!(
+        properties["opt_char"],
+        serde_json::json!({ "anyOf": [one_character_string, { "type": "null" }] })
+    );
     assert_eq!(
         properties["pair"],
         serde_json::json!({
@@ -439,12 +444,12 @@ fn test_64bit_integers_ts_definition() {
     let zod_schema = LargeNumbers::zod_schema();
     assert!(zod_schema.contains("large_unsigned: z.number().int()"));
     assert!(zod_schema.contains("large_signed: z.number().int()"));
-    assert!(
-        zod_schema.contains("optional_large_unsigned: z.union([z.number().int(), z.undefined()])")
-    );
-    assert!(
-        zod_schema.contains("optional_large_signed: z.union([z.number().int(), z.undefined()])")
-    );
+    assert!(zod_schema.contains(
+        "optional_large_unsigned: z.union([z.null().transform(() => undefined), z.number().int(), z.undefined()])"
+    ));
+    assert!(zod_schema.contains(
+        "optional_large_signed: z.union([z.null().transform(() => undefined), z.number().int(), z.undefined()])"
+    ));
     assert!(zod_schema.contains("array_of_u64: z.array(z.number().int())"));
     assert!(zod_schema.contains("array_of_i64: z.array(z.number().int())"));
 }
@@ -605,9 +610,11 @@ fn test_primitive_types_typescript_generation_details() {
     assert_zod_fields_contain(
         &zod_schema,
         &["opt_i8", "opt_u64"],
-        "z.union([z.number().int(), z.undefined()])",
+        "z.union([z.null().transform(() => undefined), z.number().int(), z.undefined()])",
     );
-    assert!(zod_schema.contains("opt_f64: z.union([z.number(), z.undefined()])"));
+    assert!(zod_schema.contains(
+        "opt_f64: z.union([z.null().transform(() => undefined), z.number(), z.undefined()])"
+    ));
 
     assert_zod_fields_contain(
         &zod_schema,

--- a/tests/readme_example_tests/tests.rs
+++ b/tests/readme_example_tests/tests.rs
@@ -295,7 +295,7 @@ fn test_the_object_id_example_is_declarable_and_shows_what_it_emits() {
         "pub struct Document {",
         &Document::zod_schema(),
         &[
-            "  parent_id: z.union([z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: \"Invalid ObjectId\" }) }), z.undefined()]).prefault(undefined),",
+            "  parent_id: z.union([z.null().transform(() => undefined), z.object({ $oid: z.string().regex(/^[a-f0-9]{24}$/, { message: \"Invalid ObjectId\" }) }), z.undefined()]).prefault(undefined),",
         ],
     );
 }
@@ -343,7 +343,7 @@ fn test_the_chrono_example_is_declarable_and_shows_what_it_emits() {
         &Event::zod_schema(),
         &[
             "  created_at: z.coerce.date(),",
-            "  updated_at: z.union([z.coerce.date(), z.undefined()]).prefault(undefined),",
+            "  updated_at: z.union([z.null().transform(() => undefined), z.coerce.date(), z.undefined()]).prefault(undefined),",
         ],
     );
 }

--- a/tests/recursive_type_tests/tests.rs
+++ b/tests/recursive_type_tests/tests.rs
@@ -158,7 +158,7 @@ mod describes {
         let body = &document["$defs"]["ChainNode"];
         assert_eq!(
             body["properties"]["next"],
-            json!({ "$ref": "#/$defs/ChainNode" })
+            json!({ "anyOf": [{ "$ref": "#/$defs/ChainNode" }, { "type": "null" }] })
         );
         assert_eq!(body["properties"]["label"], json!({ "type": "string" }));
         assert_eq!(body["required"], json!(["label"]));

--- a/tests/serde_tests/tests.rs
+++ b/tests/serde_tests/tests.rs
@@ -57,6 +57,19 @@ struct CompliantOptionals {
     tag: Option<String>,
 }
 
+/// The two `Option` flavors side by side: `generation_token` drops its key for a `None` (the
+/// default), `template_id` writes `null` instead (`nullable`).
+#[model_schema()]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+struct IndexEntry {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub generation_token: Option<String>,
+    pub name: String,
+    #[model_schema_prop(nullable)]
+    pub template_id: Option<String>,
+}
+
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "lowercase")]
@@ -257,8 +270,12 @@ fn test_serde_with_optional_fields_zod() {
     let zod = OptionalFields::zod_schema();
 
     assert!(zod.contains("requiredField: z.string()"));
-    assert!(zod.contains("optionalField: z.union([z.string(), z.undefined()])"));
-    assert!(zod.contains("customOptional: z.union([z.number().int(), z.undefined()])"));
+    assert!(zod.contains(
+        "optionalField: z.union([z.null().transform(() => undefined), z.string(), z.undefined()])"
+    ));
+    assert!(zod.contains(
+        "customOptional: z.union([z.null().transform(() => undefined), z.number().int(), z.undefined()])"
+    ));
 }
 
 #[test]
@@ -356,7 +373,9 @@ fn test_compliant_optionals_zod_keeps_undefined_union() {
     let zod = CompliantOptionals::zod_schema();
 
     assert!(zod.contains("z.strictObject"));
-    assert!(zod.contains("z.union([z.string(), z.undefined()]).prefault(undefined)"));
+    assert!(zod.contains(
+        "z.union([z.null().transform(() => undefined), z.string(), z.undefined()]).prefault(undefined)"
+    ));
     assert!(!zod.contains("z.nullable"));
 }
 
@@ -383,6 +402,46 @@ fn test_compliant_optionals_serialize_absent_and_parse_absent() {
         serde_json::to_string(&some).unwrap(),
         r#"{"name":"n","note":"here"}"#
     );
+}
+
+/// Each `Option` flavor writes exactly one shape for a `None`: the default drops the key, `nullable`
+/// writes `null` and keeps it. Both read every shape either flavor writes, plus the one it does not.
+#[test]
+fn test_each_option_flavor_writes_one_shape_and_reads_both() {
+    let entry = IndexEntry {
+        name: "invoice.pdf".to_owned(),
+        generation_token: None,
+        template_id: None,
+    };
+    assert_eq!(
+        serde_json::to_string(&entry).unwrap(),
+        r#"{"name":"invoice.pdf","templateId":null}"#
+    );
+
+    let from_absent: IndexEntry =
+        serde_json::from_str(r#"{"name":"invoice.pdf","templateId":null}"#).unwrap();
+    assert_eq!(from_absent, entry);
+
+    let from_null: IndexEntry =
+        serde_json::from_str(r#"{"name":"invoice.pdf","generationToken":null,"templateId":null}"#)
+            .unwrap();
+    assert_eq!(from_null, entry);
+
+    let both_keys_absent: IndexEntry = serde_json::from_str(r#"{"name":"invoice.pdf"}"#).unwrap();
+    assert_eq!(both_keys_absent, entry);
+
+    let both_some = IndexEntry {
+        name: "invoice.pdf".to_owned(),
+        generation_token: Some("tok".to_owned()),
+        template_id: Some("tmpl-1".to_owned()),
+    };
+    assert_eq!(
+        serde_json::to_string(&both_some).unwrap(),
+        r#"{"generationToken":"tok","name":"invoice.pdf","templateId":"tmpl-1"}"#
+    );
+    let round_tripped: IndexEntry =
+        serde_json::from_str(&serde_json::to_string(&both_some).unwrap()).unwrap();
+    assert_eq!(round_tripped, both_some);
 }
 
 /// The struct-field seam: a renamed key is the string serde writes, which is what the object needs

--- a/tests/tuple_field_tests/tests.rs
+++ b/tests/tuple_field_tests/tests.rs
@@ -208,7 +208,7 @@ fn test_optional_tuple_field_zod() {
     let zod = OptionalPair::zod_schema();
     assert!(
         zod.contains(
-            "values: z.union([z.tuple([z.string(), z.string()]), z.undefined()]).prefault(undefined)"
+            "values: z.union([z.null().transform(() => undefined), z.tuple([z.string(), z.string()]), z.undefined()]).prefault(undefined)"
         ),
         "Expected optional tuple wrapping. Got: {zod}"
     );

--- a/tests/untagged_tests/tests.rs
+++ b/tests/untagged_tests/tests.rs
@@ -371,7 +371,7 @@ fn test_compliant_union_zod() {
     assert!(
         zod.contains(
             "z.strictObject({ id: z.string(), \
-             note: z.union([z.string(), z.undefined()]).prefault(undefined), })"
+             note: z.union([z.null().transform(() => undefined), z.string(), z.undefined()]).prefault(undefined), })"
         ),
         "Got:\n{zod}"
     );
@@ -425,6 +425,13 @@ fn test_compliant_union_json_schema() {
     );
     assert!(
         !required.contains(&serde_json::json!("note")),
+        "Got:\n{schema}"
+    );
+
+    let properties = any_of[1]["properties"].as_object().unwrap();
+    assert_eq!(
+        properties["note"],
+        serde_json::json!({ "anyOf": [{ "type": "string" }, { "type": "null" }] }),
         "Got:\n{schema}"
     );
 }

--- a/tests/zod_tests/tests.rs
+++ b/tests/zod_tests/tests.rs
@@ -170,15 +170,21 @@ fn test_optional_fields_use_union_with_undefined() {
         "Required fields should not be wrapped. Got: {zod}"
     );
     assert!(
-        zod.contains("optional_string: z.union([z.string(), z.undefined()])"),
+        zod.contains(
+            "optional_string: z.union([z.null().transform(() => undefined), z.string(), z.undefined()])"
+        ),
         "Optional strings should use z.union with undefined. Got: {zod}"
     );
     assert!(
-        zod.contains("optional_number: z.union([z.number().int(), z.undefined()])"),
+        zod.contains(
+            "optional_number: z.union([z.null().transform(() => undefined), z.number().int(), z.undefined()])"
+        ),
         "Optional numbers should use z.union with undefined. Got: {zod}"
     );
     assert!(
-        zod.contains("optional_bool: z.union([z.boolean(), z.undefined()])"),
+        zod.contains(
+            "optional_bool: z.union([z.null().transform(() => undefined), z.boolean(), z.undefined()])"
+        ),
         "Optional booleans should use z.union with undefined. Got: {zod}"
     );
 }
@@ -196,7 +202,9 @@ fn test_vec_fields_use_z_array() {
         "Vec<i32> should use z.array(z.number().int()). Got: {zod}"
     );
     assert!(
-        zod.contains("optional_array: z.union([z.array(z.string()), z.undefined()])"),
+        zod.contains(
+            "optional_array: z.union([z.null().transform(() => undefined), z.array(z.string()), z.undefined()])"
+        ),
         "Optional arrays should wrap array in union. Got: {zod}"
     );
 }
@@ -360,7 +368,7 @@ fn test_complex_nested_collections() {
     );
     assert!(
         zod.contains(
-            "optional_map: z.union([z.record(z.string(), z.number().int()), z.undefined()])"
+            "optional_map: z.union([z.null().transform(() => undefined), z.record(z.string(), z.number().int()), z.undefined()])"
         ),
         "Optional HashMap should wrap in union. Got: {zod}"
     );
@@ -399,7 +407,9 @@ fn test_objectid_generates_proper_validation() {
         "Vec<ObjectId> should work. Got: {zod}"
     );
     assert!(
-        zod.contains("author_id: z.union([z.object({ $oid: z.string().regex("),
+        zod.contains(
+            "author_id: z.union([z.null().transform(() => undefined), z.object({ $oid: z.string().regex("
+        ),
         "Option<ObjectId> should work. Got: {zod}"
     );
 }


### PR DESCRIPTION
An `Option<T>` at object-key position rendered `z.union([T, z.undefined()]).prefault(undefined)`, which admitted an absent key and a value but refused an explicit `null`. Serde disagreed: it reads `{}` and `{"a":null}` into `None` alike, so a payload the Rust type accepted was rejected by the schema generated from that same type. Data written before a field's schema existed could not be migrated.

## What changes

**Every optional object key now accepts an explicit `null` and coerces it to `undefined`.** The null arm is written first so the coercion holds whatever `T` is — a union returns its first succeeding arm, and a base that itself admits `null` would otherwise swallow it. The key stays omittable and the TypeScript type is unchanged. JSON Schema widens to `anyOf [T, null]` at key position while the key stays out of `required`.

Slot positions — tuple element, map value, tuple-variant content — keep their `z.nullable(T)` / `T | null` rendering. JSON has no `undefined`, so those cannot round-trip one.

**New bare flag `#[model_schema_prop(nullable)]`** for a field whose empty state genuinely is `null` on the wire: renders `T | null` with the key **required** on all three surfaces, promoting the existing slot renderings rather than adding a fourth. Refused on a non-`Option` field and beside `ts_optional`; composes with `preprocess`, which wraps the whole nullable union.

**Each flavor is pinned to one output shape.** The existing guard on a bare `Option` field keeps its behaviour but states the reason that actually holds — the declared shape is `T | undefined`, so the key must be dropped. A mirror guard refuses `nullable` beside a key-dropping serde attribute, which would tell serde to drop a key the schema requires. Deserialization is untouched: both flavors read `{}` and `{"a":null}` into `None`.

## Verification

`just ci` — clean, check-all, lint-all, test, fmt — green across all 32 feature combinations, zero warnings. No suppressions of any kind. Docs updated in `README.md`, `CLAUDE.md`, and the `model_schema_prop` rustdoc.