### PR TITLE
nest an adjacently tagged struct variant's fields under the content key, where serde writes them

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -6006,7 +6006,11 @@ fn process_discriminated_enum(
 ///
 /// The per-field entries are the ones the adjacent form writes, so the two placements describe the
 /// same fields identically and only differ in where the object sits.
-#[cfg(all(feature = "serde", feature = "jsonschema"))]
+///
+/// Used both by the externally tagged form (behind `serde`, which is the only way that shape is
+/// reached) and by the adjacently tagged form's own struct variant, which is reached even without
+/// `serde` — the fallback "tag"/"value" shape `exec_model_schema` falls through to.
+#[cfg(feature = "jsonschema")]
 fn named_content_json_value(json_fields: &[proc_macro2::TokenStream]) -> proc_macro2::TokenStream {
     quote! {
         {
@@ -7962,7 +7966,12 @@ fn generate_variant_code(
             // Zod: { type: z.literal("Variant") }
         }
         VariantKind::Named => {
-            write_named_variant_fields(field_defs, Some(tag_name), self_type_name, &mut parts);
+            write_adjacent_named_variant_fields(
+                field_defs,
+                content_name,
+                self_type_name,
+                &mut parts,
+            );
         }
         VariantKind::TupleSingle => {
             write_tuple_single_variant_fields(field_defs, content_name, self_type_name, &mut parts);
@@ -7996,6 +8005,62 @@ fn generate_variant_code(
         parts.optional_fields,
         json_schema_variant,
     )
+}
+
+/// Writes an adjacently tagged struct variant's fields nested under the content key, the shape
+/// serde actually writes for it (`{"tag":"Variant","content":{...fields}}`).
+///
+/// Reuses [`write_named_variant_fields`]'s own `None`-tag rendering — the same "an object of its
+/// own" shape the externally tagged form already builds — rather than inventing a second nesting
+/// mechanism. A field reaching the enum being defined already defers through its own getter inside
+/// that object, so the content key itself never needs one: [`render_external_variant`]'s
+/// `defer_key` establishes the same thing for the externally tagged form.
+fn write_adjacent_named_variant_fields(
+    field_defs: &[FieldDef],
+    content_name: &str,
+    self_type_name: &str,
+    parts: &mut VariantParts,
+) {
+    let mut inner = VariantParts {
+        json_fields: Vec::new(),
+        optional_fields: Vec::new(),
+        schema_code: String::new(),
+        type_code: String::new(),
+    };
+    write_named_variant_fields(field_defs, None, self_type_name, &mut inner);
+
+    let content_key = ts_member_key(content_name);
+    let _ = writeln!(
+        parts.type_code,
+        "  {content_key}: {{\n{}}};",
+        inner.type_code
+    );
+
+    #[cfg(feature = "zod")]
+    let _ = writeln!(
+        parts.schema_code,
+        "  {content_key}: z.strictObject({{\n{}}}),",
+        inner.schema_code
+    );
+
+    #[cfg(feature = "jsonschema")]
+    push_named_content_json_field(&mut parts.json_fields, content_name, &inner.json_fields);
+}
+
+/// Pushes the JSON-schema property/required entries for an adjacently tagged struct variant's
+/// content key, mirroring [`push_single_tuple_json_field`] for the tuple-single case.
+#[cfg(feature = "jsonschema")]
+fn push_named_content_json_field(
+    json_schema_variant_fields: &mut Vec<proc_macro2::TokenStream>,
+    content_name: &str,
+    inner_json_fields: &[proc_macro2::TokenStream],
+) {
+    let content_name_str = content_name.to_owned();
+    let inner = named_content_json_value(inner_json_fields);
+    json_schema_variant_fields.push(quote! {
+        properties.insert(#content_name_str.to_string(), #inner);
+        required.push(serde_json::Value::String(#content_name_str.to_string()));
+    });
 }
 
 /// Writes the named-field portion of an enum variant (TypeScript, Zod, JSON Schema).

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -7463,6 +7463,39 @@ fn discriminated_union_rendering_is_stable_across_runs() {
     }
 }
 
+/// A struct variant with no fields is still `Named`, and the adjacent form nests its (empty)
+/// content under the content key rather than treating it as a unit: `Empty {}` writes
+/// `{"kind":"Empty","data":{}}` on the wire, not `{"kind":"Empty"}`.
+///
+/// Built through `parse_quote!` rather than a real item declaration: an empty-braced struct variant
+/// is exactly the shape `clippy::empty_enum_variants_with_brackets` (a `deny`d restriction lint
+/// here) refuses declared in source. Read as a value at run time, the shape never becomes an item
+/// in this crate's own AST, so the lint has nothing to see.
+#[test]
+fn adjacently_tagged_empty_named_variant_nests_an_empty_content_object() {
+    let mut item: syn::ItemEnum = syn::parse_quote! {
+        enum Probe {
+            Empty {},
+            Unit,
+        }
+    };
+    let variants = collect_discriminated_variants(&mut item, None, Some("probe_schema"));
+    let rendered = render_discriminated_variants("kind", "data", "Probe", &variants.0);
+
+    let ts = &rendered.0[0];
+    assert!(ts.contains("data: {\n};"), "Got: {ts}");
+
+    #[cfg(feature = "zod")]
+    let zod = &rendered.1[0].0;
+    #[cfg(feature = "zod")]
+    assert!(zod.contains("data: z.strictObject({\n}),"), "Got: {zod}");
+
+    #[cfg(feature = "jsonschema")]
+    let json = rendered.2[0].to_string();
+    #[cfg(feature = "jsonschema")]
+    assert!(json.contains("\"data\""), "Got: {json}");
+}
+
 /// The `validate()` contribution for a field spelled `spelling`, reached from `access`, as tokens.
 #[cfg(feature = "serde")]
 fn emitted_validation_from(spelling: &str, access: MemberAccess) -> String {

--- a/tests/recursive_type_tests/tests.rs
+++ b/tests/recursive_type_tests/tests.rs
@@ -524,6 +524,17 @@ pub enum TreeEnum {
     Leaf { text: String },
 }
 
+/// `TreeEnum`'s adjacent twin: the same recursive named variant, but nested under a content key
+/// rather than sitting beside the tag. The field-level getter has to keep deferring once nested, or
+/// the content object reads a binding at its own initializer.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(tag = "type", content = "value")]
+pub enum TreeEnumAdjacent {
+    Branch { nodes: Vec<Self> },
+    Leaf { text: String },
+}
+
 /// Recursive struct with `Vec` of self.
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -652,6 +663,27 @@ fn test_recursive_named_struct_variant() {
         zod.contains("text: z.string()"),
         "Non-recursive text field should use normal syntax. Got: {zod}"
     );
+}
+
+/// Test 8b: the same recursive field, now nested under an adjacent form's content key. The field's
+/// own getter still has to defer the reference; the content key itself needs none; wrapping it in a
+/// second getter would be wrong precedent (see `render_external_variant`'s `defer_key`, which never
+/// sets it for a `Named` variant either).
+#[test]
+fn test_recursive_named_struct_variant_adjacent() {
+    let zod = TreeEnumAdjacent::zod_schema();
+
+    assert!(
+        zod.contains("get nodes() { return z.array(TreeEnumAdjacent$Schema); },"),
+        "Got: {zod}"
+    );
+    assert!(zod.contains("text: z.string()"), "Got: {zod}");
+    assert!(
+        zod.contains("value: z.strictObject({"),
+        "The content key holds the field-level getter directly; it needs none of its own. Got: {zod}"
+    );
+    assert!(!zod.contains("get value()"), "Got: {zod}");
+    assert!(!zod.contains("get \"value\""), "Got: {zod}");
 }
 
 /// Test 9: Struct holding at most one of itself.

--- a/tests/rename_all_tests/tests.rs
+++ b/tests/rename_all_tests/tests.rs
@@ -469,31 +469,40 @@ fn externally_tagged_rename_all_json_schema_matches_serde_wire() {
     );
 }
 
-// The adjacently-tagged branch below asserts against `properties` directly rather than a
-// `data`-nested object: the content-key nesting the wire actually uses is a separate,
-// pre-existing gap the JSON Schema surface does not render yet. This test only pins the seam
-// this bug is about -- that the field key itself is untouched by the enum's own `rename_all`.
+// The adjacently-tagged branch below reads the field keys under `properties.data`, the object the
+// wire actually nests them in, the same depth `externally_tagged_rename_all_json_schema_matches_serde_wire`
+// reads its own content key at.
 #[cfg(feature = "jsonschema")]
 #[test]
 fn adjacently_tagged_rename_all_json_schema_matches_serde_wire() {
     let schema = AdjacentlyTaggedRename::json_schema();
     let one_of = schema["oneOf"].as_array().unwrap();
+
+    let unmarked = AdjacentlyTaggedRename::Unmarked {
+        field_one: "a".to_owned(),
+    };
     let unmarked_branch = one_of
         .iter()
         .find(|branch| branch["properties"]["kind"]["const"] == "unmarked")
         .unwrap();
+    assert_branch_accepts(unmarked_branch, &unmarked);
     assert!(
-        unmarked_branch["properties"]
+        unmarked_branch["properties"]["data"]["properties"]
             .as_object()
             .unwrap()
             .contains_key("field_one")
     );
+
+    let marked = AdjacentlyTaggedRename::Marked {
+        field_two: "b".to_owned(),
+    };
     let marked_branch = one_of
         .iter()
         .find(|branch| branch["properties"]["kind"]["const"] == "marked")
         .unwrap();
+    assert_branch_accepts(marked_branch, &marked);
     assert!(
-        marked_branch["properties"]
+        marked_branch["properties"]["data"]["properties"]
             .as_object()
             .unwrap()
             .contains_key("field-two")

--- a/tests/skipped_field_tests/tests.rs
+++ b/tests/skipped_field_tests/tests.rs
@@ -261,11 +261,16 @@ fn the_json_schema_neither_describes_nor_requires_the_field_serde_never_carries(
 #[cfg(feature = "jsonschema")]
 fn the_json_schema_drops_the_variant_member_too() {
     let tagged = SkippedVariantField::json_schema();
-    assert!(
-        tagged["oneOf"][0]["properties"]["internal"].is_null(),
-        "Got: {tagged}"
-    );
-    let required = tagged["oneOf"][0]["required"].as_array().unwrap().clone();
+    // With `serde`, `kind` is read as the internal tag and the member sits beside it. Without
+    // `serde`, the tag attribute can't be read at all, so the type falls back to the adjacent
+    // form (`src/model_schema.rs:5178-5180`) and the member nests one level down, under `value`.
+    #[cfg(feature = "serde")]
+    let member = &tagged["oneOf"][0];
+    #[cfg(not(feature = "serde"))]
+    let member = &tagged["oneOf"][0]["properties"]["value"];
+
+    assert!(member["properties"]["internal"].is_null(), "Got: {tagged}");
+    let required = member["required"].as_array().unwrap().clone();
     assert!(
         !required.contains(&serde_json::json!("internal")),
         "Got: {tagged}"
@@ -273,8 +278,14 @@ fn the_json_schema_drops_the_variant_member_too() {
     assert!(required.contains(&serde_json::json!("id")), "Got: {tagged}");
 
     let untagged = SkippedUntaggedField::json_schema();
+    // Same split: with `serde` the variant is untagged and sits at the top of `anyOf`; without
+    // it, `untagged` is equally unreadable and the same adjacent fallback applies.
+    #[cfg(feature = "serde")]
+    let untagged_member = &untagged["anyOf"][0];
+    #[cfg(not(feature = "serde"))]
+    let untagged_member = &untagged["oneOf"][0]["properties"]["value"];
     assert!(
-        untagged["anyOf"][0]["properties"]["internal"].is_null(),
+        untagged_member["properties"]["internal"].is_null(),
         "Got: {untagged}"
     );
 }

--- a/tests/tuple_variant_tests/tests.rs
+++ b/tests/tuple_variant_tests/tests.rs
@@ -39,6 +39,24 @@ pub enum SlotElements {
     Pair(String, Option<u32>),
 }
 
+/// A struct variant of an adjacently tagged enum: serde nests its fields in an object under the
+/// content key rather than splicing them beside the tag. `Named`'s optional `y` covers key
+/// optionality at the nested depth. The empty-content case (`Empty {}`) has no way to be declared
+/// here without tripping `clippy::empty_enum_variants_with_brackets`, so it is covered by
+/// `adjacently_tagged_empty_named_variant_nests_an_empty_content_object` in
+/// `src/model_schema/tests.rs` instead, built through `parse_quote!` rather than a real item.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(tag = "kind", content = "data")]
+pub enum AdjacentNamed {
+    Named {
+        x: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        y: Option<u32>,
+    },
+    Unit,
+}
+
 /// An enum carrying no `#[serde(tag = ..., content = ...)]` is externally tagged: serde writes the
 /// variant name as the sole key of an object holding the content, and a unit variant as the bare
 /// name. The four variants below are the four contents that key can hold, plus the one that has no
@@ -651,6 +669,88 @@ fn test_custom_content_field_zod() {
     assert!(
         zod.contains("data: z.number()"),
         "Should use 'data' as content field"
+    );
+}
+
+/// Test 6c: a struct variant of an adjacently tagged enum nests its fields under the content key on
+/// the wire — the bug this fixture exists to catch. The zero-field case (`Empty {}`) is covered
+/// separately in `src/model_schema/tests.rs`; see this file's `AdjacentNamed` doc comment.
+#[test]
+fn test_adjacent_named_variant_matches_the_serde_wire() {
+    let named = AdjacentNamed::Named {
+        x: "y".to_owned(),
+        y: Some(3),
+    };
+    let named_json = serde_json::to_value(&named).unwrap();
+    assert_eq!(
+        named_json,
+        serde_json::json!({ "kind": "Named", "data": { "x": "y", "y": 3_u32 } })
+    );
+    assert_eq!(
+        serde_json::from_value::<AdjacentNamed>(named_json).unwrap(),
+        named
+    );
+
+    assert_eq!(
+        serde_json::to_value(AdjacentNamed::Unit).unwrap(),
+        serde_json::json!({ "kind": "Unit" })
+    );
+}
+
+/// Test 6d: and the `TypeScript` surface holds the same nesting.
+#[test]
+fn test_adjacent_named_variant_typescript_nests_under_content_key() {
+    let ts = AdjacentNamed::ts_definition();
+    assert!(ts.contains("kind: \"Named\""), "Got: {ts}");
+    assert!(ts.contains("data: {"), "Got: {ts}");
+    assert!(ts.contains("x: string"), "Got: {ts}");
+    assert!(ts.contains("y: number | undefined"), "Got: {ts}");
+    assert!(ts.contains("kind: \"Unit\""), "Got: {ts}");
+}
+
+/// Test 6e: and the Zod surface, the recursive-field precedent's own reasoning applying here too —
+/// see `test_recursive_named_struct_variant_adjacent` in `recursive_type_tests`.
+#[cfg(feature = "zod")]
+#[test]
+fn test_adjacent_named_variant_zod_nests_under_content_key() {
+    let zod = AdjacentNamed::zod_schema();
+    assert!(zod.contains("data: z.strictObject({"), "Got: {zod}");
+    assert!(zod.contains("x: z.string()"), "Got: {zod}");
+    assert!(
+        zod.contains(
+            "y: z.union([z.null().transform(() => undefined), z.number().int(), z.undefined()])"
+        ),
+        "Got: {zod}"
+    );
+}
+
+/// Test 6f: and the JSON-schema surface — a closed object under `data`, `x` required and `y` not,
+/// `kind` and `data` both required on the branch itself.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn test_adjacent_named_variant_json_schema_nests_under_content_key() {
+    let schema = AdjacentNamed::json_schema();
+    let one_of = schema["oneOf"].as_array().unwrap();
+
+    let named_branch = one_of
+        .iter()
+        .find(|branch| branch["properties"]["kind"]["const"] == "Named")
+        .unwrap();
+    assert_eq!(
+        named_branch["required"],
+        serde_json::json!(["kind", "data"])
+    );
+    let data = &named_branch["properties"]["data"];
+    assert_eq!(data["type"], "object");
+    assert_eq!(data["additionalProperties"], false);
+    assert_eq!(data["required"], serde_json::json!(["x"]));
+    assert_eq!(
+        data["properties"]["x"],
+        serde_json::json!({ "type": "string" })
+    );
+    assert!(
+        data["properties"].as_object().unwrap().contains_key("y"),
+        "Got: {data}"
     );
 }
 


### PR DESCRIPTION
A struct variant of an enum carrying both `tag` and `content` had its fields
spliced beside the discriminator — the *internally* tagged shape — rather than
nested in an object under the content key. `generate_variant_code` took
`content_name` and its `VariantKind::Named` arm ignored it, while both tuple
arms used it.

serde nests them, so the document described a shape serde never writes, and
being closed it rejected the payload serde does write:

    #[serde(tag = "kind", content = "data")]
    enum Adj { Named { x: String } }

    serde writes   {"kind":"Named","data":{"x":"y"}}
    described      { kind: "Named", x: string }

This was reported against the JSON Schema alone. Capturing all three surfaces
shows TypeScript and Zod carry it identically, so all three are fixed together
— fixing one would have left the other two disagreeing with the wire. Tuple
variants, single and multiple, and unit variants were already right.

The nesting reuses `write_named_variant_fields`'s own `None`-tag rendering, the
same "an object of its own" the externally tagged form already builds, rather
than a second mechanism for the same shape. A field reaching the enum being
defined still defers through its own getter inside that object, so the content
key itself never needs one.

No condition is tested for the adjacent form because none is needed:
`generate_variant_code` is reachable only through `process_discriminated_enum`,
and the internally and externally tagged forms are routed away before it.

Without the `serde` feature no attribute is readable and the adjacent form is
what the crate falls through to, so an enum's struct variant nests there too.
One test in the skipped-field suite read a member at the branch level, which is
its depth only when serde is on; it now resolves the member object per
configuration and asserts the same thing — that a skipped field is neither
described nor required — at whichever depth that representation uses.

just lint, just lint-all across all 68 toggles, and the test powerset across all
68 in four partitions — all green.

