### PR TITLE
say what the map-key rule and the brand shapes actually are, and let private-item rustdoc build

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,18 +200,33 @@ pub struct MyType { ... }
 
 ### 3. HashMap Key Restriction
 
-**ONLY `HashMap<String, T>` is supported**. Non-string keys cause compilation errors.
+A map key must be one serde can write as a JSON object key. `String` is the open case: any string
+is a key. `bool`, the numeric types, `char`, and the chrono date/time types are accepted too —
+serde stringifies each one (`7` → `"7"`, `true` → `"true"`) — so the map describes as an open
+object while TypeScript and Zod keep the key's own type (`HashMap<u32, T>` →
+`Partial<Record<number, T>>`). A plain `#[model_schema()]` enum key narrows the object to its
+members. A key serde does not stringify — a struct, tuple, `Vec`/array, `Option`, nested map, or
+`ObjectId` — is refused at expansion:
 
 ```rust
-// ✅ Supported
+// ✅ Supported — string, and any key serde stringifies (bool/numeric/char/chrono)
 pub struct Config {
     pub settings: HashMap<String, String>,
+    pub counts: HashMap<u32, String>,
 }
 
-// ❌ NOT supported - will fail
-pub struct BadConfig {
-    pub settings: HashMap<i32, String>,
+// ❌ NOT supported - refused at expansion
+#[model_schema()]
+pub struct KeyStruct {
+    pub value: String,
 }
+
+#[model_schema()]
+pub struct BadMapKey {
+    pub m: HashMap<KeyStruct, u32>,
+}
+// error: field `m`: a map key must be a plain `#[model_schema()]` enum, whose members
+// become the object's keys — `KeyStruct` resolves to a type with no `enum_members()`
 ```
 
 ### 4. Type Mappings (Rust → TypeScript)
@@ -363,31 +378,78 @@ constraints.
 
 Single-field tuple structs with `#[serde(transparent)]` are treated as branded/opaque types. If the Rust name has a `Json` suffix, it is stripped from the TypeScript name.
 
+A non-generic brand publishes a `$RawSchema`/`$Schema` const pair:
+
 ```rust
-#[model_schema(default_types(ID_TYPE = String))]
+#[model_schema()]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct UserId<ID_TYPE>(pub ID_TYPE);
+pub struct CorrelationId(pub String);
 ```
 
 With `zod` + `typescript` features:
 ```typescript
-export type UserId<ID_TYPE> = ID_TYPE & z.$brand<"UserId">;
-const UserId$RawSchema = z.string().brand<"UserId">();
-export const UserId$Schema: ZodType<UserId<string>> = UserId$RawSchema;
+export type CorrelationId = string & z.$brand<"CorrelationId">;
+const CorrelationId$RawSchema = z.string().brand<"CorrelationId">().meta({
+  description: "CorrelationId",
+});
+
+export const CorrelationId$Schema: $ZodBranded<ZodString, "CorrelationId"> = CorrelationId$RawSchema;
+```
+
+A brand with a type parameter publishes `X$SchemaFactory` plus `X$SchemaDefault` instead, exactly
+like any other generic item — never a plain `const`:
+
+```rust
+#[model_schema(default_types(IdType = String))]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct UserId<IdType>(pub IdType);
+```
+
+```typescript
+export type UserId<IdType> = IdType & z.$brand<"UserId">;
+const buildUserId$Schema = <IdType extends ZodType>(
+  idType: IdType,
+) =>
+  idType.meta({
+  description: "UserId",
+}).brand<"UserId">();
+
+type UserId$SchemaOf<IdType extends ZodType> = ReturnType<
+  typeof buildUserId$Schema<IdType>
+>;
+
+const UserId$SchemaFactoryCache = new WeakMap<ZodType, UserId$SchemaOf<ZodType>>();
+
+export function UserId$SchemaFactory<IdType extends ZodType>(
+  idType: IdType,
+): UserId$SchemaOf<IdType>;
+export function UserId$SchemaFactory(
+  idType: ZodType,
+): UserId$SchemaOf<ZodType> {
+  const hit = UserId$SchemaFactoryCache.get(idType);
+  if (hit) return hit;
+
+  const schema = buildUserId$Schema(idType);
+  UserId$SchemaFactoryCache.set(idType, schema);
+  return schema;
+}
+
+export const UserId$SchemaDefault: $ZodBranded<ZodString, "UserId"> = UserId$SchemaFactory(z.string());
 ```
 
 With `typescript` only (no `zod`):
 ```typescript
 declare const __brand_UserId: unique symbol;
-export type UserId<ID_TYPE> = ID_TYPE & { readonly [__brand_UserId]: true };
+export type UserId<IdType> = IdType & { readonly [__brand_UserId]: true };
 ```
 
 Rules:
-- Generic parameter names are preserved exactly (`ID_TYPE` stays `ID_TYPE` in TypeScript)
-- Non-generic: `struct CorrelationId(pub String)` generates `string & z.$brand<"CorrelationId">`
-- A brand publishes a `const`, so a parameter in its inner has no argument to name and renders as
-  the opaque `z.unknown()`
+- Generic parameter names are preserved exactly (`IdType` stays `IdType` in TypeScript)
+- A brand with no type parameter publishes the `$RawSchema`/`$Schema` const pair; a brand with a
+  type parameter publishes `$SchemaFactory`/`$SchemaDefault` instead — the parameter's inner
+  composes the factory's bound argument (`idType`), never the opaque `z.unknown()`
 - Serde transparent serialization works normally — the newtype is invisible in JSON
 
 ### Generic Types and Zod Factories

--- a/src/features/model_schema_prop.rs
+++ b/src/features/model_schema_prop.rs
@@ -228,8 +228,8 @@ fn numeric_bound(nested: &ParseNestedMeta, key: &str) -> syn::Result<f64> {
 }
 
 /// The [`LiteralValue`] a `literal` key was written as, kept in whichever of the four kinds the
-/// author wrote — the kind [`crate::model_schema`]'s own guard then measures against the field's
-/// declared Rust type.
+/// author wrote — the kind [`crate::model_schema`](macro@crate::model_schema)'s own guard then
+/// measures against the field's declared Rust type.
 fn literal_prop_value(nested: &ParseNestedMeta) -> syn::Result<LiteralValue> {
     let lit: Lit = nested.value()?.parse()?;
     if let Lit::Str(str_lit) = &lit {

--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -113,7 +113,7 @@ pub enum FieldDefType {
     ObjectId,
     /// Reference to another struct/enum type, potentially with generics
     /// First String is the type name (without Json suffix in TS)
-    /// Vec<FieldDef> holds generic parameters if any.
+    /// `Vec<FieldDef>` holds generic parameters if any.
     SiblingType(String, Vec<FieldDef>),
     /// String primitive - maps to string.
     String,

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -7160,8 +7160,8 @@ fn string_field_json_schema_value(fld: &FieldDef) -> proc_macro2::TokenStream {
 }
 
 /// Builds a standalone `serde_json::Value` token expression for a single field, with `Vec<T>`
-/// array wrapping. Sibling type of [`flatten_field_json_schema_ref`]; used by untagged enum
-/// members where the JSON value is consumed directly (not inserted under a property name).
+/// array wrapping; used by untagged enum members where the JSON value is consumed directly (not
+/// inserted under a property name).
 #[cfg(all(feature = "serde", feature = "jsonschema"))]
 fn field_json_schema_value(fld: &FieldDef) -> proc_macro2::TokenStream {
     // A covered sequence wrapper writes the JSON array of its element, so the member is dispatched

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -235,7 +235,7 @@ pub struct AliasInfo {
     #[cfg(all(feature = "serde", feature = "typescript"))]
     pub ts_union_members: Vec<String>,
     /// What the value surface written under this name is, in the vocabulary a constrained brand's
-    /// refusal names shapes by — and [`PublishedShape::Flat(None)`] both when that surface is one
+    /// refusal names shapes by — and `PublishedShape::Flat(None)` both when that surface is one
     /// string checks land on and when nothing has been recorded at all. Filled by
     /// [`record_value_shape`] as each item registers.
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
@@ -721,9 +721,10 @@ pub fn publishes_zod_factory(rust_ident: &str) -> bool {
     ZOD_FACTORY_PUBLISHERS.with(|names| names.borrow().contains(rust_ident))
 }
 
-/// Records `rust_ident`'s own `$SchemaDefault` fold-comparison keys — the plain [`FieldDef::zod_type`]
-/// rendering of each declared-default field, one per parameter in declaration order, computed
-/// before deferral and before a constrained brand's `.min`/`.max`/`.check` chain is appended.
+/// Records `rust_ident`'s own `$SchemaDefault` fold-comparison keys — the plain
+/// [`FieldDef::zod_type`](crate::field_type::FieldDef::zod_type) rendering of each declared-default
+/// field, one per parameter in declaration order, computed before deferral and before a
+/// constrained brand's `.min`/`.max`/`.check` chain is appended.
 #[cfg(feature = "zod")]
 pub fn record_zod_default_arguments(rust_ident: &str, arguments: Vec<String>) {
     ZOD_DEFAULT_ARGUMENTS.with(|map| {


### PR DESCRIPTION
Three documentation defects, each a claim the code does not make.

The map-key rule read "ONLY `HashMap<String, T>` is supported. Non-string keys
cause compilation errors", with `HashMap<i32, String>` shown as the failing
example. That example compiles. `map_key_path` accepts every key serde can
write as an object key — `bool`, the numeric types, `char`, the chrono
date/time types — describing each as the string serde stringifies it to, while
TypeScript and Zod keep the key's own type. A plain enum key narrows the object
to its members. What is actually refused is a key serde does not stringify: a
struct, a tuple, a `Vec`, an `Option`, a nested map, an `ObjectId`. The section
now states that, and its failing example is one that genuinely fails, quoted
with the diagnostic the guard really emits.

The branded-newtype section paired a *generic* brand with plain-const output.
A generic brand does not publish a const — it publishes a factory and a
`$SchemaDefault`. The section now shows both shapes against captured output: the
non-generic `$RawSchema`/`$Schema` pair, and the generic factory beside its
default.

`RUSTDOCFLAGS="-D warnings" cargo doc --document-private-items` exited 101. Two
links named things that no longer exist or cannot be named — a function removed
in an earlier refactor, and an enum variant written with its payload — one named
a type the module does not import, one was ambiguous between a module and an
attribute macro of the same name, and a bare `Vec<FieldDef>` in prose was read
as an unclosed HTML tag. Each is now a resolving link, a code span, or a
disambiguated path; none is silenced. The command exits 0, and the ungated
`cargo doc` recipe is unaffected.

just lint, just lint-all across all 68 toggles, the test powerset across all 68
in four partitions, and private-item rustdoc under -D warnings — all green.

