### PR TITLE
read through the interior-mutability wrappers, which serde writes as the value they guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ The key position is the one place TypeScript stops rendering a parameter as itse
 
 This is what lets a type hold itself: `Option<Box<Self>>` is the self-reference, deferred in the generated schema the way any self-reference is. An `Rc` or `Arc` field needs serde's `rc` feature, which is where serde's impls for those two live.
 
+`RefCell<T>`, `Cell<T>`, `Mutex<T>` and `RwLock<T>` describe as `T` on every surface the same way: serde writes each as the value it guards, returning a serialization error rather than panicking when the guard cannot be taken (an already-mutably-borrowed `RefCell`, a poisoned `Mutex`/`RwLock`) — the same fallible path a schema does not describe for any other type. What sets them apart from `Box`/`Rc`/`Arc`/`Cow` is `Deref`: none of the four implements it, so `#[model_schema_prop(pattern = ..., minLength = ..., maxLength = ..., minimum = ..., maximum = ...)]` cannot reach through one to the value it guards, and is refused at expansion, naming the wrapper, wherever it is combined with one.
+
 ```rust
 use std::borrow::Cow;
 use std::sync::Arc;

--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -1272,9 +1272,26 @@ fn container_wire_arity(name: &str) -> Option<usize> {
     }
 }
 
-/// The one list of std wrappers the crate reads straight through to what they hold.
+/// The one list of std wrappers the crate reads straight through to what they hold: everything
+/// serde writes as the value alone, with no wrapper of its own on the wire.
 pub fn is_transparent_wrapper(name: &str) -> bool {
+    is_ownership_wrapper(name) || is_interior_mutability_wrapper(name)
+}
+
+/// The ownership and borrow wrappers: each implements `Deref`, so a constraint's generated
+/// validator reaches the inner value with a plain `&**value`.
+pub fn is_ownership_wrapper(name: &str) -> bool {
     matches!(name, "Arc" | "Box" | "Cow" | "Rc")
+}
+
+/// The interior-mutability wrappers: serde writes each as the value it guards, with `RefCell` and
+/// `Mutex`/`RwLock` returning a serialization error — not a panic — when the guard cannot be taken
+/// (an already-mutably-borrowed `RefCell`, a poisoned `Mutex`/`RwLock`), the same fallible path a
+/// schema does not describe for any other type. None of the four implements `Deref`, which is why a
+/// constraint's generated validator cannot reach through one the way it reaches through an
+/// ownership wrapper — see `generic_wrap` in `model_schema.rs`.
+pub fn is_interior_mutability_wrapper(name: &str) -> bool {
+    matches!(name, "Cell" | "Mutex" | "RefCell" | "RwLock")
 }
 
 /// Classifies a `syn::Variant` into its `VariantKind`.

--- a/src/field_type/tests.rs
+++ b/src/field_type/tests.rs
@@ -261,7 +261,9 @@ fn test_a_fixed_array_keeps_its_bound_across_the_sequence_normalization() {
 /// in a way of its own.
 #[test]
 fn test_the_covered_transparent_wrappers_are_exactly_the_recorded_list() {
-    for name in ["Arc", "Box", "Cow", "Rc"] {
+    for name in [
+        "Arc", "Box", "Cell", "Cow", "Mutex", "Rc", "RefCell", "RwLock",
+    ] {
         assert!(super::is_transparent_wrapper(name), "for: {name}");
     }
     for name in ["BTreeMap", "HashMap", "Option", "Vec"] {
@@ -269,11 +271,35 @@ fn test_the_covered_transparent_wrappers_are_exactly_the_recorded_list() {
     }
 }
 
+/// The ownership/borrow split the covered list is built from: only the first four implement
+/// `Deref`, which is what a constraint's generated validator needs to reach through one.
+#[test]
+fn test_ownership_and_interior_mutability_partition_the_covered_list() {
+    for name in ["Arc", "Box", "Cow", "Rc"] {
+        assert!(super::is_ownership_wrapper(name), "for: {name}");
+        assert!(!super::is_interior_mutability_wrapper(name), "for: {name}");
+    }
+    for name in ["Cell", "Mutex", "RefCell", "RwLock"] {
+        assert!(!super::is_ownership_wrapper(name), "for: {name}");
+        assert!(super::is_interior_mutability_wrapper(name), "for: {name}");
+    }
+}
+
 /// A covered wrapper writes nothing of its own, so the field it wraps is the field the parser
 /// produces — name and docs included, both of which belong to where the field was written.
 #[test]
 fn test_a_transparent_wrapper_parses_as_the_field_it_wraps() {
-    for spelling in ["Arc<u32>", "Box<u32>", "Cow<'a, u32>", "Rc<u32>", "u32"] {
+    for spelling in [
+        "Arc<u32>",
+        "Box<u32>",
+        "Cell<u32>",
+        "Cow<'a, u32>",
+        "Mutex<u32>",
+        "Rc<u32>",
+        "RefCell<u32>",
+        "RwLock<u32>",
+        "u32",
+    ] {
         let ty: syn::Type = syn::parse_str(spelling).unwrap();
         let parsed = super::get_field_def("items", &ty, " * items");
         assert!(

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -78,7 +78,7 @@ use crate::field_type::{parse_serde_field_attributes, parse_serde_type_attribute
 use crate::field_type::is_sequence_wrapper;
 
 #[cfg(feature = "serde")]
-use crate::field_type::is_transparent_wrapper;
+use crate::field_type::{is_interior_mutability_wrapper, is_ownership_wrapper};
 
 use crate::features::model_schema_prop::{
     LiteralValue, ModelSchemaPropMeta, parse_model_schema_prop_attributes,
@@ -7297,7 +7297,7 @@ fn untagged_member_field_def(
     field_name: &str,
     prop_meta: ModelSchemaPropMeta,
     serde_field_meta: &SerdeFieldMeta,
-    positional_constraint_error: Option<proc_macro2::TokenStream>,
+    field_validation_guard_error: Option<proc_macro2::TokenStream>,
 ) -> (FieldDef, Vec<proc_macro2::TokenStream>) {
     // The wire key: field-level rename wins outright, otherwise the variant's own rename_all cases
     // the Rust ident — the same resolution `process_field` runs for a struct field. Diagnostics
@@ -7317,7 +7317,7 @@ fn untagged_member_field_def(
         prop_meta.nullable,
         serde_field_meta,
         ctx.container_defaulted,
-        positional_constraint_error,
+        field_validation_guard_error,
     );
     let member_guard_errors = collect_field_guard_errors(
         field,
@@ -7373,14 +7373,15 @@ fn collect_untagged_variant_members(
 
         let new_attrs = declaration_attrs(field);
         let mut injected_attrs: Vec<syn::Attribute> = Vec::new();
-        let (validation_fn, validate_body, positional_constraint_error) = generate_field_validation(
-            field,
-            schema_module_name,
-            &field_name,
-            Some(&variant_name),
-            &prop_meta,
-            &mut injected_attrs,
-        );
+        let (validation_fn, validate_body, field_validation_guard_error) =
+            generate_field_validation(
+                field,
+                schema_module_name,
+                &field_name,
+                Some(&variant_name),
+                &prop_meta,
+                &mut injected_attrs,
+            );
         field.attrs = new_attrs;
         walked.deferred_attrs.push(injected_attrs);
         walked.validation_fns.extend(validation_fn);
@@ -7403,7 +7404,7 @@ fn collect_untagged_variant_members(
             &field_name,
             prop_meta,
             &serde_field_meta,
-            positional_constraint_error,
+            field_validation_guard_error,
         );
         walked.guard_errors.extend(member_guard_errors);
         if positional && omission.absent_from_wire() {
@@ -10064,6 +10065,37 @@ fn constrained_shape(ty: &syn::Type) -> Option<ConstrainedShape> {
     }
 }
 
+/// The interior-mutability wrapper on a field's constrained path, when there is one.
+///
+/// `constrained_shape` cannot say *why* a shape failed to classify — a `HashMap` value and a
+/// `RefCell` both just stop the walk. This retraces the same path far enough to tell whether the
+/// stop was one of the four wrappers `generic_wrap` deliberately does not read through, so the
+/// caller can name it in a diagnostic instead of silently dropping the constraint.
+#[cfg(feature = "serde")]
+fn blocking_interior_mutability_wrapper(ty: &syn::Type) -> Option<String> {
+    let mut current = ty;
+    loop {
+        current = written_type(current);
+        if let syn::Type::Array(array) = current {
+            current = &array.elem;
+        } else if let syn::Type::Slice(slice) = current {
+            current = &slice.elem;
+        } else if let syn::Type::Path(path) = current {
+            let segment = path.path.segments.last()?;
+            let ident = segment.ident.to_string();
+            if is_interior_mutability_wrapper(&ident) {
+                return Some(ident);
+            }
+            let syn::PathArguments::AngleBracketed(args) = &segment.arguments else {
+                return None;
+            };
+            current = sole_type_argument(args)?;
+        } else {
+            return None;
+        }
+    }
+}
+
 /// Adds the lifetimes a wrapper spells to the ones already collected, skipping `'static` — which
 /// needs no declaration — and any already there, since a lifetime can only be declared once.
 #[cfg(feature = "serde")]
@@ -10082,13 +10114,18 @@ fn collect_lifetimes(
 }
 
 /// The wrapper a generic type stands for, or `None` if it is not one the constraint reads through.
+///
+/// An interior-mutability wrapper is deliberately absent: it is on the wire-transparent list
+/// (`is_transparent_wrapper`) the schema surfaces read, but it does not implement `Deref`, so the
+/// walk below has no safe way to reach through one — see `blocking_interior_mutability_wrapper`,
+/// which turns that case into a named diagnostic instead of a silently dropped constraint.
 #[cfg(feature = "serde")]
 fn generic_wrap(ident: &str) -> Option<ConstraintWrap> {
     if ident == "Option" {
         Some(ConstraintWrap::Optional)
     } else if is_sequence_wrapper(ident) {
         Some(ConstraintWrap::Sequence)
-    } else if is_transparent_wrapper(ident) {
+    } else if is_ownership_wrapper(ident) {
         Some(ConstraintWrap::Transparent)
     } else {
         None
@@ -10286,8 +10323,9 @@ fn check_omitted_key_is_readable(
 ///
 /// A hidden serde attribute leaves every serde-read diagnostic unreliable — the `Option`-null and
 /// `nullable`-key guards included, since the wrapper is exactly what kept its evidence out of the
-/// meta. The positional-constraint guard reads no serde attribute, so it stands whatever the
-/// wrapper hid.
+/// meta. `field_validation_guard_error` — the positional-constraint guard, or the
+/// interior-mutability-wrapper guard — reads no serde attribute, so it stands whatever the wrapper
+/// hid.
 #[cfg(feature = "serde")]
 fn field_guard_errors(
     field: &Field,
@@ -10296,9 +10334,9 @@ fn field_guard_errors(
     is_nullable: bool,
     serde_field_meta: &SerdeFieldMeta,
     container_defaulted: bool,
-    positional_constraint_error: Option<proc_macro2::TokenStream>,
+    field_validation_guard_error: Option<proc_macro2::TokenStream>,
 ) -> Vec<proc_macro2::TokenStream> {
-    positional_constraint_error
+    field_validation_guard_error
         .into_iter()
         .chain(serde_field_meta.cfg_attr_rejection.as_ref().map_or_else(
             || {
@@ -10667,7 +10705,7 @@ fn process_field(
 
     // Generate validation code and hold back the serde attribute it hangs on the field
     #[cfg(feature = "serde")]
-    let (validation_fn, validate_body, positional_constraint_error) = generate_field_validation(
+    let (validation_fn, validate_body, field_validation_guard_error) = generate_field_validation(
         field,
         ctx.schema_module_name,
         &raw_field_ident,
@@ -10720,7 +10758,7 @@ fn process_field(
         model_schema_prop_meta.nullable,
         &serde_field_meta,
         ctx.container_defaulted,
-        positional_constraint_error,
+        field_validation_guard_error,
     );
     #[cfg(not(feature = "serde"))]
     let serde_guard_errors: Vec<proc_macro2::TokenStream> = {
@@ -10774,6 +10812,33 @@ fn positional_constraint_guard_error(
     .to_compile_error()
 }
 
+/// The `compile_error!` tokens for a length or range constraint written on a field reached through
+/// an interior-mutability wrapper.
+///
+/// Every other covered wrapper (`Box`, `Rc`, `Arc`, `Cow`) implements `Deref`, so the generated
+/// validator reaches its inner value with a plain `&**value`. `RefCell`, `Cell`, `Mutex` and
+/// `RwLock` do not: reaching one takes a runtime-checked borrow or lock, which the constraint
+/// walk has no way to fold into `validate(&self)` — so the combination is refused here instead of
+/// the constraint silently going unchecked.
+#[cfg(feature = "serde")]
+fn interior_mutability_constraint_guard_error(
+    field: &Field,
+    raw_field_ident: &str,
+    wrapper: &str,
+) -> proc_macro2::TokenStream {
+    syn::Error::new_spanned(
+        field,
+        format!(
+            "model_schema: {}: pattern, minLength, maxLength, minimum and maximum are unsupported \
+             on a field reached through `{wrapper}` — unlike `Box`, `Rc`, `Arc` and `Cow`, it does \
+             not implement `Deref`, so the generated validator has no safe way to reach its inner \
+             value. Drop the constraint, or move the value out from under `{wrapper}`.",
+            field_label(raw_field_ident)
+        ),
+    )
+    .to_compile_error()
+}
+
 /// Generates per-field serde validation code (static validator + `deserialize_with`) and, when
 /// constraints apply, collects the corresponding `#[serde(deserialize_with = ...)]` attribute into
 /// `injected_attrs` — plus the `#[serde(default)]` that keeps an optional key optional under one.
@@ -10806,6 +10871,19 @@ fn generate_field_validation(
 
     let (Some(module_name), Some(shape)) = (schema_module_name, constrained_shape(&field.ty))
     else {
+        if (has_string_constraints || has_numeric_constraints)
+            && let Some(wrapper) = blocking_interior_mutability_wrapper(&field.ty)
+        {
+            return (
+                None,
+                None,
+                Some(interior_mutability_constraint_guard_error(
+                    field,
+                    raw_field_ident,
+                    &wrapper,
+                )),
+            );
+        }
         return (None, None, None);
     };
 

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -7783,6 +7783,47 @@ fn a_constraint_on_a_positional_field_is_refused_before_a_name_is_spelled() {
     assert_eq!(unconstrained, (false, false, None, 0));
 }
 
+/// `RefCell`, `Cell`, `Mutex` and `RwLock` are on the wire-transparent list — the schema surfaces
+/// describe a field under one as the field it wraps — but none of the four is `Deref`, so a length
+/// or range constraint on one is refused by name instead of the validator silently going unwritten.
+/// An unconstrained field under the same wrapper is untouched, exactly like a positional slot.
+#[cfg(feature = "serde")]
+#[test]
+fn a_constraint_under_an_interior_mutability_wrapper_names_the_wrapper() {
+    for (spelling, wrapper) in [
+        ("RefCell<String>", "RefCell"),
+        ("Cell<u32>", "Cell"),
+        ("Mutex<String>", "Mutex"),
+        ("RwLock<String>", "RwLock"),
+    ] {
+        let ty: syn::Type = syn::parse_str(spelling).unwrap();
+        let item: syn::ItemStruct = syn::parse_quote! {
+            struct Probe { guarded: #ty }
+        };
+
+        let (module_items, validate_body, guard_error, injected_attrs) = generated_field_validation(
+            &item,
+            &ModelSchemaPropMeta {
+                min_length: Some(3),
+                ..ModelSchemaPropMeta::default()
+            },
+        );
+        let error = guard_error.unwrap();
+        assert!(error.contains("compile_error"), "for {spelling}: {error}");
+        assert!(error.contains(wrapper), "for {spelling}: {error}");
+        assert!(error.contains("Deref"), "for {spelling}: {error}");
+        assert!(!module_items, "a refused field generated helpers: {error}");
+        assert!(
+            !validate_body,
+            "a refused field reached validate(): {error}"
+        );
+        assert_eq!(injected_attrs, 0, "a refused field was given a serde hook");
+
+        let unconstrained = generated_field_validation(&item, &ModelSchemaPropMeta::default());
+        assert_eq!(unconstrained, (false, false, None, 0), "for {spelling}");
+    }
+}
+
 /// The whole expansion is what a panicking `Ident` cost, so the enum the bug was found on must
 /// come back as diagnostics — one per offending slot, and none for the slot that carries no
 /// constraint.

--- a/tests/transparent_wrapper_tests/tests.rs
+++ b/tests/transparent_wrapper_tests/tests.rs
@@ -1,13 +1,17 @@
 use alloc::borrow::Cow;
 use alloc::rc::Rc;
 use alloc::sync::Arc;
+use core::cell::{Cell, RefCell};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::sync::{Mutex, RwLock};
 use tixschema::model_schema;
 
 /// The covered wrappers by the name a generated surface could leak.
 #[cfg(any(feature = "typescript", feature = "zod"))]
-const TRANSPARENT_WRAPPERS: [&str; 4] = ["Arc", "Box", "Cow", "Rc"];
+const TRANSPARENT_WRAPPERS: [&str; 8] = [
+    "Arc", "Box", "Cell", "Cow", "Mutex", "Rc", "RefCell", "RwLock",
+];
 
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -81,6 +85,68 @@ struct CowFields {
     text: Cow<'static, str>,
 }
 
+// `RefCell::new` takes a `Sized` value, so unlike `Box`/`Rc`/`Arc`/`Cow` above it cannot hold an
+// unsized `[String]`/`str` directly — the owned `Vec<String>`/`String` spellings stand in, and
+// still collapse onto the same field `PlainFields` does.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct RefCellFields {
+    count: RefCell<u64>,
+    labels: RefCell<Vec<String>>,
+    #[serde(default, skip_serializing_if = "ref_cell_option_is_none")]
+    maybe_count: RefCell<Option<u64>>,
+    #[serde(default, skip_serializing_if = "ref_cell_option_is_none")]
+    maybe_tag: RefCell<Option<Tag>>,
+    tag: RefCell<Tag>,
+    text: RefCell<String>,
+}
+
+// `Mutex` implements neither `Clone` nor `PartialEq` regardless of what it holds, unlike the other
+// covered wrappers.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug)]
+struct MutexFields {
+    count: Mutex<u64>,
+    labels: Mutex<Vec<String>>,
+    #[serde(default, skip_serializing_if = "mutex_option_is_none")]
+    maybe_count: Mutex<Option<u64>>,
+    #[serde(default, skip_serializing_if = "mutex_option_is_none")]
+    maybe_tag: Mutex<Option<Tag>>,
+    tag: Mutex<Tag>,
+    text: Mutex<String>,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug)]
+struct RwLockFields {
+    count: RwLock<u64>,
+    labels: RwLock<Vec<String>>,
+    #[serde(default, skip_serializing_if = "rwlock_option_is_none")]
+    maybe_count: RwLock<Option<u64>>,
+    #[serde(default, skip_serializing_if = "rwlock_option_is_none")]
+    maybe_tag: RwLock<Option<Tag>>,
+    tag: RwLock<Tag>,
+    text: RwLock<String>,
+}
+
+// `Cell<T>` requires `T: Copy` for serde's own `Serialize` impl, so its fixture -- and the plain
+// spelling held against it -- are reduced to the `PlainFields` fields that are `Copy`.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct CellFields {
+    count: Cell<u64>,
+    #[serde(default, skip_serializing_if = "cell_option_is_none")]
+    maybe_count: Cell<Option<u64>>,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct PlainCopyFields {
+    count: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    maybe_count: Option<u64>,
+}
+
 // A wrapper written under something else: inside an `Option`, inside a sequence, in a map's value
 // slot. Each position reads the collapsed field, so none of them sees a wrapper at all.
 #[model_schema()]
@@ -126,6 +192,28 @@ struct TreeNode {
     label: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     next: Option<Box<Self>>,
+}
+
+// None of the four is `Deref`, so `skip_serializing_if = "Option::is_none"` -- which reaches an
+// `Option` field under `Box`/`Rc`/`Arc`/`Cow` by deref coercion -- has no field to coerce to here.
+// Each predicate reaches the guarded `Option` through the wrapper's own accessor instead.
+fn ref_cell_option_is_none<T>(value: &RefCell<Option<T>>) -> bool {
+    value.borrow().is_none()
+}
+
+fn mutex_option_is_none<T>(value: &Mutex<Option<T>>) -> bool {
+    value.lock().unwrap().is_none()
+}
+
+fn rwlock_option_is_none<T>(value: &RwLock<Option<T>>) -> bool {
+    value.read().unwrap().is_none()
+}
+
+fn cell_option_is_none<T>(value: &Cell<Option<T>>) -> bool
+where
+    T: Copy,
+{
+    value.get().is_none()
 }
 
 fn tag() -> Tag {
@@ -189,6 +277,53 @@ fn cow_fields() -> CowFields {
     }
 }
 
+fn ref_cell_fields() -> RefCellFields {
+    RefCellFields {
+        count: RefCell::new(7),
+        labels: RefCell::new(vec!["x".to_owned()]),
+        maybe_count: RefCell::new(Some(3)),
+        maybe_tag: RefCell::new(Some(tag())),
+        tag: RefCell::new(tag()),
+        text: RefCell::new("t".to_owned()),
+    }
+}
+
+fn mutex_fields() -> MutexFields {
+    MutexFields {
+        count: Mutex::new(7),
+        labels: Mutex::new(vec!["x".to_owned()]),
+        maybe_count: Mutex::new(Some(3)),
+        maybe_tag: Mutex::new(Some(tag())),
+        tag: Mutex::new(tag()),
+        text: Mutex::new("t".to_owned()),
+    }
+}
+
+fn rwlock_fields() -> RwLockFields {
+    RwLockFields {
+        count: RwLock::new(7),
+        labels: RwLock::new(vec!["x".to_owned()]),
+        maybe_count: RwLock::new(Some(3)),
+        maybe_tag: RwLock::new(Some(tag())),
+        tag: RwLock::new(tag()),
+        text: RwLock::new("t".to_owned()),
+    }
+}
+
+fn cell_fields() -> CellFields {
+    CellFields {
+        count: Cell::new(7),
+        maybe_count: Cell::new(Some(3)),
+    }
+}
+
+fn plain_copy_fields() -> PlainCopyFields {
+    PlainCopyFields {
+        count: 7,
+        maybe_count: Some(3),
+    }
+}
+
 /// The field declarations of a generated `TypeScript` definition, without the `JSDoc` around them.
 #[cfg(feature = "typescript")]
 fn ts_field_declarations(definition: &str) -> Vec<String> {
@@ -200,18 +335,24 @@ fn ts_field_declarations(definition: &str) -> Vec<String> {
 }
 
 /// One populated instance of every wrapper twin, serialized, beside the bare spelling's.
-fn covered_wrapper_payloads() -> [(&'static str, serde_json::Value); 4] {
+///
+/// `Cell` is not among them: its fixture holds a different, reduced field set (see
+/// `test_cell_field_writes_its_inner_value` and its neighbors below).
+fn covered_wrapper_payloads() -> [(&'static str, serde_json::Value); 7] {
     [
         ("Box", serde_json::to_value(boxed_fields()).unwrap()),
         ("Rc", serde_json::to_value(rc_fields()).unwrap()),
         ("Arc", serde_json::to_value(arc_fields()).unwrap()),
         ("Cow", serde_json::to_value(cow_fields()).unwrap()),
+        ("RefCell", serde_json::to_value(ref_cell_fields()).unwrap()),
+        ("Mutex", serde_json::to_value(mutex_fields()).unwrap()),
+        ("RwLock", serde_json::to_value(rwlock_fields()).unwrap()),
     ]
 }
 
 /// Every wrapper twin's generated `TypeScript`, under the bare spelling's type name.
 #[cfg(feature = "typescript")]
-fn covered_wrapper_ts_definitions() -> [(&'static str, String); 4] {
+fn covered_wrapper_ts_definitions() -> [(&'static str, String); 7] {
     [
         (
             "Box",
@@ -229,12 +370,24 @@ fn covered_wrapper_ts_definitions() -> [(&'static str, String); 4] {
             "Cow",
             CowFields::ts_definition().replace("CowFields", "PlainFields"),
         ),
+        (
+            "RefCell",
+            RefCellFields::ts_definition().replace("RefCellFields", "PlainFields"),
+        ),
+        (
+            "Mutex",
+            MutexFields::ts_definition().replace("MutexFields", "PlainFields"),
+        ),
+        (
+            "RwLock",
+            RwLockFields::ts_definition().replace("RwLockFields", "PlainFields"),
+        ),
     ]
 }
 
 /// The same for Zod.
 #[cfg(feature = "zod")]
-fn covered_wrapper_zod_schemas() -> [(&'static str, String); 4] {
+fn covered_wrapper_zod_schemas() -> [(&'static str, String); 7] {
     [
         (
             "Box",
@@ -252,16 +405,31 @@ fn covered_wrapper_zod_schemas() -> [(&'static str, String); 4] {
             "Cow",
             CowFields::zod_schema().replace("CowFields", "PlainFields"),
         ),
+        (
+            "RefCell",
+            RefCellFields::zod_schema().replace("RefCellFields", "PlainFields"),
+        ),
+        (
+            "Mutex",
+            MutexFields::zod_schema().replace("MutexFields", "PlainFields"),
+        ),
+        (
+            "RwLock",
+            RwLockFields::zod_schema().replace("RwLockFields", "PlainFields"),
+        ),
     ]
 }
 
 #[cfg(feature = "jsonschema")]
-fn covered_wrapper_json_schemas() -> [(&'static str, serde_json::Value); 4] {
+fn covered_wrapper_json_schemas() -> [(&'static str, serde_json::Value); 7] {
     [
         ("Box", BoxedFields::json_schema()),
         ("Rc", RcFields::json_schema()),
         ("Arc", ArcFields::json_schema()),
         ("Cow", CowFields::json_schema()),
+        ("RefCell", RefCellFields::json_schema()),
+        ("Mutex", MutexFields::json_schema()),
+        ("RwLock", RwLockFields::json_schema()),
     ]
 }
 
@@ -271,6 +439,17 @@ fn test_transparent_wrapper_structs_constructible() {
     assert_eq!(*rc_fields().count, plain_fields().count);
     assert_eq!(*arc_fields().count, plain_fields().count);
     assert_eq!(*cow_fields().count, plain_fields().count);
+    // Not `Deref`: each reads its guarded value through its own accessor instead of `*value`.
+    assert_eq!(*ref_cell_fields().count.borrow(), plain_fields().count);
+    assert_eq!(
+        mutex_fields().count.into_inner().unwrap(),
+        plain_fields().count
+    );
+    assert_eq!(
+        rwlock_fields().count.into_inner().unwrap(),
+        plain_fields().count
+    );
+    assert_eq!(cell_fields().count.get(), plain_copy_fields().count);
 
     let node = TreeNode {
         label: "root".to_owned(),
@@ -465,5 +644,61 @@ fn test_boxed_self_reference_validates_as_the_self_reference() {
     assert!(schema.contains("label: z.string()"), "Got: {schema}");
     for name in TRANSPARENT_WRAPPERS {
         assert!(!schema.contains(name), "Got: {schema}");
+    }
+}
+
+/// `Cell` writes its inner value exactly as the other covered wrappers do, over its own reduced
+/// (`Copy`-only) field set.
+#[test]
+fn test_cell_field_writes_its_inner_value() {
+    assert_eq!(
+        serde_json::to_value(cell_fields()).unwrap(),
+        serde_json::to_value(plain_copy_fields()).unwrap()
+    );
+}
+
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_cell_field_describes_as_the_inner_spelling() {
+    let cell_schema = CellFields::json_schema();
+    let plain_schema = PlainCopyFields::json_schema();
+    assert_eq!(cell_schema["properties"], plain_schema["properties"]);
+    assert_eq!(cell_schema["required"], plain_schema["required"]);
+}
+
+#[test]
+#[cfg(feature = "typescript")]
+fn test_cell_field_types_as_the_inner_spelling() {
+    assert_eq!(
+        CellFields::ts_definition().replace("CellFields", "PlainCopyFields"),
+        PlainCopyFields::ts_definition()
+    );
+}
+
+#[test]
+#[cfg(feature = "zod")]
+fn test_cell_field_validates_as_the_inner_spelling() {
+    assert_eq!(
+        CellFields::zod_schema().replace("CellFields", "PlainCopyFields"),
+        PlainCopyFields::zod_schema()
+    );
+}
+
+#[test]
+#[cfg(any(feature = "typescript", feature = "zod"))]
+fn test_no_cell_name_survives_into_generated_output() {
+    #[cfg(feature = "typescript")]
+    {
+        let ts = CellFields::ts_definition().replace("CellFields", "PlainCopyFields");
+        for name in TRANSPARENT_WRAPPERS {
+            assert!(!ts.contains(name), "Got: {ts}");
+        }
+    }
+    #[cfg(feature = "zod")]
+    {
+        let zod = CellFields::zod_schema().replace("CellFields", "PlainCopyFields");
+        for name in TRANSPARENT_WRAPPERS {
+            assert!(!zod.contains(name), "Got: {zod}");
+        }
     }
 }


### PR DESCRIPTION
`RefCell`, `Cell`, `Mutex` and `RwLock` meet the criterion the transparent
wrapper list is built on — serde writes each as the value it holds, with no
wrapper of its own on the wire, exactly as it writes `Box`/`Rc`/`Arc`/`Cow` —
and none of them was on it. A field under one parsed as a sibling type, and the
JSON-schema path emitted a reference to a schema module named after the wrapper.
No such module exists, so the expansion did not compile.

All four were measured rather than assumed; the report had only probed one:

    RefCell<u32>   error[E0433]: cannot find module or crate `ref_cell_schema`
    Cell<u32>      error[E0433]: … `cell_schema`
    Mutex<u32>     error[E0433]: … `mutex_schema`
    RwLock<u32>    error[E0433]: … `rw_lock_schema`

They are added through the list itself rather than a second mechanism, so every
surface reads them the way it already reads an ownership wrapper.

They are not interchangeable with that list everywhere, though. A constraint's
generated validator reaches the inner value with `&**value`, which needs
`Deref`, and none of these four implements it — so folding them into one
predicate would have compiled and silently dropped a `minLength` or a `minimum`
written on a field wrapped in one. The predicate is split: the surfaces read the
wire-transparent list, the validator walk reads the ownership list alone, and a
constraint written through an interior-mutability wrapper is now refused with a
diagnostic that names the wrapper, instead of disappearing.

The fallible guard is not described and does not need to be. An already-borrowed
`RefCell` and a poisoned `Mutex`/`RwLock` make serde return a serialization
error rather than panic — read off serde's own impls — which is the same
fallible path no other type's schema describes either.

`Ref`, `RefMut`, the three lock guards, and the `Once`/`Lazy` cells were checked
against the same source and are not added: none carries a `Serialize` or
`Deserialize` impl at all, so none is a wrapper this crate can see through.

just lint, just lint-all across all 68 toggles, and the test powerset across all
68 in four partitions — all green.

