### PR TITLE
write a branded newtype's exported type with the bare brand again

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -389,7 +389,7 @@ pub struct CorrelationId(pub String);
 
 With `zod` + `typescript` features:
 ```typescript
-export type CorrelationId = string & z.$brand<"CorrelationId">;
+export type CorrelationId = string & $brand<"CorrelationId">;
 const CorrelationId$RawSchema = z.string().brand<"CorrelationId">().meta({
   description: "CorrelationId",
 });
@@ -408,7 +408,7 @@ pub struct UserId<IdType>(pub IdType);
 ```
 
 ```typescript
-export type UserId<IdType> = IdType & z.$brand<"UserId">;
+export type UserId<IdType> = IdType & $brand<"UserId">;
 const buildUserId$Schema = <IdType extends ZodType>(
   idType: IdType,
 ) =>

--- a/README.md
+++ b/README.md
@@ -1034,7 +1034,7 @@ pub struct CorrelationId(pub String);
 Generated TypeScript (with `zod` feature):
 
 ```typescript
-export type UserId<IdType> = IdType & z.$brand<"UserId">;
+export type UserId<IdType> = IdType & $brand<"UserId">;
 const buildUserId$Schema = <IdType extends ZodType>(
   idType: IdType,
 ) =>
@@ -1064,7 +1064,7 @@ export function UserId$SchemaFactory(
 
 export const UserId$SchemaDefault: $ZodBranded<ZodString, "UserId"> = UserId$SchemaFactory(z.string());
 
-export type CorrelationId = string & z.$brand<"CorrelationId">;
+export type CorrelationId = string & $brand<"CorrelationId">;
 const CorrelationId$RawSchema = z.string().brand<"CorrelationId">().meta({
   description: "CorrelationId",
 });

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -4449,9 +4449,6 @@ fn branded_zod_instantiated_type_name(name: &str, args: &[FieldDef]) -> String {
 }
 
 /// Builds the `ts_definition()` method for a branded newtype's schema module.
-///
-/// `$brand` is spelled off the `z` namespace: it is not a top-level export of `"zod"`, only
-/// reachable as `z.$brand` under the documented `import { z } from "zod";` line.
 #[cfg(feature = "typescript")]
 fn build_branded_ts_definition_method(
     item_name: &str,
@@ -4463,7 +4460,7 @@ fn build_branded_ts_definition_method(
     #[cfg(feature = "zod")]
     {
         let type_str = format!(
-            "export type {item_name}{ts_generics} = {ts_inner_type} & z.$brand<\"{item_name}\">;{reexport}"
+            "export type {item_name}{ts_generics} = {ts_inner_type} & $brand<\"{item_name}\">;{reexport}"
         );
         quote! {
             pub fn ts_definition() -> String {

--- a/tests/branded_newtype_tests/tests.rs
+++ b/tests/branded_newtype_tests/tests.rs
@@ -40,7 +40,7 @@ mod zod_ts_tests {
     fn test_branded_newtype_ts_definition() {
         let ts = RoleId::<String>::ts_definition();
         assert!(
-            ts.contains("export type RoleId<IdType> = IdType & z.$brand<\"RoleId\">"),
+            ts.contains("export type RoleId<IdType> = IdType & $brand<\"RoleId\">"),
             "Got: {ts}"
         );
     }
@@ -92,7 +92,7 @@ mod zod_ts_tests {
     fn test_branded_newtype_non_generic() {
         let ts = CorrelationId::ts_definition();
         assert!(
-            ts.contains("export type CorrelationId = string & z.$brand<\"CorrelationId\">"),
+            ts.contains("export type CorrelationId = string & $brand<\"CorrelationId\">"),
             "Got: {ts}"
         );
     }
@@ -124,7 +124,7 @@ mod zod_ts_tests {
     fn test_branded_newtype_integer_inner() {
         let ts = SequenceNum::ts_definition();
         assert!(
-            ts.contains("export type SequenceNum = number & z.$brand<\"SequenceNum\">"),
+            ts.contains("export type SequenceNum = number & $brand<\"SequenceNum\">"),
             "Should have number branded type. Got: {ts}"
         );
 
@@ -426,7 +426,7 @@ mod objectid_branded_surface_tests {
     fn an_unconstrained_objectid_brand_describes_the_oid_object_on_every_surface() {
         assert_eq!(
             PlainObjectId::ts_definition(),
-            r#"export type PlainObjectId = ObjectId & z.$brand<"PlainObjectId">;"#
+            r#"export type PlainObjectId = ObjectId & $brand<"PlainObjectId">;"#
         );
         let zod = PlainObjectId::zod_schema();
         assert!(
@@ -1317,7 +1317,7 @@ mod branded_composite_inner_tests {
     fn an_array_brand_describes_the_array_on_every_surface() {
         assert_eq!(
             LabelList::ts_definition(),
-            r#"export type LabelList = Array<string> & z.$brand<"LabelList">;"#
+            r#"export type LabelList = Array<string> & $brand<"LabelList">;"#
         );
         let zod = LabelList::zod_schema();
         assert!(
@@ -1338,7 +1338,7 @@ mod branded_composite_inner_tests {
     fn a_map_brand_describes_the_object_on_every_surface() {
         assert_eq!(
             WeightMap::ts_definition(),
-            r#"export type WeightMap = Partial<Record<string, number>> & z.$brand<"WeightMap">;"#
+            r#"export type WeightMap = Partial<Record<string, number>> & $brand<"WeightMap">;"#
         );
         let zod = WeightMap::zod_schema();
         assert!(
@@ -1361,7 +1361,7 @@ mod branded_composite_inner_tests {
     fn a_tuple_brand_describes_the_fixed_arity_array_on_every_surface() {
         assert_eq!(
             LabelPair::ts_definition(),
-            r#"export type LabelPair = [string, number] & z.$brand<"LabelPair">;"#
+            r#"export type LabelPair = [string, number] & $brand<"LabelPair">;"#
         );
         let zod = LabelPair::zod_schema();
         assert!(
@@ -1422,7 +1422,7 @@ mod branded_composite_inner_tests {
     fn an_opaque_brand_admits_any_value() {
         assert_eq!(
             Payload::ts_definition(),
-            r#"export type Payload = unknown & z.$brand<"Payload">;"#
+            r#"export type Payload = unknown & $brand<"Payload">;"#
         );
         let zod = Payload::zod_schema();
         assert!(
@@ -1561,7 +1561,7 @@ mod branded_generic_inner_tests {
     fn an_arrayed_parameter_brand_describes_the_array_on_every_surface() {
         assert_eq!(
             TagList::<String>::ts_definition(),
-            r#"export type TagList<T> = Array<T> & z.$brand<"TagList">;"#
+            r#"export type TagList<T> = Array<T> & $brand<"TagList">;"#
         );
         let zod = TagList::<String>::zod_schema();
         assert!(zod.contains("  z.array(t).meta({"), "Got:\n{zod}");
@@ -1580,7 +1580,7 @@ mod branded_generic_inner_tests {
     fn a_mapped_parameter_brand_describes_the_object_on_every_surface() {
         assert_eq!(
             WeightIndex::<u32>::ts_definition(),
-            r#"export type WeightIndex<T> = Partial<Record<string, T>> & z.$brand<"WeightIndex">;"#
+            r#"export type WeightIndex<T> = Partial<Record<string, T>> & $brand<"WeightIndex">;"#
         );
         let zod = WeightIndex::<u32>::zod_schema();
         assert!(
@@ -1609,7 +1609,7 @@ mod branded_generic_inner_tests {
     fn a_bare_parameter_brand_matches_the_generic_field_convention() {
         assert_eq!(
             BareTag::<String>::ts_definition(),
-            r#"export type BareTag<T> = T & z.$brand<"BareTag">;"#
+            r#"export type BareTag<T> = T & $brand<"BareTag">;"#
         );
         let zod = BareTag::<String>::zod_schema();
         assert!(zod.contains("  t.meta({"), "Got:\n{zod}");
@@ -1948,7 +1948,7 @@ mod branded_sibling_inner_tests {
     fn a_sibling_brand_describes_the_named_type_on_every_surface() {
         assert_eq!(
             WrappedPart::ts_definition(),
-            r#"export type WrappedPart = Part & z.$brand<"WrappedPart">;"#
+            r#"export type WrappedPart = Part & $brand<"WrappedPart">;"#
         );
         let zod = WrappedPart::zod_schema();
         assert!(
@@ -2095,7 +2095,7 @@ mod branded_sibling_inner_tests {
         );
         assert_eq!(
             TrailingFixedTag::ts_definition(),
-            r#"export type TrailingFixedTag = LateTag<string> & z.$brand<"TrailingFixedTag">;"#
+            r#"export type TrailingFixedTag = LateTag<string> & $brand<"TrailingFixedTag">;"#
         );
         TrailingFixedTag(LateTag("abcd".to_owned()))
             .validate()
@@ -2115,7 +2115,7 @@ mod branded_sibling_inner_tests {
     fn an_unconstrained_generic_brand_over_a_parameterised_inner_is_unchanged() {
         assert_eq!(
             OpenTag::<String>::ts_definition(),
-            r#"export type OpenTag<TagType> = LateTag<TagType> & z.$brand<"OpenTag">;"#
+            r#"export type OpenTag<TagType> = LateTag<TagType> & $brand<"OpenTag">;"#
         );
         let zod = OpenTag::<String>::zod_schema();
         assert!(
@@ -2341,7 +2341,7 @@ mod branded_chrono_inner_tests {
         );
         assert_eq!(
             Stamp::ts_definition(),
-            r#"export type Stamp = string & z.$brand<"Stamp">;"#
+            r#"export type Stamp = string & $brand<"Stamp">;"#
         );
     }
 }

--- a/tests/generic_types_tests/whole_type_tests.rs
+++ b/tests/generic_types_tests/whole_type_tests.rs
@@ -58,14 +58,14 @@ mod typescript {
     /// binds its parameter and spends it in the intersection — and the type holding one names the
     /// brand with the argument it forwards, two levels from where the parameter was declared.
     ///
-    /// Which marker is written is the value surface's business — `z.$brand<"Name">` is Zod's — so the
+    /// Which marker is written is the value surface's business — `$brand<"Name">` is Zod's — so the
     /// intersection is read where that surface compiles.
     #[cfg(feature = "zod")]
     #[test]
     fn a_generic_brand_is_named_with_the_argument_forwarded_to_it() {
         let brand = ArchiveId::<String>::ts_definition();
         assert!(
-            brand.contains("export type ArchiveId<IdType> = IdType & z.$brand<\"ArchiveId\">;"),
+            brand.contains("export type ArchiveId<IdType> = IdType & $brand<\"ArchiveId\">;"),
             "Got: {brand}"
         );
         let holder = ArchiveStamp::<String>::ts_definition();

--- a/tests/item_rename_tests/tests.rs
+++ b/tests/item_rename_tests/tests.rs
@@ -144,7 +144,7 @@ fn every_renamed_shape_is_written_under_the_override() {
 #[test]
 fn a_renamed_brand_is_tagged_by_the_override() {
     let ts = BrandUnderRustName::ts_definition();
-    assert!(ts.contains("z.$brand<\"RenamedBrand\">"), "got: {ts}");
+    assert!(ts.contains("$brand<\"RenamedBrand\">"), "got: {ts}");
     let zod = BrandUnderRustName::zod_schema();
     assert!(zod.contains(".brand<\"RenamedBrand\">()"), "got: {zod}");
 }


### PR DESCRIPTION
The brand annotation was qualified onto the `z` namespace, and every Zod class
this crate emits is written bare. It goes back to bare:

    export type UserId<IdType> = IdType & $brand<"UserId">;

The pinned expectations that had been moved with it are moved back: the two
README blocks, the CLAUDE.md branded section, and the assertions across the
branded newtype, item rename and whole-type generic suites.

just check, just quick, just lint-all across all 68 toggles, and the test
powerset across all 68 in four partitions — all green.

