### PR TITLE
resolve an untagged variant member's key the way serde writes it, not the way it was declared

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -7224,9 +7224,14 @@ fn untagged_member_field_defs(
 }
 /// The [`FieldContext`] one untagged variant hands each of its members: the variant is the
 /// container the omission is read against, and the enum is the type the names resolve in.
+///
+/// `rename_all` is the variant's own `#[serde(rename_all = "...")]`, not the enum's: serde treats a
+/// struct variant as the container for its own fields, and the enum's container-level `rename_all`
+/// reaches variant names only, never the fields inside one.
 #[cfg(feature = "serde")]
 const fn untagged_variant_context<'ctx>(
     variant_defaulted: bool,
+    rename_all: Option<&'ctx str>,
     schema_module_name: Option<&'ctx str>,
     enum_type_name: &'ctx str,
     type_parameters: &'ctx [String],
@@ -7234,7 +7239,7 @@ const fn untagged_variant_context<'ctx>(
 ) -> FieldContext<'ctx> {
     FieldContext {
         container_defaulted: variant_defaulted,
-        rename_all: None,
+        rename_all,
         schema_module_name,
         type_name: enum_type_name,
         type_parameters,
@@ -7257,8 +7262,16 @@ fn untagged_member_field_def(
     serde_field_meta: &SerdeFieldMeta,
     positional_constraint_error: Option<proc_macro2::TokenStream>,
 ) -> (FieldDef, Vec<proc_macro2::TokenStream>) {
+    // The wire key: field-level rename wins outright, otherwise the variant's own rename_all cases
+    // the Rust ident — the same resolution `process_field` runs for a struct field. Diagnostics
+    // below still name the field the author wrote it as, not the key it is rendered under.
+    let final_field_name = get_final_field_name(
+        field_name,
+        serde_field_meta.rename.as_deref(),
+        ctx.rename_all,
+    );
     let (mut field_def, written_def) =
-        untagged_member_field_defs(field, field_name, ctx.type_parameters);
+        untagged_member_field_defs(field, &final_field_name, ctx.type_parameters);
     apply_serde_key_omission(&mut field_def, field);
     let serde_guard_errors = field_guard_errors(
         field,
@@ -7278,7 +7291,7 @@ fn untagged_member_field_def(
         serde_guard_errors,
     );
     field_def.resolve_self_references(ctx.type_name, ctx.type_parameters);
-    apply_model_schema_prop_meta(&mut field_def, prop_meta, field_name);
+    apply_model_schema_prop_meta(&mut field_def, prop_meta, &final_field_name);
     (field_def, member_guard_errors)
 }
 
@@ -7295,6 +7308,7 @@ fn collect_untagged_variant_members(
 ) -> UntaggedVariantMembers {
     let variant_name = variant.ident.to_string();
     let variant_defaulted = has_serde_default(&variant.attrs);
+    let variant_rename_all = parse_serde_type_attributes(&variant.attrs).rename_all;
     let mut walked = UntaggedVariantMembers {
         bound: Vec::new(),
         checks: Vec::new(),
@@ -7340,6 +7354,7 @@ fn collect_untagged_variant_members(
 
         let member_ctx = untagged_variant_context(
             variant_defaulted,
+            variant_rename_all.as_deref(),
             schema_module_name,
             enum_type_name,
             type_parameters,

--- a/tests/serde_tests/tests.rs
+++ b/tests/serde_tests/tests.rs
@@ -93,11 +93,16 @@ struct UserWithSerde {
 }
 
 #[model_schema()]
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(untagged)]
 enum Body {
-    Fresh { subject: String },
-    Reply { reply_to: String },
+    Fresh {
+        subject: String,
+    },
+    Reply {
+        #[serde(rename = "reply-to")]
+        reply_to: String,
+    },
 }
 
 #[model_schema()]
@@ -496,22 +501,111 @@ fn test_a_hyphenated_variant_field_key_is_written_as_a_string() {
     );
 }
 
-/// The flatten-operand seam and the sibling exclusion beside it, both written from keys an
-/// identifier can hold: the whole intersection is spelled as it always was.
-///
-/// The quoted half of this seam is held in the unit tests, against the closer directly. It cannot be
-/// reached from here: a key on this path is the field's own name whatever serde was told to rename
-/// it to, so no rename spells one an identifier cannot hold.
+/// The untagged-member seam: a renamed field inside a `Named` untagged variant is written as the key
+/// serde writes it as, not the Rust ident it never reaches the wire under. `Fresh`'s untouched field
+/// stays exactly as it was.
 #[test]
 #[cfg(feature = "typescript")]
-fn test_a_flatten_operand_and_its_sibling_exclusions_stay_bare_for_identifier_keys() {
+fn test_a_renamed_untagged_member_field_is_written_as_a_string() {
+    let ts = Body::ts_definition();
+
+    assert!(
+        ts.contains(r#"export type Body = { subject: string } | { "reply-to": string };"#),
+        "expected the renamed member key quoted, the untouched one bare:\n{ts}"
+    );
+}
+
+/// The same key on the Zod surface.
+#[test]
+#[cfg(feature = "zod")]
+fn test_a_renamed_untagged_member_field_is_written_as_a_string_in_zod() {
+    let zod = Body::zod_schema();
+
+    assert!(
+        zod.contains(r#""reply-to": z.string()"#),
+        "expected the key as a string member:\n{zod}"
+    );
+    assert!(
+        zod.contains("subject: z.string()"),
+        "an identifier-legal key stays bare:\n{zod}"
+    );
+}
+
+/// The same key in the JSON schema, where quoting is moot — a property name is a plain string either
+/// way — but the key itself must still be the one serde writes.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_a_renamed_untagged_member_field_reaches_the_json_schema() {
+    let schema = Body::json_schema();
+    let any_of = schema["anyOf"].as_array().unwrap();
+    let reply_branch = any_of
+        .iter()
+        .find(|branch| {
+            branch["properties"]
+                .as_object()
+                .unwrap()
+                .contains_key("reply-to")
+        })
+        .unwrap();
+    assert_eq!(reply_branch["required"], serde_json::json!(["reply-to"]));
+    assert!(
+        !reply_branch["properties"]
+            .as_object()
+            .unwrap()
+            .contains_key("reply_to"),
+        "the Rust ident leaked into the schema:\n{schema}"
+    );
+}
+
+/// serde's own wire, beside the schema above: the closed document — every leaf `additionalProperties:
+/// false` — accepts exactly the payload serde writes for the renamed member, and the value round-trips
+/// through it.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_a_renamed_untagged_member_round_trips_through_its_closed_schema() {
+    let value = Body::Reply {
+        reply_to: "x".to_owned(),
+    };
+    let payload = serde_json::to_value(&value).unwrap();
+    assert_eq!(payload, serde_json::json!({ "reply-to": "x" }));
+
+    let schema = Body::json_schema();
+    let any_of = schema["anyOf"].as_array().unwrap();
+    let reply_branch = any_of
+        .iter()
+        .find(|branch| {
+            branch["properties"]
+                .as_object()
+                .unwrap()
+                .contains_key("reply-to")
+        })
+        .unwrap();
+    let named = reply_branch["properties"].as_object().unwrap();
+    let required = reply_branch["required"].as_array().unwrap();
+    let written = payload.as_object().unwrap();
+    assert!(written.keys().all(|key| named.contains_key(key)));
+    assert!(
+        required
+            .iter()
+            .all(|key| written.contains_key(key.as_str().unwrap()))
+    );
+
+    let back: Body = serde_json::from_value(payload).unwrap();
+    assert_eq!(back, value);
+}
+
+/// The flatten-operand seam and the sibling exclusion beside it: `Reply`'s renamed field reaches
+/// both as the key serde writes, quoted, while `Fresh`'s untouched field stays bare in both.
+#[test]
+#[cfg(feature = "typescript")]
+fn test_a_flatten_operand_and_its_sibling_exclusions_carry_a_renamed_key() {
     let ts = Envelope::ts_definition();
 
     assert!(
         ts.contains(
-            "} & ({ subject: string; reply_to?: never } | { reply_to: string; subject?: never });"
+            "} & ({ subject: string; \"reply-to\"?: never } | { \"reply-to\": string; subject?: never });"
         ),
-        "expected the intersection unchanged:\n{ts}"
+        "expected the renamed key quoted on both sides of the union:\n{ts}"
     );
 }
 

--- a/tests/untagged_tests/tests.rs
+++ b/tests/untagged_tests/tests.rs
@@ -59,6 +59,42 @@ enum NamedUnion {
     B { y: i64 },
 }
 
+// A struct variant's own `rename_all` cases its fields — the container rule serde applies to a
+// struct variant, distinct from the enum's own `rename_all` (which cases variant names, never the
+// fields inside one). Both variants carry one so the flatten holder below closes two renamed keys
+// against each other.
+#[model_schema()]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+enum RenameAllUnion {
+    #[serde(rename_all = "kebab-case")]
+    Fresh { subject_line: String },
+    #[serde(rename_all = "kebab-case")]
+    Reply { reply_to: String },
+}
+
+#[cfg(feature = "typescript")]
+#[model_schema()]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RenameAllUnionHolder {
+    #[serde(flatten)]
+    body: RenameAllUnion,
+    own: String,
+}
+
+// The identifier-legal control: a rename needing no quoting, proving the fix reaches every rename
+// rather than only the ones the quoting rule happens to also cover.
+#[cfg(feature = "typescript")]
+#[model_schema()]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+enum RenamedIdentifierUnion {
+    One {
+        #[serde(rename = "replyTo")]
+        reply_to: String,
+    },
+}
+
 // Untagged enum whose struct variant carries an `Option` that keeps `None` off the wire, matching
 // the absent form the union member renders.
 #[model_schema()]
@@ -297,6 +333,45 @@ fn test_named_union_typescript() {
     );
 }
 
+/// A variant's own `rename_all` reaches its fields on the untagged path, the same as it does on the
+/// struct-field path — quoted here since kebab-case is not identifier-legal.
+#[test]
+#[cfg(feature = "typescript")]
+fn test_rename_all_union_typescript() {
+    let ts = RenameAllUnion::ts_definition();
+    assert!(
+        ts.contains(
+            r#"export type RenameAllUnion = { "subject-line": string } | { "reply-to": string };"#
+        ),
+        "Got:\n{ts}"
+    );
+}
+
+/// The identifier-legal control: the rename still reaches the surface, quoting or not.
+#[test]
+#[cfg(feature = "typescript")]
+fn test_renamed_identifier_union_typescript() {
+    let ts = RenamedIdentifierUnion::ts_definition();
+    assert!(
+        ts.contains("export type RenamedIdentifierUnion = { replyTo: string };"),
+        "Got:\n{ts}"
+    );
+}
+
+/// The flatten-operand seam and its sibling exclusions, both members renamed: neither key is the
+/// Rust ident, on either side of the union.
+#[test]
+#[cfg(feature = "typescript")]
+fn test_rename_all_union_flatten_sibling_exclusions() {
+    let ts = RenameAllUnionHolder::ts_definition();
+    assert!(
+        ts.contains(
+            "} & ({ \"subject-line\": string; \"reply-to\"?: never } | { \"reply-to\": string; \"subject-line\"?: never });"
+        ),
+        "Got:\n{ts}"
+    );
+}
+
 #[test]
 #[cfg(feature = "typescript")]
 fn test_compliant_union_typescript() {
@@ -366,6 +441,20 @@ fn test_named_union_zod() {
 
 #[test]
 #[cfg(feature = "zod")]
+fn test_rename_all_union_zod() {
+    let zod = RenameAllUnion::zod_schema();
+    assert!(
+        zod.contains(r#"z.strictObject({ "reply-to": z.string(), })"#),
+        "Got:\n{zod}"
+    );
+    assert!(
+        zod.contains(r#"z.strictObject({ "subject-line": z.string(), })"#),
+        "Got:\n{zod}"
+    );
+}
+
+#[test]
+#[cfg(feature = "zod")]
 fn test_compliant_union_zod() {
     let zod = CompliantUnion::zod_schema();
     assert!(
@@ -415,6 +504,59 @@ fn test_named_union_json_schema() {
 
 #[test]
 #[cfg(feature = "jsonschema")]
+fn test_rename_all_union_json_schema() {
+    let schema = RenameAllUnion::json_schema();
+    let any_of = schema["anyOf"].as_array().unwrap();
+    let branch = any_of
+        .iter()
+        .find(|branch| {
+            branch["properties"]
+                .as_object()
+                .unwrap()
+                .contains_key("reply-to")
+        })
+        .unwrap();
+    assert_eq!(branch["required"], serde_json::json!(["reply-to"]));
+}
+
+/// A closed document — every leaf `additionalProperties: false` — accepts exactly the payload serde
+/// writes for a variant-`rename_all` member, and the value round-trips through it.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_rename_all_union_round_trips_through_its_closed_schema() {
+    let value = RenameAllUnion::Reply {
+        reply_to: "x".to_owned(),
+    };
+    let payload = serde_json::to_value(&value).unwrap();
+    assert_eq!(payload, serde_json::json!({ "reply-to": "x" }));
+
+    let schema = RenameAllUnion::json_schema();
+    let any_of = schema["anyOf"].as_array().unwrap();
+    let branch = any_of
+        .iter()
+        .find(|branch| {
+            branch["properties"]
+                .as_object()
+                .unwrap()
+                .contains_key("reply-to")
+        })
+        .unwrap();
+    let named = branch["properties"].as_object().unwrap();
+    let required = branch["required"].as_array().unwrap();
+    let written = payload.as_object().unwrap();
+    assert!(written.keys().all(|key| named.contains_key(key)));
+    assert!(
+        required
+            .iter()
+            .all(|key| written.contains_key(key.as_str().unwrap()))
+    );
+
+    let back: RenameAllUnion = serde_json::from_value(payload).unwrap();
+    assert_eq!(back, value);
+}
+
+#[test]
+#[cfg(feature = "jsonschema")]
 fn test_compliant_union_json_schema() {
     let schema = CompliantUnion::json_schema();
     let any_of = schema["anyOf"].as_array().unwrap();
@@ -456,6 +598,28 @@ fn test_serde_round_trip_string_member() {
     let json = serde_json::to_string(&value).unwrap();
     assert_eq!(json, "\"2026-06-26\"");
     let back: DateValue = serde_json::from_str(&json).unwrap();
+    assert_eq!(back, value);
+}
+
+/// The unrenamed member is untouched by the fix: `Fresh` still writes and reads its own field name.
+#[test]
+fn test_serde_round_trip_unrenamed_untagged_member() {
+    let value = NamedUnion::A {
+        x: "text".to_owned(),
+    };
+    let json = serde_json::to_string(&value).unwrap();
+    assert_eq!(json, r#"{"x":"text"}"#);
+}
+
+/// A variant's own `rename_all` reaches the wire, not just the schema surfaces above.
+#[test]
+fn test_serde_round_trip_rename_all_union_member() {
+    let value = RenameAllUnion::Fresh {
+        subject_line: "hi".to_owned(),
+    };
+    let json = serde_json::to_string(&value).unwrap();
+    assert_eq!(json, r#"{"subject-line":"hi"}"#);
+    let back: RenameAllUnion = serde_json::from_str(&json).unwrap();
     assert_eq!(back, value);
 }
 


### PR DESCRIPTION
On the untagged path a member's `FieldDef` was built straight from the Rust
ident. `untagged_member_field_def` called `get_field_def(field_name, …)` where
`process_field` calls `get_final_field_name` first, and
`untagged_variant_context` hardcoded `rename_all: None`, so neither spelling of
a rename had a path to the member: not a field's own `#[serde(rename)]`, not the
variant's `#[serde(rename_all)]`.

Every surface reads `FieldDef.name`, so the wrong key propagated to all of them
at once — TypeScript, Zod, and the JSON Schema. The document is closed, so it
did not merely describe the wrong key, it rejected the payload serde writes:

    enum Body { Reply { #[serde(rename = "reply-to")] reply_to: String } }

    ts_definition()   { reply_to: string }
    json_schema()     "properties": { "reply_to": … }, "required": ["reply_to"]
    serde writes      {"reply-to":"x"}

The key is now resolved once, at the one seam the member is built from, and
the resolved name is what feeds both `get_field_def` and
`apply_model_schema_prop_meta`. Diagnostics keep naming the field as the author
wrote it, which is what `process_field` does too.

The `rename_all` threaded in is the variant's own, never the enum's. serde
treats a struct variant as the container for its own fields; an enum's
container-level `rename_all` reaches variant names only. That distinction is
what the tagged paths still get wrong, and it is tracked separately.

The regression tests tie the document to serde rather than to a string: the
round-trip test serializes the value, asserts every key it wrote is named by the
branch and every required key is present, and reads it back. Covered on all
three surfaces, for both spellings of the rename, plus the flattened holder
whose sibling exclusions carry the renamed keys on both sides of the union, and
an identifier-legal rename as the control that the drop was never about quoting.

just all green — clippy and tests across all 68 feature toggles, zero warnings.

