### PR TITLE
scope an enum's rename_all to its variant names, and let a variant's own rename_all reach its fields

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,14 +229,14 @@ export const Status$Schema: ZodType<Status> = Status$RawSchema;
  *         "timestamp": {
  *           "type": "string"
  *         },
- *         "userId": {
+ *         "user_id": {
  *           "type": "string"
  *         }
  *       },
  *       "required": [
  *         "type",
  *         "timestamp",
- *         "userId"
+ *         "user_id"
  *       ]
  *     },
  *     {
@@ -256,13 +256,13 @@ export const Status$Schema: ZodType<Status> = Status$RawSchema;
  *             }
  *           ]
  *         },
- *         "userId": {
+ *         "user_id": {
  *           "type": "string"
  *         }
  *       },
  *       "required": [
  *         "type",
- *         "userId"
+ *         "user_id"
  *       ]
  *     }
  *   ]
@@ -280,10 +280,10 @@ export type Event = {
    */
   timestamp: string;
   /**
-   * userId
+   * user_id
    * 
    */
-  userId: string;
+  user_id: string;
 } | {
   /**
    * userDeleted
@@ -296,10 +296,10 @@ export type Event = {
    */
   reason: string | undefined;
   /**
-   * userId
+   * user_id
    * 
    */
-  userId: string;
+  user_id: string;
 };
 ```"#]
 ///
@@ -309,11 +309,11 @@ export type Event = {
 const Event$RawSchema = z.discriminatedUnion("type", [z.strictObject({
   type: z.literal("userCreated"),
   timestamp: z.string(),
-  userId: z.string(),
+  user_id: z.string(),
 }), z.strictObject({
   type: z.literal("userDeleted"),
   reason: z.union([z.null().transform(() => undefined), z.string(), z.undefined()]).prefault(undefined),
-  userId: z.string(),
+  user_id: z.string(),
 })]);
 
 export const Event$Schema: ZodType<Event> = Event$RawSchema;

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -5639,6 +5639,13 @@ fn collect_discriminated_variants(
         let field_rename = parse_serde_field_attributes(&item.attrs).rename;
         #[cfg(not(feature = "serde"))]
         let field_rename: Option<String> = None;
+        // serde treats a struct variant as the container for its own fields: its own
+        // `rename_all` (if any) reaches them, the enum's container-level `rename_all` never does
+        // — that one renames variant names only.
+        #[cfg(feature = "serde")]
+        let variant_rename_all = parse_serde_type_attributes(&item.attrs).rename_all;
+        #[cfg(not(feature = "serde"))]
+        let variant_rename_all: Option<String> = None;
 
         let variant_ident = item.ident.to_string();
         let final_name =
@@ -5670,7 +5677,7 @@ fn collect_discriminated_variants(
             let (f_def, validation_fn, validate_body, field_guard_errors) = process_field(
                 &FieldContext {
                     container_defaulted: variant_defaulted,
-                    rename_all,
+                    rename_all: variant_rename_all.as_deref(),
                     schema_module_name: enum_module_name_opt,
                     type_name: &enum_type_name,
                     type_parameters: &type_parameters,

--- a/tests/advanced_tests/tests.rs
+++ b/tests/advanced_tests/tests.rs
@@ -340,9 +340,11 @@ fn test_complex_nested_ts_definition() {
     assert!(retirement_definition.contains("type: \"option401k\""));
     assert!(retirement_definition.contains("type: \"pension\""));
     assert!(retirement_definition.contains("type: \"roth\""));
-    assert!(retirement_definition.contains("employerMatchPercentage: number;"));
-    assert!(retirement_definition.contains("yearsOfServiceRequired: number;"));
-    assert!(retirement_definition.contains("contributionLimit: number;"));
+    // RetirementPlan's own rename_all cases its discriminator alone; its variants carry no rename
+    // of their own, so their fields stay as declared, matching what serde writes on the wire.
+    assert!(retirement_definition.contains("employer_match_percentage: number;"));
+    assert!(retirement_definition.contains("years_of_service_required: number;"));
+    assert!(retirement_definition.contains("contribution_limit: number;"));
 
     let company_zod_schema = Company::zod_schema();
     let employee_zod_schema = Employee::zod_schema();
@@ -503,16 +505,18 @@ fn test_complex_discriminated_union() {
     assert!(ts_definition.contains("eventType: \"purchaseCompleted\""));
     assert!(ts_definition.contains("eventType: \"systemMaintenance\""));
 
-    assert!(ts_definition.contains("userId: string;"));
-    assert!(ts_definition.contains("registrationSource: string;"));
-    assert!(ts_definition.contains("orderId: string;"));
-    assert!(ts_definition.contains("totalAmount: number;"));
-    assert!(ts_definition.contains("paymentMethod: string;"));
-    assert!(ts_definition.contains("shippingAddress: Address | undefined;"));
-    assert!(ts_definition.contains("scheduledStart: string;"));
-    assert!(ts_definition.contains("estimatedDuration: number;"));
-    assert!(ts_definition.contains("affectedServices: Array<string>;"));
-    assert!(ts_definition.contains("notificationSent: boolean;"));
+    // ComplexEvent's own rename_all cases eventType alone; its variants carry no rename of their
+    // own, so their fields stay as declared, matching what serde writes on the wire.
+    assert!(ts_definition.contains("user_id: string;"));
+    assert!(ts_definition.contains("registration_source: string;"));
+    assert!(ts_definition.contains("order_id: string;"));
+    assert!(ts_definition.contains("total_amount: number;"));
+    assert!(ts_definition.contains("payment_method: string;"));
+    assert!(ts_definition.contains("shipping_address: Address | undefined;"));
+    assert!(ts_definition.contains("scheduled_start: string;"));
+    assert!(ts_definition.contains("estimated_duration: number;"));
+    assert!(ts_definition.contains("affected_services: Array<string>;"));
+    assert!(ts_definition.contains("notification_sent: boolean;"));
 
     let zod_schema = ComplexEvent::zod_schema();
     assert!(zod_schema.contains("z.discriminatedUnion(\"eventType\""));

--- a/tests/enum_tests/tests.rs
+++ b/tests/enum_tests/tests.rs
@@ -341,10 +341,12 @@ fn test_discriminated_union_ts_definition() {
     assert!(ts_definition.contains("type: \"bankTransfer\""));
     assert!(ts_definition.contains("type: \"payPal\""));
 
-    assert!(ts_definition.contains("cardNumber: string;"));
-    assert!(ts_definition.contains("expiryDate: string;"));
-    assert!(ts_definition.contains("accountNumber: string;"));
-    assert!(ts_definition.contains("routingNumber: string;"));
+    // The enum's own rename_all cases the discriminator value alone; PaymentMethod's fields carry
+    // no rename of their own, so they stay as declared, matching what serde writes on the wire.
+    assert!(ts_definition.contains("card_number: string;"));
+    assert!(ts_definition.contains("expiry_date: string;"));
+    assert!(ts_definition.contains("account_number: string;"));
+    assert!(ts_definition.contains("routing_number: string;"));
 
     let zod_schema = PaymentMethod::zod_schema();
     assert!(zod_schema.contains("z.discriminatedUnion(\"type\""));

--- a/tests/rename_all_tests/tests.rs
+++ b/tests/rename_all_tests/tests.rs
@@ -46,6 +46,49 @@ enum SandboxKind {
     PlainAdd,
 }
 
+// One struct-variant enum per tagged representation, each carrying an enum-level `rename_all` and
+// two variants: `Unmarked` has no rename of its own, so its field must stay as declared — the
+// container-level rule cases the discriminator alone, never a variant's fields. `Marked` carries
+// its own `rename_all`, which serde treats as the container for its own fields and does apply.
+#[model_schema()]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+enum InternallyTaggedRename {
+    #[serde(rename_all = "kebab-case")]
+    Marked {
+        field_two: String,
+    },
+    Unmarked {
+        field_one: String,
+    },
+}
+
+#[model_schema()]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+enum ExternallyTaggedRename {
+    #[serde(rename_all = "kebab-case")]
+    Marked {
+        field_two: String,
+    },
+    Unmarked {
+        field_one: String,
+    },
+}
+
+#[model_schema()]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "kind", content = "data", rename_all = "camelCase")]
+enum AdjacentlyTaggedRename {
+    #[serde(rename_all = "kebab-case")]
+    Marked {
+        field_two: String,
+    },
+    Unmarked {
+        field_one: String,
+    },
+}
+
 /// The string serde itself writes for a unit variant.
 fn serde_wire_name<T>(variant: &T) -> String
 where
@@ -173,5 +216,286 @@ fn snake_case_json_schema_matches_serde_wire() {
     assert_eq!(
         values.iter().map(ToString::to_string).collect::<Vec<_>>(),
         ["\"body_only\"", "\"noop\"", "\"verbatim\""]
+    );
+}
+
+// Struct-variant field renaming under each of serde's three tagged representations: the
+// container-level `rename_all` must not reach a variant's fields, and a variant's own
+// `rename_all` must.
+
+#[test]
+fn internally_tagged_rename_all_reaches_the_wire_correctly() {
+    let unmarked = InternallyTaggedRename::Unmarked {
+        field_one: "a".to_owned(),
+    };
+    let unmarked_json = serde_json::to_value(&unmarked).unwrap();
+    assert_eq!(
+        unmarked_json,
+        serde_json::json!({ "kind": "unmarked", "field_one": "a" })
+    );
+    assert_eq!(
+        serde_json::from_value::<InternallyTaggedRename>(unmarked_json).unwrap(),
+        unmarked
+    );
+
+    let marked = InternallyTaggedRename::Marked {
+        field_two: "b".to_owned(),
+    };
+    let marked_json = serde_json::to_value(&marked).unwrap();
+    assert_eq!(
+        marked_json,
+        serde_json::json!({ "kind": "marked", "field-two": "b" })
+    );
+    assert_eq!(
+        serde_json::from_value::<InternallyTaggedRename>(marked_json).unwrap(),
+        marked
+    );
+}
+
+#[test]
+fn externally_tagged_rename_all_reaches_the_wire_correctly() {
+    let unmarked = ExternallyTaggedRename::Unmarked {
+        field_one: "a".to_owned(),
+    };
+    let unmarked_json = serde_json::to_value(&unmarked).unwrap();
+    assert_eq!(
+        unmarked_json,
+        serde_json::json!({ "unmarked": { "field_one": "a" } })
+    );
+    assert_eq!(
+        serde_json::from_value::<ExternallyTaggedRename>(unmarked_json).unwrap(),
+        unmarked
+    );
+
+    let marked = ExternallyTaggedRename::Marked {
+        field_two: "b".to_owned(),
+    };
+    let marked_json = serde_json::to_value(&marked).unwrap();
+    assert_eq!(
+        marked_json,
+        serde_json::json!({ "marked": { "field-two": "b" } })
+    );
+    assert_eq!(
+        serde_json::from_value::<ExternallyTaggedRename>(marked_json).unwrap(),
+        marked
+    );
+}
+
+#[test]
+fn adjacently_tagged_rename_all_reaches_the_wire_correctly() {
+    let unmarked = AdjacentlyTaggedRename::Unmarked {
+        field_one: "a".to_owned(),
+    };
+    let unmarked_json = serde_json::to_value(&unmarked).unwrap();
+    assert_eq!(
+        unmarked_json,
+        serde_json::json!({ "kind": "unmarked", "data": { "field_one": "a" } })
+    );
+    assert_eq!(
+        serde_json::from_value::<AdjacentlyTaggedRename>(unmarked_json).unwrap(),
+        unmarked
+    );
+
+    let marked = AdjacentlyTaggedRename::Marked {
+        field_two: "b".to_owned(),
+    };
+    let marked_json = serde_json::to_value(&marked).unwrap();
+    assert_eq!(
+        marked_json,
+        serde_json::json!({ "kind": "marked", "data": { "field-two": "b" } })
+    );
+    assert_eq!(
+        serde_json::from_value::<AdjacentlyTaggedRename>(marked_json).unwrap(),
+        marked
+    );
+}
+
+#[cfg(feature = "typescript")]
+#[test]
+fn internally_tagged_rename_all_typescript_matches_serde_wire() {
+    let ts = InternallyTaggedRename::ts_definition();
+    assert!(ts.contains("kind: \"unmarked\""), "Got:\n{ts}");
+    assert!(ts.contains("field_one: string"), "Got:\n{ts}");
+    assert!(ts.contains("kind: \"marked\""), "Got:\n{ts}");
+    assert!(ts.contains("\"field-two\": string"), "Got:\n{ts}");
+}
+
+#[cfg(feature = "typescript")]
+#[test]
+fn externally_tagged_rename_all_typescript_matches_serde_wire() {
+    let ts = ExternallyTaggedRename::ts_definition();
+    assert!(ts.contains("\"unmarked\": {"), "Got:\n{ts}");
+    assert!(ts.contains("field_one: string"), "Got:\n{ts}");
+    assert!(ts.contains("\"marked\": {"), "Got:\n{ts}");
+    assert!(ts.contains("\"field-two\": string"), "Got:\n{ts}");
+}
+
+#[cfg(feature = "typescript")]
+#[test]
+fn adjacently_tagged_rename_all_typescript_matches_serde_wire() {
+    let ts = AdjacentlyTaggedRename::ts_definition();
+    assert!(ts.contains("kind: \"unmarked\""), "Got:\n{ts}");
+    assert!(ts.contains("field_one: string"), "Got:\n{ts}");
+    assert!(ts.contains("kind: \"marked\""), "Got:\n{ts}");
+    assert!(ts.contains("\"field-two\": string"), "Got:\n{ts}");
+}
+
+#[cfg(feature = "zod")]
+#[test]
+fn internally_tagged_rename_all_zod_matches_serde_wire() {
+    let zod = InternallyTaggedRename::zod_schema();
+    assert!(zod.contains("kind: z.literal(\"unmarked\")"), "Got:\n{zod}");
+    assert!(zod.contains("field_one: z.string()"), "Got:\n{zod}");
+    assert!(zod.contains("kind: z.literal(\"marked\")"), "Got:\n{zod}");
+    assert!(zod.contains("\"field-two\": z.string()"), "Got:\n{zod}");
+}
+
+#[cfg(feature = "zod")]
+#[test]
+fn externally_tagged_rename_all_zod_matches_serde_wire() {
+    let zod = ExternallyTaggedRename::zod_schema();
+    assert!(
+        zod.contains("\"unmarked\": z.strictObject({"),
+        "Got:\n{zod}"
+    );
+    assert!(zod.contains("field_one: z.string()"), "Got:\n{zod}");
+    assert!(zod.contains("\"marked\": z.strictObject({"), "Got:\n{zod}");
+    assert!(zod.contains("\"field-two\": z.string()"), "Got:\n{zod}");
+}
+
+#[cfg(feature = "zod")]
+#[test]
+fn adjacently_tagged_rename_all_zod_matches_serde_wire() {
+    let zod = AdjacentlyTaggedRename::zod_schema();
+    assert!(zod.contains("kind: z.literal(\"unmarked\")"), "Got:\n{zod}");
+    assert!(zod.contains("field_one: z.string()"), "Got:\n{zod}");
+    assert!(zod.contains("kind: z.literal(\"marked\")"), "Got:\n{zod}");
+    assert!(zod.contains("\"field-two\": z.string()"), "Got:\n{zod}");
+}
+
+/// A closed branch (`additionalProperties: false`) describes exactly the keys serde wrote for
+/// `value`: every key on the wire is named in `properties`, and every `required` key is on the
+/// wire.
+#[cfg(feature = "jsonschema")]
+fn assert_branch_accepts<T>(branch: &serde_json::Value, value: &T)
+where
+    T: serde::Serialize,
+{
+    let payload = serde_json::to_value(value).unwrap();
+    let named = branch["properties"].as_object().unwrap();
+    let required = branch["required"].as_array().unwrap();
+    let written = payload.as_object().unwrap();
+    assert!(
+        written.keys().all(|key| named.contains_key(key)),
+        "schema does not name a key serde wrote:\nwire: {payload}\nbranch: {branch}"
+    );
+    assert!(
+        required
+            .iter()
+            .all(|key| written.contains_key(key.as_str().unwrap())),
+        "schema requires a key serde did not write:\nwire: {payload}\nbranch: {branch}"
+    );
+}
+
+#[cfg(feature = "jsonschema")]
+#[test]
+fn internally_tagged_rename_all_json_schema_matches_serde_wire() {
+    let schema = InternallyTaggedRename::json_schema();
+    let one_of = schema["oneOf"].as_array().unwrap();
+
+    let unmarked = InternallyTaggedRename::Unmarked {
+        field_one: "a".to_owned(),
+    };
+    let unmarked_branch = one_of
+        .iter()
+        .find(|branch| branch["properties"]["kind"]["const"] == "unmarked")
+        .unwrap();
+    assert_branch_accepts(unmarked_branch, &unmarked);
+
+    let marked = InternallyTaggedRename::Marked {
+        field_two: "b".to_owned(),
+    };
+    let marked_branch = one_of
+        .iter()
+        .find(|branch| branch["properties"]["kind"]["const"] == "marked")
+        .unwrap();
+    assert_branch_accepts(marked_branch, &marked);
+}
+
+#[cfg(feature = "jsonschema")]
+#[test]
+fn externally_tagged_rename_all_json_schema_matches_serde_wire() {
+    let schema = ExternallyTaggedRename::json_schema();
+    let one_of = schema["oneOf"].as_array().unwrap();
+
+    let unmarked = ExternallyTaggedRename::Unmarked {
+        field_one: "a".to_owned(),
+    };
+    let unmarked_branch = one_of
+        .iter()
+        .find(|branch| {
+            branch["properties"]
+                .as_object()
+                .unwrap()
+                .contains_key("unmarked")
+        })
+        .unwrap();
+    assert_branch_accepts(unmarked_branch, &unmarked);
+    assert!(
+        unmarked_branch["properties"]["unmarked"]["properties"]
+            .as_object()
+            .unwrap()
+            .contains_key("field_one")
+    );
+
+    let marked = ExternallyTaggedRename::Marked {
+        field_two: "b".to_owned(),
+    };
+    let marked_branch = one_of
+        .iter()
+        .find(|branch| {
+            branch["properties"]
+                .as_object()
+                .unwrap()
+                .contains_key("marked")
+        })
+        .unwrap();
+    assert_branch_accepts(marked_branch, &marked);
+    assert!(
+        marked_branch["properties"]["marked"]["properties"]
+            .as_object()
+            .unwrap()
+            .contains_key("field-two")
+    );
+}
+
+// The adjacently-tagged branch below asserts against `properties` directly rather than a
+// `data`-nested object: the content-key nesting the wire actually uses is a separate,
+// pre-existing gap the JSON Schema surface does not render yet. This test only pins the seam
+// this bug is about -- that the field key itself is untouched by the enum's own `rename_all`.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn adjacently_tagged_rename_all_json_schema_matches_serde_wire() {
+    let schema = AdjacentlyTaggedRename::json_schema();
+    let one_of = schema["oneOf"].as_array().unwrap();
+    let unmarked_branch = one_of
+        .iter()
+        .find(|branch| branch["properties"]["kind"]["const"] == "unmarked")
+        .unwrap();
+    assert!(
+        unmarked_branch["properties"]
+            .as_object()
+            .unwrap()
+            .contains_key("field_one")
+    );
+    let marked_branch = one_of
+        .iter()
+        .find(|branch| branch["properties"]["kind"]["const"] == "marked")
+        .unwrap();
+    assert!(
+        marked_branch["properties"]
+            .as_object()
+            .unwrap()
+            .contains_key("field-two")
     );
 }

--- a/tests/serde_tests/tests.rs
+++ b/tests/serde_tests/tests.rs
@@ -339,8 +339,11 @@ fn test_discriminated_union_with_serde_typescript() {
     assert!(ts.contains("type: \"userDeleted\""));
     assert!(ts.contains("type: \"userUpdated\""));
 
-    assert!(ts.contains("userId: string;"));
-    assert!(ts.contains("userName: string;"));
+    // The enum's own rename_all cases the discriminator alone; `user_id`/`user_name` carry no
+    // rename of their own and stay as declared, while `email`'s own field-level rename still
+    // applies regardless of the container.
+    assert!(ts.contains("user_id: string;"));
+    assert!(ts.contains("user_name: string;"));
     assert!(ts.contains("newEmail: string;"));
 }
 
@@ -351,8 +354,8 @@ fn test_discriminated_union_with_serde_zod() {
 
     assert!(zod.contains("z.discriminatedUnion"));
     assert!(zod.contains("\"type\""));
-    assert!(zod.contains("userId"));
-    assert!(zod.contains("userName"));
+    assert!(zod.contains("user_id"));
+    assert!(zod.contains("user_name"));
     assert!(zod.contains("newEmail"));
 }
 


### PR DESCRIPTION
`collect_discriminated_variants` is the single seam all three tagged
representations are built through — internally, externally and adjacently
tagged — and it threaded the *enum's* container-level `rename_all` into the
`FieldContext` every struct variant's fields resolve against.

serde does not do that. A container-level `rename_all` on an enum cases variant
names, and the discriminator value with them; the fields inside a struct variant
are cased by a `rename_all` written on the *variant*, which is a separate rule.
Both halves of the defect were the one line: the enum's rule reached fields it
should never have touched, and the variant's own rule was never read at all.

The generated document is closed, so this did not merely describe the wrong
keys — it rejected every payload the enum actually writes:

    #[serde(tag = "kind", rename_all = "camelCase")]
    enum PlainEvent { ItemCreated { archive_id: String } }

    described   { "kind": "itemCreated", "archiveId": … }
    serde wrote { "kind": "itemCreated", "archive_id": … }

The variant's own attributes are now what the fields resolve against. The enum's
`rename_all` still cases the variant name through `get_final_variant_name`,
untouched, and a field's own `#[serde(rename)]` still wins over both. This is
the same model the untagged path was just put on, so the two agree.

The regression tests fix the rule to serde rather than to a string: each of the
three representations serializes a real value and asserts the exact document
serde produced — `{"kind":"unmarked","field_one":"a"}` for a variant with no
rule of its own, `{"kind":"marked","field-two":"b"}` for one carrying
`rename_all = "kebab-case"` — then checks TypeScript, Zod and the JSON Schema
against that same wire.

Four fixtures whose assertions had encoded the old behaviour are corrected to
what serde writes: `PaymentMethod`, `ComplexEvent`, `RetirementPlan` and
`Event`. The `Event` rustdoc pins generated output, so its three surfaces move
with them.

just all green — clippy across all 68 feature toggles, and the test powerset
across all 68, run in four partitions.

