### PR TITLE
give a constrained brand's to_string call the inner field's location, now that a span can carry one without its hygiene

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -3933,7 +3933,12 @@ fn build_branded_validation(
     args.has_string_constraints().then(|| {
         let measures_path = branded_inner_measures_path(inner_ty);
         let (checked_param, rendering) = checked_value_parts(measures_path);
-        let checked_v = branded_checked_value(measures_path, &quote! { v });
+        // `resolved_at` keeps the inner field's location (what E0599 underlines on a non-`Display`
+        // inner) while giving the token the macro's own hygiene, so a consumer's lints still judge
+        // it as generated rather than hand-written — see `doc_lines_with_spans` in utils.rs for the
+        // same trade-off measured against the same clippy suite.
+        let to_string_span = inner_ty.span().resolved_at(proc_macro2::Span::call_site());
+        let checked_v = branded_checked_value(measures_path, to_string_span, &quote! { v });
         let mut checks: Vec<proc_macro2::TokenStream> = Vec::new();
 
         if let Some(min_len) = args.min_length {
@@ -3990,10 +3995,6 @@ fn build_branded_validation(
                 }
             }
         } else {
-            // Deliberately unspanned: a `to_string()` carrying the user's span is judged by the
-            // consumer's lints as hand-written, and on a `String` inner it is a redundant clone.
-            // The inner field's `Display` requirement is blamed by the static assertion instead,
-            // which is inert wherever it lands.
             quote! {
                 pub fn deserialize_value<'de, D>(deserializer: D) -> Result<#inner_ty, D::Error>
                 where
@@ -4008,7 +4009,7 @@ fn build_branded_validation(
         };
 
         BrandedValidation {
-            checked_inner: branded_checked_value(measures_path, &quote! { self.0 }),
+            checked_inner: branded_checked_value(measures_path, to_string_span, &quote! { self.0 }),
             deserialize_fn,
             validate_fn,
         }
@@ -4033,19 +4034,23 @@ fn branded_inner_measures_path(inner_ty: &syn::Type) -> bool {
 
 /// How a constrained brand hands `receiver` to `validate_value`: a path goes borrowed — deref
 /// coercion carries it through whatever transparent wrappers it was written under — since the
-/// validator renders it itself; every other inner is rendered through `Display` first.
+/// validator renders it itself; every other inner is rendered through `Display` first, the
+/// `to_string()` call carrying `to_string_span` so a non-`Display` inner's `E0599` lands beside the
+/// field's own `E0277` instead of on the attribute — `resolved_at(Span::call_site())`, the caller's
+/// only legal input, keeps the tokens hygienically the macro's own.
 #[cfg(all(
     feature = "serde",
     any(feature = "typescript", feature = "zod", feature = "jsonschema")
 ))]
 fn branded_checked_value(
     measures_path: bool,
+    to_string_span: proc_macro2::Span,
     receiver: &proc_macro2::TokenStream,
 ) -> proc_macro2::TokenStream {
     if measures_path {
         quote! { &#receiver }
     } else {
-        quote! { &#receiver.to_string() }
+        quote_spanned! {to_string_span=> &#receiver.to_string() }
     }
 }
 

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -5526,26 +5526,31 @@ fn constrained_brand_inner_spanned_tokens(source: &str, inner: &str) -> (usize, 
     (count(&validation.deserialize_fn), count(&validate_method))
 }
 
-/// Neither `to_string()` the constrained path emits may carry the inner field's span. Spanned
-/// tokens are judged by the consumer's lints as if hand-written, and on a `String` inner
-/// `self.0.to_string()` is a redundant clone — the whole test suite fails on it. The `Display`
-/// requirement is blamed by the static assertion instead, whose tokens are inert wherever they
-/// land. Only the interpolated `#inner_ty` may point at the field here.
+/// Both `to_string()` calls the constrained path emits now carry the inner field's location — via
+/// `resolved_at`, not a bare respan — so a non-`Display` inner's `E0599` lands beside the field's
+/// own `E0277` instead of on the attribute. `deserializer` counts the two pre-existing interpolated
+/// `#inner_ty` occurrences plus the three literal tokens (`&`, `.`, `to_string`) `quote_spanned!`
+/// respans around `checked_v`; `validate_method` interpolates no inner type, so its three come from
+/// `checked_inner`'s own `&`, `.`, `to_string` alone. The `#receiver` tokens themselves (`v`, or
+/// `self` `.` `0`) are interpolated rather than written by the `quote_spanned!` template, so they
+/// keep their own unlocated span — this location-count alone cannot see whether the *hygiene*
+/// context also carried over; that is measured by the crate's own deny-heavy clippy run staying
+/// clean on the `String`-inner brands the existing suite already declares.
 #[cfg(all(
     feature = "serde",
     any(feature = "typescript", feature = "zod", feature = "jsonschema")
 ))]
 #[test]
-fn neither_constrained_to_string_call_carries_the_inner_fields_span() {
+fn constrained_to_string_calls_carry_the_inner_fields_location() {
     let (deserializer, validate_method) =
         constrained_brand_inner_spanned_tokens("pub struct SlugId(pub Tags);", "Tags");
     assert_eq!(
-        deserializer, 2,
-        "the two interpolated type names and nothing else"
+        deserializer, 5,
+        "two interpolated type names plus the three respanned to_string() tokens"
     );
     assert_eq!(
-        validate_method, 0,
-        "`validate()` interpolates no inner type"
+        validate_method, 3,
+        "the three respanned to_string() tokens alone"
     );
 }
 


### PR DESCRIPTION
A constrained branded newtype over a sibling inner with no `Display` raised two
errors: the primary `E0277` at the field, correct and attributable, and a
secondary `E0599` on the whole `#[model_schema(...)]` attribute, from the
generated `to_string()` calls, which carried no location at all.

Spanning those two call sites was tried before and reverted. A user span carries
the consumer's hygiene with it, so the generated `self.0.to_string()` reads to
their lints as hand-written — on a `String` inner that is a redundant clone, and
it earned 14 findings across the suites under a deny-heavy profile. The comment
left behind recorded the call sites as deliberately unspanned.

`resolved_at(Span::call_site())` separates the two halves that were assumed to
travel together: it keeps the location a diagnostic underlines while leaving the
tokens hygienically the macro's own. It is the same trade-off measured for the
doc-comment example spans, and it makes the reverted fix available:

    before   error[E0599]: `Inner` doesn't implement `std::fmt::Display`
              --> tests/probe.rs:8:1
             8 | #[model_schema(no_display, minLength = 1)]
               | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

    after    error[E0599]: `Inner` doesn't implement `std::fmt::Display`
              --> tests/probe.rs:11:28
            11 | pub struct Constrained(pub Inner);
               |                           ^^^^^ method cannot be called on `Inner`

The span is computed once and both call sites route through the one function
that renders the checked value, so neither can drift from the other. Nothing
spurious came back: the crate's own profile already denies all, pedantic,
restriction and nursery — the profile the first attempt regressed under — and it
is clean against every existing `String`-inner constrained brand fixture.

One thing this does not reach, and it is worth being exact about: the field
becomes the only error when the brand also sets `no_display`. Without it, the
generated `Display` impl's own `self.0.fmt(f)` raises its own `E0599` on a
non-`Display` inner. That is unchanged by this commit, present before and after,
and tracked separately.

just lint, just lint-all across all 68 toggles, and the test powerset across all
68 in four partitions — all green.

