### PR TITLE
read the class a brand over a generic instantiation composes to, instead of falling through to ZodString

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -4403,15 +4403,48 @@ fn branded_zod_type_name(inner: &FieldDef) -> String {
             BrandedComposite::Tuple => "ZodTuple".to_owned(),
         };
     }
-    if let FieldDefType::SiblingType(_, args) = &inner.field_type
-        && args.is_empty()
-    {
-        return format!("typeof {}", inner.zod_type());
+    if let FieldDefType::SiblingType(name, args) = &inner.field_type {
+        return if args.is_empty() {
+            format!("typeof {}", inner.zod_type())
+        } else {
+            branded_zod_instantiated_type_name(name, args)
+        };
     }
     match inner.typescript_typename().as_str() {
         "number" => "ZodNumber".to_owned(),
         "boolean" => "ZodBoolean".to_owned(),
         _ => "ZodString".to_owned(),
+    }
+}
+
+/// The Zod class a reference to another registered generic name, filled with `args`, composes to —
+/// read off the same [`PublishedShape`] the constrained-brand guard's own
+/// [`instantiated_value_shape`] consults, but answered in this dispatch's own vocabulary of classes
+/// rather than that guard's coarse "numeric"/"container"/"opaque" words.
+///
+/// A family publisher — a generic item whose whole published value *is* one of its own parameters —
+/// composes to whatever class the written argument at that parameter's position does, peeling
+/// through the named item's own brand exactly the way `$ZodBranded<T, Brand>` is still assignable to
+/// plain `T`. Nothing else here has one class to prove: a fixed-shape publisher's class depends on
+/// how its shape is built (a plain union and a discriminated one share the same recorded shape but
+/// not a class), an unregistered name may not have expanded yet, and an argument that is itself an
+/// outer, not-yet-filled type parameter carries no class of its own to inherit — so all three widen
+/// to the class every Zod schema is an instance of rather than guess one that might not be it.
+#[cfg(all(feature = "zod", feature = "typescript"))]
+fn branded_zod_instantiated_type_name(name: &str, args: &[FieldDef]) -> String {
+    let Some(PublishedShape::Parameter(position)) =
+        lookup_alias_info(name).map(|info| info.value_shape)
+    else {
+        return "ZodType".to_owned();
+    };
+    match args.get(position) {
+        Some(argument)
+            if argument.is_array()
+                || !matches!(argument.field_type, FieldDefType::TypeParam(_)) =>
+        {
+            branded_zod_type_name(argument)
+        }
+        _ => "ZodType".to_owned(),
     }
 }
 

--- a/tests/branded_newtype_tests/tests.rs
+++ b/tests/branded_newtype_tests/tests.rs
@@ -1905,6 +1905,29 @@ mod branded_sibling_inner_tests {
     #[serde(transparent)]
     pub struct TrailingFixedTag(pub LateTag<String>);
 
+    // A brand over a concrete instantiation of a generic sibling, at each scalar filling the
+    // constrained-brand guard's own vocabulary names — the shape a family publisher like `LateTag`
+    // resolves an argument to.
+    #[model_schema()]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct PlainNumTag(pub LateTag<u32>);
+
+    #[model_schema()]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct PlainBoolTag(pub LateTag<bool>);
+
+    #[model_schema()]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct PlainStrTag(pub LateTag<String>);
+
+    #[model_schema()]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct PlainCount(pub u64);
+
     #[test]
     fn a_sibling_brand_writes_the_object_its_inner_writes() {
         let part = Part {
@@ -2105,6 +2128,92 @@ mod branded_sibling_inner_tests {
         );
         assert!(
             zod.contains("export function OpenTag$SchemaFactory<TagType extends ZodType>("),
+            "Got:\n{zod}"
+        );
+    }
+
+    /// A brand's inner naming a family publisher — a generic item whose whole published value is
+    /// one of its own parameters, like `LateTag<TagType>(pub TagType)` — composes to the class the
+    /// written argument itself resolves to, not the class of the sibling's own (irrelevant) name.
+    /// Guessing `ZodString` here, as the annotation once did regardless of the argument, is what
+    /// left `tsc` unable to compile the module: the runtime value is
+    /// `$ZodBranded<$ZodBranded<ZodNumber, "LateTag">, "PlainNumTag">` for the numeric filling, and
+    /// no number-shaped value is a `ZodString`.
+    #[test]
+    fn a_brand_over_a_numeric_generic_instantiation_is_annotated_by_the_arguments_own_class() {
+        let zod = PlainNumTag::zod_schema();
+        assert!(
+            zod.contains(r#"PlainNumTag$Schema: $ZodBranded<ZodNumber, "PlainNumTag">"#),
+            "Got:\n{zod}"
+        );
+    }
+
+    /// The same guessed-`ZodString` defect, at the boolean filling.
+    #[test]
+    fn a_brand_over_a_boolean_generic_instantiation_is_annotated_by_the_arguments_own_class() {
+        let zod = PlainBoolTag::zod_schema();
+        assert!(
+            zod.contains(r#"PlainBoolTag$Schema: $ZodBranded<ZodBoolean, "PlainBoolTag">"#),
+            "Got:\n{zod}"
+        );
+    }
+
+    /// The filling `ZodString` already named by coincidence — pinned so the fix is proven to keep
+    /// the case it used to get right, not only the two it got wrong.
+    #[test]
+    fn a_brand_over_a_string_generic_instantiation_is_annotated_by_the_arguments_own_class() {
+        let zod = PlainStrTag::zod_schema();
+        assert!(
+            zod.contains(r#"PlainStrTag$Schema: $ZodBranded<ZodString, "PlainStrTag">"#),
+            "Got:\n{zod}"
+        );
+    }
+
+    /// A brand over a plain, non-generic inner takes the scalar arm it always has — untouched by
+    /// what a *generic* sibling's own argument resolves to, since this inner names no sibling at
+    /// all.
+    #[test]
+    fn a_brand_over_a_plain_concrete_inner_is_unchanged() {
+        let zod = PlainCount::zod_schema();
+        assert!(
+            zod.contains(r#"PlainCount$Schema: $ZodBranded<ZodNumber, "PlainCount">"#),
+            "Got:\n{zod}"
+        );
+    }
+
+    /// `FixedTag` reaches `LateTag` before it has registered (declared above it — see the comment
+    /// on `FixedTag` itself), so nothing proves what class its argument resolves to; widening to
+    /// the class every Zod schema is an instance of still compiles, where guessing would not.
+    #[test]
+    fn a_forward_declared_family_publisher_widens_its_annotation() {
+        let zod = FixedTag::zod_schema();
+        assert!(
+            zod.contains(r#"FixedTag$Schema: $ZodBranded<ZodType, "FixedTag">"#),
+            "Got:\n{zod}"
+        );
+    }
+
+    /// `TrailingFixedTag` reaches the same name `FixedTag` does, after it has registered, and gets
+    /// the precise class instead of the widened one — the same runtime value, two annotations, both
+    /// sound.
+    #[test]
+    fn a_trailing_family_publisher_reference_is_annotated_precisely() {
+        let zod = TrailingFixedTag::zod_schema();
+        assert!(
+            zod.contains(r#"TrailingFixedTag$Schema: $ZodBranded<ZodString, "TrailingFixedTag">"#),
+            "Got:\n{zod}"
+        );
+    }
+
+    /// A generic brand's own inner naming another generic sibling (`LateTag<TagType>`) leaves
+    /// `TagType` itself unresolved at the point `$SchemaDefault`'s annotation is built — there is no
+    /// argument class to read yet, only the outer parameter — so it widens rather than guessing off
+    /// the parameter's own written name.
+    #[test]
+    fn a_generic_brands_default_over_a_generic_sibling_widens_its_annotation() {
+        let zod = OpenTag::<String>::zod_schema();
+        assert!(
+            zod.contains(r#"OpenTag$SchemaDefault: $ZodBranded<ZodType, "OpenTag"> ="#),
             "Got:\n{zod}"
         );
     }


### PR DESCRIPTION
`branded_zod_type_name` answered a `SiblingType` inner only when it carried no
arguments. An instantiation fell past that arm into a match on the rendered
TypeScript name, which for a sibling is the sibling's own written name — not
`"number"`, not `"boolean"`, so it landed on the catch-all `_ => "ZodString"`:

    struct LateTag<T>(pub T);
    struct PlainNumTag(pub LateTag<u32>);
    struct PlainBoolTag(pub LateTag<bool>);

    export const PlainNumTag$Schema:  $ZodBranded<ZodString, "PlainNumTag">  = …
    export const PlainBoolTag$Schema: $ZodBranded<ZodString, "PlainBoolTag"> = …

Both annotations are wrong and the module does not type-check. The catch-all was
guessing, and a guess that names a concrete class is the one answer that cannot
be right for every shape it catches.

An instantiation is now read off the same `PublishedShape` the constrained-brand
guard consults, answered in this dispatch's own vocabulary of Zod classes. A
family publisher — a generic whose whole published value *is* one of its own
parameters — composes to whatever class the written argument at that position
does, peeling through the named item's own brand, since `$ZodBranded<T, Brand>`
stays assignable to plain `T`.

Everything else widens to `ZodType`. A fixed-shape publisher's class depends on
how its shape is built, and a plain union and a discriminated one record the
same shape without sharing a class; an unregistered name may not have expanded
yet; an argument that is itself an outer, not-yet-filled parameter has no class
to inherit. `ZodType` is the class every schema is an instance of, so the module
compiles instead of being annotated with a class it might not be. `typeof` is
not an option there — it takes an identifier, not a call.

The same function answers a generic brand's `$SchemaDefault`, which was wrong in
the same way and only looked right because the fixture in place defaulted to
`String`; a default of `u32` shows it.

just lint, just lint-all across all 68 toggles, and the test powerset across all
68 in four partitions — all green.

