### PR TITLE
step over a list-form serde key, so the attributes written after one are still read

### DIFF
--- a/src/features/serde.rs
+++ b/src/features/serde.rs
@@ -10,9 +10,11 @@
 
 #[cfg(all(test, feature = "serde"))]
 use crate::rename_rule::resolve_rename_rule;
+use proc_macro2::Group;
 #[cfg(feature = "serde")]
 use proc_macro2::{Delimiter, TokenTree};
 use syn::meta::ParseNestedMeta;
+use syn::token::Paren;
 use syn::{Attribute, Token};
 #[cfg(feature = "serde")]
 use syn::{Error, LitStr, Meta};
@@ -123,14 +125,24 @@ pub fn parse_serde_key_omission(attrs: &[Attribute]) -> SerdeKeyOmission {
     omission
 }
 
-/// Consumes the value of a `key = value` the walk had no use for.
+/// Consumes the value of a `key = value` or the group of a `key(...)` list the walk had no use
+/// for.
 ///
-/// An unread value ends the walk on the comma that follows it, taking every attribute written
-/// after it along — so which attributes a declaration is read by would otherwise depend on the
-/// order someone happened to write them in.
+/// An unread value or list ends the walk on the comma that follows it, taking every attribute
+/// written after it along — so which attributes a declaration is read by would otherwise depend
+/// on the order someone happened to write them in. The list is consumed whole, as a single
+/// `Group` token, rather than parsed: nothing here reads `serialize`/`deserialize` out of
+/// `bound(...)`/`rename(...)`/`rename_all(...)`, only steps past them. With both spellings
+/// swallowed, a walk that still fails is a `#[serde(...)]` attribute malformed in some other way
+/// — serde's own derive will refuse it too — so the trace-level swallow below stays as the walk's
+/// resilience against that, rather than a channel this fix needs to redesign.
 fn consume_unread_value(nested: &ParseNestedMeta<'_>) -> syn::Result<()> {
     if nested.input.peek(Token![=]) {
         nested.value()?.parse::<syn::Expr>()?;
+    } else if nested.input.peek(Paren) {
+        nested.input.parse::<Group>()?;
+    } else {
+        // Neither `= value` nor `(...)`: a bare key like `untagged`, nothing to step over.
     }
     Ok(())
 }
@@ -185,8 +197,10 @@ pub fn parse_serde_type_attributes(attrs: &[Attribute]) -> SerdeTypeMeta {
                     let lit: LitStr = value.parse()?;
                     meta.content = Some(lit.value());
                 }
-                // Handle `rename_all = "value"`
-                else if nested.path.is_ident("rename_all") {
+                // Handle `rename_all = "value"`. The list form `rename_all(serialize = "...",
+                // deserialize = "...")` is left to fall through to `consume_unread_value` below,
+                // the same as any other key this walk has no use for.
+                else if nested.path.is_ident("rename_all") && nested.input.peek(Token![=]) {
                     let value = nested.value()?;
                     let lit: LitStr = value.parse()?;
                     meta.rename_all = Some(lit.value());
@@ -221,8 +235,10 @@ pub fn parse_serde_field_attributes(attrs: &[Attribute]) -> SerdeFieldMeta {
             meta.cfg_attr_rejection = cfg_attr_serde_rejection(attr);
         } else if attr.path().is_ident("serde") {
             attr.parse_nested_meta(|nested| {
-                // Handle `rename = "value"`
-                if nested.path.is_ident("rename") {
+                // Handle `rename = "value"`. The list form `rename(serialize = "...",
+                // deserialize = "...")` is left to fall through to `consume_unread_value` below,
+                // the same as any other key this walk has no use for.
+                if nested.path.is_ident("rename") && nested.input.peek(Token![=]) {
                     let value = nested.value()?;
                     let lit: LitStr = value.parse()?;
                     meta.rename = Some(lit.value());

--- a/src/features/serde/key_omission_tests.rs
+++ b/src/features/serde/key_omission_tests.rs
@@ -110,3 +110,21 @@ fn test_omission_keys_after_an_unread_value_are_still_read() {
         "default is written after an unread value"
     );
 }
+
+/// `rename(...)` is a documented serde list form this walk has no dedicated branch for, so it
+/// falls to the same unread-value path as `skip_serializing_if = "..."` above — but a
+/// parenthesised list was left uncounted for, so `skip` written after it was never seen.
+#[test]
+fn test_skip_after_a_list_form_rename_is_still_read() {
+    let item: syn::ItemStruct = syn::parse_quote! {
+        struct S {
+            #[serde(rename(serialize = "ser", deserialize = "de"), skip)]
+            foo: String,
+        }
+    };
+    assert!(
+        omission(&item).omits_key,
+        "skip is written after a list-form rename(...)"
+    );
+    assert!(omission(&item).skips_deserializing);
+}

--- a/src/features/serde/tests.rs
+++ b/src/features/serde/tests.rs
@@ -307,3 +307,65 @@ fn test_type_attributes_without_unread_values_are_unchanged() {
     assert!(!meta.untagged);
     assert!(meta.cfg_attr_rejection.is_none());
 }
+
+/// `bound(...)` has no dedicated branch, so it was always meant to fall through to
+/// `consume_unread_value` — but the helper only knew how to step over `key = value`, not a
+/// parenthesised list, so the tag written after it was lost.
+#[test]
+fn test_tag_after_a_list_form_bound_is_still_read() {
+    let item: syn::ItemEnum = syn::parse_quote! {
+        #[serde(bound(serialize = "T: Clone", deserialize = "T: Clone"), tag = "kind")]
+        enum E<T> {
+            A(T),
+        }
+    };
+    let meta = parse_serde_type_attributes(&item.attrs);
+    assert_eq!(
+        meta.tag.as_deref(),
+        Some("kind"),
+        "tag is written after a list-form bound(...)"
+    );
+}
+
+/// `rename_all` has a dedicated branch, but list-form syntax leaves this crate nothing to read —
+/// only the tag written after it must survive, the same as the `bound(...)` case above.
+#[test]
+fn test_tag_after_a_list_form_rename_all_is_still_read() {
+    let item: syn::ItemEnum = syn::parse_quote! {
+        #[serde(rename_all(serialize = "camelCase"), tag = "kind")]
+        enum E {
+            A(String),
+        }
+    };
+    let meta = parse_serde_type_attributes(&item.attrs);
+    assert_eq!(
+        meta.rename_all, None,
+        "list-form rename_all carries a value this crate does not read"
+    );
+    assert_eq!(
+        meta.tag.as_deref(),
+        Some("kind"),
+        "tag is written after a list-form rename_all(...)"
+    );
+}
+
+/// `rename` has a dedicated branch too, and its list form must not swallow `flatten` written
+/// after it.
+#[test]
+fn test_flatten_after_a_list_form_rename_is_still_read() {
+    let item: syn::ItemStruct = syn::parse_quote! {
+        struct S {
+            #[serde(rename(serialize = "ser", deserialize = "de"), flatten)]
+            foo: String,
+        }
+    };
+    let meta = field_meta(&item);
+    assert_eq!(
+        meta.rename, None,
+        "list-form rename carries a value this crate does not read"
+    );
+    assert!(
+        meta.flatten,
+        "flatten is written after a list-form rename(...)"
+    );
+}


### PR DESCRIPTION
`consume_unread_value` exists so that an attribute the walk has no use for does
not decide whether the ones after it are seen. It only ever peeked for `=`,
though, so a `key(...)` list was left whole on the parse stream, the walk failed
on the comma that followed, and `unwrap_or_else(log::trace)` swallowed the
failure — every attribute written after the list silently unread:

    #[serde(bound(serialize = "T: Clone"), tag = "kind")]   tag = None
    #[serde(rename_all(serialize = "camelCase"), tag = "kind")]   tag = None

`bound(...)`, `rename(...)` and `rename_all(...)` are ordinary documented serde
syntax, so this was not an exotic spelling — and the schema that came out
described a shape the type does not have, with nothing said about it.

Two seams had to move, the second only visible once the first was fixed.
`consume_unread_value` now takes a parenthesized group as a single `Group`
token when no `=` follows. That alone fixed `bound(...)` but not the other two:
the `rename_all` and `rename` branches call `nested.value()?` outright, so a
list form failed inside its own branch before ever reaching the consumer. Each
now takes the `=` path only when `=` is actually next, and otherwise falls
through to the same handling every unread key gets.

The list is stepped over, not read. Nothing here takes `serialize`/`deserialize`
out of `rename(...)`/`rename_all(...)` — that is a separate gap, tracked
separately; this change is only about the attributes that follow one no longer
disappearing.

The trace-level swallow is left alone deliberately. With both spellings
consumed, a walk that still fails is a `#[serde(...)]` malformed in some way
serde's own derive will refuse too, so the swallow stays as resilience rather
than a silent wrong answer.

just lint, just lint-all across all 68 toggles, and the test powerset across all
68 in four partitions — all green.

