### PR TITLE
read a literal in the kind it was written, and refuse one the field's own type cannot carry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,7 +293,9 @@ All validation constraints generate checks in **Zod (frontend), JSON Schema, and
 | `maxLength = N` | `String` | `.max(N)` | `"maxLength"` | validator + deserializer |
 | `minimum = N` | numeric | `.min(N)` | `"minimum"` | validator + deserializer |
 | `maximum = N` | numeric | `.max(N)` | `"maximum"` | validator + deserializer |
-| `literal = "val"` | `String` | `z.literal("val")` | `"const"` | — |
+| `literal = "val"` | `String` | `z.literal("val")` | `{"type": "string", "const": "val"}` | — |
+| `literal = true` | `bool` | `z.literal(true)` | `{"type": "boolean", "const": true}` | — |
+| `literal = 214` | numeric | `z.literal(214)` | `{"type": "number", "const": 214}` | — |
 | `preprocess = ["fn"]` | any | `z.preprocess(fn, ...)` | — | — (Zod-only) |
 | `ts_optional` | `Option<T>` | — | — | — (TypeScript-only) |
 | `as_number` | `DateTime<Tz>` | inline `z.preprocess(..., z.number())` | — | — (TS+Zod) |
@@ -301,6 +303,13 @@ All validation constraints generate checks in **Zod (frontend), JSON Schema, and
 
 Multiple constraints on one field are combined. Multiple `preprocess` functions nest:
 `z.preprocess(fn1, z.preprocess(fn2, innerSchema))`.
+
+`literal` takes a string, boolean, integer or float literal. The kind written must match what the
+field's Rust type can carry — a boolean literal only on a `bool` field, a numeric literal only on a
+numeric field (`u8`–`f64`), a string literal only on a `String` field — or the attribute is a
+compile error naming both the literal's kind and the field's declared type. A numeric literal is
+stored as `f64` and rendered without a trailing `.0` on TypeScript and Zod; the JSON Schema `const`
+is always written under `"type": "number"`, never `"integer"`.
 
 `ts_optional` is a bare flag (no value): it renders an `Option<T>` field as the optional TypeScript key `field?: T` instead of the default `field: T | undefined`. Zod and JSON Schema output are unchanged. It is only valid on `Option<T>` fields (non-`Option` is a compile error) and composes with `as = Type`.
 

--- a/README.md
+++ b/README.md
@@ -1595,6 +1595,36 @@ export const Action$Schema = z.discriminatedUnion("type", [
 ]);
 ```
 
+`literal` also accepts a boolean or a numeric value, provided the field's own Rust type can carry it: `literal = true`/`literal = false` on a `bool` field, `literal = 214` on any numeric field. Every surface renders the literal in the field's own kind, so the kind written must match the field's declared type — `literal = true` on a `String` field, or `literal = "x"` on a `bool` field, is a compile error naming both sides.
+
+```rust
+#[model_schema()]
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AdminUser {
+    pub id: String,
+    #[model_schema_prop(literal = true)]
+    pub is_system_admin: bool,
+    pub email: String,
+}
+```
+
+Generated:
+
+```typescript
+export type AdminUser = {
+  id: string;
+  isSystemAdmin: true;
+  email: string;
+};
+
+export const AdminUser$Schema = z.strictObject({
+  id: z.string(),
+  isSystemAdmin: z.literal(true),
+  email: z.string(),
+});
+```
+
 **Recommended: Single-value enums over literal strings.** While `model_schema_prop(literal = ...)` works, a single-value enum provides type safety in Rust -- the field can only hold the correct value at compile time, whereas a `String` with a literal annotation can hold any string in Rust (the constraint only applies in the generated TypeScript/Zod output).
 
 ```rust

--- a/src/features/model_schema_prop.rs
+++ b/src/features/model_schema_prop.rs
@@ -4,7 +4,7 @@
 //! of TypeScript type and Zod schema generation.
 
 use syn::meta::ParseNestedMeta;
-use syn::{Attribute, LitStr, Type};
+use syn::{Attribute, Lit, LitStr, Type};
 
 use crate::utils::{constraining_pattern, portable_pattern};
 
@@ -25,6 +25,16 @@ const KNOWN_KEYS: &[&str] = &[
     "as_number",
     "nullable",
 ];
+
+/// The value a `literal` key was written with, kept in the kind it was written as. The kind decides
+/// which [`crate::field_type::FieldDefType`] the field collapses to and which Rust type may carry
+/// it.
+#[derive(Clone, Debug, PartialEq)]
+pub enum LiteralValue {
+    Bool(bool),
+    Number(f64),
+    Str(String),
+}
 
 /// Metadata for `model_schema_prop` attributes applied to a field.
 ///
@@ -73,7 +83,10 @@ const KNOWN_KEYS: &[&str] = &[
 /// - `as = Type` — name the type emitted for this field. The target must be the field's own type
 ///   or the value under its wrappers (`as = String` on a `Vec<String>`); any other target is a
 ///   compile error. Cannot be written beside `preprocess`.
-/// - `literal = "value"` — emit as a string literal type instead of `string`.
+/// - `literal = "value"` — emit as a literal type instead of the field's own primitive. Takes a
+///   string, boolean, integer or float literal; the kind written must match what the field's Rust
+///   type can carry (a boolean literal on a `bool` field, a numeric literal on a numeric field, a
+///   string literal on a `String` field) or the attribute is a compile error naming the mismatch.
 /// - `ts_optional` — for an `Option<T>` field, emit `field?: T` instead of `field: T | undefined`
 ///   (TypeScript only; a non-`Option` field is a compile error). It decides the key only on a field
 ///   no serde key-omission attribute speaks for, since such an attribute already writes the
@@ -114,11 +127,11 @@ pub struct ModelSchemaPropMeta {
     /// The parser's refusal of the attribute — a key it does not read, or a value it cannot read —
     /// spanned on the tokens that earned it.
     pub attr_rejection: Option<syn::Error>,
-    pub literal: Option<String>, // e.g., "Tixena" from literal = "Tixena"
-    pub max_length: Option<usize>, // e.g., 50 from maxLength = 50
-    pub maximum: Option<f64>,    // e.g., 100.0 from maximum = 100
-    pub min_length: Option<usize>, // e.g., 1 from minLength = 1
-    pub minimum: Option<f64>,    // e.g., 0.0 from minimum = 0
+    pub literal: Option<LiteralValue>, // e.g., Str("Tixena") from literal = "Tixena"
+    pub max_length: Option<usize>,     // e.g., 50 from maxLength = 50
+    pub maximum: Option<f64>,          // e.g., 100.0 from maximum = 100
+    pub min_length: Option<usize>,     // e.g., 1 from minLength = 1
+    pub minimum: Option<f64>,          // e.g., 0.0 from minimum = 0
     pub nullable: bool, // Option<T> at object-key position renders `T | null` with the key required
     /// `pattern` in the spelling every surface reads the same way, or as it was written when it
     /// earned a [`Self::pattern_rejection`].
@@ -157,8 +170,7 @@ fn parse_prop_key(nested: &ParseNestedMeta, meta: &mut ModelSchemaPropMeta) -> s
     if nested.path.is_ident("as") {
         meta.as_type = Some(nested.value()?.parse::<Type>()?);
     } else if nested.path.is_ident("literal") {
-        let lit: LitStr = nested.value()?.parse()?;
-        meta.literal = Some(lit.value());
+        meta.literal = Some(literal_prop_value(nested)?);
     } else if nested.path.is_ident("minLength") {
         meta.min_length = Some(nested.value()?.parse::<syn::LitInt>()?.base10_parse()?);
     } else if nested.path.is_ident("maxLength") {
@@ -211,6 +223,27 @@ fn numeric_bound(nested: &ParseNestedMeta, key: &str) -> syn::Result<f64> {
         Err(syn::Error::new_spanned(
             &lit,
             format!("`model_schema_prop` key `{key}` takes an integer or float literal"),
+        ))
+    }
+}
+
+/// The [`LiteralValue`] a `literal` key was written as, kept in whichever of the four kinds the
+/// author wrote — the kind [`crate::model_schema`]'s own guard then measures against the field's
+/// declared Rust type.
+fn literal_prop_value(nested: &ParseNestedMeta) -> syn::Result<LiteralValue> {
+    let lit: Lit = nested.value()?.parse()?;
+    if let Lit::Str(str_lit) = &lit {
+        Ok(LiteralValue::Str(str_lit.value()))
+    } else if let Lit::Bool(bool_lit) = &lit {
+        Ok(LiteralValue::Bool(bool_lit.value()))
+    } else if let Lit::Int(int_lit) = &lit {
+        Ok(LiteralValue::Number(int_lit.base10_parse()?))
+    } else if let Lit::Float(float_lit) = &lit {
+        Ok(LiteralValue::Number(float_lit.base10_parse()?))
+    } else {
+        Err(syn::Error::new_spanned(
+            &lit,
+            "`model_schema_prop` key `literal` takes a string, boolean, integer or float literal",
         ))
     }
 }

--- a/src/features/model_schema_prop/tests.rs
+++ b/src/features/model_schema_prop/tests.rs
@@ -25,9 +25,36 @@ fn test_parse_literal() {
     let attr: Attribute = parse_quote! { #[model_schema_prop(literal = "Tixena")] };
     let meta = parse_model_schema_prop_attributes(&[attr]);
     assert!(meta.as_type.is_none());
-    assert!(meta.literal.is_some());
-    assert_eq!(meta.literal.unwrap(), "Tixena");
+    assert_eq!(meta.literal, Some(LiteralValue::Str("Tixena".to_owned())));
     assert!(meta.min_length.is_none());
+}
+
+#[test]
+fn test_parse_literal_bool_true() {
+    let attr: Attribute = parse_quote! { #[model_schema_prop(literal = true)] };
+    let meta = parse_model_schema_prop_attributes(&[attr]);
+    assert_eq!(meta.literal, Some(LiteralValue::Bool(true)));
+}
+
+#[test]
+fn test_parse_literal_bool_false() {
+    let attr: Attribute = parse_quote! { #[model_schema_prop(literal = false)] };
+    let meta = parse_model_schema_prop_attributes(&[attr]);
+    assert_eq!(meta.literal, Some(LiteralValue::Bool(false)));
+}
+
+#[test]
+fn test_parse_literal_number_integer() {
+    let attr: Attribute = parse_quote! { #[model_schema_prop(literal = 214)] };
+    let meta = parse_model_schema_prop_attributes(&[attr]);
+    assert_eq!(meta.literal, Some(LiteralValue::Number(214.0)));
+}
+
+#[test]
+fn test_parse_literal_number_float() {
+    let attr: Attribute = parse_quote! { #[model_schema_prop(literal = 3.5)] };
+    let meta = parse_model_schema_prop_attributes(&[attr]);
+    assert_eq!(meta.literal, Some(LiteralValue::Number(3.5)));
 }
 
 #[test]
@@ -36,8 +63,7 @@ fn test_parse_both_as_and_literal() {
     let meta = parse_model_schema_prop_attributes(&[attr]);
     assert!(meta.as_type.is_some());
     assert_eq!(meta.as_type.unwrap(), parse_quote!(String));
-    assert!(meta.literal.is_some());
-    assert_eq!(meta.literal.unwrap(), "Tixena");
+    assert_eq!(meta.literal, Some(LiteralValue::Str("Tixena".to_owned())));
     assert!(meta.min_length.is_none());
 }
 
@@ -110,8 +136,7 @@ fn test_parse_all_attributes() {
     let meta = parse_model_schema_prop_attributes(&[attr]);
     assert!(meta.as_type.is_some());
     assert_eq!(meta.as_type.unwrap(), parse_quote!(String));
-    assert!(meta.literal.is_some());
-    assert_eq!(meta.literal.unwrap(), "test");
+    assert_eq!(meta.literal, Some(LiteralValue::Str("test".to_owned())));
     assert!(meta.min_length.is_some());
     assert_eq!(meta.min_length.unwrap(), 3);
 }

--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -58,6 +58,9 @@ pub enum VariantKind {
 pub enum FieldDefType {
     /// Boolean primitive - maps to boolean.
     Boolean,
+    /// Boolean literal type — added via `model_schema_prop(literal = true)`.
+    /// Maps to `true`/`false` in TS, `z.literal(true)`/`z.literal(false)` in Zod.
+    BooleanLiteral(bool),
     /// `char` primitive - serde writes it as a one-character string and reads only that back, so
     /// it is described as one: TypeScript `string`, Zod `z.string().length(1)`, JSON Schema
     /// `{"type": "string", "minLength": 1, "maxLength": 1}`.
@@ -97,6 +100,10 @@ pub enum FieldDefType {
     /// Zod: `z.string().time()`.
     /// JSON Schema: string with format "time".
     NaiveTime,
+    /// Numeric literal type — added via `model_schema_prop(literal = 214)`.
+    /// Maps to `214` in TS, `z.literal(214)` in Zod. Stored as `f64` regardless of the field's own
+    /// integer or float type, so a whole value renders without the trailing `.0` `f64` carries.
+    NumberLiteral(f64),
     #[cfg(feature = "object_id")]
     /// `MongoDB` `ObjectId` type - requires "`object_id`" feature.
     /// Maps to `ObjectId` interface in TS with `$oid: string`.
@@ -125,6 +132,28 @@ pub enum FieldDefType {
     /// Unknown or unsupported type - generates 'unknown' in TS/Zod.
     Unknown,
     Usize,
+}
+
+impl FieldDefType {
+    /// Whether this is one of the numeric primitives — every integer and float kind a
+    /// `literal = N` may collapse into a [`Self::NumberLiteral`].
+    pub const fn is_numeric(&self) -> bool {
+        matches!(
+            self,
+            Self::U8
+                | Self::U16
+                | Self::U32
+                | Self::U64
+                | Self::I8
+                | Self::I16
+                | Self::I32
+                | Self::I64
+                | Self::Usize
+                | Self::Isize
+                | Self::F32
+                | Self::F64
+        )
+    }
 }
 
 /// Struct representing a field's definition for schema generation.
@@ -176,6 +205,8 @@ impl FieldDef {
             FieldDefType::TypeParam(_)
             | FieldDefType::Unknown
             | FieldDefType::StringLiteral(_)
+            | FieldDefType::BooleanLiteral(_)
+            | FieldDefType::NumberLiteral(_)
             | FieldDefType::Boolean
             | FieldDefType::Char
             | FieldDefType::String
@@ -238,6 +269,8 @@ impl FieldDef {
             | FieldDefType::TypeParam(_)
             | FieldDefType::Unknown
             | FieldDefType::StringLiteral(_)
+            | FieldDefType::BooleanLiteral(_)
+            | FieldDefType::NumberLiteral(_)
             | FieldDefType::Boolean
             | FieldDefType::Char
             | FieldDefType::String
@@ -289,6 +322,8 @@ impl FieldDef {
             FieldDefType::TypeParam(_)
             | FieldDefType::Unknown
             | FieldDefType::StringLiteral(_)
+            | FieldDefType::BooleanLiteral(_)
+            | FieldDefType::NumberLiteral(_)
             | FieldDefType::Boolean
             | FieldDefType::Char
             | FieldDefType::String
@@ -360,6 +395,8 @@ impl FieldDef {
             | FieldDefType::TypeParam(_)
             | FieldDefType::Unknown
             | FieldDefType::StringLiteral(_)
+            | FieldDefType::BooleanLiteral(_)
+            | FieldDefType::NumberLiteral(_)
             | FieldDefType::Boolean
             | FieldDefType::Char
             | FieldDefType::String
@@ -496,6 +533,8 @@ impl FieldDef {
             FieldDefType::TypeParam(_)
             | FieldDefType::Unknown
             | FieldDefType::StringLiteral(_)
+            | FieldDefType::BooleanLiteral(_)
+            | FieldDefType::NumberLiteral(_)
             | FieldDefType::Boolean
             | FieldDefType::Char
             | FieldDefType::String
@@ -536,6 +575,8 @@ impl FieldDef {
             FieldDefType::TypeParam(_)
             | FieldDefType::Unknown
             | FieldDefType::StringLiteral(_)
+            | FieldDefType::BooleanLiteral(_)
+            | FieldDefType::NumberLiteral(_)
             | FieldDefType::Boolean
             | FieldDefType::Char
             | FieldDefType::String
@@ -583,6 +624,8 @@ impl FieldDef {
             FieldDefType::TypeParam(_)
             | FieldDefType::Unknown
             | FieldDefType::StringLiteral(_)
+            | FieldDefType::BooleanLiteral(_)
+            | FieldDefType::NumberLiteral(_)
             | FieldDefType::Boolean
             | FieldDefType::Char
             | FieldDefType::String
@@ -626,6 +669,8 @@ impl FieldDef {
             | FieldDefType::Tuple(_)
             | FieldDefType::Unknown
             | FieldDefType::StringLiteral(_)
+            | FieldDefType::BooleanLiteral(_)
+            | FieldDefType::NumberLiteral(_)
             | FieldDefType::Boolean
             | FieldDefType::Char
             | FieldDefType::String
@@ -670,6 +715,8 @@ impl FieldDef {
             FieldDefType::TypeParam(_)
             | FieldDefType::Unknown
             | FieldDefType::StringLiteral(_)
+            | FieldDefType::BooleanLiteral(_)
+            | FieldDefType::NumberLiteral(_)
             | FieldDefType::Boolean
             | FieldDefType::Char
             | FieldDefType::String
@@ -733,6 +780,8 @@ impl FieldDef {
             FieldDefType::TypeParam(_)
             | FieldDefType::Unknown
             | FieldDefType::StringLiteral(_)
+            | FieldDefType::BooleanLiteral(_)
+            | FieldDefType::NumberLiteral(_)
             | FieldDefType::Boolean
             | FieldDefType::Char
             | FieldDefType::String
@@ -837,6 +886,8 @@ impl FieldDef {
             FieldDefType::Boolean => "boolean".to_owned(),
             FieldDefType::Char | FieldDefType::String => "string".to_owned(),
             FieldDefType::StringLiteral(literal) => format!("\"{literal}\""),
+            FieldDefType::BooleanLiteral(value) => value.to_string(),
+            FieldDefType::NumberLiteral(value) => format_number_literal(*value),
             FieldDefType::U8
             | FieldDefType::U16
             | FieldDefType::U32
@@ -992,6 +1043,10 @@ impl FieldDef {
             FieldDefType::Char => "z.string().length(1)".to_owned(),
             FieldDefType::String => self.zod_string_type(),
             FieldDefType::StringLiteral(literal) => format!("z.literal(\"{literal}\")"),
+            FieldDefType::BooleanLiteral(value) => format!("z.literal({value})"),
+            FieldDefType::NumberLiteral(value) => {
+                format!("z.literal({})", format_number_literal(*value))
+            }
             FieldDefType::U8
             | FieldDefType::U16
             | FieldDefType::U32
@@ -1167,6 +1222,16 @@ impl FieldDef {
             return Vec::new();
         };
         lookup_alias_info(name).map_or_else(Vec::new, |info| info.zod_union_members)
+    }
+}
+
+/// The `f64` a `literal = N` was written with, formatted the way TypeScript and Zod read a numeric
+/// literal type: a whole value renders without the trailing `.0` `f64`'s own `Display` carries.
+pub fn format_number_literal(value: f64) -> String {
+    if value.is_finite() && value.fract() == 0.0 {
+        format!("{value:.0}")
+    } else {
+        value.to_string()
     }
 }
 

--- a/src/field_type/tests.rs
+++ b/src/field_type/tests.rs
@@ -603,3 +603,59 @@ fn test_a_sequence_wrapper_name_is_never_itself_a_forward_reference() {
     ));
     assert!(wrapper_around_a_forward_element.reaches_a_type_declared_later());
 }
+
+#[test]
+fn test_boolean_literal_typescript() {
+    assert_eq!(
+        field(FieldDefType::BooleanLiteral(true)).typescript_typename(),
+        "true"
+    );
+    assert_eq!(
+        field(FieldDefType::BooleanLiteral(false)).typescript_typename(),
+        "false"
+    );
+}
+
+/// A whole value renders without the trailing `.0` `f64`'s own `Display` carries; a fractional one
+/// keeps its digits.
+#[test]
+fn test_number_literal_typescript_has_no_trailing_zero() {
+    assert_eq!(
+        field(FieldDefType::NumberLiteral(214.0)).typescript_typename(),
+        "214"
+    );
+    assert_eq!(
+        field(FieldDefType::NumberLiteral(-5.0)).typescript_typename(),
+        "-5"
+    );
+    assert_eq!(
+        field(FieldDefType::NumberLiteral(3.5)).typescript_typename(),
+        "3.5"
+    );
+}
+
+#[cfg(feature = "zod")]
+#[test]
+fn test_boolean_literal_zod() {
+    assert_eq!(
+        field(FieldDefType::BooleanLiteral(true)).zod_type(),
+        "z.literal(true)"
+    );
+    assert_eq!(
+        field(FieldDefType::BooleanLiteral(false)).zod_type(),
+        "z.literal(false)"
+    );
+}
+
+#[cfg(feature = "zod")]
+#[test]
+fn test_number_literal_zod_has_no_trailing_zero() {
+    assert_eq!(
+        field(FieldDefType::NumberLiteral(214.0)).zod_type(),
+        "z.literal(214)"
+    );
+    assert_eq!(
+        field(FieldDefType::NumberLiteral(3.5)).zod_type(),
+        "z.literal(3.5)"
+    );
+}

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -20,7 +20,8 @@ use syn::Ident;
 
 use crate::{
     field_type::{
-        FieldDef, FieldDefType, VariantKind, classify_variant, get_field_def, is_plain_enum,
+        FieldDef, FieldDefType, VariantKind, classify_variant, format_number_literal,
+        get_field_def, is_plain_enum,
     },
     utils::{get_field_docs, get_variant_docs, strip_examples_from_docs},
 };
@@ -79,7 +80,9 @@ use crate::field_type::is_sequence_wrapper;
 #[cfg(feature = "serde")]
 use crate::field_type::is_transparent_wrapper;
 
-use crate::features::model_schema_prop::{ModelSchemaPropMeta, parse_model_schema_prop_attributes};
+use crate::features::model_schema_prop::{
+    LiteralValue, ModelSchemaPropMeta, parse_model_schema_prop_attributes,
+};
 
 #[cfg(feature = "jsonschema")]
 use crate::features::jsonschema::{
@@ -2931,7 +2934,7 @@ fn non_string_inner_shape(inner: &FieldDef) -> Option<&'static str> {
             instantiated_value_shape(inner_name, arguments)
         }
         FieldDefType::Map(..) | FieldDefType::Tuple(..) => Some("container"),
-        FieldDefType::Boolean => Some("boolean"),
+        FieldDefType::Boolean | FieldDefType::BooleanLiteral(_) => Some("boolean"),
         FieldDefType::U8
         | FieldDefType::U16
         | FieldDefType::U32
@@ -2943,7 +2946,8 @@ fn non_string_inner_shape(inner: &FieldDef) -> Option<&'static str> {
         | FieldDefType::Usize
         | FieldDefType::Isize
         | FieldDefType::F32
-        | FieldDefType::F64 => Some("numeric"),
+        | FieldDefType::F64
+        | FieldDefType::NumberLiteral(_) => Some("numeric"),
         FieldDefType::TypeParam(_) | FieldDefType::Unknown => Some("opaque"),
         // A `char` writes the one-character string every other string-shaped arm here does, and
         // `validate()` reaches it the same way it reaches a numeric or boolean inner: through
@@ -2989,8 +2993,8 @@ fn registered_non_object_wire(rust_ident: &str) -> Option<&'static str> {
 ))]
 const fn scalar_json_type_keyword(field_type: &FieldDefType) -> Option<&'static str> {
     match *field_type {
-        FieldDefType::Boolean => Some("boolean"),
-        FieldDefType::F32 | FieldDefType::F64 => Some("number"),
+        FieldDefType::Boolean | FieldDefType::BooleanLiteral(_) => Some("boolean"),
+        FieldDefType::F32 | FieldDefType::F64 | FieldDefType::NumberLiteral(_) => Some("number"),
         FieldDefType::I8
         | FieldDefType::I16
         | FieldDefType::I32
@@ -4341,6 +4345,7 @@ fn branded_inner_composite(inner: &FieldDef) -> Option<BrandedComposite> {
         FieldDefType::Tuple(..) => Some(BrandedComposite::Tuple),
         FieldDefType::TypeParam(_) | FieldDefType::Unknown => Some(BrandedComposite::Opaque),
         FieldDefType::Boolean
+        | FieldDefType::BooleanLiteral(_)
         | FieldDefType::Char
         | FieldDefType::F32
         | FieldDefType::F64
@@ -4349,6 +4354,7 @@ fn branded_inner_composite(inner: &FieldDef) -> Option<BrandedComposite> {
         | FieldDefType::I32
         | FieldDefType::I64
         | FieldDefType::Isize
+        | FieldDefType::NumberLiteral(_)
         | FieldDefType::SiblingType(..)
         | FieldDefType::String
         | FieldDefType::StringLiteral(_)
@@ -6463,8 +6469,11 @@ fn tagged_content(inner: &FieldDef) -> TaggedContent {
     }
     match inner.field_type {
         FieldDefType::SiblingType(..) => TaggedContent::Flattened,
-        FieldDefType::Boolean => TaggedContent::Refused("a boolean"),
+        FieldDefType::Boolean | FieldDefType::BooleanLiteral(_) => {
+            TaggedContent::Refused("a boolean")
+        }
         FieldDefType::F32 | FieldDefType::F64 => TaggedContent::Refused("a float"),
+        FieldDefType::NumberLiteral(_) => TaggedContent::Refused("a number"),
         FieldDefType::I8
         | FieldDefType::I16
         | FieldDefType::I32
@@ -7136,6 +7145,12 @@ fn field_json_schema_value(fld: &FieldDef) -> proc_macro2::TokenStream {
         }
         FieldDefType::StringLiteral(literal) => {
             quote! { serde_json::json!({ "type": "string", "const": #literal }) }
+        }
+        FieldDefType::BooleanLiteral(value) => {
+            quote! { serde_json::json!({ "type": "boolean", "const": #value }) }
+        }
+        FieldDefType::NumberLiteral(value) => {
+            quote! { serde_json::json!({ "type": "number", "const": #value }) }
         }
         FieldDefType::U8
         | FieldDefType::U16
@@ -8209,6 +8224,7 @@ const fn chrono_json_schema_format(field_type: &FieldDefType) -> Option<&'static
         FieldDefType::NaiveTime => Some("time"),
         FieldDefType::NaiveDateTime | FieldDefType::DateTime => Some("date-time"),
         FieldDefType::Boolean
+        | FieldDefType::BooleanLiteral(_)
         | FieldDefType::Char
         | FieldDefType::F32
         | FieldDefType::F64
@@ -8218,6 +8234,7 @@ const fn chrono_json_schema_format(field_type: &FieldDefType) -> Option<&'static
         | FieldDefType::I64
         | FieldDefType::Isize
         | FieldDefType::Map(..)
+        | FieldDefType::NumberLiteral(_)
         | FieldDefType::SiblingType(..)
         | FieldDefType::String
         | FieldDefType::StringLiteral(_)
@@ -8256,6 +8273,12 @@ fn scalar_field_json_schema_item(fld: &FieldDef) -> Option<proc_macro2::TokenStr
         FieldDefType::Char => quote! { { "type": "string", "minLength": 1, "maxLength": 1 } },
         FieldDefType::StringLiteral(literal) => {
             quote! { { "type": "string", "const": #literal } }
+        }
+        FieldDefType::BooleanLiteral(value) => {
+            quote! { { "type": "boolean", "const": #value } }
+        }
+        FieldDefType::NumberLiteral(value) => {
+            quote! { { "type": "number", "const": #value } }
         }
         FieldDefType::U8
         | FieldDefType::U16
@@ -8535,8 +8558,10 @@ fn map_key_path(key: &FieldDef) -> MapKeyPath<'_> {
         FieldDefType::SiblingType(..)
         | FieldDefType::Unknown
         | FieldDefType::Boolean
+        | FieldDefType::BooleanLiteral(_)
         | FieldDefType::Char
         | FieldDefType::StringLiteral(_)
+        | FieldDefType::NumberLiteral(_)
         | FieldDefType::U8
         | FieldDefType::U16
         | FieldDefType::U32
@@ -8594,7 +8619,8 @@ fn map_key_element_name(key: &FieldDef) -> String {
             key_type_name.clone()
         }
         FieldDefType::String | FieldDefType::StringLiteral(_) => "String".to_owned(),
-        FieldDefType::Boolean => "bool".to_owned(),
+        FieldDefType::Boolean | FieldDefType::BooleanLiteral(_) => "bool".to_owned(),
+        FieldDefType::NumberLiteral(_) => "f64".to_owned(),
         FieldDefType::Char => "char".to_owned(),
         FieldDefType::U8 => "u8".to_owned(),
         FieldDefType::U16 => "u16".to_owned(),
@@ -8658,6 +8684,8 @@ fn map_key_rejection(fld: &FieldDef) -> Option<MapKeyRejection> {
         FieldDefType::TypeParam(_)
         | FieldDefType::Unknown
         | FieldDefType::StringLiteral(_)
+        | FieldDefType::BooleanLiteral(_)
+        | FieldDefType::NumberLiteral(_)
         | FieldDefType::Boolean
         | FieldDefType::Char
         | FieldDefType::String
@@ -8857,6 +8885,7 @@ fn build_map_member_item(value: &FieldDef) -> Result<MapMemberItem, MapMemberRej
         // `None`. Named exhaustively rather than caught by a wildcard: a new variant must be given
         // a member schema, not silently widened into an open object.
         FieldDefType::Boolean
+        | FieldDefType::BooleanLiteral(_)
         | FieldDefType::Char
         | FieldDefType::F32
         | FieldDefType::F64
@@ -8865,6 +8894,7 @@ fn build_map_member_item(value: &FieldDef) -> Result<MapMemberItem, MapMemberRej
         | FieldDefType::I32
         | FieldDefType::I64
         | FieldDefType::Isize
+        | FieldDefType::NumberLiteral(_)
         | FieldDefType::String
         | FieldDefType::StringLiteral(_)
         | FieldDefType::Tuple(..)
@@ -9078,6 +9108,44 @@ fn build_string_literal_field_schema(
     }
 }
 
+/// Builds the JSON schema for a boolean literal field (`const` value).
+#[cfg(feature = "jsonschema")]
+fn build_boolean_literal_field_schema(
+    fld: &FieldDef,
+    field_name_str: &str,
+    value: bool,
+) -> proc_macro2::TokenStream {
+    let schema = nullable_slot_json_schema_value(
+        fld,
+        arrayed_json_schema_value(
+            fld,
+            quote! { serde_json::json!({ "type": "boolean", "const": #value }) },
+        ),
+    );
+    quote! {
+        properties.insert(#field_name_str.to_string(), { #schema });
+    }
+}
+
+/// Builds the JSON schema for a numeric literal field (`const` value).
+#[cfg(feature = "jsonschema")]
+fn build_number_literal_field_schema(
+    fld: &FieldDef,
+    field_name_str: &str,
+    value: f64,
+) -> proc_macro2::TokenStream {
+    let schema = nullable_slot_json_schema_value(
+        fld,
+        arrayed_json_schema_value(
+            fld,
+            quote! { serde_json::json!({ "type": "number", "const": #value }) },
+        ),
+    );
+    quote! {
+        properties.insert(#field_name_str.to_string(), { #schema });
+    }
+}
+
 /// Builds the JSON schema for a numeric field (`integer` or `number`), applying min/max constraints.
 #[cfg(feature = "jsonschema")]
 fn build_numeric_field_schema(
@@ -9277,6 +9345,12 @@ fn build_field_type_schema(fld: &FieldDef, field_name_str: &str) -> proc_macro2:
         FieldDefType::String => build_string_field_schema(fld, field_name_str),
         FieldDefType::StringLiteral(literal) => {
             build_string_literal_field_schema(fld, field_name_str, literal)
+        }
+        FieldDefType::BooleanLiteral(value) => {
+            build_boolean_literal_field_schema(fld, field_name_str, *value)
+        }
+        FieldDefType::NumberLiteral(value) => {
+            build_number_literal_field_schema(fld, field_name_str, *value)
         }
         FieldDefType::U32
         | FieldDefType::U16
@@ -10181,6 +10255,7 @@ fn model_schema_prop_guard_errors(
 ) -> Vec<proc_macro2::TokenStream> {
     let refusals = [
         check_fixed_shape_constraints(field, field_def, prop_meta, label).err(),
+        check_literal_kind_match(field, field_def, prop_meta, label).err(),
         check_as_type_override(field, written_def, prop_meta, label).err(),
         check_as_preprocess_conflict(field, prop_meta, label).err(),
         flag_guard_error(
@@ -10298,6 +10373,70 @@ fn check_fixed_shape_constraints(
              holds it to anything written here, so the constraint would reach none of them. \
              Constrain the argument instead — declare the type the instantiation supplies as a \
              branded newtype carrying the bound — or drop it."
+        ),
+    ))
+}
+
+/// The `FieldDefType` a `literal` collapses the field to, or `None` when its own kind and the
+/// field's declared Rust type disagree — the pair [`check_literal_kind_match`] already refused, with
+/// nothing left to render.
+fn literal_field_type(literal: &LiteralValue, field_type: &FieldDefType) -> Option<FieldDefType> {
+    match literal {
+        LiteralValue::Bool(value) => matches!(field_type, FieldDefType::Boolean)
+            .then_some(FieldDefType::BooleanLiteral(*value)),
+        LiteralValue::Number(value) => field_type
+            .is_numeric()
+            .then_some(FieldDefType::NumberLiteral(*value)),
+        LiteralValue::Str(value) => matches!(field_type, FieldDefType::String)
+            .then(|| FieldDefType::StringLiteral(value.clone())),
+    }
+}
+
+/// The `literal = …` value as the author wrote it, for the mismatch message to name.
+fn literal_written(literal: &LiteralValue) -> String {
+    match literal {
+        LiteralValue::Str(value) => format!("\"{value}\""),
+        LiteralValue::Bool(value) => value.to_string(),
+        LiteralValue::Number(value) => format_number_literal(*value),
+    }
+}
+
+/// The adjective a `literal`'s own kind reads as ("a boolean literal…"), and the Rust type that
+/// carries it — what [`check_literal_kind_match`] names on either side of the refusal.
+const fn literal_kind_words(literal: &LiteralValue) -> (&'static str, &'static str) {
+    match literal {
+        LiteralValue::Str(_) => ("a string", "a `String`"),
+        LiteralValue::Bool(_) => ("a boolean", "a `bool`"),
+        LiteralValue::Number(_) => ("a numeric", "a numeric type"),
+    }
+}
+
+/// Rejects a `literal` whose own kind the field's declared Rust type cannot carry — a boolean
+/// literal on a `String` field, a string literal on a `bool` field, and so on: every surface renders
+/// the literal in the field's own kind, so a kind neither side agrees on has nothing to render.
+fn check_literal_kind_match(
+    field: &Field,
+    field_def: &FieldDef,
+    prop_meta: &ModelSchemaPropMeta,
+    label: &str,
+) -> Result<(), syn::Error> {
+    let Some(literal) = &prop_meta.literal else {
+        return Ok(());
+    };
+    if literal_field_type(literal, &field_def.field_type).is_some() {
+        return Ok(());
+    }
+    let declared_type = &field.ty;
+    let declared = quote!(#declared_type).to_string();
+    let written = literal_written(literal);
+    let (adjective, carrier) = literal_kind_words(literal);
+    Err(syn::Error::new_spanned(
+        field,
+        format!(
+            "model_schema: {label}: `literal = {written}` cannot apply to a `{declared}` field — \
+             {adjective} literal is carried by {carrier}, and the generated TypeScript, Zod and \
+             JSON schema all render the literal in the field's own kind. Declare the field as \
+             {carrier}, or write the literal as a value the field's own type can carry."
         ),
     ))
 }
@@ -10633,8 +10772,9 @@ fn apply_model_schema_prop_meta(
 
     if let Some(meta) = &field_def.model_schema_prop_meta
         && let Some(literal) = &meta.literal
+        && let Some(collapsed) = literal_field_type(literal, &field_def.field_type)
     {
-        field_def.field_type = FieldDefType::StringLiteral(literal.clone());
+        field_def.field_type = collapsed;
     }
 
     apply_constraint_docs(field_def, final_name);

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -2308,6 +2308,80 @@ fn a_map_or_tuple_field_without_a_bound_is_left_alone() {
     }
 }
 
+/// Every surface renders `literal` in the field's own kind, so a `literal` whose own kind the
+/// field's declared Rust type cannot carry has nothing to render and is refused where it is written,
+/// naming both the literal's kind and the field's declared type.
+#[test]
+fn a_literal_whose_kind_the_field_cannot_carry_is_refused() {
+    for (constraint, field_type, carrier) in [
+        (
+            quote::quote! { literal = true },
+            quote::quote! { String },
+            "bool",
+        ),
+        (
+            quote::quote! { literal = false },
+            quote::quote! { String },
+            "bool",
+        ),
+        (
+            quote::quote! { literal = "x" },
+            quote::quote! { bool },
+            "String",
+        ),
+        (
+            quote::quote! { literal = 214 },
+            quote::quote! { String },
+            "numeric",
+        ),
+        (
+            quote::quote! { literal = true },
+            quote::quote! { i32 },
+            "bool",
+        ),
+    ] {
+        let errors = field_prop_guard_errors(&syn::parse_quote! {
+            struct Report {
+                #[model_schema_prop(#constraint)]
+                flag: #field_type,
+            }
+        });
+        assert_eq!(
+            errors.len(),
+            1,
+            "for {constraint} on {field_type}: {errors:?}"
+        );
+        for needle in ["compile_error", "field `flag`", "literal", carrier] {
+            assert!(
+                errors[0].contains(needle),
+                "{needle} missing for {constraint} on {field_type}: {}",
+                errors[0]
+            );
+        }
+    }
+}
+
+/// A `literal` whose own kind the field's declared Rust type can carry earns none of these errors,
+/// under any wrapper the field's own optionality writes around it.
+#[test]
+fn a_literal_whose_kind_the_field_can_carry_is_left_alone() {
+    for field in [
+        quote::quote! { #[model_schema_prop(literal = true)] flag: bool },
+        quote::quote! { #[model_schema_prop(literal = false)] flag: bool },
+        quote::quote! { #[model_schema_prop(literal = "x")] flag: String },
+        quote::quote! { #[model_schema_prop(literal = 214)] flag: i32 },
+        quote::quote! { #[model_schema_prop(literal = 3.5)] flag: f64 },
+        quote::quote! { #[model_schema_prop(literal = true)] flag: Option<bool> },
+    ] {
+        let errors = field_prop_guard_errors(&syn::parse_quote! {
+            struct Report {
+                #field
+            }
+        });
+        assert!(errors.is_empty(), "for {field}: {errors:?}");
+    }
+}
+
 /// A parameter names no type until the item is instantiated, so a bound written on a field typed
 /// with one is held by nothing at all: the two validating surfaces describe the value as opaque,
 /// which takes no length, no pattern and no range, and the generated validator and serde read

--- a/tests/model_schema_prop_tests/tests.rs
+++ b/tests/model_schema_prop_tests/tests.rs
@@ -74,6 +74,28 @@ struct ArrayLiteral {
 #[model_schema()]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, PartialEq)]
+struct NonStringLiterals {
+    pub id: String,
+    #[model_schema_prop(literal = true)]
+    pub is_active: bool,
+    #[model_schema_prop(literal = false)]
+    pub is_disabled: bool,
+    #[model_schema_prop(literal = 214)]
+    pub priority: i32,
+}
+
+#[cfg(all(
+    test,
+    any(
+        feature = "typescript",
+        feature = "jsonschema",
+        feature = "zod",
+        feature = "serde"
+    )
+))]
+#[model_schema()]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Clone, PartialEq)]
 struct CombinedTest {
     #[model_schema_prop(as = String, literal = "fixed", minLength = 10)]
     pub fixed_field: String,
@@ -272,6 +294,13 @@ fn test_model_schema_prop_structs_constructible() {
         literal_array: Vec::new(),
     };
     assert!(array_literal.id.is_empty());
+    let non_string_literals = NonStringLiterals {
+        id: String::new(),
+        is_active: true,
+        is_disabled: false,
+        priority: 214,
+    };
+    assert!(non_string_literals.is_active);
     let combined = CombinedTest {
         fixed_field: String::new(),
         normal_field: String::new(),
@@ -465,6 +494,49 @@ fn test_array_literal_json_schema() {
     assert_eq!(literal_array_prop["type"], "array");
     assert_eq!(literal_array_prop["items"]["type"], "string");
     assert_eq!(literal_array_prop["items"]["const"], "array_item");
+}
+
+#[test]
+#[cfg(feature = "typescript")]
+fn test_boolean_and_number_literal_typescript() {
+    let ts_definition = NonStringLiterals::ts_definition();
+
+    assert!(ts_definition.contains("is_active: true;"));
+    assert!(ts_definition.contains("is_disabled: false;"));
+    assert!(ts_definition.contains("priority: 214;"));
+
+    assert!(ts_definition.contains("id: string;"));
+}
+
+#[test]
+#[cfg(feature = "zod")]
+fn test_boolean_and_number_literal_zod() {
+    let zod_schema = NonStringLiterals::zod_schema();
+
+    assert!(zod_schema.contains("is_active: z.literal(true)"));
+    assert!(zod_schema.contains("is_disabled: z.literal(false)"));
+    assert!(zod_schema.contains("priority: z.literal(214)"));
+
+    assert!(zod_schema.contains("id: z.string()"));
+}
+
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_boolean_and_number_literal_json_schema() {
+    let schema = NonStringLiterals::json_schema();
+    let properties = schema["properties"].as_object().unwrap();
+
+    let is_active_prop = &properties["is_active"];
+    assert_eq!(is_active_prop["type"], "boolean");
+    assert_eq!(is_active_prop["const"], true);
+
+    let is_disabled_prop = &properties["is_disabled"];
+    assert_eq!(is_disabled_prop["type"], "boolean");
+    assert_eq!(is_disabled_prop["const"], false);
+
+    let priority_prop = &properties["priority"];
+    assert_eq!(priority_prop["type"], "number");
+    assert_eq!(priority_prop["const"], 214.0_f64);
 }
 
 #[test]


### PR DESCRIPTION
`literal` read a `LitStr` and nothing else, so `literal = true` was a parse
error and `ModelSchemaPropMeta.literal` had nowhere to put a value that was not
a string. A field carrying a discriminant — `isSystemAdmin: true` — could not be
written at all without widening it to `boolean` and losing the one thing that
made the type distinguishable.

The key now reads all four literal kinds a field can carry, kept in the kind
they were written as:

    pub enum LiteralValue {
        Bool(bool),
        Number(f64),
        Str(String),
    }

and `FieldDefType` gains a sibling per kind beside the `StringLiteral` that was
already there, so no existing arm changes meaning — `BooleanLiteral(bool)` and
`NumberLiteral(f64)`, rendered `true` / `214` in TypeScript, `z.literal(true)` /
`z.literal(214)` in Zod, and `{"type": "boolean", "const": true}` /
`{"type": "number", "const": 214}` in JSON Schema. A numeric literal is held as
`f64` whatever the field's own integer or float type, which is what
`numeric_bound` already does for `minimum`/`maximum`; `format_number_literal`
drops the trailing `.0` that `f64`'s own `Display` writes, since `214.0` is
legal TypeScript but is not the literal type anyone wrote.

The collapse that applies the literal used to overwrite `field_type`
unconditionally, which is why `literal = "cflow"` on a non-`String` field was
accepted and silently rewrote it to a string literal. Both the collapse and the
new guard now go through one `literal_field_type`, so a kind the field's
declared type cannot carry has no `FieldDefType` to become and
`check_literal_kind_match` refuses it where it was written, naming both sides:

    model_schema: field `is_system_admin`: `literal = true` cannot apply to a
    `String` field — a boolean literal is carried by a `bool`, and the generated
    TypeScript, Zod and JSON schema all render the literal in the field's own
    kind. Declare the field as a `bool`, or write the literal as a value the
    field's own type can carry.

That guard sits in `model_schema_prop_guard_errors`, which no feature gates, so
the refusal is the same in every configuration rather than only the ones that
render. The one backward-incompatible edge is exactly that: a mismatched
`literal` that used to be accepted is now a compile error. Every
`literal = "..."` written on a `String` field is byte-identical.

just all green — clippy and tests across all 68 feature toggles, zero warnings.

