### PR TITLE
span an example's tokens on the doc lines that wrote them, not on the attribute

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -37,7 +37,7 @@ use crate::utils::written_type;
 
 #[cfg(feature = "zod")]
 use crate::utils::{
-    escape_js_regex_literal, extract_example_from_docs, publishes_zod_factory,
+    escape_js_regex_literal, extract_example_tokens, publishes_zod_factory,
     record_zod_default_arguments, record_zod_factory, zod_default_arguments, zod_factory_argument,
 };
 
@@ -97,7 +97,11 @@ use crate::utils::json_argument_binding;
 #[cfg(all(feature = "serde", feature = "jsonschema"))]
 use crate::features::jsonschema::{MergeDiagnostic, merged_object_value};
 
-#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[cfg(any(
+    feature = "typescript",
+    feature = "zod",
+    all(feature = "serde", feature = "jsonschema")
+))]
 use crate::utils::get_enum_docs;
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 use crate::utils::get_struct_docs;
@@ -107,7 +111,7 @@ use crate::utils::{compute_alias_export_name, ident_schema_module_name};
 
 use crate::utils::compute_item_export_name;
 
-#[cfg(any(feature = "typescript", feature = "zod"))]
+#[cfg(feature = "typescript")]
 use crate::utils::get_item_docs;
 #[cfg(feature = "typescript")]
 use crate::utils::ident_reexport_ts;
@@ -1264,17 +1268,12 @@ fn build_jsdoc_body(docs_vec: Option<&[String]>, fallback_name: &str) -> String 
 /// exposes.
 #[cfg(feature = "zod")]
 fn enum_schema_example_method(
-    docs_vec: Option<&[String]>,
+    attrs: &[syn::Attribute],
     name: &syn::Ident,
     generics: &syn::Generics,
     args: &ModelSchemaArgs,
 ) -> Option<proc_macro2::TokenStream> {
-    item_schema_example_method(
-        docs_vec.and_then(extract_example_from_docs).as_ref(),
-        name,
-        generics,
-        args,
-    )
+    item_schema_example_method(extract_example_tokens(attrs).as_ref(), name, generics, args)
 }
 
 #[cfg(all(
@@ -1282,7 +1281,7 @@ fn enum_schema_example_method(
     any(feature = "typescript", feature = "jsonschema")
 ))]
 const fn enum_schema_example_method(
-    _docs_vec: Option<&[String]>,
+    _attrs: &[syn::Attribute],
     _name: &syn::Ident,
     _generics: &syn::Generics,
     _args: &ModelSchemaArgs,
@@ -1319,13 +1318,12 @@ fn schema_example_value_type(
 /// every enum shape reach it the same way instead of repeating the feature pair at the call site.
 #[cfg(feature = "zod")]
 fn item_schema_example_method(
-    example_code: Option<&String>,
+    example_tokens: Option<&proc_macro2::TokenStream>,
     name: &syn::Ident,
     generics: &syn::Generics,
     args: &ModelSchemaArgs,
 ) -> Option<proc_macro2::TokenStream> {
-    let code = example_code?;
-    let code_tokens: proc_macro2::TokenStream = code.parse().unwrap();
+    let code_tokens = example_tokens?;
     let value_ty = schema_example_value_type(
         name,
         &type_parameters_in_scope(generics),
@@ -1346,7 +1344,7 @@ fn item_schema_example_method(
     any(feature = "typescript", feature = "jsonschema")
 ))]
 const fn item_schema_example_method(
-    _example_code: Option<&String>,
+    _example_tokens: Option<&proc_macro2::TokenStream>,
     _name: &syn::Ident,
     _generics: &syn::Generics,
     _args: &ModelSchemaArgs,
@@ -2369,10 +2367,7 @@ fn const_parameter_example_errors(item: &Item) -> Vec<proc_macro2::TokenStream> 
     let Some(first) = consts.first() else {
         return Vec::new();
     };
-    if get_item_docs(attrs)
-        .and_then(|docs| extract_example_from_docs(&docs))
-        .is_none()
-    {
+    if extract_example_tokens(attrs).is_none() {
         return Vec::new();
     }
     vec![attr_guard_error(
@@ -3436,15 +3431,15 @@ fn enum_module_idents(
 /// halves: what the author wrote is a fact about the declaration, and the example half already
 /// answers `None` where `zod` — the only surface that reads one — is off.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-fn struct_docs_and_example(item_struct: &syn::ItemStruct) -> (Option<Vec<String>>, Option<String>) {
+fn struct_docs_and_example(
+    item_struct: &syn::ItemStruct,
+) -> (Option<Vec<String>>, Option<proc_macro2::TokenStream>) {
     let docs_vec = get_struct_docs(item_struct);
     #[cfg(feature = "zod")]
-    let example_code = docs_vec
-        .as_ref()
-        .and_then(|docs| extract_example_from_docs(docs));
+    let example_tokens = extract_example_tokens(&item_struct.attrs);
     #[cfg(not(feature = "zod"))]
-    let example_code = None;
-    (docs_vec, example_code)
+    let example_tokens = None;
+    (docs_vec, example_tokens)
 }
 
 /// The output a struct carrying a `cfg_attr`-wrapped serde attribute on the type is refused with,
@@ -4781,15 +4776,14 @@ fn tokens_name_any(tokens: &proc_macro2::TokenStream, names: &[String]) -> bool 
 /// Builds the `schema_example()` method for a branded newtype from extracted example code.
 #[cfg(feature = "zod")]
 fn build_branded_schema_example(
-    example_code: Option<&String>,
+    example_tokens: Option<&proc_macro2::TokenStream>,
     name: &Ident,
     generic_params: &[String],
     args: &ModelSchemaArgs,
 ) -> proc_macro2::TokenStream {
-    let Some(code) = example_code else {
+    let Some(code_tokens) = example_tokens else {
         return quote! {};
     };
-    let code_tokens: proc_macro2::TokenStream = code.parse().unwrap();
     let value_ty = schema_example_value_type(name, generic_params, &args.default_types);
     quote! {
         pub fn schema_example() -> serde_json::Value {
@@ -5002,9 +4996,7 @@ fn process_branded_newtype(item_struct: syn::ItemStruct, args: &ModelSchemaArgs)
     let docs_vec = get_struct_docs(&item_struct);
 
     #[cfg(feature = "zod")]
-    let example_code = docs_vec
-        .as_ref()
-        .and_then(|docs| extract_example_from_docs(docs));
+    let example_tokens = extract_example_tokens(&item_struct.attrs);
 
     #[cfg(feature = "zod")]
     let plain_description = item_description(docs_vec.as_deref(), &item_name);
@@ -5067,13 +5059,13 @@ fn process_branded_newtype(item_struct: syn::ItemStruct, args: &ModelSchemaArgs)
 
     // --- Generate schema_example method (goes on the type impl, not the module) ---
     #[cfg(feature = "zod")]
-    let has_example = example_code.is_some();
+    let has_example = example_tokens.is_some();
     #[cfg(not(feature = "zod"))]
     let has_example = false;
 
     #[cfg(feature = "zod")]
     let schema_example_tokens =
-        build_branded_schema_example(example_code.as_ref(), &name, &generic_params, args);
+        build_branded_schema_example(example_tokens.as_ref(), &name, &generic_params, args);
     #[cfg(not(feature = "zod"))]
     let schema_example_tokens = quote! {};
 
@@ -5469,8 +5461,7 @@ fn process_plain_enum(
     #[cfg(any(feature = "typescript", feature = "zod"))]
     let rust_ident = name.to_string();
 
-    // Extract docs early for example extraction
-    #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+    #[cfg(any(feature = "typescript", feature = "zod"))]
     let docs_vec = get_enum_docs(&item_enum);
 
     let (enum_options, enum_variant_docs) = collect_plain_enum_options(&mut item_enum, rename_all);
@@ -5527,7 +5518,7 @@ fn process_plain_enum(
 
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
     let schema_example_method =
-        enum_schema_example_method(docs_vec.as_deref(), name, &item_enum.generics, args);
+        enum_schema_example_method(&item_enum.attrs, name, &item_enum.generics, args);
 
     #[cfg(any(feature = "zod", feature = "typescript", feature = "jsonschema"))]
     let schema_impl_items: Vec<proc_macro2::TokenStream> = vec![
@@ -5888,8 +5879,7 @@ fn process_discriminated_enum(
     let (module_name, module_ident) =
         enum_module_idents(name, item_name, AliasKind::NoEnumMembers, Surface::union());
 
-    // Extract docs early for example extraction
-    #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+    #[cfg(feature = "typescript")]
     let docs_vec = get_enum_docs(&item_enum);
 
     // Process each variant in the enum.
@@ -5963,7 +5953,7 @@ fn process_discriminated_enum(
     // uses type names that may not be accessible from the nested module.
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
     let schema_example_method =
-        enum_schema_example_method(docs_vec.as_deref(), name, &item_enum.generics, args);
+        enum_schema_example_method(&item_enum.attrs, name, &item_enum.generics, args);
 
     #[cfg(any(feature = "zod", feature = "typescript", feature = "jsonschema"))]
     let schema_impl_items: Vec<proc_macro2::TokenStream> = vec![
@@ -6389,7 +6379,7 @@ fn process_externally_tagged_enum(
         Surface::externally_tagged(&item_enum.variants),
     );
 
-    #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+    #[cfg(feature = "typescript")]
     let docs_vec = get_enum_docs(&item_enum);
 
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
@@ -6454,7 +6444,7 @@ fn process_externally_tagged_enum(
 
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
     let schema_example_method =
-        enum_schema_example_method(docs_vec.as_deref(), name, &item_enum.generics, args);
+        enum_schema_example_method(&item_enum.attrs, name, &item_enum.generics, args);
 
     #[cfg(any(feature = "zod", feature = "typescript", feature = "jsonschema"))]
     let schema_impl_items: Vec<proc_macro2::TokenStream> = vec![
@@ -6784,7 +6774,7 @@ fn process_internally_tagged_enum(
     let (module_name, module_ident) =
         enum_module_idents(name, item_name, AliasKind::NoEnumMembers, Surface::union());
 
-    #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+    #[cfg(feature = "typescript")]
     let docs_vec = get_enum_docs(&item_enum);
 
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
@@ -6851,7 +6841,7 @@ fn process_internally_tagged_enum(
 
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
     let schema_example_method =
-        enum_schema_example_method(docs_vec.as_deref(), name, &item_enum.generics, args);
+        enum_schema_example_method(&item_enum.attrs, name, &item_enum.generics, args);
 
     #[cfg(any(feature = "zod", feature = "typescript", feature = "jsonschema"))]
     let schema_impl_items: Vec<proc_macro2::TokenStream> = vec![
@@ -7816,7 +7806,7 @@ fn process_untagged_enum(
 
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
     let schema_example_method =
-        enum_schema_example_method(docs_vec.as_deref(), name, &item_enum.generics, args);
+        enum_schema_example_method(&item_enum.attrs, name, &item_enum.generics, args);
 
     #[cfg(any(feature = "zod", feature = "typescript", feature = "jsonschema"))]
     let schema_impl_items = build_untagged_schema_impl_items(

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -2719,8 +2719,9 @@ fn the_cfg_probe_sees_an_emitted_cfg_attribute() {
 fn struct_schema_example_carries_no_cfg_attribute() {
     let name: syn::Ident = syn::parse_quote!(Report);
     let generics = syn::Generics::default();
+    let example: proc_macro2::TokenStream = "Report { id: 1 }".parse().unwrap();
     let tokens = super::item_schema_example_method(
-        Some(&"Report { id: 1 }".to_owned()),
+        Some(&example),
         &name,
         &generics,
         &super::ModelSchemaArgs::default(),
@@ -2737,7 +2738,7 @@ fn struct_schema_example_carries_no_cfg_attribute() {
 #[test]
 fn struct_schema_example_instantiates_every_type_parameter() {
     let name: syn::Ident = syn::parse_quote!(Report);
-    let example = "Report { id: 1 }".to_owned();
+    let example: proc_macro2::TokenStream = "Report { id: 1 }".parse().unwrap();
     for (generics, expected) in [
         (syn::Generics::default(), "let value : Report ="),
         (syn::parse_quote!(<A>), "let value : Report < String > ="),
@@ -2767,7 +2768,7 @@ fn struct_schema_example_instantiates_every_type_parameter() {
 #[test]
 fn struct_schema_example_instantiates_each_parameter_at_its_declared_filling() {
     let name: syn::Ident = syn::parse_quote!(Report);
-    let example = "Report { id: 1 }".to_owned();
+    let example: proc_macro2::TokenStream = "Report { id: 1 }".parse().unwrap();
     let generics: syn::Generics = syn::parse_quote!(<A, B>);
     let count: (syn::Ident, syn::Type) = (syn::parse_quote!(A), syn::parse_quote!(u32));
     let held: (syn::Ident, syn::Type) = (syn::parse_quote!(B), syn::parse_quote!(Vec<u8>));
@@ -2800,7 +2801,7 @@ fn struct_schema_example_instantiates_each_parameter_at_its_declared_filling() {
 #[test]
 fn a_string_filling_annotates_the_example_as_no_filling_does() {
     let name: syn::Ident = syn::parse_quote!(Report);
-    let example = "Report { id: 1 }".to_owned();
+    let example: proc_macro2::TokenStream = "Report { id: 1 }".parse().unwrap();
     let generics: syn::Generics = syn::parse_quote!(<A>);
     let filled = super::ModelSchemaArgs {
         default_types: vec![(syn::parse_quote!(A), syn::parse_quote!(String))],
@@ -2981,7 +2982,7 @@ fn branded_json_inners() -> Vec<super::BrandedJsonInner> {
 #[test]
 fn branded_schema_example_carries_no_cfg_attribute() {
     let name: syn::Ident = syn::parse_quote!(DocumentId);
-    let example = "DocumentId(\"abc\".to_string())".to_owned();
+    let example: proc_macro2::TokenStream = "DocumentId(\"abc\".to_string())".parse().unwrap();
     for generic_params in [
         Vec::new(),
         vec!["A".to_owned()],
@@ -3003,7 +3004,7 @@ fn branded_schema_example_carries_no_cfg_attribute() {
 #[test]
 fn branded_schema_example_instantiates_every_parameter() {
     let name: syn::Ident = syn::parse_quote!(DocumentId);
-    let example = "DocumentId(\"abc\".to_string())".to_owned();
+    let example: proc_macro2::TokenStream = "DocumentId(\"abc\".to_string())".parse().unwrap();
     for (generic_params, expected) in [
         (Vec::new(), "let value : DocumentId ="),
         (vec!["A".to_owned()], "let value : DocumentId < String > ="),
@@ -3029,7 +3030,7 @@ fn branded_schema_example_instantiates_every_parameter() {
 #[test]
 fn branded_schema_example_instantiates_each_parameter_at_its_declared_filling() {
     let name: syn::Ident = syn::parse_quote!(DocumentId);
-    let example = "DocumentId(\"abc\".to_string())".to_owned();
+    let example: proc_macro2::TokenStream = "DocumentId(\"abc\".to_string())".parse().unwrap();
     let args = super::ModelSchemaArgs {
         default_types: vec![(syn::parse_quote!(A), syn::parse_quote!(u32))],
         ..Default::default()

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,6 @@
 use core::cell::RefCell;
+#[cfg(feature = "zod")]
+use core::mem;
 use core::ops::Range;
 #[cfg(feature = "serde")]
 use core::slice::from_ref;
@@ -14,7 +16,11 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use syn::{Attribute, Expr, Field, GenericParam, Generics, Lit, LitStr, Meta, Type, Variant};
 
-#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[cfg(any(
+    feature = "typescript",
+    feature = "zod",
+    all(feature = "serde", feature = "jsonschema")
+))]
 use syn::ItemEnum;
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 use syn::ItemStruct;
@@ -253,6 +259,16 @@ struct JsSpelling {
     /// The byte span of each construct that is rewritten, beside what it is rewritten to.
     edits: Vec<(Range<usize>, &'static str)>,
     refusal: Option<Unportable>,
+}
+
+/// A doc-comment line paired with the span of the `#[doc = "..."]` literal it came from. Each
+/// `///` line lowers to its own doc attribute with a real source span; a block comment's
+/// embedded lines share the span of the one literal that carries all of them.
+#[cfg(feature = "zod")]
+#[derive(Clone)]
+struct DocLine {
+    span: proc_macro2::Span,
+    text: String,
 }
 
 /// A construct the `regex` crate reads that a JavaScript regex literal cannot be handed as written.
@@ -873,9 +889,15 @@ pub fn get_struct_docs(item_struct: &ItemStruct) -> Option<Vec<String>> {
     collect_doc_lines(&item_struct.attrs)
 }
 
-/// An enum's doc lines. Reachable in every schema build, not just the two that publish prose: the
-/// `schema_example()` an item's ` ```rust example ` block earns is read off these too.
-#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+/// An enum's doc lines, read for the prose two surfaces publish (a plain enum's `JSDoc`, every
+/// shape's item description) — not for its ` ```rust example ` block, which
+/// [`extract_example_tokens`] reads off the attributes directly so the tokens it builds keep their
+/// spans.
+#[cfg(any(
+    feature = "typescript",
+    feature = "zod",
+    all(feature = "serde", feature = "jsonschema")
+))]
 pub fn get_enum_docs(item_enum: &ItemEnum) -> Option<Vec<String>> {
     collect_doc_lines(&item_enum.attrs)
 }
@@ -888,10 +910,9 @@ pub fn get_field_docs(field: &Field) -> Option<Vec<String>> {
     collect_doc_lines(&field.attrs)
 }
 
-/// The doc lines of anything carrying attributes. Read by the `TypeScript` surface for the prose it
-/// publishes, and by the guard that answers for a ` ```rust example ` block written on an item no
-/// annotation can be spelled for.
-#[cfg(any(feature = "typescript", feature = "zod"))]
+/// The doc lines of anything carrying attributes, read by the `TypeScript` surface for the prose
+/// an alias publishes.
+#[cfg(feature = "typescript")]
 pub fn get_item_docs(attrs: &[Attribute]) -> Option<Vec<String>> {
     collect_doc_lines(attrs)
 }
@@ -947,21 +968,48 @@ pub fn to_snake_case(name: &str) -> String {
     result
 }
 
-/// The code inside the first ` ```rust example ` fence in these doc lines, or `None` where there is
-/// no such fence. Later fences are ignored.
+/// [`DocLine`]s for every doc attribute on `attrs`, one per physical line.
 #[cfg(feature = "zod")]
-pub fn extract_example_from_docs(docs: &[String]) -> Option<String> {
-    let mut in_example_block = false;
-    let mut example_lines = Vec::new();
+fn doc_lines_with_spans(attrs: &[Attribute]) -> Vec<DocLine> {
+    let mut lines = Vec::new();
+    for attr in attrs {
+        if attr.path().is_ident("doc")
+            && let Meta::NameValue(meta_name_value) = &attr.meta
+            && let Expr::Lit(syn::ExprLit {
+                lit: Lit::Str(lit_str),
+                ..
+            }) = &meta_name_value.value
+        {
+            // `resolved_at` keeps the doc line's location (what a diagnostic underlines) while
+            // giving the token the macro's own hygiene (what marks it as generated rather than
+            // user-written) — respanning bare would also make an ordinary lint pass (clippy's
+            // style lints, not just rustc's own type errors) treat the example as code the author
+            // typed at that doc line, rather than the illustrative snippet it is.
+            let span = lit_str.span().resolved_at(proc_macro2::Span::call_site());
+            for line in lit_str.value().lines() {
+                lines.push(DocLine {
+                    text: line.trim().to_owned(),
+                    span,
+                });
+            }
+        }
+    }
+    lines
+}
 
-    for line in docs {
-        let trimmed = line.trim();
-        // Strip leading asterisk from block-style comments
+/// The [`DocLine`]s inside the first ` ```rust example ` fence, or `None` where there is no such
+/// fence. Later fences are ignored.
+#[cfg(feature = "zod")]
+fn example_doc_lines(lines: &[DocLine]) -> Option<Vec<DocLine>> {
+    let mut in_example_block = false;
+    let mut example_lines: Vec<DocLine> = Vec::new();
+
+    for line in lines {
+        let trimmed = line.text.trim();
         let cleaned = trimmed.strip_prefix('*').unwrap_or(trimmed).trim();
 
         if cleaned == "```rust example" {
             if !example_lines.is_empty() {
-                // Already found one example, return it
                 break;
             }
             in_example_block = true;
@@ -969,11 +1017,9 @@ pub fn extract_example_from_docs(docs: &[String]) -> Option<String> {
         }
 
         if in_example_block && cleaned == "```" {
-            // Found complete example
             break;
         }
 
-        // Collect example lines
         if in_example_block {
             example_lines.push(line.clone());
         }
@@ -982,10 +1028,115 @@ pub fn extract_example_from_docs(docs: &[String]) -> Option<String> {
     if example_lines.is_empty() {
         None
     } else {
-        // Apply regex transformations to make doctest-compatible code work for schema_example
-        let code = example_lines.join("\n");
-        Some(transform_example_code(&code))
+        Some(example_lines)
     }
+}
+
+/// Whether `line` (already trimmed) is a bare `use` statement — the one pattern
+/// `transform_example_code` strips regardless of where it sits, so it is dropped line-by-line up
+/// front rather than through the whole-example regex.
+#[cfg(feature = "zod")]
+fn is_use_statement(line: &str) -> bool {
+    regex::Regex::new(r"^use\s+[^;]+;$").unwrap().is_match(line)
+}
+
+/// Recursively respans every token, and every group's own delimiter span, onto `span`.
+#[cfg(feature = "zod")]
+fn respan(tokens: proc_macro2::TokenStream, span: proc_macro2::Span) -> proc_macro2::TokenStream {
+    tokens
+        .into_iter()
+        .map(|tree| match tree {
+            proc_macro2::TokenTree::Group(group) => {
+                let mut respanned =
+                    proc_macro2::Group::new(group.delimiter(), respan(group.stream(), span));
+                respanned.set_span(span);
+                proc_macro2::TokenTree::Group(respanned)
+            }
+            mut other @ (proc_macro2::TokenTree::Ident(_)
+            | proc_macro2::TokenTree::Punct(_)
+            | proc_macro2::TokenTree::Literal(_)) => {
+                other.set_span(span);
+                other
+            }
+        })
+        .collect()
+}
+
+/// Groups `lines` into the smallest runs of consecutive lines that parse as balanced tokens on
+/// their own, pairing each run's source text with the span of the line it starts on. A single
+/// statement occupies its own run in the common case; a value split across lines (a multi-line
+/// struct literal, say) is the smallest run whose delimiters close.
+#[cfg(feature = "zod")]
+fn raw_statement_groups(lines: &[DocLine]) -> Vec<(String, proc_macro2::Span)> {
+    let mut groups = Vec::new();
+    let mut buffer = String::new();
+    let mut buffer_span: Option<proc_macro2::Span> = None;
+
+    for line in lines {
+        if buffer.is_empty() {
+            buffer_span = Some(line.span);
+        } else {
+            buffer.push('\n');
+        }
+        buffer.push_str(&line.text);
+
+        if buffer.parse::<proc_macro2::TokenStream>().is_ok() {
+            let span = buffer_span.take().unwrap();
+            groups.push((mem::take(&mut buffer), span));
+        }
+    }
+    if !buffer.is_empty() {
+        groups.push((buffer, buffer_span.unwrap()));
+    }
+    groups
+}
+
+/// The example's tokens, each respanned onto the `///` line — or, for a value split across
+/// lines, the first line of the run — it was written on.
+///
+/// `transform_example_code`'s `println!`/`let _` unwrapping only ever matches a whole example's
+/// trailing statement (its regexes anchor on the end of the input), so it is applied to the last
+/// group alone; every earlier group keeps its own raw tokens, respanned but otherwise untouched.
+#[cfg(feature = "zod")]
+fn respan_example_tokens(lines: &[DocLine]) -> proc_macro2::TokenStream {
+    let content: Vec<DocLine> = lines
+        .iter()
+        .filter(|line| {
+            let trimmed = line.text.trim();
+            !trimmed.is_empty() && !is_use_statement(trimmed)
+        })
+        .cloned()
+        .collect();
+
+    let groups = raw_statement_groups(&content);
+    let last_index = groups.len().saturating_sub(1);
+
+    let mut out = proc_macro2::TokenStream::new();
+    for (index, (source, span)) in groups.iter().enumerate() {
+        let candidate = if index == last_index {
+            transform_example_code(source)
+        } else {
+            source.clone()
+        };
+        let tokens: proc_macro2::TokenStream = candidate.parse().unwrap();
+        out.extend(respan(tokens, *span));
+    }
+    out
+}
+
+/// The example's tokens, respanned line-by-line onto the `///` lines that wrote them, or `None`
+/// where there is no ` ```rust example ` fence.
+///
+/// `str::parse::<TokenStream>()` alone stamps every token with `Span::call_site()` — for an
+/// attribute macro, the whole `#[model_schema(...)]` invocation — so a typo or a type mismatch
+/// inside the example used to be reported there instead of on the line the author wrote. Each
+/// `///` line lowers to its own `#[doc = "..."]` attribute with a real span, which is enough to
+/// point the diagnostic at that line (or, where a value spans several lines, the first of them).
+#[cfg(feature = "zod")]
+pub fn extract_example_tokens(attrs: &[Attribute]) -> Option<proc_macro2::TokenStream> {
+    let lines = doc_lines_with_spans(attrs);
+    let example_lines = example_doc_lines(&lines)?;
+    Some(respan_example_tokens(&example_lines))
 }
 
 /// Transforms doctest-compatible example code to be suitable for `schema_example()`.

--- a/src/utils/tests.rs
+++ b/src/utils/tests.rs
@@ -401,92 +401,163 @@ fn accepts(trivial: &TrivialPattern, haystack: &str) -> bool {
     }
 }
 
+/// Parses `doc_lines` as consecutive `///` lines ahead of a minimal struct, so the resulting
+/// attributes carry the real source spans a `#[model_schema]`-annotated item's would.
+#[cfg(feature = "zod")]
+fn struct_attrs_with_docs(doc_lines: &[&str]) -> Vec<syn::Attribute> {
+    let doc_block = doc_lines.iter().fold(String::new(), |mut block, line| {
+        use core::fmt::Write as _;
+        writeln!(block, "/// {line}").unwrap();
+        block
+    });
+    let source = format!("{doc_block}struct Probe;");
+    let item: syn::ItemStruct = syn::parse_str(&source).unwrap();
+    item.attrs
+}
+
+/// The source text each top-level token's span reports, in order.
+#[cfg(feature = "zod")]
+fn top_level_source_texts(tokens: &proc_macro2::TokenStream) -> Vec<Option<String>> {
+    tokens
+        .clone()
+        .into_iter()
+        .map(|tree| tree.span().source_text())
+        .collect()
+}
+
 #[cfg(feature = "zod")]
 #[test]
 fn test_extract_example_simple() {
-    let docs = vec![
-        "User profile".to_owned(),
-        "```rust example".to_owned(),
-        "User { name: \"John\".to_string(), age: 25 }".to_owned(),
-        "```".to_owned(),
-    ];
-
-    let example = extract_example_from_docs(&docs);
-    assert!(example.is_some());
-    assert_eq!(
-        example.unwrap(),
-        "User { name: \"John\".to_string(), age: 25 }"
-    );
+    let attrs = struct_attrs_with_docs(&[
+        "User profile",
+        "```rust example",
+        "User { name: \"John\".to_string(), age: 25 }",
+        "```",
+    ]);
+    let tokens = extract_example_tokens(&attrs);
+    assert!(tokens.is_some());
+    let expected: proc_macro2::TokenStream = "User { name: \"John\".to_string(), age: 25 }"
+        .parse()
+        .unwrap();
+    assert_eq!(tokens.unwrap().to_string(), expected.to_string());
 }
 
 #[cfg(feature = "zod")]
 #[test]
 fn test_extract_example_multiline() {
-    let docs = vec![
-        "Complex example".to_owned(),
-        "```rust example".to_owned(),
-        "let x = 5;".to_owned(),
-        "let y = 10;".to_owned(),
-        "User { age: x + y }".to_owned(),
-        "```".to_owned(),
-    ];
-
-    let example = extract_example_from_docs(&docs);
-    assert!(example.is_some());
-    let code = example.unwrap();
-    assert!(code.contains("let x = 5;"));
-    assert!(code.contains("let y = 10;"));
-    assert!(code.contains("User { age: x + y }"));
+    let attrs = struct_attrs_with_docs(&[
+        "Complex example",
+        "```rust example",
+        "let x = 5;",
+        "let y = 10;",
+        "User { age: x + y }",
+        "```",
+    ]);
+    let tokens = extract_example_tokens(&attrs);
+    assert!(tokens.is_some());
+    let expected: proc_macro2::TokenStream = "let x = 5; let y = 10; User { age: x + y }"
+        .parse()
+        .unwrap();
+    assert_eq!(tokens.unwrap().to_string(), expected.to_string());
 }
 
 #[cfg(feature = "zod")]
 #[test]
 fn test_extract_example_first_only() {
-    let docs = vec![
-        "Multiple examples".to_owned(),
-        "```rust example".to_owned(),
-        "User { age: 25 }".to_owned(),
-        "```".to_owned(),
-        "Another description".to_owned(),
-        "```rust example".to_owned(),
-        "User { age: 30 }".to_owned(),
-        "```".to_owned(),
-    ];
-
-    let example = extract_example_from_docs(&docs);
-    assert!(example.is_some());
-    assert_eq!(example.unwrap(), "User { age: 25 }");
+    let attrs = struct_attrs_with_docs(&[
+        "Multiple examples",
+        "```rust example",
+        "User { age: 25 }",
+        "```",
+        "Another description",
+        "```rust example",
+        "User { age: 30 }",
+        "```",
+    ]);
+    let tokens = extract_example_tokens(&attrs);
+    assert!(tokens.is_some());
+    let expected: proc_macro2::TokenStream = "User { age: 25 }".parse().unwrap();
+    assert_eq!(tokens.unwrap().to_string(), expected.to_string());
 }
 
 #[cfg(feature = "zod")]
 #[test]
 fn test_extract_example_none() {
-    let docs = vec!["User profile".to_owned(), "No examples here".to_owned()];
-
-    let example = extract_example_from_docs(&docs);
-    assert!(example.is_none());
+    let attrs = struct_attrs_with_docs(&["User profile", "No examples here"]);
+    assert!(extract_example_tokens(&attrs).is_none());
 }
 
 #[cfg(feature = "zod")]
 #[test]
 fn test_extract_example_empty_docs() {
-    let docs: Vec<String> = vec![];
-    let example = extract_example_from_docs(&docs);
-    assert!(example.is_none());
+    let attrs = struct_attrs_with_docs(&[]);
+    assert!(extract_example_tokens(&attrs).is_none());
 }
 
 #[cfg(feature = "zod")]
 #[test]
 fn test_extract_example_regular_code_fence_ignored() {
-    let docs = vec![
-        "Example with regular fence".to_owned(),
-        "```rust".to_owned(),
-        "User { age: 25 }".to_owned(),
-        "```".to_owned(),
-    ];
+    let attrs = struct_attrs_with_docs(&[
+        "Example with regular fence",
+        "```rust",
+        "User { age: 25 }",
+        "```",
+    ]);
+    assert!(extract_example_tokens(&attrs).is_none());
+}
 
-    let example = extract_example_from_docs(&docs);
-    assert!(example.is_none());
+/// The bug this seam exists to fix: each line's tokens point at that line, not at the whole
+/// example or the enclosing attribute.
+#[cfg(feature = "zod")]
+#[test]
+fn extract_example_tokens_respans_each_line_onto_itself() {
+    let attrs = struct_attrs_with_docs(&[
+        "```rust example",
+        "let ok = 1;",
+        "Counted { count: ok }",
+        "```",
+    ]);
+    let tokens = extract_example_tokens(&attrs).unwrap();
+    let texts = top_level_source_texts(&tokens);
+
+    // `source_text()` reports the whole physical line the doc literal spans, `///` included.
+    assert_eq!(texts.first().unwrap().as_deref(), Some("/// let ok = 1;"));
+    assert_eq!(
+        texts.last().unwrap().as_deref(),
+        Some("/// Counted { count: ok }")
+    );
+}
+
+/// A value split across lines has no single line of its own to point at, so the whole run is
+/// spanned on the line it starts on — an ambiguous run take the first line's span, per design.
+#[cfg(feature = "zod")]
+#[test]
+fn extract_example_tokens_spans_a_multiline_value_on_its_first_line() {
+    let attrs = struct_attrs_with_docs(&["```rust example", "Counted {", "count: 1,", "}", "```"]);
+    let tokens = extract_example_tokens(&attrs).unwrap();
+    let texts = top_level_source_texts(&tokens);
+
+    assert!(
+        texts
+            .iter()
+            .all(|text| text.as_deref() == Some("/// Counted {")),
+        "{texts:?}"
+    );
+}
+
+/// The `println!`/`let _` unwrapping `transform_example_code` performs still applies — it is
+/// only the span that changed, not the emitted tokens.
+#[cfg(feature = "zod")]
+#[test]
+fn extract_example_tokens_still_unwraps_the_doctest_println_pattern() {
+    let attrs = struct_attrs_with_docs(&[
+        "```rust example",
+        "let data_type = 1;",
+        concat!("println!(\"{", ":?}\", data_type);"),
+        "```",
+    ]);
+    let tokens = extract_example_tokens(&attrs).unwrap();
+    assert_eq!(tokens.to_string(), "let data_type = 1 ; data_type");
 }
 
 #[cfg(feature = "zod")]


### PR DESCRIPTION
A ` ```rust example ` block was extracted as a `String` and turned back into
tokens with `str::parse::<TokenStream>()`, which stamps every token with
`Span::call_site()` — for an attribute macro, the whole `#[model_schema(...)]`
invocation. Every source location inside the example was lost, so any error the
author's own example earned was reported on the attribute:

    error[E0308]: mismatched types
     --> tests/probe.rs:9:1
    9 | #[model_schema()]
      | ^^^^^^^^^^^^^^^^^ expected `u32`, found `String`

Each `///` line lowers to its own `#[doc = "..."]` attribute carrying a real
span, which is enough to point at the line. The example is now read off the
attributes rather than off already-flattened strings, grouped into the smallest
runs of lines that parse balanced on their own, and each run's tokens respanned
onto the line it starts on:

    error[E0308]: mismatched types
      --> tests/probe.rs:8:1
     8 | /// Counted { count: "x".to_owned() }
       | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u32`, found `String`
    10 | #[model_schema()]
       | ----------------- in this attribute macro expansion

Per-line for the common case; for a value split across lines, the first line of
the run. That is the finest grain available — a doc literal carries one span per
physical line, not per-token positions, and a string that has been through
`parse` has no positions left to recover.

The span is taken with `resolved_at(Span::call_site())`, not bare. Respanning
bare moves the hygiene along with the location, and an example then reads to
every lint as code the author typed at that line rather than the illustrative
snippet it is — clippy's own style lints started firing across the existing
suite. `resolved_at` keeps the location a diagnostic underlines while leaving
the macro's hygiene in place.

`transform_example_code` is applied to the last group alone, its regexes being
anchored on the end of the input and only ever matching a whole example's
trailing statement; earlier groups keep their own tokens untouched.

just lint, just lint-all across all 68 toggles, and the test powerset across all
68 in four partitions — all green.

