### PR TITLE
key a hoisted definition by the filling that built it, not by the name alone

### DIFF
--- a/src/features/jsonschema.rs
+++ b/src/features/jsonschema.rs
@@ -2,7 +2,12 @@
 //!
 //! This module handles JSON schema generation when the "jsonschema" feature is enabled.
 
-/// What every pointer the crate writes opens with; what follows it is the name being deferred.
+/// What every pointer the crate writes opens with; what follows it is the key a definition is
+/// hoisted under — a bare name, or a name discriminated by the filling that built it.
+///
+/// The crate writes draft 2020-12 (`prefixItems` with `"items": false` is that draft's fixed-arity
+/// array, and the draft before it spells the same array with `items`/`additionalItems`), whose
+/// deferred schema is a `$ref` into the document's own `$defs`.
 const DEFS_PREFIX: &str = "#/$defs/";
 
 /// How a merge that cannot proceed names itself in the diagnostic it raises.
@@ -46,15 +51,6 @@ pub struct SchemaParameter {
     pub default: proc_macro2::TokenStream,
 }
 
-/// Where a document holds the definition of `def_name`.
-///
-/// The crate writes draft 2020-12 (`prefixItems` with `"items": false` is that draft's fixed-arity
-/// array, and the draft before it spells the same array with `items`/`additionalItems`), whose
-/// deferred schema is a `$ref` into the document's own `$defs`.
-fn defs_pointer(def_name: &str) -> String {
-    format!("{DEFS_PREFIX}{def_name}")
-}
-
 /// The JSON-schema methods a schema module publishes.
 pub fn json_schema_methods(
     def_name: &str,
@@ -63,7 +59,7 @@ pub fn json_schema_methods(
 ) -> proc_macro2::TokenStream {
     let in_flight_type = in_flight_type();
     if parameters.is_empty() {
-        let described = guarded_description(def_name, body, &quote::quote! { Vec::new() });
+        let described = guarded_description(def_name, body, &quote::quote! { Vec::new() }, false);
         let rooted = rooted_document(
             &quote::quote! { Self::json_schema_within(&mut in_flight, &mut hoisted_defs) },
         );
@@ -80,7 +76,7 @@ pub fn json_schema_methods(
             }
         };
     }
-    let described = guarded_description(def_name, body, &bound_filling(parameters));
+    let described = guarded_description(def_name, body, &bound_filling(parameters), true);
     let rooted = rooted_document(
         &quote::quote! { Self::json_schema_within(&mut in_flight, &mut hoisted_defs) },
     );
@@ -139,31 +135,102 @@ fn bound_filling(parameters: &[SchemaParameter]) -> proc_macro2::TokenStream {
 ///
 /// `filling` is the documents this frame's parameters were filled with, which is what the guard
 /// reads the re-entry against: the same filling is the cycle the pointer describes, a different one
-/// the body the document cannot hold.
+/// the body the document cannot hold. It is also what the hoisted key is built from: a generic name
+/// can be reached at more than one filling across a document, sequentially rather than nested — two
+/// sibling fields naming it at different fillings, neither ever in flight while the other runs — so
+/// a bare name would let the second write silently clobber the first's definition.
+///
+/// `discriminate_by_filling` is decided by the caller, not read off `filling` at runtime: a name
+/// declaring no parameter always fills at `Vec::new()`, and a name declaring one or more always
+/// fills at a `vec![...]` of that many arguments, so which of the two this frame is is already
+/// known at expansion time. Keying every call the same way — reading each argument's `"type"`
+/// keyword — would plant that literal text in the parameterless form's own source too, breaking a
+/// caller that reads the generated tokens rather than running them; picking the tokens to emit
+/// instead of the value to compute keeps a parameterless name keyed the bare, undiscriminated way
+/// it always has been, byte-identical down to the source text and not only the runtime value.
+///
+/// A non-empty filling's key must also be a legal `$ref` URI-reference, which the canonical JSON
+/// text of the filling is not — it carries quotes, braces and colons a URI-reference forbids
+/// outright, RFC 6901's `~0`/`~1` escaping being answerable only for what a *pointer* forbids. The
+/// discriminator built here instead reads each argument's own recognizable name where the argument
+/// carries one — a sibling reference's own key (already URI-safe, by the same rule applied one
+/// level down), or a primitive's `"type"` keyword — and joins those into a readable label. Two
+/// fillings a label cannot tell apart (`u32` and `i64` both read `"integer"`) still cannot collide,
+/// because a digest of the filling's canonical text is appended regardless of whether a label was
+/// found; a filling with no labeled argument at all (a bare type parameter's opaque `{}`) keys off
+/// that digest alone.
 fn guarded_description(
     def_name: &str,
     body: &proc_macro2::TokenStream,
     filling: &proc_macro2::TokenStream,
+    discriminate_by_filling: bool,
 ) -> proc_macro2::TokenStream {
-    let pointer = defs_pointer(def_name);
     let refusal = refilled_cycle_refusal(def_name);
+    let defs_prefix = DEFS_PREFIX;
+    let key_binding = if discriminate_by_filling {
+        quote::quote! {
+            let key = {
+                // The FNV-1a offset basis and prime: an algorithm spelled out here rather than
+                // reached for from `std::hash::Hasher`, whose documented internals are free to
+                // change between compiler versions and would make the key of an identical filling
+                // drift across builds.
+                fn digest(bytes: &[u8]) -> u64 {
+                    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+                    for byte in bytes {
+                        hash ^= u64::from(*byte);
+                        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+                    }
+                    hash
+                }
+                // An argument's own recognizable name: another hoisted key, read back off its
+                // `$ref`, or a primitive's `"type"` keyword. An inlined struct or a bare type
+                // parameter's `{}` has neither, and contributes nothing to the label — the digest
+                // is what tells its filling apart from another's regardless.
+                fn argument_label(argument: &serde_json::Value) -> Option<String> {
+                    if let Some(reference) =
+                        argument.get("$ref").and_then(serde_json::Value::as_str)
+                    {
+                        return reference.rsplit('/').next().map(str::to_string);
+                    }
+                    argument
+                        .get("type")
+                        .and_then(serde_json::Value::as_str)
+                        .map(str::to_string)
+                }
+                let canonical = serde_json::to_string(&filling).unwrap_or_default();
+                let fingerprint = digest(canonical.as_bytes());
+                let labels: Vec<String> = filling.iter().filter_map(argument_label).collect();
+                if labels.is_empty() {
+                    format!("{}.{fingerprint:016x}", #def_name)
+                } else {
+                    format!("{}.{}-{fingerprint:016x}", #def_name, labels.join("_"))
+                }
+            };
+        }
+    } else {
+        quote::quote! {
+            let key = #def_name.to_string();
+        }
+    };
     quote::quote! {
         let filling: Vec<serde_json::Value> = #filling;
+        #key_binding
+        let pointer = format!("{}{key}", #defs_prefix);
         if let Some((_, in_flight_filling)) =
             in_flight.iter().find(|(named, _)| *named == #def_name)
         {
             #refusal
             // Reserved rather than written: the frame that put this name in flight is still
             // writing the body, and fills the entry in once it has one.
-            hoisted_defs.entry(#def_name).or_insert(serde_json::Value::Null);
-            return serde_json::json!({ "$ref": #pointer });
+            hoisted_defs.entry(key).or_insert(serde_json::Value::Null);
+            return serde_json::json!({ "$ref": pointer });
         }
         in_flight.push((#def_name, filling));
         let described = #body;
         in_flight.pop();
-        if hoisted_defs.contains_key(#def_name) {
-            hoisted_defs.insert(#def_name.to_string(), described);
-            return serde_json::json!({ "$ref": #pointer });
+        if hoisted_defs.contains_key(&key) {
+            hoisted_defs.insert(key, described);
+            return serde_json::json!({ "$ref": pointer });
         }
         described
     }

--- a/src/features/jsonschema/tests.rs
+++ b/src/features/jsonschema/tests.rs
@@ -182,16 +182,24 @@ fn test_json_schema_methods_pair_an_entry_point_with_a_guarded_body() {
 }
 
 /// The pointer and the `$defs` key are two spellings of one name; a document whose reference
-/// pointed anywhere but at the entry it hoists would resolve to nothing.
+/// pointed anywhere but at the entry it hoists would resolve to nothing. A name declaring no
+/// parameter always fills at an empty list, so the key it resolves to at runtime is the bare
+/// name — but the pointer is built from that runtime `key`, not from a literal embedding the name
+/// carries at macro-expansion time, since a generic name's key also carries the filling that
+/// built it (see the filling-keyed tests in the whole-type generic fixtures).
 #[test]
 fn test_the_deferred_reference_points_at_the_hoisted_defs_entry() {
     let methods = json_schema_methods("Node", &quote::quote! { body }, &[]).to_string();
 
     assert!(
-        methods.contains("\"#/$defs/Node\""),
-        "no pointer: {methods}"
+        methods.contains("\"#/$defs/\""),
+        "no pointer prefix: {methods}"
     );
     assert!(methods.contains("\"Node\""), "not keyed by name: {methods}");
+    assert!(
+        methods.contains("format ! (\"{}{key}\""),
+        "the pointer is not built off the same key the entry is hoisted under: {methods}"
+    );
 }
 
 /// A plain enum names nothing, but a type that names it reaches it through the guarded method

--- a/tests/generic_types_tests/tests.rs
+++ b/tests/generic_types_tests/tests.rs
@@ -1346,18 +1346,28 @@ mod jsonschema {
     }
 
     /// A cycle written at the filling it was entered at is the one a document holding a single
-    /// definition per name can describe, and it describes exactly as it always has: the definition
-    /// at that filling, and a reference into it wherever the name comes back around.
+    /// definition per name and filling can describe, and it describes exactly as it always has:
+    /// the definition at that filling, and a reference into it wherever the name comes back
+    /// around. The key itself now carries the filling — a readable label off the argument's own
+    /// `"type"` keyword, plus a digest that keeps two labels alike from colliding — so the pinned
+    /// string below gained that text, and no character in it is one a URI-reference forbids.
     #[test]
     fn a_cycle_that_keeps_its_filling_defers_through_the_one_definition() {
+        let document = super::Recurring::<String>::json_schema();
         assert_eq!(
-            serde_json::to_string(&super::Recurring::<String>::json_schema()).unwrap(),
-            "{\"$defs\":{\"Recurring\":{\"type\":\"object\",\"additionalProperties\":false,\
-             \"properties\":{\"next\":{\"anyOf\":[{\"$ref\":\"#/$defs/Recurring\"},\
-             {\"type\":\"null\"}]},\
-             \"value\":{\"type\":\"string\"}},\"required\":[\"value\"]}},\
-             \"$ref\":\"#/$defs/Recurring\"}"
+            serde_json::to_string(&document).unwrap(),
+            "{\"$defs\":{\"Recurring.string-1579594ac99678fa\":{\"type\":\"object\",\"additionalPr\
+             operties\":false,\"properties\":{\"next\":{\"anyOf\":[{\"$ref\":\"#/$defs/Recurring.s\
+             tring-1579594ac99678fa\"},{\"type\":\"null\"}]},\"value\":{\"type\":\"string\"}},\"req\
+             uired\":[\"value\"]}},\"$ref\":\"#/$defs/Recurring.string-1579594ac99678fa\"}"
         );
+        let reference = document["$ref"].as_str().unwrap();
+        for forbidden in ['"', '{', '}', '[', ']', ',', ':', ' '] {
+            assert!(
+                !reference.contains(forbidden),
+                "$ref carries a character a URI-reference forbids: {forbidden:?} in {reference}"
+            );
+        }
     }
 
     /// A reference that comes back around to a name at a filling the document is not being written

--- a/tests/generic_types_tests/whole_type_tests.rs
+++ b/tests/generic_types_tests/whole_type_tests.rs
@@ -286,7 +286,7 @@ mod zod {
 mod json_schema {
     use super::{
         ArchiveBranch, ArchiveEntry, ArchiveEvent, ArchiveId, ArchiveNode, ArchiveStamp,
-        ArchiveTrunk, ArchiveWire,
+        ArchiveTrunk, ArchiveWire, Looped, TwoLoopedFillings,
     };
 
     /// JSON Schema has no type parameters, so the document exists at one filling: the declared one.
@@ -346,16 +346,19 @@ mod json_schema {
     }
 
     /// A document cannot be written to the bottom of a recursion, so the type is hoisted into
-    /// `$defs` once and the recursive member points a `$ref` back at it. One definition per name,
-    /// which holds because every reference around this cycle carries the same filling.
+    /// `$defs` once and the recursive member points a `$ref` back at it. One definition per name
+    /// *and filling* — the key carries a readable label off the filling's own `"type"` keyword
+    /// plus a digest, since a document can hold this same generic name again at a different
+    /// filling (see the sibling-fillings test below), and a bare name would let the two collide.
     #[test]
     fn a_recursive_generic_is_hoisted_once_and_pointed_back_at() {
         assert_eq!(
             serde_json::to_string(&ArchiveNode::<String>::json_schema()).unwrap(),
-            "{\"$defs\":{\"ArchiveNode\":{\"type\":\"object\",\"additionalProperties\":false,\"prop\
-             erties\":{\"children\":{\"type\":\"array\",\"items\":{\"$ref\":\"#/$defs/ArchiveNode\"\
-             }},\"id\":{\"type\":\"string\"}},\"required\":[\"children\",\"id\"]}},\"$ref\":\"#/$de\
-             fs/ArchiveNode\"}"
+            "{\"$defs\":{\"ArchiveNode.string-1579594ac99678fa\":{\"type\":\"object\",\"additional\
+             Properties\":false,\"properties\":{\"children\":{\"type\":\"array\",\"items\":{\"$ref\
+             \":\"#/$defs/ArchiveNode.string-1579594ac99678fa\"}},\"id\":{\"type\":\"string\"}},\"r\
+             equired\":[\"children\",\"id\"]}},\"$ref\":\"#/$defs/ArchiveNode.string-1579594ac9967\
+             8fa\"}"
         );
     }
 
@@ -366,22 +369,114 @@ mod json_schema {
     fn a_generic_cycle_is_hoisted_at_whichever_type_the_document_is_built_from() {
         assert_eq!(
             serde_json::to_string(&ArchiveBranch::<String>::json_schema()).unwrap(),
-            "{\"$defs\":{\"ArchiveBranch\":{\"type\":\"object\",\"additionalProperties\":false,\"pr\
-             operties\":{\"entries\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"additiona\
-             lProperties\":false,\"properties\":{\"branches\":{\"type\":\"array\",\"items\":{\"$ref\
-             \":\"#/$defs/ArchiveBranch\"}},\"id\":{\"type\":\"string\"}},\"required\":[\"branches\
-             \",\"id\"]}},\"label\":{\"type\":\"string\"}},\"required\":[\"entries\",\"label\"]}},\
-             \"$ref\":\"#/$defs/ArchiveBranch\"}"
+            "{\"$defs\":{\"ArchiveBranch.string-1579594ac99678fa\":{\"type\":\"object\",\"addition\
+             alProperties\":false,\"properties\":{\"entries\":{\"type\":\"array\",\"items\":{\"type\
+             \":\"object\",\"additionalProperties\":false,\"properties\":{\"branches\":{\"type\":\"\
+             array\",\"items\":{\"$ref\":\"#/$defs/ArchiveBranch.string-1579594ac99678fa\"}},\"id\"\
+             :{\"type\":\"string\"}},\"required\":[\"branches\",\"id\"]}},\"label\":{\"type\":\"str\
+             ing\"}},\"required\":[\"entries\",\"label\"]}},\"$ref\":\"#/$defs/ArchiveBranch.strin\
+             g-1579594ac99678fa\"}"
         );
 
         assert_eq!(
             serde_json::to_string(&ArchiveTrunk::<String>::json_schema()).unwrap(),
-            "{\"$defs\":{\"ArchiveTrunk\":{\"type\":\"object\",\"additionalProperties\":false,\"pro\
-             perties\":{\"branches\":{\"type\":\"array\",\"items\":{\"type\":\"object\",\"additiona\
-             lProperties\":false,\"properties\":{\"entries\":{\"type\":\"array\",\"items\":{\"$ref\
-             \":\"#/$defs/ArchiveTrunk\"}},\"label\":{\"type\":\"string\"}},\"required\":[\"entries\
-             \",\"label\"]}},\"id\":{\"type\":\"string\"}},\"required\":[\"branches\",\"id\"]}},\"$\
-             ref\":\"#/$defs/ArchiveTrunk\"}"
+            "{\"$defs\":{\"ArchiveTrunk.string-1579594ac99678fa\":{\"type\":\"object\",\"additiona\
+             lProperties\":false,\"properties\":{\"branches\":{\"type\":\"array\",\"items\":{\"type\
+             \":\"object\",\"additionalProperties\":false,\"properties\":{\"entries\":{\"type\":\"a\
+             rray\",\"items\":{\"$ref\":\"#/$defs/ArchiveTrunk.string-1579594ac99678fa\"}},\"label\
+             \":{\"type\":\"string\"}},\"required\":[\"entries\",\"label\"]}},\"id\":{\"type\":\"st\
+             ring\"}},\"required\":[\"branches\",\"id\"]}},\"$ref\":\"#/$defs/ArchiveTrunk.string\
+             -1579594ac99678fa\"}"
+        );
+    }
+
+    /// Two sibling fields naming the same recursive generic at different fillings are the shape
+    /// neither the in-flight cycle check nor a bare `$defs` key can tell apart: the frames are
+    /// sequential rather than nested, so neither reference is ever in flight while the other runs.
+    /// Each filling gets its own definition and its own `$ref`; a third field at the same filling
+    /// as the first still shares that one definition; and each definition's own recursive member
+    /// resolves back to its own filling rather than whichever filling was written last.
+    #[test]
+    fn siblings_at_different_fillings_of_one_recursive_generic_each_get_their_own_definition() {
+        let document = TwoLoopedFillings::json_schema();
+        let defs = document["$defs"].as_object().unwrap();
+        assert_eq!(
+            defs.len(),
+            2,
+            "one definition per distinct filling: {defs:?}"
+        );
+
+        let strings_ref = &document["properties"]["strings"];
+        let also_strings_ref = &document["properties"]["also_strings"];
+        let numbers_ref = &document["properties"]["numbers"];
+        assert_eq!(
+            strings_ref, also_strings_ref,
+            "two references at the same filling still share one definition: {document}"
+        );
+        assert_ne!(
+            strings_ref, numbers_ref,
+            "two references at different fillings must not share a definition: {document}"
+        );
+
+        let key_of = |reference: &serde_json::Value| {
+            reference["$ref"]
+                .as_str()
+                .and_then(|r| r.strip_prefix("#/$defs/"))
+                .unwrap()
+                .to_owned()
+        };
+        let strings_key = key_of(strings_ref);
+        let numbers_key = key_of(numbers_ref);
+        assert_ne!(strings_key, numbers_key);
+
+        // A `$ref` is a URI-reference; RFC 3986 forbids all of these in one, whatever filling built
+        // the key it points at.
+        for key in [&strings_key, &numbers_key] {
+            for forbidden in ['"', '{', '}', '[', ']', ',', ':', ' '] {
+                assert!(
+                    !key.contains(forbidden),
+                    "$defs key carries a character a URI-reference forbids: {forbidden:?} in {key}"
+                );
+            }
+        }
+
+        let strings_body = &defs[&strings_key];
+        let numbers_body = &defs[&numbers_key];
+        assert_eq!(
+            strings_body["properties"]["value"],
+            serde_json::json!({ "type": "string" })
+        );
+        assert_eq!(
+            numbers_body["properties"]["value"],
+            serde_json::json!({ "type": "integer" })
+        );
+
+        // Each definition's own recursive member closes back on itself, not on the other filling.
+        assert_eq!(
+            strings_body["properties"]["children"]["items"],
+            serde_json::json!({ "$ref": format!("#/$defs/{strings_key}") })
+        );
+        assert_eq!(
+            numbers_body["properties"]["children"]["items"],
+            serde_json::json!({ "$ref": format!("#/$defs/{numbers_key}") })
+        );
+
+        // What each definition actually admits is what serde actually writes for that filling.
+        let string_node = Looped::<String> {
+            children: Vec::new(),
+            value: "leaf".to_owned(),
+        };
+        assert_eq!(
+            serde_json::to_value(&string_node).unwrap()["value"],
+            serde_json::json!("leaf")
+        );
+        let number_node = Looped::<u32> {
+            children: Vec::new(),
+            value: 7_u32,
+        };
+        assert_eq!(
+            serde_json::to_value(&number_node).unwrap()["value"],
+            serde_json::json!(7_u32)
         );
     }
 }
@@ -604,6 +699,27 @@ pub struct ArchiveBranch<IdType> {
 pub struct ArchiveTrunk<IdType> {
     pub branches: Vec<ArchiveBranch<IdType>>,
     pub id: IdType,
+}
+
+/// A recursive generic reached by two sibling fields at two different fillings — sequential rather
+/// than nested, so neither reference is ever in flight while the other runs and the in-flight
+/// filling comparison never sees the pair at all. Read by the JSON surface alone, which is the one
+/// that hoists a recursive type into a `$defs` entry a bare name could collide under.
+#[cfg(all(feature = "jsonschema", feature = "serde"))]
+#[model_schema(default_types(ValueType = String))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Looped<ValueType> {
+    pub children: Vec<Self>,
+    pub value: ValueType,
+}
+
+#[cfg(all(feature = "jsonschema", feature = "serde"))]
+#[model_schema()]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TwoLoopedFillings {
+    pub also_strings: Looped<String>,
+    pub numbers: Looped<u32>,
+    pub strings: Looped<String>,
 }
 
 /// The declaration itself is the assertion in a build that reads no surface: an item that does not


### PR DESCRIPTION
Two fields naming one recursive generic at different fillings each hoisted a
`$defs` entry under the bare type name, so the second write replaced the first
and both fields' `$ref`s resolved to whichever filling happened to be described
last:

    struct TwoFillings { a: SelfCycle<String>, b: SelfCycle<u32> }

    "$defs": { "SelfCycle": { … "value": { "type": "integer" } } }
    with `a` and `b` both pointing at it

The in-flight cycle guard cannot see this. It compares the filling of a name
already on the stack, and these two frames are sequential — neither is ever in
flight while the other runs — so no amount of cycle detection reaches it. The
identity of a hoisted definition is what was wrong: a `$defs` key has to name a
type *at a filling*, not a type.

A name reached at no filling keys the bare name it always has. Which of the two
a frame is is decided by the caller at expansion time rather than read off the
filling at runtime, because a parameterless name always fills at `Vec::new()`
and a parameterized one never does — and emitting the discriminating branch
regardless would plant its literal text in the parameterless form's generated
source, which a caller reading the emitted tokens can see even though it never
runs.

A non-empty filling keys `Name.label-digest`. The label reads each argument's
own recognizable name — another hoisted key, read back off its `$ref`, or a
primitive's `"type"` keyword — so a document says which filling a definition
belongs to on sight:

    "$defs": { "ArchiveNode.string-1579594ac99678fa": { … } }
    "$ref": "#/$defs/ArchiveNode.string-1579594ac99678fa"

Two fillings a label cannot separate (`u32` and `i64` both read `integer`) are
separated by the digest, which is appended whether or not a label was found; a
filling with no labelled argument at all keys off the digest alone. The digest
is FNV-1a written out here rather than taken from `std::hash`, whose internals
are documented as free to change between compiler versions — an identical
filling has to key identically across builds, or two references at one filling
stop folding onto one definition.

The character set is letters, digits, `.`, `-` and `_`, so the pointer is a
legal URI-reference as it stands. That is a requirement, not a preference:
`$ref` must be a URI-reference, and the filling's own canonical JSON text is not
one — it carries quotes, braces and colons that RFC 3986 forbids, which RFC
6901's `~0`/`~1` escaping does not answer for since that addresses what a
*pointer* forbids, not a URI. A test now asserts the emitted pointer carries
none of those characters.

Non-generic output is untouched, byte-identical down to the generated source
text; the 21 non-generic recursive-type tests pin that.

just lint, just lint-all across all 68 toggles, and the test powerset across all
68 in four partitions — all green.

