### PR TITLE
bound a brand's Display impl on the inner field itself, and name the class an object-shaped instantiation composes to

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -4432,18 +4432,20 @@ fn branded_zod_type_name(inner: &FieldDef) -> String {
 /// to the class every Zod schema is an instance of rather than guess one that might not be it.
 #[cfg(all(feature = "zod", feature = "typescript"))]
 fn branded_zod_instantiated_type_name(name: &str, args: &[FieldDef]) -> String {
-    let Some(PublishedShape::Parameter(position)) =
-        lookup_alias_info(name).map(|info| info.value_shape)
-    else {
-        return "ZodType".to_owned();
-    };
-    match args.get(position) {
-        Some(argument)
-            if argument.is_array()
-                || !matches!(argument.field_type, FieldDefType::TypeParam(_)) =>
-        {
-            branded_zod_type_name(argument)
-        }
+    match lookup_alias_info(name).map(|info| info.value_shape) {
+        Some(PublishedShape::Parameter(position)) => match args.get(position) {
+            Some(argument)
+                if argument.is_array()
+                    || !matches!(argument.field_type, FieldDefType::TypeParam(_)) =>
+            {
+                branded_zod_type_name(argument)
+            }
+            _ => "ZodType".to_owned(),
+        },
+        // A plain struct's own object shape is produced by exactly one registration site
+        // (`Surface::object()` — see its own doc comment), so unlike `union`/`container`/the
+        // bare-string bucket, the word alone already proves the Zod class.
+        Some(PublishedShape::Flat(Some("object"))) => "ZodObject".to_owned(),
         _ => "ZodType".to_owned(),
     }
 }
@@ -4665,9 +4667,14 @@ fn build_branded_delegate_items(
 
 /// Builds the `Display` impl for a branded newtype, delegating to the inner field's `Display`.
 ///
-/// The delegating call carries the inner field's span, so the method-resolution failure it raises
-/// on a non-`Display` inner is reported at the field rather than at `#[model_schema()]`. Only the
-/// span changes; the emitted tokens are the same either way.
+/// The `where` clause bounds the inner field's own type rather than only the brand's own type
+/// parameters, so a non-generic brand over a non-`Display` inner is bounded too and raises one
+/// `E0277` naming the trait, instead of leaving `self.0.fmt(f)` to raise a second, unbounded
+/// `E0599` beside it.
+///
+/// The predicate carries the field's location through `resolved_at(Span::call_site())`, which
+/// reports the refusal at the field while leaving the tokens hygienically the macro's own — the
+/// same split the doc-comment example spans rely on.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn build_branded_display_impl(
     generics: &syn::Generics,
@@ -4676,11 +4683,15 @@ fn build_branded_display_impl(
 ) -> proc_macro2::TokenStream {
     let (_, type_generics, _) = generics.split_for_impl();
     let mut display_generics = generics.clone();
-    for param in &mut display_generics.params {
-        if let syn::GenericParam::Type(tp) = param {
-            tp.bounds.push(syn::parse_quote!(std::fmt::Display));
-        }
-    }
+    let inner_ty = &inner_field.ty;
+    let bound_span = inner_field
+        .ty
+        .span()
+        .resolved_at(proc_macro2::Span::call_site());
+    display_generics
+        .make_where_clause()
+        .predicates
+        .push(syn::parse_quote_spanned!(bound_span=> #inner_ty: std::fmt::Display));
     let (display_impl_generics, _, display_where_clause) = display_generics.split_for_impl();
     let delegate = quote_spanned! {inner_field.ty.span()=> self.0.fmt(f) };
     quote! {
@@ -4711,15 +4722,14 @@ fn build_branded_display_tokens(
     if args.no_display && !validation_needs_display {
         return quote! {};
     }
-    let display_assertion = build_branded_display_assertion(inner_field, generics);
     if args.no_display {
-        return display_assertion;
+        // No impl is emitted in this branch, so nothing else asserts `Display` on the inner.
+        return build_branded_display_assertion(inner_field, generics);
     }
-    let display_impl = build_branded_display_impl(generics, name, inner_field);
-    quote! {
-        #display_assertion
-        #display_impl
-    }
+    // The impl's own `where` clause (built from the field's type, not just the brand's own
+    // generic params) now performs this exact check, spanned on the field — a separate
+    // assertion here would only double the diagnostic.
+    build_branded_display_impl(generics, name, inner_field)
 }
 
 /// Builds a static assertion that the branded newtype's inner type implements `Display`, spanned

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -5406,17 +5406,20 @@ fn display_impl_delegates_from_the_inner_field_span() {
     let tokens = super::build_branded_display_impl(&item.generics, &item.ident, field);
     assert_eq!(
         tokens.to_string(),
-        "impl std :: fmt :: Display for UserId { fn fmt (& self , f : & mut std :: fmt :: Formatter < '_ >) -> std :: fmt :: Result { self . 0 . fmt (f) } }"
+        "impl std :: fmt :: Display for UserId where String : std :: fmt :: Display { fn fmt (& self , f : & mut std :: fmt :: Formatter < '_ >) -> std :: fmt :: Result { self . 0 . fmt (f) } }"
     );
     assert_eq!(
         located_source_texts(&tokens).join(" "),
-        "UserId String String String String String String",
-        "the interpolated type name, then `self . 0 . fmt (f)` on the inner field"
+        "UserId String String String String String String String String String String String \
+         String String String String",
+        "the interpolated type name, then every token of the where-clause predicate (the bound is \
+         spanned on the field, so a non-`Display` inner is blamed there rather than at the \
+         attribute), then `self . 0 . fmt (f)` on the inner field"
     );
 }
 
-/// The generic impl keeps its own `Display` bound on every type parameter; that bound, not the
-/// skipped assertion, is what carries the requirement.
+/// The generic impl's own `where`-clause bound on the field's type — here, the bare type
+/// parameter itself — not the skipped assertion, is what carries the requirement.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
 fn generic_display_impl_bounds_every_type_parameter() {
@@ -5426,7 +5429,7 @@ fn generic_display_impl_bounds_every_type_parameter() {
     let tokens = super::build_branded_display_impl(&item.generics, &item.ident, field);
     assert_eq!(
         tokens.to_string(),
-        "impl < IdType : std :: fmt :: Display > std :: fmt :: Display for DocumentId < IdType > { fn fmt (& self , f : & mut std :: fmt :: Formatter < '_ >) -> std :: fmt :: Result { self . 0 . fmt (f) } }"
+        "impl < IdType > std :: fmt :: Display for DocumentId < IdType > where IdType : std :: fmt :: Display { fn fmt (& self , f : & mut std :: fmt :: Formatter < '_ >) -> std :: fmt :: Result { self . 0 . fmt (f) } }"
     );
 }
 
@@ -5467,22 +5470,25 @@ fn constraints_keep_the_display_assertion_when_the_brand_opts_out_of_the_impl() 
     );
 }
 
-/// The three combinations that predate the constrained-path assertion keep their exact tokens.
+/// Where the impl is emitted, its own `where`-clause bound now performs the check the separate
+/// assertion used to — so that assertion no longer appears alongside it, only the impl. The
+/// opt-out combination is untouched: it still emits neither half.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
-fn the_display_block_is_unchanged_for_every_pre_existing_combination() {
-    let assertion_and_impl = display_tokens("pub struct UserId(pub String);", &quote::quote! {});
+fn the_display_block_carries_only_the_impl_once_the_impl_is_emitted() {
+    let impl_only = display_tokens("pub struct UserId(pub String);", &quote::quote! {});
     assert!(
-        assertion_and_impl.contains("assert_display :: < String > ()")
-            && assertion_and_impl.contains("impl std :: fmt :: Display for UserId"),
-        "got: {assertion_and_impl}"
+        !impl_only.contains("assert_display")
+            && impl_only.contains("impl std :: fmt :: Display for UserId")
+            && impl_only.contains("where String : std :: fmt :: Display"),
+        "got: {impl_only}"
     );
     assert_eq!(
         display_tokens(
             "pub struct SlugId(pub String);",
             &quote::quote! { pattern = "^[a-z]+$" }
         ),
-        assertion_and_impl.replace("UserId", "SlugId"),
+        impl_only.replace("UserId", "SlugId"),
         "a constrained brand that kept its impl emits what an unconstrained one does"
     );
     assert_eq!(

--- a/tests/branded_newtype_tests/tests.rs
+++ b/tests/branded_newtype_tests/tests.rs
@@ -1109,6 +1109,7 @@ mod constrained_default_names_a_sibling_tests {
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 mod branded_display_tests {
     use super::*;
+    use core::fmt;
 
     #[model_schema(default_types(T = String))]
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -1119,6 +1120,26 @@ mod branded_display_tests {
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     #[serde(transparent)]
     pub struct SimpleDisplayId(pub String);
+
+    #[model_schema()]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    pub struct DisplayInner {
+        pub value: String,
+    }
+
+    impl fmt::Display for DisplayInner {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "inner:{}", self.value)
+        }
+    }
+
+    // A non-generic brand over a sibling inner that implements `Display` itself: the impl's own
+    // `where` clause (built from the field's type) is satisfied by the sibling's hand-written
+    // impl, same as it would be by a bound the brand's own generics happened to carry.
+    #[model_schema()]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct WrapsDisplay(pub DisplayInner);
 
     #[test]
     fn test_generic_branded_display() {
@@ -1136,6 +1157,14 @@ mod branded_display_tests {
     fn test_branded_display_to_string() {
         let id = DisplayId("hello".to_owned());
         assert_eq!(id.to_string(), "hello");
+    }
+
+    #[test]
+    fn test_branded_display_over_a_sibling_inner_with_its_own_display_impl() {
+        let wrapped = WrapsDisplay(DisplayInner {
+            value: "xyz".to_owned(),
+        });
+        assert_eq!(wrapped.to_string(), "inner:xyz");
     }
 }
 
@@ -1928,6 +1957,36 @@ mod branded_sibling_inner_tests {
     #[serde(transparent)]
     pub struct PlainCount(pub u64);
 
+    // A plain generic struct of named fields — the one shape `Surface::object()` registers, so a
+    // brand over its instantiation can be annotated the precise `ZodObject` rather than the
+    // widened `ZodType`.
+    #[model_schema(default_types(T = String))]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    pub struct Wrapper<T> {
+        pub field: T,
+    }
+
+    #[model_schema(no_display)]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct WrappedBrand(pub Wrapper<u32>);
+
+    // A generic, tag-discriminated enum — a union-shaped sibling, whose registered word stays
+    // genuinely ambiguous between a plain and a discriminated union, so a brand over it keeps
+    // widening to `ZodType`.
+    #[model_schema(default_types(T = String))]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(tag = "kind")]
+    pub enum Choice<T> {
+        First { value: T },
+        Second,
+    }
+
+    #[model_schema(no_display)]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct WrappedChoice(pub Choice<u32>);
+
     #[test]
     fn a_sibling_brand_writes_the_object_its_inner_writes() {
         let part = Part {
@@ -2214,6 +2273,30 @@ mod branded_sibling_inner_tests {
         let zod = OpenTag::<String>::zod_schema();
         assert!(
             zod.contains(r#"OpenTag$SchemaDefault: $ZodBranded<ZodType, "OpenTag"> ="#),
+            "Got:\n{zod}"
+        );
+    }
+
+    /// A brand over a plain generic struct instantiation is annotated the precise `ZodObject`:
+    /// the sibling's registered shape (`Surface::object()`) is produced by exactly one site, used
+    /// for exactly one thing, so the word alone already proves the class.
+    #[test]
+    fn a_brand_over_a_plain_generic_struct_instantiation_is_annotated_zodobject() {
+        let zod = WrappedBrand::zod_schema();
+        assert!(
+            zod.contains(r#"WrappedBrand$Schema: $ZodBranded<ZodObject, "WrappedBrand">"#),
+            "Got:\n{zod}"
+        );
+    }
+
+    /// A brand over a union-shaped generic sibling instantiation keeps widening to `ZodType`: the
+    /// registered word covers more than one Zod class, so nothing proves which one without
+    /// guessing.
+    #[test]
+    fn a_brand_over_a_union_shaped_generic_instantiation_stays_widened() {
+        let zod = WrappedChoice::zod_schema();
+        assert!(
+            zod.contains(r#"WrappedChoice$Schema: $ZodBranded<ZodType, "WrappedChoice">"#),
             "Got:\n{zod}"
         );
     }


### PR DESCRIPTION
Two defects in the branded emission.

A brand's `Display` impl bounded only the brand's own type parameters, so a
non-generic brand over a sibling inner with no `Display` had nothing bounding
it. The impl body's `self.0.fmt(f)` was left to fail on its own, raising an
unbounded `E0599` beside the constraint assertion's `E0277` — two errors for one
cause, and the assertion was itself redundant with a bound that should have
existed. The `where` clause now bounds the inner field's own type, the separate
assertion is dropped where the impl already carries the requirement, and the
predicate takes the field's location through `resolved_at(Span::call_site())`,
which reports at the field while leaving the tokens hygienically the macro's
own:

    struct Inner { value: String }
    #[model_schema_prop(minLength = 1)] struct Constrained(pub Inner);

    before   4 diagnostics, the E0599 among them landing on the attribute
    after    error[E0277]: `Inner` doesn't implement `std::fmt::Display`
              --> probe.rs:14:28
            14 | pub struct Constrained(pub Inner);
               |                            ^^^^^

Second, a brand over a generic instantiation widened to `ZodType` whenever the
named item was not a family publisher, including where the recorded shape
already proves the class. `Flat(Some("object"))` is registered by exactly one
site, and every value carrying it is a plain object, so it now annotates
`ZodObject`. The other shape words stay widened: a union and a discriminated
union share one recorded word without sharing a class, and a container's does
not name one either. No `enumerated` arm is added — it cannot be reached, a unit
enum being unable to declare a type parameter at all.

just check, just quick, just lint-all across all 68 toggles, and the test
powerset across all 68 in four partitions — all green.

