### PR TITLE
cut the comments that restate the code, echo a name, or argue a design

### DIFF
--- a/src/features/jsonschema.rs
+++ b/src/features/jsonschema.rs
@@ -3,17 +3,13 @@
 //! This module handles JSON schema generation when the "jsonschema" feature is enabled.
 
 /// What every pointer the crate writes opens with; what follows it is the key a definition is
-/// hoisted under — a bare name, or a name discriminated by the filling that built it.
-///
-/// The crate writes draft 2020-12 (`prefixItems` with `"items": false` is that draft's fixed-arity
-/// array, and the draft before it spells the same array with `items`/`additionalItems`), whose
-/// deferred schema is a `$ref` into the document's own `$defs`.
+/// hoisted under — a bare name, or a name discriminated by the filling that built it. The crate
+/// writes draft 2020-12, whose deferred schema is a `$ref` into the document's own `$defs`.
 const DEFS_PREFIX: &str = "#/$defs/";
 
-/// How a merge that cannot proceed names itself in the diagnostic it raises.
-///
-/// `subject` is the frame that reads the merge, `edge` what the merged schema was reached through,
-/// and each remedy the way out in the spelling that applies where that edge was written.
+/// How a merge that cannot proceed names itself in the diagnostic it raises: `subject` is the
+/// frame that reads the merge, `edge` what the merged schema was reached through, and each remedy
+/// the way out in the spelling that applies where that edge was written.
 pub struct MergeDiagnostic<'msg> {
     /// The way out of a cycle: what makes the edge defer rather than merge.
     pub cycle_remedy: &'msg str,
@@ -24,11 +20,9 @@ pub struct MergeDiagnostic<'msg> {
     pub subject: &'msg str,
 }
 
-/// One schema merged into a base, together with how the author named it.
-///
-/// A merged schema is a `serde_json` expression by the time it reaches the merge and no longer
-/// carries the name it came from, so the label travels beside it — it is what a diagnostic points
-/// the author at.
+/// One schema merged into a base, together with how the author named it. A merged schema is a
+/// `serde_json` expression by the time it reaches the merge and no longer carries the name it came
+/// from, so the label travels beside it — it is what a diagnostic points the author at.
 pub struct MergedSource {
     pub label: String,
     /// Whether the value was reached through an `Option`. serde writes the members of a `Some` into
@@ -113,11 +107,9 @@ pub fn json_schema_methods(
 }
 
 /// The names whose descriptions are still being written, as the type every `within` form carries
-/// them in.
-///
-/// Each name travels with the documents its parameters were filled with, that being what says
-/// which body the definition the name is deferred to will hold. A name declaring no parameter
-/// carries an empty list, and compares equal to itself the way it always did.
+/// them in. Each name travels with the documents its parameters were filled with — what says which
+/// body the definition the name is deferred to will hold; a name declaring no parameter carries an
+/// empty list.
 pub fn in_flight_type() -> proc_macro2::TokenStream {
     quote::quote! { Vec<(&'static str, Vec<serde_json::Value>)> }
 }
@@ -131,34 +123,15 @@ fn bound_filling(parameters: &[SchemaParameter]) -> proc_macro2::TokenStream {
 }
 
 /// The description guarded against re-entering a name still being written, as the tokens the
-/// `within` form's body is.
-///
-/// `filling` is the documents this frame's parameters were filled with, which is what the guard
-/// reads the re-entry against: the same filling is the cycle the pointer describes, a different one
-/// the body the document cannot hold. It is also what the hoisted key is built from: a generic name
-/// can be reached at more than one filling across a document, sequentially rather than nested — two
-/// sibling fields naming it at different fillings, neither ever in flight while the other runs — so
-/// a bare name would let the second write silently clobber the first's definition.
-///
-/// `discriminate_by_filling` is decided by the caller, not read off `filling` at runtime: a name
-/// declaring no parameter always fills at `Vec::new()`, and a name declaring one or more always
-/// fills at a `vec![...]` of that many arguments, so which of the two this frame is is already
-/// known at expansion time. Keying every call the same way — reading each argument's `"type"`
-/// keyword — would plant that literal text in the parameterless form's own source too, breaking a
-/// caller that reads the generated tokens rather than running them; picking the tokens to emit
-/// instead of the value to compute keeps a parameterless name keyed the bare, undiscriminated way
-/// it always has been, byte-identical down to the source text and not only the runtime value.
-///
-/// A non-empty filling's key must also be a legal `$ref` URI-reference, which the canonical JSON
-/// text of the filling is not — it carries quotes, braces and colons a URI-reference forbids
-/// outright, RFC 6901's `~0`/`~1` escaping being answerable only for what a *pointer* forbids. The
-/// discriminator built here instead reads each argument's own recognizable name where the argument
-/// carries one — a sibling reference's own key (already URI-safe, by the same rule applied one
-/// level down), or a primitive's `"type"` keyword — and joins those into a readable label. Two
-/// fillings a label cannot tell apart (`u32` and `i64` both read `"integer"`) still cannot collide,
-/// because a digest of the filling's canonical text is appended regardless of whether a label was
-/// found; a filling with no labeled argument at all (a bare type parameter's opaque `{}`) keys off
-/// that digest alone.
+/// `within` form's body is. `filling` is the documents this frame's parameters were filled with —
+/// what the re-entry guard compares against, and what the hoisted key is built from, since a
+/// generic name reached at more than one filling across a document must not let the second write
+/// clobber the first's definition. `discriminate_by_filling` is fixed by the caller at expansion
+/// time rather than read off `filling` at runtime, so a parameterless name's generated source
+/// stays byte-identical. A filling's key reads each argument's own recognizable name (a sibling
+/// reference's key, or a primitive's `"type"` keyword) into a readable label, with a digest of the
+/// filling's canonical JSON always appended so fillings a label cannot tell apart still cannot
+/// collide.
 fn guarded_description(
     def_name: &str,
     body: &proc_macro2::TokenStream,
@@ -170,10 +143,9 @@ fn guarded_description(
     let key_binding = if discriminate_by_filling {
         quote::quote! {
             let key = {
-                // The FNV-1a offset basis and prime: an algorithm spelled out here rather than
-                // reached for from `std::hash::Hasher`, whose documented internals are free to
-                // change between compiler versions and would make the key of an identical filling
-                // drift across builds.
+                // The FNV-1a offset basis and prime, spelled out rather than reached for from
+                // `std::hash::Hasher`: its documented internals may change between compiler
+                // versions, which would make the key of an identical filling drift across builds.
                 fn digest(bytes: &[u8]) -> u64 {
                     let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
                     for byte in bytes {
@@ -182,10 +154,9 @@ fn guarded_description(
                     }
                     hash
                 }
-                // An argument's own recognizable name: another hoisted key, read back off its
-                // `$ref`, or a primitive's `"type"` keyword. An inlined struct or a bare type
-                // parameter's `{}` has neither, and contributes nothing to the label — the digest
-                // is what tells its filling apart from another's regardless.
+                // An argument's own recognizable name: another hoisted key (off its `$ref`), or a
+                // primitive's `"type"` keyword. An inlined struct or bare type parameter's `{}`
+                // has neither and contributes nothing to the label — the digest tells those apart.
                 fn argument_label(argument: &serde_json::Value) -> Option<String> {
                     if let Some(reference) =
                         argument.get("$ref").and_then(serde_json::Value::as_str)
@@ -304,12 +275,9 @@ fn argument_bindings(parameters: &[SchemaParameter]) -> proc_macro2::TokenStream
     quote::quote! { #(#bound)* }
 }
 
-/// Generates the JSON schema method implementation for structs.
-///
-/// When the struct has `#[serde(flatten)]` fields, the base properties are
-/// distributed into each branch of the flattened types' schemas (cross-product
-/// over any `oneOf`), producing a strict closed schema that validates the base
-/// fields and the flattened union together.
+/// When the struct has `#[serde(flatten)]` fields, the base properties are distributed into each
+/// branch of the flattened types' schemas (cross-product over any `oneOf`), producing a strict
+/// closed schema that validates the base fields and the flattened union together.
 pub fn generate_struct_json_schema_method(
     json_schema_fields: &[proc_macro2::TokenStream],
     flatten_json_schemas: &[MergedSource],
@@ -385,10 +353,8 @@ fn merge_readers() -> proc_macro2::TokenStream {
         }
 
         // A merged schema that names itself describes as a reference into the definitions being
-        // hoisted, and a reference is the one thing with no properties to merge. The body it
-        // points at is written by then — the frame that deferred the name fills the entry in
-        // before it returns — so the merge reads it back. A union member defers the same way the
-        // whole merged body does, so both ends read it through here.
+        // hoisted — the body it points at is written by then, since the frame that deferred the
+        // name fills the entry in before it returns, so the merge reads it back.
         fn deferred_name(schema: &serde_json::Value) -> Option<&str> {
             schema.get("$ref")?.as_str()?.strip_prefix(#defs_prefix)
         }
@@ -400,14 +366,11 @@ fn merge_readers() -> proc_macro2::TokenStream {
             schema.get("type")?.as_str()
         }
 
-        // What serde picked one of, and how the source spelled the choice. A discriminated enum
-        // writes `oneOf` and an untagged one `anyOf`; the merge owes both the same branches — the
-        // value that reached it wrote whichever branch matched, so the branch is what the base
-        // joins — and owes each its own spelling, which is what says whether a payload two branches
-        // admit is an error or the ordinary case.
-        //
-        // A schema that offers no choice answers with none, which is what tells the expansion it has
-        // reached something the base can merge rather than descend into.
+        // What serde picked one of, and how the source spelled the choice: a discriminated enum
+        // writes `oneOf`, an untagged one `anyOf` — each spelling says whether a payload two
+        // branches admit is an error or the ordinary case. `None` means the schema offers no
+        // choice, so the expansion has reached something the base can merge rather than descend
+        // into.
         fn union_branches(schema: &serde_json::Value) -> Option<(&'static str, &[serde_json::Value])> {
             for keyword in ["oneOf", "anyOf"] {
                 if let Some(union) = schema.get(keyword).and_then(serde_json::Value::as_array) {
@@ -417,14 +380,11 @@ fn merge_readers() -> proc_macro2::TokenStream {
             None
         }
 
-        // The variant name a branch of an externally tagged enum's `oneOf` pins, and `None` for
-        // every branch that pins none.
-        //
-        // The two spellings a union is written under say which enum wrote it: `oneOf` is the
-        // exclusive choice a tagged enum publishes, where a branch describing a bare string is a
-        // unit variant and the description pins the name serde writes it as. `anyOf` is the
-        // first-match choice an untagged enum publishes and a nullable value's own, where a string
-        // branch is a value serde writes as that string and nothing tags.
+        // The variant name a branch of an externally tagged enum's `oneOf` pins, or `None` for
+        // every branch that pins none. `oneOf` is the exclusive choice a tagged enum publishes,
+        // where a bare-string branch is a unit variant pinning the name serde writes; `anyOf` is
+        // the first-match choice an untagged enum (or a nullable value) publishes, where a string
+        // branch is just a value and nothing tags.
         fn tagged_unit_variant(schema: &serde_json::Value) -> Option<&str> {
             (described_type(schema)? == "string").then_some(())?;
             schema.get("const")?.as_str()
@@ -499,16 +459,10 @@ fn merged_tree() -> proc_macro2::TokenStream {
                 }
             }
 
-            // The same source with its own absence offered beside it — what an `Option` makes of
-            // whatever it wraps. One object cannot say that a group of keys is written together or
-            // not at all: required of every payload rejects the absent one, and required of none
-            // admits a base written in part, which is a payload the source never writes. A choice
-            // between two key sets is exactly what the two forms are, so it is written as one.
-            //
-            // `anyOf` is the rule that choice was written under. A source whose own members are all
-            // optional writes nothing for some of its values, and that payload is the one its
-            // absence writes too — two branches admitting it is the ordinary case rather than the
-            // ambiguity `oneOf` would call it.
+            // What an `Option` makes of whatever it wraps: one object cannot say that a group of
+            // keys is written together or not at all, so the choice is written as `anyOf` between
+            // two key sets — the ordinary case for a source whose own members are all optional,
+            // not the ambiguity `oneOf` would call it.
             fn or_absent(self) -> Self {
                 Self::Union("anyOf", vec![self, Self::Absent])
             }
@@ -650,12 +604,10 @@ fn branch_expansion() -> proc_macro2::TokenStream {
 
             if let Some(named) = described_type(body) {
                 // A `null` among the choices the flatten edge itself offers is the absence rather
-                // than a refusal: the source is nullable, serde writes no member of it for that
-                // value, and the payload carrying none of them is the one serde reads back as that
-                // value — the same two key sets a source reached through an `Option` writes. A
-                // `null` below that level is a member of a choice serde matched by shape, where the
-                // absent form is one serde writes and then matches no member for, and the refusal
-                // stands.
+                // than a refusal: the source is nullable and the payload carrying none of its
+                // members is the one serde reads back as that value — the same two key sets an
+                // `Option` writes. A `null` below that level is a member of a choice serde matched
+                // by shape, and the refusal stands.
                 if named == "null" && position.len() == 1 {
                     return Some(Branches::Absent);
                 }
@@ -676,12 +628,10 @@ fn branch_expansion() -> proc_macro2::TokenStream {
             let mut expanded: Vec<Branches<'defs>> = Vec::new();
             for (index, branch) in branches.iter().enumerate() {
                 position.push(index + 1);
-                // A unit variant of the choice the flatten edge itself offers, which is the one
-                // depth at which the enum being flattened *is* the source. serde writes the
-                // variant's name into the object being merged there, so the branch is a key set
-                // like any other. One level down the enum is a member of a choice serde matched by
-                // shape, where the same value is the bare string it was written as and joins
-                // nothing — the refusal that position already carries.
+                // A unit variant of the choice the flatten edge itself offers is the one depth at
+                // which the enum being flattened *is* the source, so the branch is a key set like
+                // any other. One level down, the enum is a member of a choice matched by shape,
+                // where the same value joins nothing — the refusal that position already carries.
                 let tagged = (position.len() == 1 && spelling == "oneOf")
                     .then(|| tagged_unit_variant(branch))
                     .flatten();
@@ -743,10 +693,9 @@ pub fn merged_object_value(
     }
 }
 
-/// The struct's own fields distributed into each branch of the flattened types' schemas.
-///
-/// A flatten edge that closes a cycle is rejected where it is read rather than merged: `def_name`
-/// is the frame that reads it, and names one end of the closing edge in the diagnostic.
+/// The struct's own fields distributed into each branch of the flattened types' schemas. A flatten
+/// edge that closes a cycle is rejected where it is read rather than merged: `def_name` names one
+/// end of the closing edge in the diagnostic.
 fn flattened_object_body(
     json_schema_fields: &[proc_macro2::TokenStream],
     flatten_json_schemas: &[MergedSource],

--- a/src/features/model_schema_prop.rs
+++ b/src/features/model_schema_prop.rs
@@ -8,10 +8,8 @@ use syn::{Attribute, Lit, LitStr, Type};
 
 use crate::utils::{constraining_pattern, portable_pattern};
 
-/// Every key the parser reads, in the order it tries them, as the unknown-key rejection names them.
-///
-/// A key added to [`parse_prop_key`] belongs here too: `no_key_the_parser_reads_is_rejected` walks
-/// this list back through the parser and fails on any name here it does not read.
+/// Every key the parser reads, in the order the unknown-key rejection names them. Add a new key to
+/// [`parse_prop_key`], add it here too, or `no_key_the_parser_reads_is_rejected` fails.
 const KNOWN_KEYS: &[&str] = &[
     "as",
     "literal",
@@ -144,12 +142,8 @@ pub struct ModelSchemaPropMeta {
     pub ts_optional: bool,
 }
 
-/// Parses `model_schema_prop` attributes from a field.
-///
 /// What the parser cannot read is recorded as [`ModelSchemaPropMeta::attr_rejection`] rather than
-/// dropped: this attribute is read here and nowhere else, so a key or value that stops at this
-/// parser reaches no emitter, and the field it was written to constrain is emitted as though the
-/// attribute had been left off.
+/// dropped, and the field is emitted as though the attribute had been left off.
 pub fn parse_model_schema_prop_attributes(attrs: &[Attribute]) -> ModelSchemaPropMeta {
     let mut meta = ModelSchemaPropMeta::default();
 
@@ -209,10 +203,9 @@ fn parse_prop_key(nested: &ParseNestedMeta, meta: &mut ModelSchemaPropMeta) -> s
     Ok(())
 }
 
-/// The `f64` a numeric bound was written as.
-///
-/// Both bounds reach a numeric comparison in the Rust validator and a numeric literal in the Zod
-/// and JSON schemas, so a value that is not a number is one no surface can carry.
+/// The `f64` a numeric bound was written as: both bounds reach a numeric comparison in the Rust
+/// validator and a numeric literal in the Zod and JSON schemas, so a non-number is one no surface
+/// can carry.
 fn numeric_bound(nested: &ParseNestedMeta, key: &str) -> syn::Result<f64> {
     let lit: syn::Lit = nested.value()?.parse()?;
     if let syn::Lit::Int(int) = &lit {

--- a/src/features/model_schema_prop/tests.rs
+++ b/src/features/model_schema_prop/tests.rs
@@ -216,8 +216,6 @@ fn a_value_the_parser_cannot_read_is_refused() {
     }
 }
 
-/// A key the parser reads before the refused one still lands: the refusal reports the attribute,
-/// it does not discard what was already read.
 #[test]
 fn a_refusal_keeps_what_the_parser_had_already_read() {
     let meta = parse_model_schema_prop_attributes(&[parse_quote! {

--- a/src/features/serde.rs
+++ b/src/features/serde.rs
@@ -1,12 +1,9 @@
-//! Serde integration feature module.
-//!
-//! This module handles serde attribute parsing and field name transformation.
+//! Serde integration feature module: attribute parsing and field name transformation.
 //!
 //! Most of it is gated on the "serde" feature: renaming, tagging, and the guards are all things
-//! the feature buys. The omission walk at the top is not. Whether a key reaches the serialized
-//! object is a fact about the wire, the attribute stating it is on the field under every toggle,
-//! and every build emits surfaces that claim to describe that wire — so a build that could not
-//! read the attribute would describe a different wire than the one serde writes.
+//! the feature buys. The omission walk at the top is not — whether a key reaches the serialized
+//! object is a fact about the wire under every toggle, and every build emits surfaces that claim
+//! to describe that wire.
 
 #[cfg(all(test, feature = "serde"))]
 use crate::rename_rule::resolve_rename_rule;
@@ -25,12 +22,9 @@ const CFG_ATTR_SERDE_REJECTION: &str = "cfg_attr-wrapped serde attribute is invi
      model_schema and will be silently ignored by the generator; write #[serde(...)] \
      unconditionally (serde attrs are inert without the serde derive)";
 
-/// What a field's serde attributes say about the key it writes.
-///
-/// Read in every build, unlike the rest of this module. The three questions are asked together
-/// because one walk answers all of them and because the guard that polices the combination needs
-/// them side by side: an attribute that drops the key while serde still insists on reading the
-/// field is only coherent when something writes the value the missing key does not carry.
+/// What a field's serde attributes say about the key it writes. Read in every build, unlike the
+/// rest of this module, since one walk answers all three questions together and the guard that
+/// polices their combination needs them side by side.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct SerdeKeyOmission {
     /// A `default` in either spelling (`default` or `default = "path"`) — the field supplies a
@@ -45,10 +39,9 @@ pub struct SerdeKeyOmission {
 
 impl SerdeKeyOmission {
     /// Whether the attributes take the member out of both of serde's directions at once: nothing
-    /// serde writes carries it, and nothing serde reads keeps what a payload put there.
-    ///
-    /// The conjunction is what is read rather than the word `skip`, because `skip_serializing` and
-    /// `skip_deserializing` written side by side are that same wire spelled out.
+    /// serde writes carries it, and nothing serde reads keeps what a payload put there — the
+    /// conjunction, not the word `skip`, since `skip_serializing` + `skip_deserializing` side by
+    /// side is that same wire spelled out.
     pub const fn absent_from_wire(self) -> bool {
         self.omits_key && self.skips_deserializing
     }
@@ -72,11 +65,9 @@ pub struct SerdeTypeMeta {
     pub untagged: bool,          // Whether the enum is `#[serde(untagged)]`
 }
 
-/// Metadata for serde attributes applied to a field.
-///
-/// Whether the field's key is omitted is not here: [`parse_serde_key_omission`] answers that in
-/// every build, and one answer read from one place is what keeps the surfaces from disagreeing
-/// across the feature toggle.
+/// Metadata for serde attributes applied to a field. Whether the field's key is omitted is not
+/// here: [`parse_serde_key_omission`] answers that in every build, keeping the surfaces from
+/// disagreeing across the feature toggle.
 #[cfg(feature = "serde")]
 #[derive(Clone, Debug, Default)]
 pub struct SerdeFieldMeta {
@@ -88,10 +79,8 @@ pub struct SerdeFieldMeta {
 }
 
 /// Walks the serde attributes for exactly the keys [`SerdeKeyOmission`] names, ignoring every
-/// other one.
-///
-/// Attributes wrapped in a `cfg_attr` are not reached, the same way nothing else in this module
-/// reaches them — a predicate a proc macro cannot evaluate is not one this walk may guess at.
+/// other one. Attributes wrapped in a `cfg_attr` are not reached — a predicate a proc macro cannot
+/// evaluate is not one this walk may guess at.
 pub fn parse_serde_key_omission(attrs: &[Attribute]) -> SerdeKeyOmission {
     let mut omission = SerdeKeyOmission::default();
 
@@ -126,16 +115,9 @@ pub fn parse_serde_key_omission(attrs: &[Attribute]) -> SerdeKeyOmission {
 }
 
 /// Consumes the value of a `key = value` or the group of a `key(...)` list the walk had no use
-/// for.
-///
-/// An unread value or list ends the walk on the comma that follows it, taking every attribute
-/// written after it along — so which attributes a declaration is read by would otherwise depend
-/// on the order someone happened to write them in. The list is consumed whole, as a single
-/// `Group` token, rather than parsed: nothing here reads `serialize`/`deserialize` out of
-/// `bound(...)`/`rename(...)`/`rename_all(...)`, only steps past them. With both spellings
-/// swallowed, a walk that still fails is a `#[serde(...)]` attribute malformed in some other way
-/// — serde's own derive will refuse it too — so the trace-level swallow below stays as the walk's
-/// resilience against that, rather than a channel this fix needs to redesign.
+/// for, so an unread value doesn't end the walk early and drop every attribute written after it.
+/// The list is consumed whole rather than parsed — nothing here reads into `bound(...)`,
+/// `rename(...)`, or `rename_all(...)`, only steps past them.
 fn consume_unread_value(nested: &ParseNestedMeta<'_>) -> syn::Result<()> {
     if nested.input.peek(Token![=]) {
         nested.value()?.parse::<syn::Expr>()?;

--- a/src/features/serde/tests.rs
+++ b/src/features/serde/tests.rs
@@ -194,10 +194,8 @@ fn test_untagged_default_is_false() {
     assert!(!meta.untagged);
 }
 
-/// The walk reads every attribute in the list, wherever it sits. A `key = value` this parser has
-/// no use for still has to be consumed: an unread value ends the walk on the comma after it, and
-/// everything written past that point would go unseen — which is a field diagnosed by the
-/// attributes someone happened to write first.
+/// An unread `key = value` this parser has no use for still has to be consumed: it ends the walk
+/// on the comma after it, and everything written past that point would go unseen.
 #[test]
 fn test_attributes_after_an_unread_value_are_still_read() {
     let item: syn::ItemStruct = syn::parse_quote! {
@@ -291,7 +289,6 @@ fn test_every_ignored_value_carrying_type_key_is_survived() {
     }
 }
 
-/// A list with nothing to step over is read exactly as it was, key for key.
 #[test]
 fn test_type_attributes_without_unread_values_are_unchanged() {
     let item: syn::ItemEnum = syn::parse_quote! {

--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -33,9 +33,7 @@ use crate::features::serde::{
 #[cfg(feature = "serde")]
 use crate::features::serde::{SerdeFieldMeta, SerdeTypeMeta};
 
-/// Classifies how an enum variant stores its data.
-///
-/// This is used to determine the correct TypeScript/Zod generation strategy
+/// Classifies how an enum variant stores its data, driving the TypeScript/Zod generation strategy
 /// for discriminated union variants.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum VariantKind {
@@ -173,11 +171,9 @@ pub struct FieldDef {
 }
 
 /// Two field defs are equal when they describe the same value on every surface: the same type, the
-/// same array levels, the same fixed lengths and the same nullable levels.
-///
-/// What the author wrote *around* the value is left out. A name, a doc comment and a
-/// `model_schema_prop` are the field's, not the type's, and two fields differing only in those
-/// render the same schema — which is exactly the question `as = Type` asks of its target.
+/// same array levels, the same fixed lengths and the same nullable levels. What the author wrote
+/// *around* the value — a name, a doc comment, a `model_schema_prop` — is left out, which is
+/// exactly the question `as = Type` asks of its target.
 impl PartialEq for FieldDef {
     fn eq(&self, other: &Self) -> bool {
         self.array_depth == other.array_depth
@@ -416,11 +412,9 @@ impl FieldDef {
     }
 
     /// What an object flattening this field joins for each variant of the externally tagged enum it
-    /// names, as that enum recorded them, and nothing for a field that names no such enum.
-    ///
-    /// Answered under the same bound [`Self::zod_union_members`] is answered under, and for the same
-    /// reason: what is spliced in the name's place has to be the whole of what the operand
-    /// validates.
+    /// names, as that enum recorded them, and nothing for a field that names no such enum. Answered
+    /// under the same bound [`Self::zod_union_members`] is, and for the same reason: what is
+    /// spliced in the name's place has to be the whole of what the operand validates.
     #[cfg(all(feature = "serde", any(feature = "typescript", feature = "zod")))]
     pub fn flatten_variants(&self) -> Vec<FlattenVariant> {
         let wrapped = self
@@ -460,11 +454,10 @@ impl FieldDef {
         self.array_depth > 0
     }
 
-    /// Whether the value sitting at array level `level` was written as an `Option`.
-    ///
-    /// Levels count from the innermost value outward: level 0 is what `field_type` names, level
-    /// `array_depth` is the field as a whole. Below the outermost, a `None` reaches the wire as a
-    /// `null` among the items of the array one level up — the array itself is always written.
+    /// Whether the value sitting at array level `level` was written as an `Option`. Levels count
+    /// from the innermost value outward: level 0 is what `field_type` names, level `array_depth`
+    /// is the field as a whole. Below the outermost, a `None` reaches the wire as a `null` among
+    /// the items of the array one level up — the array itself is always written.
     pub fn is_nullable_at(&self, level: u8) -> bool {
         self.nullable_levels.contains(&level)
     }
@@ -489,12 +482,10 @@ impl FieldDef {
         }
     }
 
-    /// Whether the object key this field writes may be absent — `field?: T` admits the payload
-    /// with no such key, `field: T | undefined` demands it.
-    ///
-    /// The key-dropping serde attribute is deliberately not read for an `Option`: the
-    /// `Option`-null guard requires one of every named `Option` field, so reading it here would
-    /// leave `ts_optional` inert on every field that carries it.
+    /// Whether the object key this field writes may be absent — `field?: T` admits the payload with
+    /// no such key, `field: T | undefined` demands it. The key-dropping serde attribute is
+    /// deliberately not read for an `Option`, since the `Option`-null guard already requires one on
+    /// every named `Option` field.
     fn key_may_be_absent(&self) -> bool {
         if self.is_optional() {
             self.model_schema_prop_meta
@@ -560,12 +551,11 @@ impl FieldDef {
         }
     }
 
-    /// The defs written inside this one, which is every position a type parameter can be reached
-    /// at below the top: a `SiblingType`'s generic arguments, a `Map`'s key and value, a `Tuple`'s
-    /// elements. Every other variant names a type outright and holds no def.
-    ///
-    /// Listed exhaustively and in one place, so a variant that grows a nested position has to be
-    /// classified here rather than silently escaping every walk that reads a parameter.
+    /// The defs written inside this one, which is every position a type parameter can be reached at
+    /// below the top: a `SiblingType`'s generic arguments, a `Map`'s key and value, a `Tuple`'s
+    /// elements — every other variant names a type outright and holds no def. Listed exhaustively
+    /// so a variant that grows a nested position cannot silently escape a walk that reads a
+    /// parameter.
     fn nested_type_positions(&mut self) -> Vec<&mut Self> {
         match &mut self.field_type {
             FieldDefType::SiblingType(_, generics) => generics.iter_mut().collect(),
@@ -977,11 +967,10 @@ impl FieldDef {
     }
 
     /// The value this field's wrappers hold, as a field of its own: the same type with the
-    /// `Option`s and the array levels dropped.
-    ///
-    /// The wrappers are the field's to declare and the value under them is what a type name stands
-    /// for, so this is what an `as = Type` is compared against when the target names a bare type —
-    /// the spelling `as = String` on a `Vec<String>` uses.
+    /// `Option`s and the array levels dropped. The wrappers are the field's to declare and the
+    /// value under them is what a type name stands for, so this is what an `as = Type` is compared
+    /// against when the target names a bare type — the spelling `as = String` on a `Vec<String>`
+    /// uses.
     pub fn value_under_wrappers(&self) -> Self {
         let mut value = self.clone();
         value.array_depth = 0;
@@ -1235,11 +1224,10 @@ pub fn format_number_literal(value: f64) -> String {
     }
 }
 
-/// A reference to a type that publishes a factory, as the call it has to be.
-///
-/// Each argument is rendered by the renderer that renders the reference itself, so an argument that
-/// is a forwarded parameter, a primitive, a date, or another generic reference all reach the call
-/// the same way — and one that is itself generic composes at whatever depth it was written at.
+/// A reference to a type that publishes a factory, as the call it has to be. Each argument is
+/// rendered by the renderer that renders the reference itself, so an argument that is a forwarded
+/// parameter, a primitive, a date, or another generic reference all reach the call the same way —
+/// and one that is itself generic composes at whatever depth it was written at.
 #[cfg(feature = "zod")]
 fn zod_factory_call(name: &str, arguments: &[FieldDef]) -> String {
     format!(
@@ -1489,12 +1477,10 @@ fn collapsed_wrapper_def(
     Some(result)
 }
 
-/// The element count a fixed-size array was written with, when the expansion can read it.
-///
-/// A literal is the whole of that. A const generic parameter, a `const` item and any computed
-/// length each name a value only the compiler has, and the macro runs before there is one to ask
-/// for; each therefore describes as the unbounded array every other sequence spelling describes as,
-/// which is the honest answer when the count is unknown.
+/// The element count a fixed-size array was written with, when the expansion can read it — a
+/// literal is the whole of that. A const generic parameter, a `const` item and any computed length
+/// each name a value only the compiler has, and the macro runs before there is one to ask for, so
+/// each describes as the unbounded array every other sequence spelling describes as.
 fn literal_array_length(len: &syn::Expr) -> Option<usize> {
     let syn::Expr::Lit(syn::ExprLit {
         lit: syn::Lit::Int(literal),
@@ -1636,23 +1622,15 @@ pub fn is_undescribable_primitive(name: &str) -> bool {
     matches!(name, "i128" | "u128" | "f16" | "f128")
 }
 
-/// Parses serde attributes from struct/enum attributes (requires "serde" feature).
-///
-/// Delegates to features/serde.rs for actual parsing.
-/// Used in `model_schema.rs` to get type-level serde metadata like `rename_all`.
-///
-/// Without "serde" feature: No attribute processing, uses Rust names as-is.
+/// Delegates to [`crate::features::serde::parse_serde_type_attributes`] for the type-level serde
+/// metadata (`rename_all`, `tag`, …) `model_schema.rs` reads.
 #[cfg(feature = "serde")]
 pub fn parse_serde_type_attributes(attrs: &[Attribute]) -> SerdeTypeMeta {
     parse_serde_type_attributes_impl(attrs)
 }
 
-/// Parses serde attributes from field attributes (requires "serde" feature).
-///
-/// Similar to `parse_serde_type_attributes` but for individual fields.
-/// Handles field rename, `skip_serializing_if`, etc.
-///
-/// Integrates with FieldDef.name if rename present.
+/// Delegates to [`crate::features::serde::parse_serde_field_attributes`] for a field's rename and
+/// `flatten`.
 #[cfg(feature = "serde")]
 pub fn parse_serde_field_attributes(attrs: &[Attribute]) -> SerdeFieldMeta {
     parse_serde_field_attributes_impl(attrs)

--- a/src/field_type/tests.rs
+++ b/src/field_type/tests.rs
@@ -211,9 +211,8 @@ fn test_the_parser_counts_one_array_level_per_wrapper_written() {
 }
 
 /// A fixed-size array is written at one level and bounds that level alone, so the count lands on
-/// the level the `[T; N]` spells rather than on the field. A count the expansion cannot read — a
-/// const generic, a `const` item, a computed expression — and a slice, which spells no count at
-/// all, leave the level as unbounded as every other sequence spelling leaves it.
+/// the level the `[T; N]` spells rather than on the field. A count the expansion cannot read (a
+/// const generic, a `const` item, a computed expression) or a slice leaves the level unbounded.
 #[test]
 fn test_the_parser_records_a_fixed_array_length_at_the_level_it_bounds() {
     for (spelling, array_lengths) in [
@@ -439,9 +438,8 @@ fn test_a_schematizable_field_is_not_reported_as_an_os_string() {
 }
 
 /// An `Option` written inside a sequence wrapper and one written around it are two different
-/// values on the wire — `[null]` against `null` — so the parse has to keep them apart. The level
-/// each is recorded at is the level it was written at: the element's below the array it sits in,
-/// the field's own at the top, where `is_optional` answers for it.
+/// values on the wire — `[null]` against `null` — so the parse keeps them apart: each is recorded
+/// at the level it was written at, the element's below the array and the field's own at the top.
 #[test]
 fn test_the_parser_records_the_level_each_option_was_written_at() {
     for (spelling, array_depth, nullable_levels) in [
@@ -468,8 +466,7 @@ fn test_the_parser_records_the_level_each_option_was_written_at() {
 
 /// A covered wrapper writes the array its element decides, so the element's own `Option` is
 /// recorded at the level the wrapper puts it at — the same level the `Vec` spelling of the same
-/// field records it at, whichever wrapper name was written. Read off the surfaces, which is where
-/// the level shows.
+/// field records it at, whichever wrapper name was written.
 #[test]
 fn test_a_covered_wrapper_records_its_element_option_where_the_vec_spelling_does() {
     let vec_spelling: syn::Type = syn::parse_str("Vec<Option<u32>>").unwrap();
@@ -498,9 +495,8 @@ fn test_a_covered_wrapper_records_its_element_option_where_the_vec_spelling_does
 }
 
 /// The tokens a `macro_rules!` `$t:ty` substitution reaches an expansion as: the type's own tokens
-/// inside an invisible group, which is what keeps the substitution one unit whatever the expansion
-/// writes around it. Built here rather than expanded, so the depth can be chosen — a metavariable
-/// passed on through a second `macro_rules!` arrives grouped again.
+/// inside an invisible group, which keeps the substitution one unit whatever the expansion writes
+/// around it. Built here rather than expanded, so the depth can be chosen.
 fn substituted(spelling: &str, depth: usize) -> proc_macro2::TokenStream {
     let mut tokens: proc_macro2::TokenStream = spelling.parse().unwrap();
     for _ in 0..depth {
@@ -579,10 +575,9 @@ fn test_a_substitution_inside_a_written_shape_is_read_through() {
     }
 }
 
-/// [`FieldDef::reaches_a_type_declared_later`]'s zero-argument arm: a bare sibling reference to a
-/// `#[model_schema]` item not yet registered (declared below the one being expanded) has to defer
-/// exactly as a generic forward reference already does; a registered name (declared above) stays
-/// the eager baseline.
+/// [`FieldDef::reaches_a_type_declared_later`]'s zero-argument arm: a bare sibling reference to an
+/// unregistered `#[model_schema]` item defers exactly as a generic forward reference already does;
+/// a registered name stays the eager baseline.
 #[cfg(feature = "zod")]
 #[test]
 fn test_reaches_a_type_declared_later_answers_for_a_zero_argument_sibling() {

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -139,11 +139,9 @@ use crate::utils::to_snake_case;
 
 use crate::rename_rule::resolve_rename_rule;
 
-/// Every argument the `model_schema` parser reads, in the order it tries them, as the
-/// unknown-argument rejection names them.
-///
-/// An argument added to [`apply_arg`] belongs here too: `no_argument_the_parser_reads_is_rejected`
-/// walks this list back through the parser and fails on any name here it does not read.
+/// Every argument the `model_schema` parser reads, in the order the unknown-argument rejection
+/// names them. Add a new argument to [`apply_arg`], add it here too, or
+/// `no_argument_the_parser_reads_is_rejected` fails.
 const KNOWN_ARGS: &[&str] = &[
     "name",
     "pattern",
@@ -205,11 +203,10 @@ type ZodMergeParts = Vec<ZodUnionMember>;
 #[cfg(all(feature = "serde", not(feature = "zod")))]
 type ZodMergeParts = Vec<String>;
 
-/// Per-member data collected from an untagged enum: the TypeScript member types, what those members
-/// are spelled as where an object merges the enum, the Zod member schemas, what those Zod members
-/// contribute to an object that merges the enum, the JSON-schema value tokens, the `compile_error!`
-/// tokens for any field-level guard violations, the per-member serde validation functions, and the
-/// `validate()` match arms those functions are run from.
+/// Per-member data from an untagged enum's member walk: TypeScript member types, their merged
+/// spelling, Zod member schemas, their merged contribution, JSON-schema value tokens,
+/// `compile_error!` tokens for guard violations, per-member serde validators, and the
+/// `validate()` match arms those validators run from.
 #[cfg(feature = "serde")]
 type UntaggedMemberData = (
     Vec<String>,
@@ -325,10 +322,8 @@ enum ConstraintLeaf {
     Str,
 }
 
-/// What the end of a walk does with a violation it found.
-///
-/// `validate()` answers with every violation in the instance, so its walk collects; a
-/// `Deserializer` answers with one error, so the wire walk stops at the first.
+/// What the end of a walk does with a violation: `validate()` collects every one, a
+/// `Deserializer` fails at the first.
 #[cfg(feature = "serde")]
 #[derive(Clone, Copy)]
 enum CheckSink {
@@ -336,11 +331,8 @@ enum CheckSink {
     Fail,
 }
 
-/// How the body that checks a constrained member reaches the value.
-///
-/// A struct's field is read off `self`, which is what `validate()` is called on. A variant's member
-/// is not reachable that way — the value only names it once the arm that matched the variant has
-/// bound it — so the check reads the binding the arm introduced.
+/// How a constrained member's check reaches its value: a struct field off `self`, a variant member
+/// off the binding its match arm introduced.
 #[cfg(feature = "serde")]
 #[derive(Clone, Copy)]
 enum MemberAccess {
@@ -348,11 +340,8 @@ enum MemberAccess {
     VariantBinding,
 }
 
-/// A wrapper a constrained field can be written under, outermost first.
-///
-/// Each one says how to reach one level further in, and nothing else: an `Option` yields what its
-/// `Some` holds, a sequence yields each element, and a transparent wrapper — being nothing on the
-/// wire — yields only what it derefs to.
+/// A wrapper a constrained field can be written under, outermost first: `Option` yields its `Some`,
+/// a sequence yields each element, a transparent wrapper yields what it derefs to.
 #[cfg(feature = "serde")]
 #[derive(Clone, Copy)]
 enum ConstraintWrap {
@@ -392,11 +381,8 @@ enum MapMemberRejection {
     Tuple,
 }
 
-/// What a map key opens: one open member set, the members it enumerates, nothing this expansion can
-/// narrow, or no object at all.
-///
-/// Every position a map is written in reads its key through this one classification, so a key
-/// cannot enumerate its members in field position and stay open in a slot.
+/// What a map key opens: an open member set, the members it enumerates, nothing this expansion can
+/// narrow, or no object at all — read the same way at every position a map is written in.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 enum MapKeyPath<'key> {
     /// A key named by a type path, whose `enum_members()` become the object's keys.
@@ -458,10 +444,9 @@ struct ModelSchemaArgs {
     /// The parser's refusal of the attribute's arguments — one it does not read, or a value it
     /// cannot read — spanned on the tokens that earned it.
     arg_rejection: Option<syn::Error>,
-    /// The default type declared for each of the item's own type parameters, in the order they
-    /// were written: `default_types(IdType = String, DateType = f64)`. Read by JSON-schema
-    /// generation, which has no type parameters of its own and so has to build its document from
-    /// one concrete filling.
+    /// The default type declared per type parameter, in written order: `default_types(IdType =
+    /// String, DateType = f64)`. Read by JSON-schema generation, which has no type parameters of
+    /// its own and builds its document from one concrete filling.
     default_types: Vec<(syn::Ident, syn::Type)>,
     max_length: Option<usize>,
     min_length: Option<usize>,
@@ -472,11 +457,9 @@ struct ModelSchemaArgs {
     /// `pattern` in the spelling every surface reads the same way, or as it was written when it
     /// earned a `pattern_rejection`.
     pattern: Option<String>,
-    /// What keeps `pattern` off the surfaces it was written for -- a regex the `regex` crate
-    /// cannot parse, a construct a JavaScript regex literal cannot carry, or a shape that admits
-    /// every value and so says nothing on any of them -- spanned on the literal it was written as.
-    /// Only the brand path splices the argument, and only a schema feature builds that path;
-    /// without one, a type-level constraint never reaches a surface at all.
+    /// What keeps `pattern` off the surfaces it was written for: an unparseable regex, a construct
+    /// a JavaScript regex literal cannot carry, or a shape that admits every value — spanned on
+    /// the literal it was written as.
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
     pattern_rejection: Option<syn::Error>,
 }
@@ -486,10 +469,9 @@ struct ModelSchemaArgs {
 #[cfg(any(feature = "typescript", feature = "zod"))]
 struct MergedOperand {
     absence: SourceAbsence,
-    /// What the source contributes to each branch when it names a choice the registry recorded the
-    /// branches of — one operand per branch — and empty for every other source, which contributes
-    /// `spelling`. Zod only: TypeScript distributes an intersection over a union on its own, so
-    /// there the choice is spelled as the one operand it is.
+    /// What the source contributes per branch when it names a registered choice — one operand per
+    /// branch, empty otherwise (falls back to `spelling`). Zod-only: TypeScript distributes an
+    /// intersection over a union on its own.
     #[cfg(feature = "zod")]
     branches: Vec<String>,
     spelling: String,
@@ -515,11 +497,9 @@ impl SourceAbsence {
         !matches!(self, Self::Never)
     }
 
-    /// What a flattened source offers, read off the two spellings that reach the same absence: the
-    /// field's own `Option`, and the leaves the name it holds recorded. The `Option` is asked first
-    /// because it is the outer of the two — a source written `Option<Name>` writes nothing for its
-    /// own `None` whatever the name goes on to publish, and the spelling the merge holds is the one
-    /// inside the `Option`.
+    /// What a flattened source offers: the field's own `Option` is checked first (an
+    /// `Option<Name>` writes nothing for `None` regardless of what `Name` publishes), then falls
+    /// back to what the name itself publishes.
     fn written(fld: &FieldDef) -> Self {
         if fld.is_optional() {
             Self::Field
@@ -542,10 +522,6 @@ struct Surface {
 
 /// What a [`Surface`] carries for the merge: the leaves a written type published, or the one
 /// keyword a surface read off no written type names.
-///
-/// The two are one recording — [`Surface::record`] writes either as leaves — and are held apart
-/// only so a surface named outright can be built without one, which is what lets the four fixed
-/// surfaces be `const`.
 #[cfg(all(feature = "serde", any(feature = "zod", feature = "typescript")))]
 enum RecordedWire {
     Leaves(Vec<WireLeaf>),
@@ -624,12 +600,8 @@ struct ZodDefaultInputs<'defaults> {
     default_types: &'defaults [(syn::Ident, syn::Type)],
 }
 
-/// What a branded newtype's `$SchemaDefault` is annotated with, read off the shape of the
-/// brand's own inner rather than off any one parameter's filling — see
-/// [`branded_default_annotation`]. Only [`branded_default_annotation`] reads it, and that
-/// function is itself `typescript`-gated (the annotation it writes is a TypeScript-surface
-/// concern), so the enum carries the same gate rather than existing unread in a zod-without-
-/// typescript build.
+/// What a branded newtype's `$SchemaDefault` is annotated with, read off the shape of the brand's
+/// own inner rather than off any one parameter's filling — see [`branded_default_annotation`].
 #[cfg(all(feature = "zod", feature = "typescript"))]
 enum BrandedAnnotation<'defaults> {
     /// The inner is exactly one bare type parameter (`pub struct Name<T>(pub T)`) — the erased
@@ -643,10 +615,8 @@ enum BrandedAnnotation<'defaults> {
 }
 
 /// What [`default_zod_rendering`] found: a self-contained expression left eager, or a name
-/// [`deferred_zod_operand`] still has to wrap — kept apart from the final string so
-/// [`zod_default_block`] can tell which one it has before deciding where a constrained brand's
-/// checks belong: chained directly onto an eager expression, or composed inside the thunk of a
-/// deferred one, whose own annotation is not guaranteed to carry `ZodString`'s chain methods.
+/// [`deferred_zod_operand`] still has to wrap — [`zod_default_block`] needs to know which, since a
+/// constrained brand's checks chain onto an eager expression but must land inside a deferred thunk.
 #[cfg(feature = "zod")]
 enum DefaultZodRendering {
     Deferred(String),
@@ -782,11 +752,9 @@ impl Surface {
         Self::named(Some("union"), None)
     }
 
-    /// The surface a written type publishes, both answers read off the one def.
-    ///
-    /// `parameters` is the item's own type-parameter list, in the order it declares them: a target
-    /// that *is* one of them publishes a family rather than a shape, and the position is what the
-    /// shape answer records for it — see [`PublishedShape`].
+    /// The surface a written type publishes, both answers read off the one def. `parameters` is
+    /// the item's own type-parameter list; a target that *is* one of them publishes a family
+    /// rather than a shape — see [`PublishedShape`].
     fn written(written: &FieldDef, parameters: &[String]) -> Self {
         Self {
             shape: published_value_shape(written, parameters),
@@ -805,12 +773,8 @@ impl Parse for DefaultTypeEntry {
     }
 }
 
-/// Parses the arguments of a `model_schema` attribute.
-///
 /// What the parser cannot read is recorded as [`ModelSchemaArgs::arg_rejection`] rather than
-/// dropped: these arguments are read here and nowhere else, so one that stops at this parser
-/// reaches no emitter, and the item is expanded as though it had been left off — a misspelled
-/// `name` yields the unrenamed schema on every surface.
+/// dropped, and the item is expanded as though the argument had been left off.
 fn parse_model_schema_args(args: proc_macro2::TokenStream) -> ModelSchemaArgs {
     let mut result = ModelSchemaArgs::default();
 
@@ -831,9 +795,7 @@ fn parse_model_schema_args(args: proc_macro2::TokenStream) -> ModelSchemaArgs {
     result
 }
 
-/// Applies one `model_schema` argument to `result`.
-///
-/// The name is read before the shape, so an argument this parser knows written the wrong way is
+/// The name is read before the shape, so an argument this parser knows, written the wrong way, is
 /// answered with what it takes rather than reported as unknown.
 fn apply_arg(result: &mut ModelSchemaArgs, meta: &Meta) -> syn::Result<()> {
     let path = meta.path();
@@ -855,10 +817,8 @@ fn apply_arg(result: &mut ModelSchemaArgs, meta: &Meta) -> syn::Result<()> {
     Ok(())
 }
 
-/// The literal an argument's value was written as.
-///
-/// Every valued `model_schema` argument reaches a surface as a literal — a name, a regex, a bound
-/// — so a value written as anything else is one no argument can carry.
+/// The literal an argument's value was written as — every valued `model_schema` argument reaches
+/// a surface as a literal, so anything else is one no argument can carry.
 fn arg_literal<'meta>(meta: &'meta Meta, name: &str, takes: &str) -> syn::Result<&'meta syn::Lit> {
     let Meta::NameValue(name_value) = meta else {
         return Err(arg_rejection(meta, name, takes));
@@ -882,11 +842,8 @@ fn str_arg<'meta>(meta: &'meta Meta, name: &str) -> syn::Result<&'meta syn::LitS
 }
 
 /// The name a `name = "…"` argument was written as, once it is one a name can be spelled from.
-///
-/// The value is the type's name on every surface and, snake-cased, the Rust module its schema is
-/// published from. `Ident::new` builds that module, and it panics on a string that is not an
-/// identifier — a panic reports no span and names no argument, so the check is here, where the
-/// literal the author wrote is still in hand.
+/// Checked here because `Ident::new` panics on a non-identifier with no span — better caught
+/// while the literal the author wrote is still in hand.
 fn name_arg_value(lit: &syn::LitStr) -> syn::Result<String> {
     let value = lit.value();
     let mut chars = value.chars();
@@ -906,10 +863,8 @@ fn name_arg_value(lit: &syn::LitStr) -> syn::Result<String> {
     ))
 }
 
-/// The length a `minLength = N` argument was written as.
-///
-/// The bound is compared against a `usize` in the generated validator, so one the target type
-/// cannot hold is a bound no surface can enforce.
+/// The length a `minLength = N` argument was written as, as a `usize` — the type the generated
+/// validator compares it against.
 fn length_arg(meta: &Meta, name: &str) -> syn::Result<usize> {
     let takes = format!("an integer literal `usize` can hold, written `{name} = 3`");
     let lit = arg_literal(meta, name, &takes)?;
@@ -942,12 +897,8 @@ fn default_types_arg(meta: &Meta) -> syn::Result<Vec<(syn::Ident, syn::Type)>> {
     Ok(read)
 }
 
-/// The refusal a second entry for one parameter earns, spanned on the name as the repeat spelled
-/// it — the first entry declares what its author meant, and it is the second that leaves the
-/// declaration with two answers.
-///
-/// Both fillings are named: a reader told only that the parameter repeats still has to go back to
-/// the list to see which one was dropped.
+/// The refusal a second `default_types` entry for one parameter earns, spanned on the repeat (the
+/// first entry declares what its author meant) and naming both fillings.
 fn repeated_entry_rejection(
     name: &syn::Ident,
     declared: &syn::Type,
@@ -1008,11 +959,9 @@ fn unknown_arg_rejection(meta: &Meta) -> syn::Error {
     )
 }
 
-/// Records a `pattern` argument, in the spelling the brand path can splice into every surface, or
-/// as written alongside what keeps it off them.
-///
-/// A refused pattern is recorded as written: the guards that answer for what a `pattern` may sit on
-/// read that one was given, not what it says.
+/// Records a `pattern` argument in splice-ready spelling, or, when refused, as written alongside
+/// what keeps it off every surface — the guards that answer for it read that one was given, not
+/// what it says.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn record_pattern(result: &mut ModelSchemaArgs, lit_str: &syn::LitStr) {
     match portable_pattern(lit_str).and_then(|portable| constraining_pattern(lit_str, portable)) {
@@ -1031,9 +980,6 @@ fn record_pattern(result: &mut ModelSchemaArgs, lit_str: &syn::LitStr) {
     result.pattern = Some(lit_str.value());
 }
 
-/// Executes the `model_schema` macro processing to generate TypeScript and Zod schema definitions.
-///
-/// This function is the main entry point for the `model_schema` macro and handles both struct and enum types.
 pub fn exec_model_schema(args: TokenStream, input: TokenStream) -> TokenStream {
     let parsed_args = parse_model_schema_args(args.into());
     let item = parse_macro_input!(input as Item);
@@ -1149,10 +1095,8 @@ fn flattened_plain_enum(inner: &FieldDef) -> Option<&str> {
 }
 
 /// The alias schema module is referenced by all three schema features — `typescript` and `zod`
-/// through the alias's registered export name, `jsonschema` through a Rust path to
-/// `#module_ident::Schema::json_schema()`. So the module and its `register_alias_info` call are
-/// driven by the union: gating them on `typescript` alone left the jsonschema references
-/// dangling. The module's *contents* are chosen per feature while building the tokens.
+/// through the export name, `jsonschema` through `#module_ident::Schema::json_schema()` — so the
+/// module and its `register_alias_info` call are gated on the union, not `typescript` alone.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn process_type_alias(item_type: ItemType, args: &ModelSchemaArgs) -> TokenStream {
     let mut alias = item_type;
@@ -1246,14 +1190,9 @@ fn has_serde_transparent(attrs: &[syn::Attribute]) -> bool {
     false
 }
 
-/// Builds the `JSDoc` comment body (lines prefixed with ` * `) that precedes an item's
-/// `export type`, and the one each field and enum variant inside it is emitted under. The item
-/// shapes that publish a zod `description` alongside spell both from the same lines in
-/// `build_item_docs_and_description`; a member publishes no second surface.
-///
-/// The no-docs fallback names what is documented as it is exported, not as it is declared in Rust,
-/// so a `JSDoc` header never contradicts the line under it. A ` ```rust example ` block is dropped
-/// on the way in — it is Rust source, unreadable as such from a `TypeScript` comment.
+/// Builds the `JSDoc` comment body (lines prefixed with ` * `) for an item, field, or enum
+/// variant. The no-docs fallback names what is exported, not as declared in Rust, and a
+/// ` ```rust example ` block is dropped as unreadable from a TypeScript comment.
 fn build_jsdoc_body(docs_vec: Option<&[String]>, fallback_name: &str) -> String {
     item_jsdoc_body(&item_lines_or_name(docs_vec, fallback_name, |doc_lines| {
         strip_examples_from_docs(doc_lines)
@@ -1312,10 +1251,7 @@ fn schema_example_value_type(
 
 /// The type-level `schema_example()` a declared item publishes: the value its ` ```rust example `
 /// block builds, or `None` where there is nothing to build one from — no example written, or no
-/// `zod`, which is the only surface that reads one.
-///
-/// The `None` answer is the seam's own rather than each caller's, so a struct, a tuple struct and
-/// every enum shape reach it the same way instead of repeating the feature pair at the call site.
+/// `zod`, the only surface that reads one.
 #[cfg(feature = "zod")]
 fn item_schema_example_method(
     example_tokens: Option<&proc_macro2::TokenStream>,
@@ -1490,11 +1426,8 @@ const fn struct_validate_method(
 }
 
 /// Builds the type-level `validate()` method that aggregates per-field validators, or `None` when
-/// the struct has no constrained fields.
-///
-/// The generated `validate(&self) -> Result<(), Vec<String>>` calls every per-field
-/// `validate_{field}_value` (the same validators serde's `deserialize_with` hooks use), so the
-/// same rules apply during deserialization and when validating a programmatically built instance.
+/// the struct has no constrained fields. It calls the same `validate_{field}_value` functions
+/// serde's `deserialize_with` hooks use, so both paths enforce identical rules.
 #[cfg(all(
     feature = "serde",
     any(feature = "typescript", feature = "zod", feature = "jsonschema")
@@ -1518,11 +1451,8 @@ fn build_struct_validate_method(
     })
 }
 
-/// The pattern one variant is matched by in the enum-level `validate()`.
-///
-/// Only the constrained members are bound, each under the name its check reads; everything else the
-/// variant holds is left unread, and a variant that binds every member it has needs no rest pattern
-/// to say so.
+/// The pattern one variant is matched by in the enum-level `validate()`. Only the constrained
+/// members are bound, each under the name its check reads; everything else is left unread.
 fn variant_check_pattern(
     variant_ident: &proc_macro2::Ident,
     kind: &VariantKind,
@@ -2108,10 +2038,8 @@ fn fillings_no_document_can_be_built_from(args: &ModelSchemaArgs) -> Vec<syn::Er
 }
 
 /// The name a type is written as when it is written as a bare name and nothing else — no
-/// qualifier, no path, no arguments — or `None` for every other spelling.
-///
-/// Only that shape can be checked against a list of reserved names: `some::path::char` names
-/// whatever that path resolves to, and a name carrying arguments is not a primitive at all.
+/// qualifier, no path, no arguments — or `None` for every other spelling. Only that shape can be
+/// checked against reserved names: `some::path::char` names whatever the path resolves to.
 #[cfg(feature = "jsonschema")]
 fn bare_type_name(filling: &syn::Type) -> Option<String> {
     let syn::Type::Path(type_path) = filling else {
@@ -2290,11 +2218,9 @@ fn named_parameter(bounded_ty: &syn::Type) -> Option<&syn::Ident> {
     type_path.path.get_ident()
 }
 
-/// Whether a bound reads any generic parameter of the item other than the one it bounds.
-///
-/// Asked of the tokens rather than the parsed bound because the answer only ever withholds a check:
-/// a path segment that happens to spell a parameter's name is read as the parameter, which costs
-/// the item nothing it had before.
+/// Whether a bound reads any generic parameter of the item other than the one it bounds. Asked of
+/// the tokens rather than the parsed bound: a false positive only withholds a check, costing
+/// nothing.
 fn mentions_another_parameter(
     bound: &syn::TypeParamBound,
     generics: &syn::Generics,
@@ -2340,13 +2266,8 @@ fn with_prefixed_tokens(expanded: TokenStream, prefix: &[proc_macro2::TokenStrea
 }
 
 /// The `compile_error!` tokens an item earns for carrying a ` ```rust example ` block while
-/// declaring a const parameter, or none where it carries no example and none where it declares no
-/// const.
-///
-/// A doc example is annotated with the item's own name at one instantiation, and a const takes no
-/// filling from that convention — both spellings name a type, and a const is a value. So the
-/// example is refused where it was written rather than expanded into an `E0107`. An alias is left
-/// out deliberately: it publishes no `schema_example()`, so its example is already unread.
+/// declaring a const parameter — a doc example is annotated at one type instantiation, which a
+/// const cannot fill. Aliases are excluded: they publish no `schema_example()`.
 #[cfg(feature = "zod")]
 fn const_parameter_example_errors(item: &Item) -> Vec<proc_macro2::TokenStream> {
     let (generics, attrs) = if let Item::Struct(item_struct) = item {
@@ -2575,10 +2496,8 @@ const fn const_parameter_argument_errors(_item: &Item) -> Vec<proc_macro2::Token
 }
 
 /// The `compile_error!` tokens for every `cfg_attr`-wrapped serde attribute an enum carries: on the
-/// type (tagging, variant casing) and on each variant (`rename`).
-///
-/// Collected before the enum is dispatched to its shape, since all three shapes read those same
-/// attributes and each would otherwise render a contract the wrapper had quietly emptied.
+/// type (tagging, variant casing) and on each variant (`rename`). Collected before the enum is
+/// dispatched, since all three shapes read those same attributes.
 #[cfg(feature = "serde")]
 fn enum_cfg_attr_guard_errors(
     item_enum: &syn::ItemEnum,
@@ -2684,11 +2603,9 @@ fn branded_constraint_inner_error(
     Some(syn::Error::new_spanned(inner_field, message).to_compile_error())
 }
 
-/// The Rust spelling of `parameter`'s declared default, for the refusal that names it — `String`
-/// for an entry the declaration left out, the same fallback [`declared_default_field`] resolves to
-/// a `FieldDef` from. Only reached once that fallback has already proven *not* string-shaped, so
-/// the fallback branch here is unreachable in practice; it is total anyway because a refusal
-/// message is not the place to let a lookup miss go unspelled.
+/// The Rust spelling of `parameter`'s declared default, for the refusal that names it — the same
+/// `String` fallback [`declared_default_field`] resolves a `FieldDef` from. Practically
+/// unreachable here, but total anyway rather than leaving a lookup miss unspelled.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn declared_default_type_name(
     parameter: &str,
@@ -2716,9 +2633,8 @@ fn declared_default_constraint_message(name: &Ident, parameter: &str, default_ty
 }
 
 /// `parameter`'s declared default as a `syn::Type`, for substituting a concrete Rust type rather
-/// than spelling one for a diagnostic. Falls back to `String` for an entry the declaration left
-/// out — the same fallback [`declared_default_type_name`] and [`declared_default_field`] resolve
-/// to, so all three readers of an absent entry agree.
+/// than spelling one for a diagnostic. Falls back to `String` for an entry left out — the same
+/// fallback [`declared_default_type_name`] and [`declared_default_field`] use, so all three agree.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn declared_default_syn_type(
     parameter: &str,
@@ -2731,9 +2647,8 @@ fn declared_default_syn_type(
 }
 
 /// The `impl` header and self-type a type's *declared-default* `validate()` is written against:
-/// every type parameter is replaced by [`declared_default_syn_type`], while a lifetime or const
-/// parameter carries through unchanged — `default_types` only ever fills a type parameter, so
-/// there is nothing declared for the other two to substitute.
+/// every type parameter is replaced by [`declared_default_syn_type`]; a lifetime or const
+/// parameter carries through unchanged, since `default_types` only ever fills a type parameter.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn default_instantiation(
     name: &Ident,
@@ -2774,11 +2689,8 @@ fn default_instantiation(
 }
 
 /// Splits a generated `validate()` away from a type's other delegate methods when the type has
-/// parameters: the checks a `validate()` runs belong to the declared default (see
-/// [`default_instantiation`]), not to every instantiation, so a generic type's `validate()` moves
-/// into its own `impl Name<DeclaredDefault> { .. }` block rather than sitting on the same
-/// `impl<T> Name<T>` the schema delegates (`ts_definition`, `zod_schema`, …) still share — those
-/// do not depend on the constraints, so they are unaffected.
+/// parameters: the checks belong to the declared default (see [`default_instantiation`]), so it
+/// moves into its own `impl Name<DeclaredDefault>` rather than the shared `impl<T> Name<T>`.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn place_validate_method(
     validate_method: Option<proc_macro2::TokenStream>,
@@ -2805,10 +2717,8 @@ fn place_validate_method(
 }
 
 /// A branded newtype's `validate()`, split the same way [`assemble_schema_output`] splits a
-/// struct's or enum's: the piece that stays on the brand's own `impl` block (empty once the type is
-/// generic — see [`place_validate_method`]), and the standalone default-only `impl` block to append
-/// after it. Takes the raw (possibly empty) `TokenStream` `inject_branded_serde_attrs` returns
-/// rather than an `Option`, since that is what the brand path already has on hand.
+/// struct's or enum's. Takes a raw `TokenStream` rather than an `Option` since that is what the
+/// brand path already has on hand.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn branded_validate_split(
     raw_validate_method: proc_macro2::TokenStream,
@@ -3082,11 +2992,8 @@ const fn branded_cfg_attr_guard_errors(
 }
 
 /// The `compile_error!` tokens for a brand whose `pattern` argument a guard refuses, or `None`
-/// when it carries none or it clears them.
-///
-/// The brand is the only shape that reads a type-level `pattern`, and it splices the string into
-/// the Rust validator, the Zod literal and the JSON schema alike; every other shape is refused the
-/// argument before a surface is built.
+/// when it carries none or it clears them. The brand is the only shape that reads a type-level
+/// `pattern`; every other shape is refused the argument before a surface is built.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn branded_pattern_error(name: &Ident, args: &ModelSchemaArgs) -> Option<proc_macro2::TokenStream> {
     args.pattern_rejection
@@ -3094,12 +3001,9 @@ fn branded_pattern_error(name: &Ident, args: &ModelSchemaArgs) -> Option<proc_ma
         .map(|rejection| pattern_guard_error(rejection, &format!("type `{name}`")))
 }
 
-/// The inner type as the two validating surfaces receive it: with the brand's own type parameters
-/// already classified as parameters, which is what leaves each surface writing the filling it
-/// reaches one through rather than a reference to a type of that name.
-///
-/// The guard and the registration read the inner through this one call, so what a brand is refused
-/// for and what it records for the next brand to read cannot come apart.
+/// The inner type as the two validating surfaces receive it, with the brand's own type parameters
+/// already classified as parameters. The guard and the registration both read the inner through
+/// this one call, so what a brand is refused for and what it records cannot come apart.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn branded_inner_value_surface(generics: &syn::Generics, inner_field: &Field) -> FieldDef {
     surface_field_def(generics, &get_field_def("_inner", &inner_field.ty, ""))
@@ -3156,10 +3060,8 @@ fn branded_guard_errors(
 }
 
 /// The `compile_error!` tokens for a `#[serde(flatten)]` field the registry proves is a plain enum,
-/// or `None` for every other field.
-///
-/// Read from the declaration rather than from the collected field so the diagnostic keeps the span
-/// of the type it rejects.
+/// or `None` for every other field. Read from the declaration, not the collected field, so the
+/// diagnostic keeps the span of the type it rejects.
 #[cfg(all(
     feature = "serde",
     any(feature = "typescript", feature = "zod", feature = "jsonschema")
@@ -3193,10 +3095,9 @@ fn flattened_field_guard_error(
     )
 }
 
-/// The attributes the emitted field keeps from the declaration it was written with: everything but
-/// this crate's own `model_schema_prop`, which is inert to every derive, so a copy left on the
-/// emitted item is one rustc reports as an attribute that does not exist, pointing at the author's
-/// line with a diagnostic naming the wrong macro.
+/// The attributes the emitted field keeps: everything but this crate's own `model_schema_prop`,
+/// which is inert to every derive — left on the emitted item, rustc reports it as an attribute
+/// that does not exist.
 fn declaration_attrs(field: &Field) -> Vec<syn::Attribute> {
     field
         .attrs
@@ -3407,10 +3308,9 @@ fn struct_module_idents(
     (item_name, module_name, module_ident)
 }
 
-/// The enum counterpart of [`struct_module_idents`], down to naming the module from the Rust ident.
-/// `kind` differs per enum shape: only a plain unit enum is given an `enum_members()`, so only it
-/// can back an enum-keyed map — and only it is written as a `z.enum`, every other shape being a
-/// union of the members its variants render as.
+/// The enum counterpart of [`struct_module_idents`]. `kind` differs per enum shape: only a plain
+/// unit enum gets an `enum_members()` (and is written as `z.enum`); every other shape is a union
+/// of its variants' members.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn enum_module_idents(
     name: &syn::Ident,
@@ -3425,11 +3325,9 @@ fn enum_module_idents(
     (module_name, module_ident)
 }
 
-/// Extracts a struct's doc lines and the first ` ```rust example ` block (if any) from them.
-///
-/// Read in every build that emits a schema surface rather than only the two that render one of the
-/// halves: what the author wrote is a fact about the declaration, and the example half already
-/// answers `None` where `zod` — the only surface that reads one — is off.
+/// Extracts a struct's doc lines and the first ` ```rust example ` block (if any) from them,
+/// unconditionally: the example half already answers `None` where `zod` — the only surface that
+/// reads one — is off.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn struct_docs_and_example(
     item_struct: &syn::ItemStruct,
@@ -3443,10 +3341,8 @@ fn struct_docs_and_example(
 }
 
 /// The output a struct carrying a `cfg_attr`-wrapped serde attribute on the type is refused with,
-/// or `None` when it carries none.
-///
-/// A hidden `rename_all` reshapes every field name, so the item is refused before a single field
-/// is processed.
+/// or `None` when it carries none. A hidden `rename_all` reshapes every field name, so the item is
+/// refused before a single field is processed.
 #[cfg(feature = "serde")]
 fn struct_cfg_attr_guard_output(
     item_struct: &syn::ItemStruct,
@@ -3695,11 +3591,9 @@ fn collect_tuple_slots(
     (tuple_struct_shape(declared_slots, slots), guard_errors)
 }
 
-/// The shape a tuple struct's declared arity and described slots amount to.
-///
-/// The bare value is keyed on the *declared* arity, not on how many slots came back described: a
-/// struct declaring two slots with one of them off the wire writes a one-element array, and reading
-/// the described count would collapse it to the bare value serde does not write there.
+/// The shape a tuple struct's declared arity and described slots amount to. Keyed on the
+/// *declared* arity, not the described count: a struct declaring two slots with one off the wire
+/// still writes a one-element array, not the bare value.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn tuple_struct_shape(declared_slots: usize, mut slots: Vec<FieldDef>) -> TupleStructShape {
     if declared_slots == 1 && slots.len() == 1 {
@@ -3708,11 +3602,9 @@ fn tuple_struct_shape(declared_slots: usize, mut slots: Vec<FieldDef>) -> TupleS
     TupleStructShape::Array(slots)
 }
 
-/// The TypeScript type a tuple struct describes as.
-///
-/// The bare value is the slot's own type: serde writes a newtype struct as that value alone, with
-/// nothing around it. Every array — the empty one included, which writes `[]` — is the fixed tuple
-/// the slots on the wire describe as when they are written as a tuple field.
+/// The TypeScript type a tuple struct describes as: the bare value is the slot's own type (serde
+/// writes a newtype struct as that value alone), and every array — the empty one included — is the
+/// fixed tuple the slots describe as.
 #[cfg(feature = "typescript")]
 fn tuple_struct_ts_body(shape: &TupleStructShape) -> String {
     match shape {
@@ -3915,12 +3807,9 @@ fn process_tuple_struct(
     })
 }
 
-/// Builds the `validate_value`/`deserialize_value` functions for a constrained branded newtype.
-///
-/// Returns `None` when the newtype has no string constraints. A path inner is measured by the
-/// string serde writes for it, exactly as a path field is; every other inner is reached through
-/// `ToString`, so it works for `String`, `ObjectId`, and any generic `ID_TYPE` implementing
-/// `Display`.
+/// Builds the `validate_value`/`deserialize_value` functions for a constrained branded newtype, or
+/// `None` when it has no string constraints. A path inner is measured by the string serde writes
+/// for it; every other inner is reached through `ToString`.
 #[cfg(all(
     feature = "serde",
     any(feature = "typescript", feature = "zod", feature = "jsonschema")
@@ -4032,12 +3921,9 @@ fn branded_inner_measures_path(inner_ty: &syn::Type) -> bool {
     })
 }
 
-/// How a constrained brand hands `receiver` to `validate_value`: a path goes borrowed — deref
-/// coercion carries it through whatever transparent wrappers it was written under — since the
-/// validator renders it itself; every other inner is rendered through `Display` first, the
-/// `to_string()` call carrying `to_string_span` so a non-`Display` inner's `E0599` lands beside the
-/// field's own `E0277` instead of on the attribute — `resolved_at(Span::call_site())`, the caller's
-/// only legal input, keeps the tokens hygienically the macro's own.
+/// How a constrained brand hands `receiver` to `validate_value`: a path goes borrowed since the
+/// validator renders it itself; every other inner goes through `Display`'s `to_string()`, spanned
+/// so a non-`Display` inner's `E0599` lands beside the field rather than on the attribute.
 #[cfg(all(
     feature = "serde",
     any(feature = "typescript", feature = "zod", feature = "jsonschema")
@@ -4128,12 +4014,9 @@ fn branded_chrono_schema(args: &ModelSchemaArgs, format: &str) -> proc_macro2::T
     )
 }
 
-/// The `$oid` member an `ObjectId` brand carries: the hex string the type always holds, narrowed by
-/// the brand's own constraints, so a brand that declares none still describes the hex the type it
-/// wraps describes wherever else it is written.
-///
-/// The hex is the base's own `pattern`, which is why the brand's is layered beside it rather than
-/// written over it — see [`BasePattern`].
+/// The `$oid` member an `ObjectId` brand carries: the hex string the type always holds, narrowed
+/// by the brand's own constraints. The hex is the base's own `pattern`, so the brand's is layered
+/// beside it rather than written over it — see [`BasePattern`].
 #[cfg(all(feature = "jsonschema", feature = "object_id"))]
 fn branded_object_id_hex_schema(args: &ModelSchemaArgs) -> proc_macro2::TokenStream {
     branded_schema_obj_over(
@@ -4147,9 +4030,8 @@ fn branded_object_id_hex_schema(args: &ModelSchemaArgs) -> proc_macro2::TokenStr
 }
 
 /// The description a brand carries for an inner no `"type"` keyword names: the one the slot
-/// dispatch gives that type, so the brand describes as the type it wraps describes wherever else
-/// it is written. An inner the dispatch cannot render replaces the body with the single diagnostic
-/// naming the brand, as an unrenderable slot does in every other position.
+/// dispatch gives that type. An inner the dispatch cannot render replaces the body with the
+/// single diagnostic naming the brand, as an unrenderable slot does elsewhere.
 #[cfg(feature = "jsonschema")]
 fn branded_slot_json_schema(
     args: &ModelSchemaArgs,
@@ -4293,10 +4175,8 @@ fn branded_zod_string_checks(args: &ModelSchemaArgs) -> String {
 }
 
 /// The same three constraints [`branded_zod_string_checks`] renders, spelled instead as one
-/// `.check(...)` call over the base check functions (`z.minLength`, `z.maxLength`, `z.regex`) —
-/// the surface every Zod schema exposes, unlike `.min`/`.max`, which live on `ZodString` alone and
-/// so are not guaranteed to exist on whatever a deferred or folded default argument is annotated
-/// as. See [`zod_default_block`] for where the two spellings are chosen between.
+/// `.check(...)` call over the base functions (`z.minLength`, `z.maxLength`, `z.regex`) — the
+/// surface every Zod schema exposes, unlike `.min`/`.max`, which live on `ZodString` alone.
 #[cfg(feature = "zod")]
 fn branded_zod_base_checks(args: &ModelSchemaArgs) -> String {
     let mut checks = Vec::new();
@@ -4317,11 +4197,9 @@ fn branded_zod_base_checks(args: &ModelSchemaArgs) -> String {
     }
 }
 
-/// Whether a branded newtype's inner is an `ObjectId` written on its own, and so reaches the wire
-/// as the `$oid` object rather than as any string.
-///
-/// An arrayed inner is excluded: what it writes is the array around that object, which is not a
-/// shape this dispatch describes.
+/// Whether a branded newtype's inner is an `ObjectId` written on its own, reaching the wire as the
+/// `$oid` object rather than any string. An arrayed inner is excluded — it writes the array around
+/// that object, not this shape.
 #[cfg(all(feature = "object_id", any(feature = "zod", feature = "jsonschema")))]
 const fn branded_inner_is_object_id(inner: &FieldDef) -> bool {
     matches!(inner.field_type, FieldDefType::ObjectId) && !inner.is_array()
@@ -4417,19 +4295,8 @@ fn branded_zod_type_name(inner: &FieldDef) -> String {
     }
 }
 
-/// The Zod class a reference to another registered generic name, filled with `args`, composes to —
-/// read off the same [`PublishedShape`] the constrained-brand guard's own
-/// [`instantiated_value_shape`] consults, but answered in this dispatch's own vocabulary of classes
-/// rather than that guard's coarse "numeric"/"container"/"opaque" words.
-///
-/// A family publisher — a generic item whose whole published value *is* one of its own parameters —
-/// composes to whatever class the written argument at that parameter's position does, peeling
-/// through the named item's own brand exactly the way `$ZodBranded<T, Brand>` is still assignable to
-/// plain `T`. Nothing else here has one class to prove: a fixed-shape publisher's class depends on
-/// how its shape is built (a plain union and a discriminated one share the same recorded shape but
-/// not a class), an unregistered name may not have expanded yet, and an argument that is itself an
-/// outer, not-yet-filled type parameter carries no class of its own to inherit — so all three widen
-/// to the class every Zod schema is an instance of rather than guess one that might not be it.
+/// The Zod class a filled generic name composes to. Only a family publisher proves one — its
+/// argument's own class; every other shape widens to `ZodType` rather than guess.
 #[cfg(all(feature = "zod", feature = "typescript"))]
 fn branded_zod_instantiated_type_name(name: &str, args: &[FieldDef]) -> String {
     match lookup_alias_info(name).map(|info| info.value_shape) {
@@ -4484,11 +4351,9 @@ fn build_branded_ts_definition_method(
     }
 }
 
-/// The brand marker a build's flavour spells, appended to whatever schema the inner rendered.
-///
-/// The name is a *type* argument, which only TypeScript reads. Zod's runtime brand takes none — it
-/// hands the schema back and the marker exists in the type alone — so a build emitting no
-/// TypeScript writes the bare call, which is the same value under a spelling JavaScript parses.
+/// The brand marker a build's flavour spells, appended to whatever schema the inner rendered. The
+/// name is a *type* argument that only TypeScript reads; Zod's runtime brand takes none, so a
+/// build emitting no TypeScript writes the bare call instead.
 #[cfg(feature = "zod")]
 fn zod_brand_call(item_name: &str) -> String {
     #[cfg(feature = "typescript")]
@@ -4665,16 +4530,9 @@ fn build_branded_delegate_items(
     ]
 }
 
-/// Builds the `Display` impl for a branded newtype, delegating to the inner field's `Display`.
-///
-/// The `where` clause bounds the inner field's own type rather than only the brand's own type
-/// parameters, so a non-generic brand over a non-`Display` inner is bounded too and raises one
-/// `E0277` naming the trait, instead of leaving `self.0.fmt(f)` to raise a second, unbounded
-/// `E0599` beside it.
-///
-/// The predicate carries the field's location through `resolved_at(Span::call_site())`, which
-/// reports the refusal at the field while leaving the tokens hygienically the macro's own — the
-/// same split the doc-comment example spans rely on.
+/// The `where` clause bounds the inner field's own type, not just the brand's generic params, so
+/// a non-generic brand over a non-`Display` inner raises one `E0277` at the field instead of an
+/// unbounded `E0599` inside the generated impl.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn build_branded_display_impl(
     generics: &syn::Generics,
@@ -4933,9 +4791,8 @@ fn assemble_branded_output(parts: &BrandedNewtypeOutput) -> TokenStream {
 }
 
 /// The output a branded newtype its guards refused is replaced by, or `None` when it earns none.
-///
-/// Read before the type is registered in the alias registry: a rejected brand emits no schema, so
-/// nothing else should be able to resolve a reference to one.
+/// Read before the type is registered: a rejected brand emits no schema, so nothing else should be
+/// able to resolve a reference to one.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn branded_guard_failure_output(
     item_struct: &syn::ItemStruct,
@@ -5269,14 +5126,9 @@ fn item_plain_doc_lines(doc_lines: &[String]) -> Vec<String> {
         .collect()
 }
 
-/// An item's doc lines, flattened the way the calling surface reads them, or the one line it falls
-/// back to when it says nothing: the name it is exported under, not the one it is declared under,
-/// so a `JSDoc` header never contradicts the `export type` one line beneath it and a description
-/// never names an item something no surface exports.
-///
-/// Whether anything was said is read off the flattened lines rather than off the attribute: a
-/// ` ```rust example ` block is Rust source and is dropped, so an item documented with nothing else
-/// has an attribute and still says nothing.
+/// An item's doc lines, flattened the way the calling surface reads them, or the exported name
+/// (not the declared one) when it says nothing — so a `JSDoc` header never contradicts the
+/// `export type` line beneath it.
 fn item_lines_or_name(
     docs_vec: Option<&[String]>,
     item_name: &str,
@@ -5343,22 +5195,16 @@ fn ts_member_key(key: &str) -> String {
 }
 
 /// The one-line description a set of lines is published as, escaped for the `description: "…"` it
-/// is spliced into.
-///
-/// The escape reaches the exported name an undocumented item falls back to and does nothing there:
-/// a `name = "…"` override is refused unless it spells an identifier, and a Rust ident cannot be
-/// written with a quote in it, so no exported name carries one.
+/// is spliced into. The escape is a no-op on the exported-name fallback: a `name` override must
+/// spell an identifier, which cannot contain a quote.
 #[cfg(any(feature = "typescript", feature = "zod"))]
 fn describe_item_lines(lines: &[String]) -> String {
     lines.join("\\n").replace('"', "\\\"")
 }
 
 /// The escaped one-line description an item publishes, falling back to the exported name when it
-/// carries no docs — spelled from the same two bodies as the description of a shape that publishes
-/// a `JSDoc` header alongside it, so the two cannot drift apart.
-///
-/// Gated on the feature of its one caller: a brand is the only shape that publishes a description
-/// and no `JSDoc` header of its own, and a description is a zod surface.
+/// carries no docs — spelled from the same lines a `JSDoc` header would use, so the two cannot
+/// drift apart.
 #[cfg(feature = "zod")]
 fn item_description(docs_vec: Option<&[String]>, item_name: &str) -> String {
     describe_item_lines(&item_lines_or_name(
@@ -5614,11 +5460,8 @@ fn variant_wire_kind(variant: &syn::Variant) -> VariantKind {
 }
 
 /// Whether the variant declares exactly one slot and takes that slot off the wire in both
-/// directions — the collapse [`variant_wire_kind`] publishes a unit for.
-///
-/// Held apart from the kind it produces because two seams need the declaration back: what the
-/// collapse is written as is a unit, and what it was *declared* as is what the refusals reading this
-/// have to name. A declared unit and a collapsed one share every wire and part only here.
+/// directions — the collapse [`variant_wire_kind`] publishes a unit for. Held apart from the kind
+/// it produces because refusals need the *declared* shape back, not the collapsed one.
 fn lone_slot_off_wire(variant: &syn::Variant) -> bool {
     // `classify_variant` names `TupleSingle` for a variant of exactly one unnamed field, so the
     // first field is the lone slot whose omission decides this.
@@ -6014,14 +5857,8 @@ fn process_discriminated_enum(
 }
 
 /// The object schema a struct variant's fields sit in when they are written under a key of their
-/// own rather than beside a discriminator.
-///
-/// The per-field entries are the ones the adjacent form writes, so the two placements describe the
-/// same fields identically and only differ in where the object sits.
-///
-/// Used both by the externally tagged form (behind `serde`, which is the only way that shape is
-/// reached) and by the adjacently tagged form's own struct variant, which is reached even without
-/// `serde` — the fallback "tag"/"value" shape `exec_model_schema` falls through to.
+/// own rather than beside a discriminator. Used by both the externally tagged form and the
+/// adjacently tagged form's own struct variant.
 #[cfg(feature = "jsonschema")]
 fn named_content_json_value(json_fields: &[proc_macro2::TokenStream]) -> proc_macro2::TokenStream {
     quote! {
@@ -6300,11 +6137,9 @@ fn sibling_key_exclusions(member_keys: &[Option<Vec<String>>]) -> Vec<Vec<String
         .collect()
 }
 
-/// One externally tagged variant's flatten operand with its siblings' tags marked absent, written in
-/// the key-per-line shape [`render_external_variant`] already wrote the variant in.
-///
-/// A member that is no object literal keeps its spelling: there is no key list to add a line to, and
-/// the exclusion is best-effort in exactly the way the excess-property posture around it is.
+/// One externally tagged variant's flatten operand with its siblings' tags marked absent, written
+/// in the key-per-line shape [`render_external_variant`] already wrote the variant in. A member
+/// that is no object literal keeps its spelling — there is no key list to add a line to.
 #[cfg(all(feature = "serde", feature = "typescript"))]
 fn close_tagged_flatten_member(member: &str, excluded: &[String]) -> String {
     if excluded.is_empty() {
@@ -6322,10 +6157,8 @@ fn close_tagged_flatten_member(member: &str, excluded: &[String]) -> String {
 }
 
 /// Joins an externally tagged enum's rendered members into its three union surfaces: the
-/// JSON-schema body, the TypeScript union, and the Zod union.
-///
-/// Member order is the enum's declaration order on every surface, as it is for the other two enum
-/// forms.
+/// JSON-schema body, the TypeScript union, and the Zod union. Member order is the enum's
+/// declaration order, as for the other two enum forms.
 #[cfg(feature = "serde")]
 fn join_external_union(
     members: &[(String, String, proc_macro2::TokenStream)],
@@ -6550,11 +6383,9 @@ fn tagged_content(inner: &FieldDef) -> TaggedContent {
     }
 }
 
-/// The `compile_error!` tokens for every variant an internally tagged enum cannot carry.
-///
-/// Collected from the declaration rather than from the collected variants so each diagnostic keeps
-/// the span of the thing it rejects: the inner type for a newtype variant, the variant itself for a
-/// tuple one.
+/// The `compile_error!` tokens for every variant an internally tagged enum cannot carry. Collected
+/// from the declaration, not the collected variants, so each diagnostic keeps the span of the
+/// thing it rejects.
 #[cfg(feature = "serde")]
 fn internally_tagged_guard_errors(
     item_enum: &syn::ItemEnum,
@@ -6720,11 +6551,9 @@ fn render_internal_variant(
     )
 }
 
-/// Joins an internally tagged enum's rendered members into its three union surfaces.
-///
-/// The Zod union is a `discriminatedUnion` only while every member is an object carrying the tag in
-/// its own shape. A flattened member is an intersection, which has no shape of its own to read the
-/// discriminator out of, so one of those turns the whole union into a plain `z.union`.
+/// Joins an internally tagged enum's rendered members into its three union surfaces. The Zod
+/// union is a `discriminatedUnion` only while every member is an object carrying the tag in its
+/// own shape; a flattened member (an intersection) forces a plain `z.union` instead.
 #[cfg(feature = "serde")]
 fn join_internal_union(
     members: &[(String, String, proc_macro2::TokenStream, bool)],
@@ -6967,10 +6796,8 @@ fn unsupported_untagged_variant_error(variant: &syn::Variant, shape: &str) -> sy
 }
 
 /// Renders a `TupleSingle` (`S(T)`) untagged variant as a union member (`T` / `T$Schema` / value).
-///
-/// The inner value is a slot: untagged, the variant carries no key of its own, so the content *is*
-/// the whole serialized value and a `None` there reaches the wire as a bare `null` rather than
-/// going absent. All three surfaces read it through the slot spellings for that reason.
+/// The variant carries no key of its own, so a `None` inner reaches the wire as a bare `null`
+/// rather than going absent — read through the slot spellings for that reason.
 #[cfg(feature = "serde")]
 fn render_untagged_tuple_single(
     fld: &FieldDef,
@@ -7042,12 +6869,9 @@ fn render_untagged_named(
     (ts, zod, json_val)
 }
 
-/// The keys one untagged member names, and `None` where nothing here proves them.
-///
-/// A `Named` variant writes its own fields and is the whole of what it writes, so its keys are the
-/// ones the member already spells. Every other member is written as the type it names — the merge
-/// reads what that name published for the questions it can ask a registry, and its key list is not
-/// one of them.
+/// The keys one untagged member names, and `None` where nothing here proves them. A `Named`
+/// variant's keys are the ones it already spells; every other member is written as the type it
+/// names, and its key list is not something a registry lookup can answer.
 #[cfg(all(feature = "serde", feature = "typescript"))]
 fn untagged_member_keys(kind: &VariantKind, field_defs: &[FieldDef]) -> Option<Vec<String>> {
     matches!(kind, VariantKind::Named)
@@ -7055,11 +6879,8 @@ fn untagged_member_keys(kind: &VariantKind, field_defs: &[FieldDef]) -> Option<V
 }
 
 /// One untagged member's flatten operand with its siblings' keys marked absent, written in the
-/// one-line shape [`render_untagged_named`] already wrote the member in.
-///
-/// A member that is no object literal keeps its spelling, which is the same answer
-/// [`untagged_member_keys`] gives it: a name is what it is written as, and nothing here proves what
-/// it would have to be told to leave out.
+/// one-line shape [`render_untagged_named`] already wrote the member in. A member that is no
+/// object literal keeps its spelling.
 #[cfg(all(feature = "serde", feature = "typescript"))]
 fn close_untagged_flatten_member(member: &str, excluded: &[String]) -> String {
     if excluded.is_empty() {
@@ -7271,12 +7092,9 @@ fn untagged_member_field_defs(
     rendered.erase_type_parameters(type_parameters);
     (rendered, written)
 }
-/// The [`FieldContext`] one untagged variant hands each of its members: the variant is the
-/// container the omission is read against, and the enum is the type the names resolve in.
-///
-/// `rename_all` is the variant's own `#[serde(rename_all = "...")]`, not the enum's: serde treats a
-/// struct variant as the container for its own fields, and the enum's container-level `rename_all`
-/// reaches variant names only, never the fields inside one.
+/// The [`FieldContext`] one untagged variant hands each of its members. `rename_all` is the
+/// variant's own, not the enum's — the enum's container-level `rename_all` reaches variant names
+/// only, never the fields inside one.
 #[cfg(feature = "serde")]
 const fn untagged_variant_context<'ctx>(
     variant_defaulted: bool,
@@ -7296,12 +7114,9 @@ const fn untagged_variant_context<'ctx>(
     }
 }
 
-/// One untagged member's finished def, beside the guard verdicts it earned: built next to its
-/// written twin, stamped, guarded (serde's checks and this crate's own combined), resolved, and
-/// carrying its meta — the whole of what the collector's loop needs back for the field.
-///
-/// The context's `container_defaulted` is the variant's own `#[serde(default)]`: a struct variant
-/// is where serde accepts one, and it is the container this member's omission is read against.
+/// One untagged member's finished def, beside the guard verdicts it earned — the whole of what
+/// the collector's loop needs back for the field. `container_defaulted` is the variant's own
+/// `#[serde(default)]`, the container this member's omission is read against.
 #[cfg(feature = "serde")]
 fn untagged_member_field_def(
     ctx: &FieldContext<'_>,
@@ -7344,10 +7159,9 @@ fn untagged_member_field_def(
     (field_def, member_guard_errors)
 }
 
-/// Collects each untagged variant's union-member parts: the TypeScript member type, the Zod member
-/// schema, and the JSON-schema value token, plus the `compile_error!` tokens for any field-level
-/// guard violations. The first three are always returned; the caller selects which to use based on
-/// the enabled features.
+/// Collects each untagged variant's union-member parts: the TypeScript member type, the Zod
+/// member schema, the JSON-schema value token, and the `compile_error!` tokens for any
+/// field-level guard violations. The first three are always returned regardless of features.
 #[cfg(feature = "serde")]
 fn collect_untagged_variant_members(
     variant: &mut syn::Variant,
@@ -7562,10 +7376,9 @@ fn zod_merge_branches(
         .collect()
 }
 
-/// What one rendered member contributes below its own position: one entry for the member itself,
-/// the leaves of the union it names when it names one the registry has recorded, and — where it was
-/// written under an `Option` — those under the choice the value is, beside the choice the absence
-/// is.
+/// What one rendered member contributes below its own position: the member itself, the leaves of
+/// any union it names the registry has recorded, and — under an `Option` — both the value's choice
+/// and the absence's.
 #[cfg(all(feature = "serde", feature = "zod"))]
 fn zod_member_leaves(fld: &FieldDef, rendered: &str) -> Vec<ZodUnionMember> {
     let nested = fld.zod_union_members();
@@ -7764,10 +7577,9 @@ fn build_untagged_schema_impl_items(
     ]
 }
 
-/// Processes an untagged enum (`#[serde(untagged)]`) and generates its definitions.
-///
-/// Emits a TypeScript union (`A | B`), a Zod `z.union([...])`, and a JSON-schema `anyOf`.
-/// Mirrors [`process_discriminated_enum`]'s setup/assembly so all feature combinations compile.
+/// Processes an untagged enum (`#[serde(untagged)]`), emitting a TypeScript union (`A | B`), a Zod
+/// `z.union([...])`, and a JSON-schema `anyOf`. Mirrors [`process_discriminated_enum`]'s
+/// setup/assembly so all feature combinations compile.
 #[cfg(feature = "serde")]
 fn process_untagged_enum(
     mut item_enum: syn::ItemEnum,
@@ -7893,10 +7705,8 @@ fn generate_type_schema(
 }
 
 /// The open TypeScript and Zod member every variant of a tagged enum starts from: the tag holding
-/// the variant's discriminator, with room for whatever the variant writes beside it.
-///
-/// Both tagged forms open the same way — the tag is a key of the variant's own object — so the
-/// spelling lives here once rather than in each form's renderer.
+/// the variant's discriminator, with room for whatever the variant writes beside it. Both tagged
+/// forms open the same way, so the spelling lives here once.
 fn tagged_variant_parts(
     tag_name: &str,
     discriminator_value: &str,
@@ -7915,10 +7725,8 @@ fn tagged_variant_parts(
 }
 
 /// The closed object a tagged variant describes as, as a `serde_json::Map` expression: the tag
-/// pinned to the variant's discriminator, plus whatever the variant's own fields contributed.
-///
-/// A `Map` rather than a `Value` because the internally tagged form merges further members into it
-/// before it becomes one.
+/// pinned to the variant's discriminator, plus whatever the variant's own fields contributed. A
+/// `Map` rather than a `Value` because the internally tagged form merges further members into it.
 #[cfg(feature = "jsonschema")]
 fn tagged_variant_json_object(
     tag_name: &str,
@@ -8021,13 +7829,8 @@ fn generate_variant_code(
 }
 
 /// Writes an adjacently tagged struct variant's fields nested under the content key, the shape
-/// serde actually writes for it (`{"tag":"Variant","content":{...fields}}`).
-///
-/// Reuses [`write_named_variant_fields`]'s own `None`-tag rendering — the same "an object of its
-/// own" shape the externally tagged form already builds — rather than inventing a second nesting
-/// mechanism. A field reaching the enum being defined already defers through its own getter inside
-/// that object, so the content key itself never needs one: [`render_external_variant`]'s
-/// `defer_key` establishes the same thing for the externally tagged form.
+/// serde actually writes for it (`{"tag":"Variant","content":{...fields}}`). Reuses
+/// [`write_named_variant_fields`]'s own `None`-tag rendering rather than a second nesting mechanism.
 fn write_adjacent_named_variant_fields(
     field_defs: &[FieldDef],
     content_name: &str,
@@ -8076,11 +7879,9 @@ fn push_named_content_json_field(
     });
 }
 
-/// Writes the named-field portion of an enum variant (TypeScript, Zod, JSON Schema).
-///
-/// `tag_name` is the key the discriminator occupies beside these fields, whose JSON-schema entry
-/// the caller has already written; `None` where the variant's fields sit in an object of their own
-/// and no key is taken.
+/// Writes the named-field portion of an enum variant (TypeScript, Zod, JSON Schema). `tag_name` is
+/// the discriminator's key beside these fields (already written by the caller), or `None` where
+/// the fields sit in an object of their own.
 fn write_named_variant_fields(
     field_defs: &[FieldDef],
     tag_name: Option<&str>,
@@ -8157,11 +7958,9 @@ fn push_single_tuple_json_field(
     });
 }
 
-/// Writes the single-element tuple portion of a discriminated enum variant.
-///
-/// The content key is a slot: serde writes it for every variant that has one, so a `None` there
-/// reaches the wire as a `null` under the key rather than dropping it. All three surfaces read the
-/// element through the slot spellings for that reason.
+/// Writes the single-element tuple portion of a discriminated enum variant. The content key is a
+/// slot: a `None` there reaches the wire as `null` under the key rather than dropping it, read
+/// through the slot spellings for that reason.
 fn write_tuple_single_variant_fields(
     field_defs: &[FieldDef],
     content_name: &str,
@@ -8329,10 +8128,8 @@ fn arrayed_json_schema_fragment(
 }
 
 /// The arity a fixed-size `[T; N]` level pins, as the `minItems`/`maxItems` pair a tuple pins its
-/// own arity with — the same constraint, the two spellings serde writes a fixed-length array from.
-///
-/// Empty for every other level, which is what leaves an unbounded array unbounded. The pair carries
-/// its own leading comma so that emptiness costs the caller nothing.
+/// own arity with. Empty for every other level, leaving an unbounded array unbounded; the pair
+/// carries its own leading comma so emptiness costs the caller nothing.
 #[cfg(feature = "jsonschema")]
 fn fixed_length_json_schema_bounds(fld: &FieldDef, level: u8) -> proc_macro2::TokenStream {
     fld.fixed_length_at(level).map_or_else(
@@ -8440,10 +8237,9 @@ fn scalar_field_json_schema_item(fld: &FieldDef) -> Option<proc_macro2::TokenStr
     Some(item_schema)
 }
 
-/// [`build_map_member_item`] for a tuple element, which differs for exactly one value type: a tuple
-/// renders as the fixed-arity array its own field position renders, which is the one value the map
-/// path has no renderer for. An element is dispatched by the tuple builder itself, so the nesting
-/// costs nothing but the recursion.
+/// [`build_map_member_item`] for a tuple element, which differs for exactly one value type: a
+/// tuple renders as the fixed-arity array its own field position renders — the one value the map
+/// path has no renderer for.
 #[cfg(feature = "jsonschema")]
 fn build_tuple_element_item(value: &FieldDef) -> Result<MapMemberItem, MapMemberRejection> {
     if let FieldDefType::Tuple(elements) = &value.field_type {
@@ -8464,9 +8260,8 @@ fn build_tuple_element_base_json_schema(
 }
 
 /// The `anyOf [<base>, null]` form for a value that is an `Option`, or `None` when it is not. A
-/// slot that cannot be dropped — a tuple element or a map entry — needs it because there is no
-/// other way to write a `None` there; an object key needs it too, because serde reads an explicit
-/// `null` into `None` exactly as readily as an absent key.
+/// slot that cannot be dropped needs it since there's no other way to write `None`; an object key
+/// needs it too, since serde reads an explicit `null` into `None` as readily as an absent key.
 #[cfg(feature = "jsonschema")]
 fn nullable_slot_json_schema(
     fld: &FieldDef,
@@ -8631,12 +8426,9 @@ fn tuple_json_schema_value(
     })
 }
 
-/// What a sequence-spelled type holds, and `None` for everything else.
-///
-/// A sequence reaches a key in either of the two forms the parser leaves: the array levels it
-/// collapses a `Vec` or a `[T; N]` onto, and the wrapper name it keeps for every other spelling,
-/// which each surface normalizes onto its element at render time. Both write the same JSON array,
-/// so the classification below reads them the same way.
+/// What a sequence-spelled type holds, and `None` for everything else. A `Vec`/`[T; N]` collapses
+/// to array levels; every other sequence wrapper keeps its name, normalized onto its element at
+/// render time — both write the same JSON array.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn sequence_wrapper_element(fld: &FieldDef) -> Option<&FieldDef> {
     let FieldDefType::SiblingType(wrapper_name, wrapper_args) = &fld.field_type else {
@@ -8718,12 +8510,9 @@ fn unwritable_key(key: &FieldDef, written_as: &'static str) -> MapKeyRejection {
     }
 }
 
-/// Why this key has no rendering, and `None` for every key that may still have one.
-///
-/// A key the dispatch already refuses is ruled out by its own spelling. Below that, only a target
-/// the registry positively rules out is named — an unregistered name, a foreign type or one
-/// expanded after the type that writes the map, cannot be ruled out at this expansion and is left
-/// alone.
+/// Why this key has no rendering, and `None` for every key that may still have one. A key the
+/// dispatch already refuses is ruled out by its own spelling; otherwise only a target the registry
+/// positively rules out is named — an unregistered or not-yet-expanded name is left alone.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn key_rejection(key: &FieldDef) -> Option<MapKeyRejection> {
     match map_key_path(key) {
@@ -8789,10 +8578,8 @@ fn proves_no_enum_members(key_type_name: &str) -> bool {
 }
 
 /// What the registry says serde writes for a key spelled by this name, and `None` for a name it
-/// never saw registered.
-///
-/// An unregistered name earns nothing: the expansion cannot tell it from a plain enum declared
-/// later, which is why the dispatch above leaves such a key on the enumerating path.
+/// never saw registered — indistinguishable from a plain enum declared later, which is why the
+/// dispatch above leaves such a key on the enumerating path.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn registered_key_kind(key_type_name: &str) -> Option<AliasKind> {
     lookup_alias_info(key_type_name).map(|key_alias| key_alias.kind)
@@ -9079,10 +8866,8 @@ fn map_member_rejection_error(
 }
 
 /// The object a `String`-keyed map describes as, as a standalone `serde_json::Value` expression, or
-/// the rejection when the value type has no rendering here.
-///
-/// A `String` key enumerates nothing, so one `additionalProperties` schema stands for every
-/// member — and it is the value type's own rendering, which the key never widens.
+/// the rejection when the value type has no rendering here. A `String` key enumerates nothing, so
+/// one `additionalProperties` schema — the value's own rendering — stands for every member.
 #[cfg(feature = "jsonschema")]
 fn string_key_map_json_schema_value(
     value: &FieldDef,
@@ -9459,10 +9244,9 @@ fn build_unknown_field_schema(fld: &FieldDef, field_name_str: &str) -> proc_macr
     }
 }
 
-/// The `properties` insertion a field's type produces, without the `required` push.
-///
-/// The name is passed rather than read off `fld`: a collection element is dispatched through here
-/// standing in for the field it is the element of, and inserts under that field's name.
+/// The `properties` insertion a field's type produces, without the `required` push. The name is
+/// passed rather than read off `fld`: a collection element is dispatched through here standing in
+/// for the field it is the element of.
 #[cfg(feature = "jsonschema")]
 fn build_field_type_schema(fld: &FieldDef, field_name_str: &str) -> proc_macro2::TokenStream {
     let field_type = &fld.field_type;
@@ -9541,10 +9325,8 @@ fn build_field_schema(fld: &FieldDef) -> proc_macro2::TokenStream {
 }
 
 /// Writes the TypeScript type and conditionally Zod schema for a field to the provided buffers.
-///
-/// The `self_type_name` parameter is used to detect recursive type references.
-/// When a field references the type being defined, we use JavaScript getter syntax
-/// to defer the reference and avoid "use before declaration" errors.
+/// `self_type_name` detects recursive type references, which get JavaScript getter syntax to
+/// defer them and avoid "use before declaration" errors.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn write_field_type_and_schema(
     type_code: &mut String,
@@ -9737,11 +9519,8 @@ fn build_wrapped_deserializer(
 }
 
 /// The stem the per-field helpers are named from: `validate_{stem}_value` and `deserialize_{stem}`.
-///
-/// A field name is unique only within the variant that declares it, while one schema module holds
-/// every variant's helpers — so a variant's field carries its variant into the stem, and two
-/// variants naming one field name two constraints instead of colliding. A struct field has no
-/// variant and keeps the bare field name its helpers have always been spelled with.
+/// A field name is unique only within its variant, while one schema module holds every variant's
+/// helpers — so a variant's field carries its variant into the stem to avoid collisions.
 #[cfg(feature = "serde")]
 fn helper_name_stem(field_ident: &str, variant_ident: Option<&str>) -> String {
     variant_ident.map_or_else(
@@ -9813,11 +9592,9 @@ fn needle_pattern(needle: &str) -> proc_macro2::TokenStream {
     quote! { #needle }
 }
 
-/// The parameter a string validator takes and the rendering its checks read `value` from.
-///
-/// A path is the one leaf the checks cannot be handed as-is: it arrives borrowed — the form every
-/// reach into one already ends at — and is rendered once through `to_string_lossy`, the string
-/// serde writes for it. Every other leaf already is that string, and renders nothing.
+/// The parameter a string validator takes and the rendering its checks read `value` from. A path
+/// is the one leaf that can't be handed as-is: it arrives borrowed and is rendered once through
+/// `to_string_lossy`, the string serde writes for it. Every other leaf already is that string.
 #[cfg(feature = "serde")]
 fn checked_value_parts(
     measures_path: bool,
@@ -10078,11 +9855,8 @@ fn constrained_shape(ty: &syn::Type) -> Option<ConstrainedShape> {
 }
 
 /// The interior-mutability wrapper on a field's constrained path, when there is one.
-///
-/// `constrained_shape` cannot say *why* a shape failed to classify — a `HashMap` value and a
-/// `RefCell` both just stop the walk. This retraces the same path far enough to tell whether the
-/// stop was one of the four wrappers `generic_wrap` deliberately does not read through, so the
-/// caller can name it in a diagnostic instead of silently dropping the constraint.
+/// `constrained_shape` cannot say *why* a shape failed to classify, so this retraces the path to
+/// name the blocker for a diagnostic instead of silently dropping the constraint.
 #[cfg(feature = "serde")]
 fn blocking_interior_mutability_wrapper(ty: &syn::Type) -> Option<String> {
     let mut current = ty;
@@ -10126,11 +9900,8 @@ fn collect_lifetimes(
 }
 
 /// The wrapper a generic type stands for, or `None` if it is not one the constraint reads through.
-///
-/// An interior-mutability wrapper is deliberately absent: it is on the wire-transparent list
-/// (`is_transparent_wrapper`) the schema surfaces read, but it does not implement `Deref`, so the
-/// walk below has no safe way to reach through one — see `blocking_interior_mutability_wrapper`,
-/// which turns that case into a named diagnostic instead of a silently dropped constraint.
+/// An interior-mutability wrapper is deliberately absent: it is wire-transparent but does not
+/// implement `Deref`, so the walk has no safe way through it.
 #[cfg(feature = "serde")]
 fn generic_wrap(ident: &str) -> Option<ConstraintWrap> {
     if ident == "Option" {
@@ -10331,13 +10102,9 @@ fn check_omitted_key_is_readable(
     ))
 }
 
-/// The serde-read guard errors the field violates.
-///
-/// A hidden serde attribute leaves every serde-read diagnostic unreliable — the `Option`-null and
-/// `nullable`-key guards included, since the wrapper is exactly what kept its evidence out of the
-/// meta. `field_validation_guard_error` — the positional-constraint guard, or the
-/// interior-mutability-wrapper guard — reads no serde attribute, so it stands whatever the wrapper
-/// hid.
+/// The serde-read guard errors the field violates. A hidden serde attribute leaves every
+/// serde-read diagnostic unreliable — the `Option`-null and `nullable`-key guards included — since
+/// `field_validation_guard_error` reads no serde attribute and so stands whatever the wrapper hid.
 #[cfg(feature = "serde")]
 fn field_guard_errors(
     field: &Field,
@@ -10459,20 +10226,17 @@ fn model_schema_prop_guard_errors(
         .collect()
 }
 
-/// Turns a flag validator's refusal into a spanned error at the field that carries the flag.
-///
-/// The validator keeps its message: it is the one place the misuse is spelled, and a caller that
-/// re-spells it maintains the same sentence twice.
+/// Turns a flag validator's refusal into a spanned error at the field that carries the flag. The
+/// validator keeps its message — the one place the misuse is spelled — so a caller doesn't
+/// maintain the same sentence twice.
 fn flag_guard_error(field: &Field, label: &str, result: Result<(), String>) -> Option<syn::Error> {
     result
         .err()
         .map(|message| syn::Error::new_spanned(field, format!("model_schema: {label}: {message}")))
 }
 
-/// The bound keys a `model_schema_prop` meta carries, named as they were written.
-///
-/// A guard that answers for where a bound may sit names the ones it found, so the author is pointed
-/// at the keys to remove rather than at the attribute as a whole.
+/// The bound keys a `model_schema_prop` meta carries, named as they were written, so a guard
+/// refusing them can point at the keys to remove rather than at the attribute as a whole.
 fn written_constraint_keys(prop_meta: &ModelSchemaPropMeta) -> Vec<&'static str> {
     [
         ("minLength", prop_meta.min_length.is_some()),
@@ -10634,11 +10398,9 @@ fn check_as_type_override(
     ))
 }
 
-/// Rejects `as` and `preprocess` written on the same field.
-///
-/// `as` names the type the surfaces render and `preprocess` wraps the schema that rendering
-/// produced; this crate defines no order between them, so a field carrying both says nothing
-/// either surface can act on.
+/// Rejects `as` and `preprocess` written on the same field: `as` names the type the surfaces
+/// render and `preprocess` wraps the schema that rendering produced, and this crate defines no
+/// order between them.
 fn check_as_preprocess_conflict(
     field: &Field,
     prop_meta: &ModelSchemaPropMeta,
@@ -10658,11 +10420,9 @@ fn check_as_preprocess_conflict(
     ))
 }
 
-/// Rejects a field that reaches an `OsString`/`OsStr`, at any depth.
-///
-/// serde writes both as an externally tagged enum naming the target platform — `{"Unix":[u8, …]}`
-/// or `{"Windows":[u16, …]}` — so one Rust field has two wire forms and no schema describes both.
-/// Their owned string counterparts are what a portable field is written as instead.
+/// Rejects a field that reaches an `OsString`/`OsStr`, at any depth: serde writes both as an
+/// externally tagged enum naming the target platform (`{"Unix":[u8, …]}` or
+/// `{"Windows":[u16, …]}`), so no schema describes both wire forms.
 fn check_os_string_field(
     field: &Field,
     field_def: &FieldDef,
@@ -10801,10 +10561,9 @@ fn needs_injected_default(wraps: &[ConstraintWrap], has_default: bool) -> bool {
     matches!(first_opaque, Some(ConstraintWrap::Optional)) && !has_default
 }
 
-/// The `compile_error!` tokens for a length or range constraint written on a positional field.
-///
-/// Both helpers such a constraint generates are named from the field ident, and `validate()` reaches
-/// the value through that same ident — a spelling a tuple slot has none of.
+/// The `compile_error!` tokens for a length or range constraint written on a positional field. Both
+/// helpers such a constraint generates are named from the field ident — a spelling a tuple slot
+/// has none of.
 #[cfg(feature = "serde")]
 fn positional_constraint_guard_error(
     field: &Field,
@@ -10825,13 +10584,8 @@ fn positional_constraint_guard_error(
 }
 
 /// The `compile_error!` tokens for a length or range constraint written on a field reached through
-/// an interior-mutability wrapper.
-///
-/// Every other covered wrapper (`Box`, `Rc`, `Arc`, `Cow`) implements `Deref`, so the generated
-/// validator reaches its inner value with a plain `&**value`. `RefCell`, `Cell`, `Mutex` and
-/// `RwLock` do not: reaching one takes a runtime-checked borrow or lock, which the constraint
-/// walk has no way to fold into `validate(&self)` — so the combination is refused here instead of
-/// the constraint silently going unchecked.
+/// an interior-mutability wrapper (`RefCell`, `Cell`, `Mutex`, `RwLock`) — unlike `Box`/`Rc`/`Arc`/
+/// `Cow`, these don't implement `Deref`, so the validator has no safe way to reach the inner value.
 #[cfg(feature = "serde")]
 fn interior_mutability_constraint_guard_error(
     field: &Field,
@@ -10983,12 +10737,9 @@ fn apply_model_schema_prop_meta(
     apply_constraint_docs(field_def, final_name);
 }
 
-/// Appends length/range constraint information to a field's generated docs.
-///
-/// The sentence states the bound as a rule the value is held to, so it is written only where
-/// something holds the value to it. A placement [`check_fixed_shape_constraints`] refuses gets
-/// none: there the bound reaches no surface, and the doc would be the only place it appeared at all
-/// — the claim standing exactly where nothing backs it.
+/// Appends length/range constraint information to a field's generated docs — only where something
+/// actually holds the value to the bound. A placement [`check_fixed_shape_constraints`] refuses
+/// gets none, since the doc would be the only place the claim appeared.
 fn apply_constraint_docs(field_def: &mut FieldDef, final_name: &str) {
     if field_def.constraints_reach_nothing() {
         return;
@@ -11178,9 +10929,7 @@ fn zod_binding_suffix(rust_ident: &str, parameters: &[String]) -> &'static str {
 
 /// The zod re-export text an item's module ends with — the factory's own alongside the default's,
 /// so a renamed generic item's alias answers to both names exactly as its own declaration does.
-///
-/// [`ident_reexport_zod`] writes one binding at a time; a type with no parameter has only one to
-/// write, and a generic type has two — its factory and the default this task adds beside it.
+/// [`ident_reexport_zod`] writes one binding at a time, so a generic type needs two calls.
 #[cfg(feature = "zod")]
 fn zod_binding_reexport(rust_ident: &str, export_name: &str, parameters: &[String]) -> String {
     let mut reexport = ident_reexport_zod(
@@ -11206,12 +10955,9 @@ fn zod_factory_builder_name(item_name: &str) -> String {
     format!("build{item_name}$Schema")
 }
 
-/// The `TypeScript` parameter list a factory and everything written around it are declared under —
-/// `<IdType extends ZodType, DateType extends ZodType>`.
-///
-/// Every parameter is a parameter of the function for real. A bare `ZodType` annotation compiles
-/// and infers nothing: `ZodType` defaults its own parameters, so a field validated by such an
-/// argument comes back as `unknown` and the caller learns nothing from the schema it was handed.
+/// The `TypeScript` parameter list a factory is declared under — `<IdType extends ZodType,
+/// DateType extends ZodType>`. A bare `ZodType` annotation would compile but infer nothing:
+/// `ZodType` defaults its own parameters, so a field validated by one comes back `unknown`.
 #[cfg(all(feature = "zod", feature = "typescript"))]
 fn zod_factory_bounds(parameters: &[String]) -> String {
     format!(
@@ -11246,11 +10992,8 @@ fn zod_cache_name(item_name: &str) -> String {
 }
 
 /// What that key holds: the schema itself where the item declares one parameter, and a `WeakMap`
-/// chain keyed by the arguments after the first where it declares more.
-///
-/// Every type parameter in it is bound by the factory's own signature, so the value type depends on
-/// the key type for real — the dependency a module-scope store cannot express, and the reason
-/// nothing here is asserted.
+/// chain keyed by the arguments after the first where it declares more. Every type parameter in it
+/// is bound by the factory's own signature — a dependency a module-scope store cannot express.
 #[cfg(all(feature = "zod", feature = "typescript"))]
 fn zod_cache_type(item_name: &str, parameters: &[String]) -> String {
     let widened = parameters
@@ -11305,11 +11048,8 @@ fn zod_factory_declaration(item_name: &str, parameters: &[String], bounds: &str)
 }
 
 /// The factory's body: walk down to the map the last argument keys, hand back what is already
-/// there, and otherwise build once, store, and return the very schema that was stored — which is
-/// what makes two calls with the same arguments the same schema rather than two that agree.
-///
-/// Every argument is read on the way down, so no two argument lists share a slot: a change in the
-/// first re-keys the outermost map and a change in the last re-keys the one the schema sits in.
+/// there, and otherwise build once, store, and return the very schema that was stored — making two
+/// calls with the same arguments the same schema rather than two that merely agree.
 #[cfg(feature = "zod")]
 fn zod_factory_body(item_name: &str, parameters: &[String]) -> String {
     let arguments: Vec<String> = parameters.iter().map(|p| zod_factory_argument(p)).collect();
@@ -11336,9 +11076,8 @@ fn zod_factory_body(item_name: &str, parameters: &[String]) -> String {
 }
 
 /// The statement a factory binds the schema it is about to cache to, without its terminator.
-///
 /// Written once and read twice: [`zod_factory_body`] emits it, and the delegate injecting the
-/// item's example anchors on it — so the anchor cannot drift from the line it names.
+/// item's example anchors on it.
 #[cfg(feature = "zod")]
 fn zod_factory_memoized_binding(item_name: &str, parameters: &[String]) -> String {
     format!(
@@ -11353,11 +11092,8 @@ fn zod_factory_memoized_binding(item_name: &str, parameters: &[String]) -> Strin
 }
 
 /// The `FieldDef` one `default_types` entry parses as: the declared filling for `parameter`, or —
-/// absent one — `String`, [`schema_example_value_type`]'s own fallback for the identical gap. The
-/// fallback is only ever the *answer* in a build without `jsonschema`, the one feature that
-/// requires every parameter to declare one — but the constrained-brand guard,
-/// [`branded_constraint_inner_error`], reads this in every build, string constraints being a
-/// question the Zod and Rust surfaces answer regardless of `jsonschema`.
+/// absent one — `String`, [`schema_example_value_type`]'s own fallback for the identical gap. Only
+/// `jsonschema` requires a declared default; the constrained-brand guard reads this regardless.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn declared_default_field(parameter: &str, default_types: &[(syn::Ident, syn::Type)]) -> FieldDef {
     default_types
@@ -11401,8 +11137,7 @@ fn default_zod_rendering(field: &FieldDef) -> DefaultZodRendering {
 
 /// What a generic item appends after its factory: the factory called with each parameter's
 /// declared default, so `X$SchemaDefault === X$SchemaFactory(<the same arguments>)` by
-/// construction — through the very factory a hand-written call would go through, never the
-/// builder, which skips the memo and would build a second schema for the same filling.
+/// construction, through the very factory a hand-written call would go through.
 #[cfg(feature = "zod")]
 fn zod_default_block(
     item_name: &str,
@@ -11447,10 +11182,8 @@ fn zod_default_block(
 }
 
 /// The `$SchemaDefault` annotation [`zod_default_block`] writes: plain `ZodType<Name<...>>` for an
-/// ordinary generic item, and `$ZodBranded<Argument, Name>` for a branded newtype, whose factory
-/// always ends its chain in `.brand()` — a return type strict tsc will not accept under the plain
-/// spelling, the classic `ZodType` interface's deprecated `_output` field being computed at the
-/// pre-brand type. Classes are written bare, per [`branded_zod_type_name`].
+/// ordinary generic item, and `$ZodBranded<Argument, Name>` for a branded newtype — whose factory
+/// always ends in `.brand()`, a return type strict tsc rejects under the plain spelling.
 #[cfg(all(feature = "zod", feature = "typescript"))]
 fn branded_default_annotation(
     item_name: &str,
@@ -11488,10 +11221,9 @@ fn branded_default_annotation(
     format!(": $ZodBranded<{argument_type}, \"{item_name}\">")
 }
 
-/// The class a bare-parameter brand's own declared-default argument is annotated with, for
-/// [`branded_default_annotation`]: the eager expression's class bare, or that class inside
-/// `ZodLazy<...>` for a deferred one — spelled `typeof {schema}` where the deferred target is a
-/// binding name, and widened where it is a factory call `typeof` cannot read.
+/// The class a bare-parameter brand's own declared-default argument is annotated with: the eager
+/// expression's class bare, or that class inside `ZodLazy<...>` for a deferred one — `typeof
+/// {schema}` for a binding name, widened for a factory call `typeof` cannot read.
 #[cfg(all(feature = "zod", feature = "typescript"))]
 fn branded_default_argument_class(field: &FieldDef, rendering: &DefaultZodRendering) -> String {
     match rendering {
@@ -11553,10 +11285,8 @@ fn zod_factory_block(
 }
 
 /// The binding a type that declares no parameter publishes: the raw schema, then the exported
-/// `const` annotated with the type it validates.
-///
-/// The annotation is the only place a TypeScript type is named, so a build without `typescript`
-/// writes the same value under a bare `const`.
+/// `const` annotated with the type it validates. The annotation is the only place a TypeScript
+/// type is named, so a build without `typescript` writes the same value under a bare `const`.
 #[cfg(feature = "zod")]
 fn zod_const_block(item_name: &str, preamble: &str, expression: &str, reexport: &str) -> String {
     #[cfg(feature = "typescript")]
@@ -11680,12 +11410,9 @@ fn zod_merged_statements(
 }
 
 #[cfg(feature = "zod")]
-/// Generates the Zod schema method (Zod schemas only, no TypeScript types).
-///
 /// Each flattened base joins an intersection through [`deferred_zod_operand`]: a base names a
 /// `const` of its own, and one macro invocation sees one type, so nothing here can know whether
-/// that `const` is declared above the module this writes or below it. How many intersections there
-/// are, and what is bound ahead of them, is [`zod_merged_statements`]'.
+/// that `const` is declared above this module or below it.
 fn generate_zod_schema_method(
     item_name: &str,
     rust_ident: &str,
@@ -11753,11 +11480,8 @@ fn bind_item_jsdoc_local(docs: &str, with_json_schema: bool) -> proc_macro2::Tok
 }
 
 /// Binds the `docs` local an enum's `ts_definition()` renders, enriched with the JSON schema when
-/// this build of tixschema can produce one.
-///
-/// The enrichment reads `Self::json_schema()`, so it may only be emitted when tixschema's own
-/// features put that method in the schema module — deciding here rather than emitting a `cfg`
-/// keeps the reader and the method in agreement regardless of the consumer's feature table.
+/// this build of tixschema can produce one. The enrichment reads `Self::json_schema()`, so it may
+/// only be emitted when tixschema's own features put that method in the schema module.
 #[cfg(feature = "typescript")]
 fn generate_enum_json_docs_part(docs: &str) -> proc_macro2::TokenStream {
     bind_item_jsdoc_local(docs, cfg!(all(feature = "jsonschema", feature = "zod")))
@@ -11819,12 +11543,9 @@ fn generate_plain_enum_ts_definition_method(
 }
 
 #[cfg(feature = "zod")]
-/// Generates the Zod schema method for plain enums (Zod schemas only)
-/// Note: Example injection is handled by the delegating method on the type itself.
-///
 /// A plain enum publishes the one schema it has whatever it declares: Rust refuses a *type*
 /// parameter no variant uses, and every variant of a plain enum is a unit, so there is never a
-/// parameter here for a factory to bind.
+/// parameter for a factory to bind.
 fn generate_plain_enum_zod_schema_method(
     item_name: &str,
     rust_ident: &str,

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -88,9 +88,8 @@ const UNPORTABLE_PROBE_PATTERNS: [(&str, &str); 6] = [
 
 /// Every slot spelling the refusal reads, beside whether it is refused. A slot dropped from one of
 /// serde's directions and not the other is; the pair that drops both is the wire the description
-/// already answers for, and everything else is a slot written in its place.
-///
-/// Ungated because the variant seam reads the same list in every build.
+/// already answers for, and everything else is a slot written in its place. Ungated because the
+/// variant seam reads the same list in every build.
 const SLOT_OMISSION_SPELLINGS: [(&str, bool); 6] = [
     ("skip_serializing", true),
     ("skip_serializing_if = \"Option::is_none\"", true),
@@ -315,9 +314,8 @@ fn non_nullable_field_with_a_key_dropping_attribute_passes_the_nullable_guard() 
 }
 
 /// Read off serde itself: a `Vec` behind a `skip_serializing_if` and nothing else serializes to
-/// `{"id":"1"}` and then fails to deserialize that payload, reporting the field as missing. The
-/// surfaces now admit the absent key, so the spelling that writes a payload it cannot read back is
-/// refused rather than described.
+/// `{"id":"1"}` and then fails to deserialize that payload, reporting the field as missing — so
+/// the spelling that writes a payload it cannot read back is refused rather than described.
 #[cfg(feature = "serde")]
 #[test]
 fn a_non_option_omitted_key_with_no_default_is_rejected() {
@@ -402,9 +400,8 @@ fn an_option_around_a_covered_wrapper_is_rejected_as_the_vec_spelling_is() {
 }
 
 /// An `Option` the wrapper holds is a different `None`: the array around it is always written, so
-/// the key is always present and the `null` lands among the items, which is a value the field's
-/// schema describes rather than one it has no way to admit. The guard has no subject there and
-/// says nothing — at every depth, and whichever spelling each level takes.
+/// the key is always present and the `null` lands among the items, a value the field's schema
+/// already describes. The guard has no subject there, at every depth and whichever spelling.
 #[cfg(feature = "serde")]
 #[test]
 fn an_option_inside_a_covered_wrapper_leaves_the_guard_nothing_to_refuse() {
@@ -875,9 +872,8 @@ fn untagged_member_with_an_enumerable_map_key_is_left_alone() {
 }
 
 /// The refusal every map-key spelling no surface can write earns, read off the untagged walk.
-/// Field position refuses each of these; a member is the same map, so it is refused here too — and
-/// the walk is the only thing that has to say so, the guard failure dropping the schema surface
-/// before any member rendering reaches the author.
+/// Field position refuses each of these; a member is the same map, so it is refused here too —
+/// the guard failure dropping the schema surface before any member rendering reaches the author.
 #[cfg(all(
     feature = "serde",
     any(feature = "typescript", feature = "zod", feature = "jsonschema")
@@ -1001,10 +997,8 @@ fn untagged_member_holding_an_opaque_value_stays_permissive() {
 }
 
 /// A map value the member dispatch cannot render replaces the member's whole rendering with the
-/// diagnostic, as it replaces the insertion in field position: a schema the expansion has already
-/// rejected is not one to hand the author. No guard answers for this shape, so the rendering is
-/// where it has to be said — once, naming the field and the reason, with no rendered map left
-/// beside it.
+/// diagnostic, as it replaces the insertion in field position: no guard answers for this shape, so
+/// the rendering is where it has to be said — once, naming the field and the reason.
 #[cfg(all(feature = "serde", feature = "jsonschema"))]
 #[test]
 fn untagged_member_holding_an_unsupported_map_value_emits_only_the_compile_error() {
@@ -1426,9 +1420,8 @@ fn a_map_key_proved_to_lack_enum_members_is_refused_wherever_it_is_written() {
 
 /// A sequence-wrapped key writes a JSON array, which serde refuses as an object key outright, so
 /// no surface has an object to describe and the field is refused instead — wherever the map is
-/// written, and whichever sequence spelling wrote it, the parser having collapsed them all onto the
-/// same array levels. The element the wrapper holds is named, that being the one part of the
-/// spelling the levels leave recoverable.
+/// written and whichever sequence spelling wrote it. The element the wrapper holds is named, that
+/// being the one part of the spelling the levels leave recoverable.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
 fn a_sequence_wrapped_map_key_is_refused_wherever_it_is_written() {
@@ -1468,9 +1461,8 @@ fn a_sequence_wrapped_map_key_is_refused_wherever_it_is_written() {
 }
 
 /// A key whose own type writes a JSON array or a JSON object earns the same refusal a
-/// sequence-wrapped one does, and for the same reason: serde raises `key must be a string` and
-/// refuses the whole map, so there is no object for any surface to describe. The key is named by the
-/// shape it was written as, and what serde writes for it is named beside it.
+/// sequence-wrapped one does: serde raises `key must be a string` and refuses the whole map, so
+/// there is no object for any surface to describe. The key is named by the shape it was written as.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn assert_unwritable_map_key(field_type: &proc_macro2::TokenStream, key_name: &str) {
     let error = field_map_key_error(field_type);
@@ -1600,9 +1592,8 @@ fn an_optional_map_key_is_refused_wherever_it_is_written() {
 }
 
 /// The wrapper spellings answer in the order they were written, so a key wearing both keeps the
-/// diagnostic of its outermost one: an optional sequence is still refused as the sequence its array
-/// levels make it, and only a key whose outermost wrapper is the `Option` earns the `None`-key
-/// wording.
+/// diagnostic of its outermost one: an optional sequence is still refused as the sequence, and
+/// only a key whose outermost wrapper is the `Option` earns the `None`-key wording.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
 fn a_key_wrapped_twice_is_named_by_its_outermost_wrapper() {
@@ -1649,9 +1640,8 @@ fn a_string_wire_brand_keys_a_map_the_way_a_string_does() {
 }
 
 /// The guard is a filter, never a rewrite: a key the registry names as a plain enum, one it never
-/// saw registered, and one no position enumerates all keep the field they had. A sequence in the
-/// *value* is no key at all, so the sequence refusal does not reach across the map to it — nor does
-/// any of its siblings, an `Option` value and a tuple value being ordinary members.
+/// saw registered, and one no position enumerates all keep the field they had. A sequence, an
+/// `Option`, or a tuple in the *value* is no key at all, so the refusal does not reach across.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
 fn a_map_key_that_may_have_enum_members_is_left_alone() {
@@ -1717,12 +1707,10 @@ fn an_alias_targeting_a_map_key_with_no_members_is_refused() {
     assert!(error.contains("Doc"), "got: {error}");
 }
 
-/// A refused item still publishes the schema module every reference to it addresses.
-///
-/// The address is derived from the Rust ident and nothing else, so it is the same whatever became
-/// of the item — which is what lets a reference stand before it. An expansion that emitted no
-/// module left every referencing type with an `E0433` naming a module the author never wrote,
-/// sitting on top of the refusal they can act on.
+/// A refused item still publishes the schema module every reference to it addresses. The address
+/// is derived from the Rust ident and nothing else, so it is the same whatever became of the item —
+/// which is what lets a reference stand before it. An expansion that emitted no module left every
+/// referencing type with an `E0433` naming a module the author never wrote.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
 fn a_refused_item_publishes_the_module_a_reference_to_it_resolves_to() {
@@ -1906,9 +1894,8 @@ fn parsed_field_type(field_type: &proc_macro2::TokenStream) -> String {
 
 /// The reported failure: std's `HashMap<K, V, S>` and `HashSet<T, S>` carry a hasher past the types
 /// they write, and the arity-keyed arms read that argument as a type of its own — demoting the
-/// container to a sibling naming a schema module the expansion never writes. serde writes the same
-/// bytes whichever hasher is named, so a container is read by its own name and the arguments past
-/// its wire form are dropped before any arm is consulted.
+/// container to a sibling naming a schema module the expansion never writes. A container is now
+/// read by its own name, with the arguments past its wire form dropped first.
 #[test]
 fn a_container_written_with_a_hasher_parses_as_the_container_without_one() {
     for (written, implied) in [
@@ -2061,10 +2048,8 @@ fn a_field_pattern_naming_a_group_the_rust_way_clears_the_guard() {
 }
 
 /// A pattern every string satisfies is refused where it is written, naming the field, the way a
-/// bound written where no surface reads one is. The alternative — taking it and emitting no check
-/// — would leave the author a contract nothing enforces, and would leave the emitted
-/// `validate_..._value(value: &str)` with `value` unread, which the consumer's own deny set turns
-/// into a second failure it has no edit for.
+/// bound written where no surface reads one is. Taking it and emitting no check would leave the
+/// author a contract nothing enforces, and would leave `value` unread in the generated validator.
 #[test]
 fn a_field_pattern_admitting_every_value_names_the_field_and_says_so() {
     for pattern in ["", "^", "$", "|", "a*", "^a*"] {
@@ -2384,10 +2369,8 @@ fn a_literal_whose_kind_the_field_can_carry_is_left_alone() {
 
 /// A parameter names no type until the item is instantiated, so a bound written on a field typed
 /// with one is held by nothing at all: the two validating surfaces describe the value as opaque,
-/// which takes no length, no pattern and no range, and the generated validator and serde read
-/// whatever type the instantiation supplied. That is the map's and the tuple's loss under another
-/// spelling, and it is refused where it is written for the same reason — at every depth the
-/// parameter can be reached through, the wrappers collapsing onto the value a bound would measure.
+/// which takes no length, no pattern and no range. Refused at every depth the parameter can be
+/// reached through, the wrappers collapsing onto the value a bound would measure.
 #[test]
 fn a_bound_on_a_parameter_typed_field_is_refused() {
     for (constraint, key) in [
@@ -2432,9 +2415,8 @@ fn a_bound_on_a_parameter_typed_field_is_refused() {
 }
 
 /// The refusal turns on the bound and on the name being the item's own, so a parameter-typed field
-/// carrying none clears it — and so does the same bound on a concrete field standing beside the
-/// parameter, which every surface still reads it for. A name the item does not declare is a
-/// reference to another type and keeps whatever that type's own rendering earns.
+/// carrying none clears it — and so does the same bound on a concrete field beside the parameter.
+/// A name the item does not declare is a reference to another type, keeping its own rendering.
 #[test]
 fn a_parameter_in_scope_only_refuses_the_field_that_carries_a_bound() {
     for (field, parameters) in [
@@ -2761,9 +2743,8 @@ fn struct_schema_example_instantiates_every_type_parameter() {
 }
 
 /// Each argument is read off the `default_types` entry naming that parameter, so an item is
-/// annotated at the concrete types its author declared and in the order the parameters were
-/// written. A parameter no entry names keeps the `String` fallback, which is why a partly declared
-/// item mixes the two.
+/// annotated at the concrete types its author declared, in the order the parameters were written.
+/// A parameter no entry names keeps the `String` fallback, so a partly declared item mixes the two.
 #[cfg(feature = "zod")]
 #[test]
 fn struct_schema_example_instantiates_each_parameter_at_its_declared_filling() {
@@ -2817,8 +2798,7 @@ fn a_string_filling_annotates_the_example_as_no_filling_does() {
 
 /// The three shapes a declared default renders as. The third row is the one that matters:
 /// `IdType = DocumentId<String>` names that sibling at exactly the argument its own
-/// `$SchemaDefault` was recorded at, so the render folds onto that binding — deferred, two
-/// module-scope `const`s having no knowable order between them.
+/// `$SchemaDefault` was recorded at, so the render folds onto that binding, deferred.
 #[cfg(feature = "zod")]
 #[test]
 fn declared_default_renders_each_shape_the_table_describes() {
@@ -2912,10 +2892,9 @@ fn declared_default_renders_each_wrapped_shape_the_table_describes() {
 }
 
 /// The fold only fires where the written arguments match the sibling's own recorded default; a
-/// reference to the same generic sibling at a *different* argument still calls its factory, exactly
-/// as an ordinary field naming it does — and that call is deferred exactly as the fold's own
-/// reference is, since `DocumentId$SchemaFactory` is one more module-scope `const` this one cannot
-/// know is declared above it or below.
+/// reference to the same generic sibling at a *different* argument still calls its factory. That
+/// call is deferred exactly as the fold's own reference is, since the factory is one more
+/// module-scope `const` this one cannot know is declared above it or below.
 #[cfg(feature = "zod")]
 #[test]
 fn a_default_naming_a_sibling_at_other_than_its_own_default_calls_the_factory() {
@@ -2960,11 +2939,9 @@ fn branded_json_schema_method_carries_no_cfg_attribute() {
     }
 }
 
-/// Every shape [`super::branded_json_inner`] resolves to, so the dispatch is covered whole.
-///
-/// The `Slot` and `Chrono` shapes build their bodies through [`super::branded_slot_json_schema`]
-/// and [`super::branded_chrono_schema`], which is where a stray `cfg` attribute would land unseen,
-/// so they are walked here beside the two that render inline.
+/// Every shape [`super::branded_json_inner`] resolves to, so the dispatch is covered whole. The
+/// `Slot` and `Chrono` shapes build their bodies through [`super::branded_slot_json_schema`] and
+/// [`super::branded_chrono_schema`], which is where a stray `cfg` attribute would land unseen.
 #[cfg(feature = "jsonschema")]
 fn branded_json_inners() -> Vec<super::BrandedJsonInner> {
     let composite: syn::Type = syn::parse_quote!(Vec<String>);
@@ -3162,9 +3139,8 @@ fn an_alias_type_parameter_is_erased_at_every_depth() {
 
 /// The same erasure at the same depths on the value surface, where the consequence of skipping it
 /// is louder: a parameter left to render names a `$Schema` binding no emitted module declares, and
-/// the pasted output throws before a payload is read. What it renders as instead is the argument
-/// the alias's own factory binds for it, at whatever depth it was written. Asserted over the
-/// identical alias list the JSON test walks, so the two surfaces cannot erase at different depths.
+/// the pasted output throws before a payload is read. Asserted over the identical alias list the
+/// JSON test walks, so the two surfaces cannot erase at different depths.
 #[cfg(feature = "zod")]
 #[test]
 fn an_alias_type_parameter_is_erased_at_every_depth_on_the_value_surface() {
@@ -3363,8 +3339,7 @@ fn a_brand_pattern_that_still_constrains_clears_the_guard() {
 
 /// The brand renders its inner into the brand rather than walking it as a field, so the map-key
 /// guard has to be run here or the inner escapes it entirely — leaving TypeScript to write a
-/// `Record` keyed by a type that supplies no keys. The brand earns the same diagnostic a field of
-/// the inner's type earns, whichever reason the key has.
+/// `Record` keyed by a type that supplies no keys, the same diagnostic a field of that type earns.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
 fn a_brand_over_a_map_with_an_unwritable_key_is_refused() {
@@ -3449,11 +3424,9 @@ fn each_string_constraint_alone_rejects_a_numeric_inner() {
 }
 
 /// The shapes whose surfaces read the string constraints as something other than a string check.
-///
-/// Every sequence spelling stands beside the `Vec` it writes the same array as. A wrapper name is
-/// what the parser leaves for all but `Vec` and `[T; N]`, and reading it as a name rather than as
-/// the array it writes is what let a set through: the JSON schema then dropped `minLength` outside
-/// a string, while Zod read `.min` as a bound on how many items the array holds.
+/// Every sequence spelling stands beside the `Vec` it writes the same array as — reading a wrapper
+/// name as a name rather than as the array it writes is what let a set through: the JSON schema
+/// then dropped `minLength` outside a string, while Zod read `.min` as an item-count bound.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
 fn string_constraints_over_a_non_string_inner_are_rejected() {
@@ -3490,8 +3463,7 @@ fn string_constraints_over_a_non_string_inner_are_rejected() {
 
 /// The inners that carry the constraints faithfully. A `SiblingType` — another brand, or an
 /// unresolved user type — is admitted because expansion cannot know its shape; the constrained
-/// path's `Display` assertion is what covers it. A name carrying one argument that is not a
-/// sequence wrapper is such a name too, and stays admitted.
+/// path's `Display` assertion covers it, as it does a name carrying one non-sequence argument.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
 fn string_constraints_over_a_string_shaped_inner_pass() {
@@ -3873,9 +3845,8 @@ fn a_question_a_string_argument_answers_settles_silently() {
 
 /// A name nothing ever registers leaves its question unanswered, which is the foreign-type
 /// admission the guard makes on purpose — an unresolved user type whose schema the author supplies.
-///
-/// Read off the registry rather than off the question, so the absence that never ends is told from
-/// the one that does by the registration itself rather than by anything the brand could have known.
+/// Read off the registry rather than off the question, so an absence that never ends is told from
+/// one that does by the registration itself, not by anything the brand could have known.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
 fn a_question_no_registration_reaches_stays_unanswered() {
@@ -3941,8 +3912,7 @@ fn a_deferred_answer_reads_the_record_the_consult_would_have_read() {
 
 /// What a tuple struct records: serde writes one slot as that slot's value alone, so the schema is
 /// the slot's and carries what the slot carries; every other arity is the fixed array `z.tuple`
-/// writes, which takes no string check. An optional slot is `z.nullable(...)`, which takes none
-/// either.
+/// writes, which takes no string check, and neither does an optional slot's `z.nullable(...)`.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
 fn a_tuple_struct_records_the_value_surface_its_slots_publish() {
@@ -3986,8 +3956,7 @@ fn a_tuple_struct_records_the_value_surface_its_slots_publish() {
 
 /// A brand constraining one of its own type parameters consults that parameter's *declared
 /// default* rather than the parameter itself. An entry the declaration left out falls back to
-/// `String`, so this guard alone requires no `default_types`; `jsonschema` is what requires an
-/// entry, through the unrelated `default_types_guard_errors`.
+/// `String`, so this guard alone requires no `default_types` — `jsonschema` is what requires one.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
 fn string_constraints_over_the_brands_own_type_parameter_consult_the_declared_default() {
@@ -4239,11 +4208,9 @@ fn a_name_an_identifier_can_be_spelled_from_is_read() {
 }
 
 /// An item with no docs falls back to the name it is exported under on both surfaces, and the
-/// description surface escapes a double quote where the `JSDoc` one leaves it alone — so the two
-/// fallbacks can only be spelled from one body while no exported name can carry that character.
-/// The name has exactly two sources and neither can produce one: an override is refused unless it
-/// spells an identifier, and an unrenamed item takes the Rust ident, which the grammar refuses to
-/// tokenize with a quote in it — raw spelling included, which reaches the name as `r#`.
+/// description surface escapes a double quote where the `JSDoc` one leaves it alone — so no
+/// exported name can carry one to begin with: an override must spell an identifier, and an
+/// unrenamed item takes the Rust ident, which the grammar refuses to tokenize with a quote in it.
 #[test]
 fn an_exported_name_can_carry_no_double_quote() {
     for value in ["Weird\"Name", "\"", "\"Quoted\""] {
@@ -4481,11 +4448,8 @@ fn distinct_entries_are_read_unchanged() {
 }
 
 /// The argument shares the list with the string constraints and the name override, and reading it
-/// costs none of them. This is the one place their coexistence at the *parser* can be asked
-/// without also asking what the guard makes of it — see
-/// `string_constraints_over_the_brands_own_type_parameter_consult_the_declared_default` for that,
-/// now that a brand's bare-parameter inner reads its declared default rather than being refused
-/// outright.
+/// costs none of them — the one place their coexistence at the *parser* can be asked without also
+/// asking what the guard makes of it.
 #[test]
 fn default_types_coexists_with_every_other_argument() {
     let args = super::parse_model_schema_args(quote::quote! {
@@ -4767,9 +4731,8 @@ fn some_token_was_written_as(tokens: &proc_macro2::TokenStream, written: &str) -
 }
 
 /// Whether a filling satisfies the bounds its parameter declares is a question about trait impls,
-/// which the macro cannot answer — so it hands the filling to a function carrying those bounds and
-/// lets the compiler answer. The parameter keeps the ident it was declared under, so a bound
-/// written in terms of it still reads.
+/// which the macro cannot answer, so it hands the filling to a function carrying those bounds and
+/// lets the compiler answer, under the parameter's own declared ident.
 #[test]
 fn a_bounded_parameters_filling_is_handed_to_a_function_carrying_that_bound() {
     let checks = filling_bound_check_text(
@@ -4874,9 +4837,8 @@ fn an_unbounded_parameter_earns_no_check() {
 }
 
 /// A bound naming another parameter of the item holds only where that one is filled too, which is a
-/// joint statement no per-filling check makes — and the neighbour's name reproduced beside a single
-/// filling would resolve to nothing. So it earns no check of its own, and is carried instead by the
-/// one check that declares the whole parameter list.
+/// joint statement no per-filling check makes — the neighbour's name reproduced beside a single
+/// filling would resolve to nothing. It earns no check of its own, carried by the joint one instead.
 #[test]
 fn a_bound_naming_another_parameter_of_the_item_earns_no_check_of_its_own() {
     let checks = filling_bound_check_text(
@@ -5149,8 +5111,7 @@ fn const_example_messages(source: &str) -> Vec<String> {
 
 /// A doc example is Rust compiled at one instantiation, and no value is the one every
 /// const-parameterised example is written at, so an item that writes one while declaring a const
-/// is refused instead of expanded into a `schema_example()` that cannot compile. Both shapes that
-/// publish an example answer alike, the branded newtype among them.
+/// is refused instead of expanded into a `schema_example()` that cannot compile.
 #[cfg(feature = "zod")]
 #[test]
 fn a_doc_example_on_a_const_declaring_item_is_refused() {
@@ -5250,8 +5211,7 @@ fn const_argument_messages(source: &str) -> Vec<String> {
 
 /// An argument list is read as a list of types, so a const standing in one is taken for a type and
 /// no surface that renders the list can spell it — the JSON side names a module nothing publishes,
-/// the TypeScript side writes a name its declaration does not bind. Refused wherever a type is
-/// written, in every shape the attribute expands.
+/// the TypeScript side writes a name its declaration does not bind. Refused wherever it is written.
 #[cfg(any(feature = "typescript", feature = "jsonschema"))]
 #[test]
 fn a_const_handed_to_a_written_type_as_an_argument_is_refused() {
@@ -5532,16 +5492,10 @@ fn constrained_brand_inner_spanned_tokens(source: &str, inner: &str) -> (usize, 
     (count(&validation.deserialize_fn), count(&validate_method))
 }
 
-/// Both `to_string()` calls the constrained path emits now carry the inner field's location — via
-/// `resolved_at`, not a bare respan — so a non-`Display` inner's `E0599` lands beside the field's
-/// own `E0277` instead of on the attribute. `deserializer` counts the two pre-existing interpolated
-/// `#inner_ty` occurrences plus the three literal tokens (`&`, `.`, `to_string`) `quote_spanned!`
-/// respans around `checked_v`; `validate_method` interpolates no inner type, so its three come from
-/// `checked_inner`'s own `&`, `.`, `to_string` alone. The `#receiver` tokens themselves (`v`, or
-/// `self` `.` `0`) are interpolated rather than written by the `quote_spanned!` template, so they
-/// keep their own unlocated span — this location-count alone cannot see whether the *hygiene*
-/// context also carried over; that is measured by the crate's own deny-heavy clippy run staying
-/// clean on the `String`-inner brands the existing suite already declares.
+/// Both `to_string()` calls now carry the inner field's location via `resolved_at`, so a
+/// non-`Display` inner's `E0599` lands beside the field's own `E0277` instead of on the attribute.
+/// The counts below are the interpolated inner-type occurrences plus the respanned tokens each call
+/// site carries; the *hygiene* context itself is verified separately, by the crate's own clippy run.
 #[cfg(all(
     feature = "serde",
     any(feature = "typescript", feature = "zod", feature = "jsonschema")
@@ -5622,8 +5576,7 @@ fn the_constrained_path_renders_the_same_to_string_calls_it_always_has() {
 
 /// A brand's constrained value is its inner field, so a path inner is reached the way a path field
 /// is: the validator takes the borrowed path and renders it once, and neither call site names a
-/// `to_string()` a path has none of. A transparent wrapper adds no call of its own — the borrow the
-/// bare spelling already writes is what deref coercion carries through it.
+/// `to_string()` a path has none of. A transparent wrapper adds no call of its own.
 #[cfg(all(
     feature = "serde",
     any(feature = "typescript", feature = "zod", feature = "jsonschema")
@@ -5684,9 +5637,7 @@ fn inserted_field_value(field_type: &str) -> String {
 
 /// A value type the enum-key branch cannot render must yield the `compile_error!` *instead of* the
 /// per-member insertion loop: leaving the loop in place adds an E0425 on the `value_schema` the
-/// failed arm never bound, and that second error names macro-internal state the author cannot act on.
-/// The diagnostic names the field and the type, as the `String`-key branch's does — a message that
-/// names neither leaves the author nothing to act on.
+/// failed arm never bound, a second error naming macro-internal state the author cannot act on.
 #[cfg(feature = "jsonschema")]
 #[test]
 fn an_unsupported_enum_keyed_map_value_emits_only_the_compile_error() {
@@ -5883,9 +5834,8 @@ fn a_vec_sibling_enum_keyed_map_value_arrays_the_sibling_schema() {
 }
 
 /// A map entry cannot be dropped the way an object key can, so serde writes an `Option` value's
-/// `None` as JSON `null`. Both key paths have to admit it, and through the same seam: the enum-key
-/// branch materializes the nullable form as a `serde_json::Value`, the `String`-key branch inlines
-/// it as the map's `additionalProperties`.
+/// `None` as JSON `null`. Both key paths admit it through the same seam: the enum-key branch
+/// materializes it as a `serde_json::Value`, the `String`-key branch inlines it directly.
 #[cfg(feature = "jsonschema")]
 #[test]
 fn an_optional_map_value_is_nullable_on_both_key_paths() {
@@ -5962,11 +5912,9 @@ fn an_alias_registers_the_kind_of_what_it_targets() {
 }
 
 /// The alias path and the brand path answer the one map-key question the same way, target for
-/// inner: both spellings wrap a value whose wire form is the whole of what they carry, so a
-/// disagreement between them would be a key that opens an object under one spelling and is refused
-/// under the other. `EnumMembers` is the one verdict only the alias can reach — a type path resolves
-/// to the enum, where a brand publishes no `enum_members()` of its own — so the enum spellings are
-/// held apart rather than in this list.
+/// inner — a disagreement would be a key that opens an object under one spelling and is refused
+/// under the other. `EnumMembers` is left out: only the alias can reach it, a brand publishing
+/// none of its own.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
 fn an_alias_and_a_brand_answer_alike_for_the_same_target() {
@@ -6050,11 +5998,9 @@ fn an_alias_chain_carries_the_stringified_kind_to_its_end() {
 }
 
 /// A refused target keeps the diagnostic naming the *alias*, not the target's own rejection reason:
-/// the alias is what the author wrote at the key, and it is what they can act on. So a field keyed
-/// by an alias of a tuple reads as a name with no `enum_members()` rather than as an array wire, and
-/// so does one keyed by an alias of the wrapper spellings — a target the key dispatch refuses is
-/// refused however it was spelled, including the `Option` and the sequence around a plain enum,
-/// neither of which the alias can supply members for.
+/// the alias is what the author wrote at the key, and it is what they can act on. A target the key
+/// dispatch refuses is refused however it was spelled — a tuple, or the `Option`/sequence spellings
+/// around a plain enum, neither of which the alias can supply members for.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
 fn an_alias_of_a_refused_target_is_refused_under_its_own_name() {
@@ -6116,11 +6062,9 @@ fn brand_kind(inner: &str) -> AliasKind {
 }
 
 /// The kind a brand registers is what serde writes for its inner, the brand being
-/// `#[serde(transparent)]` over it. A string-shaped inner is written as the bare string a JSON
-/// object key is; a plain enum's variant name is that bare string too, and the brand carries no
-/// `enum_members()` of its own to close an object over; a value serde stringifies is written as the
-/// object its bare inner writes; and an inner serde refuses as a key, or one this expansion has not
-/// classified, leaves the brand refused.
+/// `#[serde(transparent)]` over it: a string-shaped inner is the bare string a JSON object key is
+/// (a plain enum's variant name too, though the brand carries no `enum_members()` of its own); a
+/// stringified inner is the object its bare inner writes; anything else leaves the brand refused.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
 fn a_brand_registers_what_serde_writes_for_its_inner() {
@@ -6679,8 +6623,7 @@ fn a_tuple_element_map_key_known_to_lack_enum_members_names_the_requirement() {
 
 /// The one emission answers for every position a map can sit in, so the object `HashMap<Slot, T>`
 /// describes as in field position is the object it describes as nested under either key flavor and
-/// in a tuple slot. Held against the field-position rendering, which is the one that has always
-/// enumerated — depth cannot widen what the key already settled.
+/// in a tuple slot — depth cannot widen what the key already settled.
 #[cfg(feature = "jsonschema")]
 #[test]
 fn an_enum_keyed_map_renders_the_same_in_every_position() {
@@ -6818,8 +6761,7 @@ fn a_sibling_string_keyed_map_value_emits_the_sibling_schema() {
 
 /// A sibling's type arguments reach its schema, JSON Schema having no parameters for the wrapper to
 /// carry: the document is written at one filling, and the reference site names it. Pinned on this
-/// key path as it is on the enum-key one: the two share a dispatcher, and a narrowing that drops
-/// the arguments on one of them has to fail on the key path it is written for.
+/// key path as it is on the enum-key one, since the two share a dispatcher.
 #[cfg(feature = "jsonschema")]
 #[test]
 fn a_generic_sibling_string_keyed_map_value_emits_the_sibling_schema() {
@@ -6835,9 +6777,8 @@ fn a_generic_sibling_string_keyed_map_value_emits_the_sibling_schema() {
 
 /// A map is a `Map` wherever it is written, never a sibling named after the container: the parser
 /// claims both 2-argument map idents ahead of the sibling fallback, and the wrappers a map can be
-/// written under either collapse onto it or hold it as a value. The sibling dispatch therefore
-/// renders no map of its own — a rendering there answers for nothing, and is free to drift from the
-/// one the map arm states.
+/// written under either collapse onto it or hold it as a value. The sibling dispatch renders no map
+/// of its own, so it cannot drift from the one the map arm states.
 #[test]
 fn a_map_never_parses_as_a_sibling_named_after_its_container() {
     for spelling in [
@@ -6924,8 +6865,7 @@ fn every_sequence_wrapper_describes_as_the_vec_of_its_element() {
 
 /// And in the two slot positions, where a value is dispatched instead of a field: a map member and
 /// a tuple element each hold whatever the value writes, so each describes a covered wrapper as the
-/// `Vec` of its element too — a slot reached by a name the field position covers alone is a slot
-/// that renders an array on one surface and a schema module of its own on another.
+/// `Vec` of its element too — never as a schema module of its own, one surface drifting from another.
 #[cfg(feature = "jsonschema")]
 #[test]
 fn every_sequence_wrapper_describes_as_the_vec_of_its_element_in_a_slot() {
@@ -6951,10 +6891,9 @@ fn every_sequence_wrapper_describes_as_the_vec_of_its_element_in_a_slot() {
     }
 }
 
-/// And in an untagged variant's member, the third position that dispatches a value. It reads the
+/// And in an untagged variant's member, the third position that dispatches a value: it reads the
 /// wrappers through the seam the other positions read them through, so a member describes a covered
-/// wrapper as the `Vec` of its element too — and none of them can name a schema module after a
-/// wrapper, which is a module the expansion never declares and rustc reports at the member's type.
+/// wrapper as the `Vec` of its element too, never as a schema module the expansion never declares.
 #[cfg(all(feature = "jsonschema", feature = "serde"))]
 #[test]
 fn every_sequence_wrapper_describes_as_the_vec_of_its_element_in_an_untagged_member() {
@@ -7020,9 +6959,8 @@ fn untagged_member_dispatch_values() -> Vec<(&'static str, super::FieldDef)> {
 }
 
 /// Every arm of the untagged-member dispatch hands the array wrap a value the wrap can carry. The
-/// wrap writes it into a `serde_json::json!` literal, where a value opening with a brace is read as
-/// a JSON object rather than as a Rust block and the macro dies inside its own array expansion — so
-/// an arm that opens with one is an arm no member holding it under a `Vec` can compile.
+/// wrap writes it into a `serde_json::json!` literal, where a value opening with a brace reads as a
+/// JSON object rather than a Rust block, so an arm opening with one fails to compile under a `Vec`.
 #[cfg(all(feature = "jsonschema", feature = "serde"))]
 #[test]
 fn every_untagged_member_value_is_one_the_array_wrap_can_carry() {
@@ -7095,8 +7033,7 @@ fn brand_json_schema_over(inner_ty: &syn::Type) -> String {
 
 /// A named type resolves to one schema module wherever it is written, a brand carrying its inner by
 /// the same reference a field does. A name the registry does not know assumes the module that
-/// name's own `#[model_schema()]` would publish, and rustc reports the `E0433` in either position —
-/// which is the whole contract, since nothing the expansion holds can tell the two cases apart.
+/// name's own `#[model_schema()]` would publish, and rustc reports the `E0433` in either position.
 #[cfg(feature = "jsonschema")]
 #[test]
 fn a_named_type_resolves_to_the_same_module_in_field_and_brand_position() {
@@ -7157,10 +7094,9 @@ fn ident_source_texts(tokens: &proc_macro2::TokenStream, name: &str) -> Vec<Opti
 }
 
 /// A generated module reaches its siblings through `use super::*`, which a type declared inside a
-/// function body never joins, and nothing the macro can read says whether it will resolve. So the
+/// function body never joins, and nothing the macro can read says whether it will resolve. The
 /// whole reference is spanned on the name the module was built from — the module ident included,
-/// that being the one the `E0433` blames — and the failure is reported at the user's type instead
-/// of at `#[model_schema()]`. Every position that carries a sibling names it the same way.
+/// so an `E0433` is reported at the user's type instead of at `#[model_schema()]`.
 #[cfg(feature = "jsonschema")]
 #[test]
 fn a_sibling_reference_points_at_the_type_the_field_names() {
@@ -7195,9 +7131,8 @@ fn a_sibling_reference_emits_the_tokens_it_always_has() {
 
 /// The registry is filled as items expand, so a key declared after the type that writes the map —
 /// like a key foreign to this crate — reads as unclassified and keeps the emitting path. Its
-/// `enum_members()` call is therefore spanned on the key the field names, so a key that carries no
-/// such method is blamed at the user's type instead of at `#[model_schema()]`. Every position a
-/// map is written in names the key the same way.
+/// `enum_members()` call is spanned on the key the field names, so a key carrying no such method is
+/// blamed at the user's type instead of at `#[model_schema()]`.
 #[cfg(feature = "jsonschema")]
 #[test]
 fn an_enum_keyed_map_points_its_members_call_at_the_key_the_field_names() {
@@ -7257,9 +7192,8 @@ fn a_tuple_element_holding_an_unrenderable_map_emits_only_the_compile_error() {
 }
 
 /// A sequence wrapper around a map is the field's array, not the map's, so the field position
-/// applies the wrap every other field type applies — and the item it wraps is the map's own
-/// rendering, unchanged. Without it the same type describes as a bare object in a field and as an
-/// array in the slot positions that already wrap it, and the field schema rejects what serde writes.
+/// applies the wrap every other field type applies, and the item it wraps is the map's own
+/// rendering, unchanged — otherwise the field schema would reject what serde actually writes.
 #[cfg(feature = "jsonschema")]
 #[test]
 fn a_sequence_wrapped_map_field_describes_as_the_array_of_the_map_it_holds() {
@@ -7400,10 +7334,9 @@ fn an_optional_sequence_wrapper_member_stays_nullable() {
 }
 
 /// Runs a fixed discriminated enum through the real collect/render pipeline, returning its
-/// TypeScript member fragments, Zod member fragments, and JSON-schema member fragments.
-///
-/// Rebuilt from scratch on every call so repeated calls exercise whatever ordering the collection
-/// stage imposes, not a single cached traversal.
+/// TypeScript member fragments, Zod member fragments, and JSON-schema member fragments. Rebuilt
+/// from scratch on every call so repeated calls exercise whatever ordering the collection stage
+/// imposes, not a single cached traversal.
 fn rendered_discriminated_union() -> (Vec<String>, Vec<String>, Vec<String>) {
     let mut item: syn::ItemEnum = syn::parse_quote! {
         enum Action {
@@ -7476,12 +7409,9 @@ fn discriminated_union_rendering_is_stable_across_runs() {
 
 /// A struct variant with no fields is still `Named`, and the adjacent form nests its (empty)
 /// content under the content key rather than treating it as a unit: `Empty {}` writes
-/// `{"kind":"Empty","data":{}}` on the wire, not `{"kind":"Empty"}`.
-///
-/// Built through `parse_quote!` rather than a real item declaration: an empty-braced struct variant
-/// is exactly the shape `clippy::empty_enum_variants_with_brackets` (a `deny`d restriction lint
-/// here) refuses declared in source. Read as a value at run time, the shape never becomes an item
-/// in this crate's own AST, so the lint has nothing to see.
+/// `{"kind":"Empty","data":{}}` on the wire, not `{"kind":"Empty"}`. Built through `parse_quote!`
+/// rather than a real item declaration, since an empty-braced struct variant is exactly the shape
+/// `clippy::empty_enum_variants_with_brackets` refuses declared in source.
 #[test]
 fn adjacently_tagged_empty_named_variant_nests_an_empty_content_object() {
     let mut item: syn::ItemEnum = syn::parse_quote! {
@@ -7797,7 +7727,6 @@ fn a_constraint_on_a_positional_field_is_refused_before_a_name_is_spelled() {
 /// `RefCell`, `Cell`, `Mutex` and `RwLock` are on the wire-transparent list — the schema surfaces
 /// describe a field under one as the field it wraps — but none of the four is `Deref`, so a length
 /// or range constraint on one is refused by name instead of the validator silently going unwritten.
-/// An unconstrained field under the same wrapper is untouched, exactly like a positional slot.
 #[cfg(feature = "serde")]
 #[test]
 fn a_constraint_under_an_interior_mutability_wrapper_names_the_wrapper() {
@@ -8076,8 +8005,7 @@ fn a_tuple_struct_describes_as_its_arity_in_json_schema() {
 
 /// The bare value is the *declared* arity's, not the described list's. Captured from serde: a
 /// struct declaring two slots with the first one taken off the wire writes `["x"]` — a one-element
-/// array, not the bare `"x"` a struct declaring one slot writes — so a described list that has
-/// shrunk to one still describes as an array.
+/// array, not the bare `"x"` a struct declaring one slot writes.
 #[cfg(feature = "typescript")]
 #[test]
 fn a_slot_dropped_off_the_wire_leaves_the_tuple_an_array() {
@@ -8133,8 +8061,7 @@ fn slot_refusal(spelling: &str, declared_slots: usize) -> Option<String> {
 
 /// Captured from serde on `struct S(#[serde(...)] Option<String>, String)`: `skip_serializing`
 /// alone writes `["x"]` and reads only `["s","x"]`, `skip_deserializing` alone writes `["s","x"]`
-/// and reads only `["x"]`. The array serde writes is not an array serde reads, and a slot has no
-/// optional spelling to describe both, so the declaration is refused.
+/// and reads only `["x"]` — an array serde writes is not one serde reads, so the slot is refused.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
 fn a_slot_dropped_from_one_direction_only_is_refused() {
@@ -8188,8 +8115,7 @@ fn variant_slot_refusals(declaration: &str) -> Vec<String> {
 
 /// Captured from serde on `enum E { One(#[serde(...)] String, u32) }`: `skip_serializing` alone
 /// writes `{"One":[7]}` and reads only `{"One":["s",7]}`, `skip_deserializing` alone writes
-/// `{"One":["s",7]}` and reads only `{"One":[7]}`. What serde writes is not what serde reads, and
-/// a slot has no optional spelling to describe both, so the declaration is refused.
+/// `{"One":["s",7]}` and reads only `{"One":[7]}` — what serde writes is not what it reads.
 #[test]
 fn a_variant_slot_dropped_from_one_direction_only_is_refused() {
     for (spelling, refused) in SLOT_OMISSION_SPELLINGS {
@@ -8223,8 +8149,7 @@ fn a_named_variant_member_is_refused_for_no_spelling() {
 
 /// The lone slot of a variant is asked the same question, which is where this seam parts from the
 /// tuple-struct one. Captured: `One(#[serde(skip_serializing)] String)` writes the bare name
-/// `"One"` and reads only `{"One":"s"}`, so the halves split a variant at every declared arity
-/// where a newtype struct ignored them outright.
+/// `"One"` and reads only `{"One":"s"}` — a split the tuple-struct newtype ignores outright.
 #[test]
 fn a_lone_variant_slot_is_refused_for_the_same_spellings() {
     for (spelling, refused) in SLOT_OMISSION_SPELLINGS {
@@ -8292,9 +8217,8 @@ fn adjacent_refusals(declaration: &str) -> Vec<String> {
 }
 
 /// Captured from serde under `#[serde(tag = "type", content = "value")]`: the variant whose lone
-/// slot is off the wire writes `{"type":"One"}` and serde then refuses to read that back (missing
-/// field `value`), while only `{"type":"One","value":null}` reads. The write set and the read set
-/// have no common member, so the declaration is refused rather than described.
+/// slot is off the wire writes `{"type":"One"}` but serde only reads `{"type":"One","value":null}`
+/// back — the write set and the read set share no member, so the declaration is refused.
 #[cfg(feature = "serde")]
 #[test]
 fn an_adjacent_variant_whose_lone_slot_is_dropped_is_refused() {
@@ -8373,8 +8297,7 @@ fn untagged_refusal(declaration: &str, members: &[super::FieldDef]) -> String {
 
 /// Captured from serde: an untagged variant whose lone slot is off the wire writes and reads `null`
 /// — the payload a declared unit variant writes there — so it takes the refusal a unit variant
-/// takes rather than describing the value nothing carries. The words are the collapse's own: a
-/// declaration holding one inner type must not be told that inner types are what the union supports.
+/// takes, worded so a declaration holding one inner type is not told inner types are unsupported.
 #[cfg(feature = "serde")]
 #[test]
 fn an_untagged_variant_whose_lone_slot_is_dropped_is_refused_for_the_collapse() {
@@ -8511,9 +8434,7 @@ fn a_wrapped_path_field_deserializes_its_declared_type() {
 
 /// A `pattern` a regex engine is avoidable work for is emitted as the `str` call
 /// `clippy::trivial_regex` names for it, with a one-character needle as a `char` so the emitted
-/// call also answers `clippy::single_char_pattern`. Both lints are denied by the crates this code
-/// is written into, and neither has an edit available at the `#[model_schema]` attribute the
-/// diagnostic lands on.
+/// call also answers `clippy::single_char_pattern`, both lints denied downstream.
 #[cfg(feature = "serde")]
 #[test]
 fn a_trivial_pattern_is_emitted_as_the_call_it_says_the_same_thing_as() {
@@ -8548,8 +8469,7 @@ fn a_pattern_of_any_real_shape_keeps_its_regex() {
 
 /// The recording a merge reads the union's members off says which of them serde writes as something
 /// other than an object, that being the one thing the spelling does not carry and the one thing a
-/// merge has to know: an intersection built on such a member is an object joined to a scalar, which
-/// no payload satisfies.
+/// merge has to know — an intersection built on a scalar member is a shape no payload satisfies.
 #[cfg(all(feature = "serde", feature = "zod"))]
 #[test]
 fn a_scalar_union_member_is_recorded_as_the_type_serde_writes_it_as() {
@@ -8819,10 +8739,8 @@ fn an_optional_scalar_union_member_is_refused_below_the_option_it_was_written_un
 
 /// A member that names another item is asked of the registry rather than left unanswered: the named
 /// item recorded the JSON type keyword its own published document carries, which is the word the
-/// other surface writes for the same member.
-///
-/// An object, a union and a name the registry cannot rule out are the three that stay unanswered,
-/// and each keeps the emission it has always had.
+/// other surface writes for the same member. An object, a union, and a name the registry cannot
+/// rule out are the three that stay unanswered, each keeping the emission it has always had.
 #[cfg(all(feature = "serde", feature = "zod"))]
 #[test]
 fn a_union_member_naming_a_registered_non_object_wire_is_recorded_as_that_wire() {
@@ -8858,8 +8776,7 @@ fn a_union_member_naming_a_registered_non_object_wire_is_recorded_as_that_wire()
 
 /// So flattening a union whose member names a brand over a string is refused in the branch-naming
 /// words, where before it emitted the object intersected with that brand — a branch no payload
-/// satisfies, and one serde refuses to write for the same reason it refuses a directly flattened
-/// brand.
+/// satisfies, for the same reason serde refuses a directly flattened brand.
 #[cfg(all(feature = "serde", feature = "zod"))]
 #[test]
 fn flattening_a_union_with_a_named_string_wire_member_is_refused_naming_the_branch() {
@@ -8951,11 +8868,10 @@ fn direct_flatten_error(field: &syn::Field) -> Option<String> {
     flatten_edge_guard_error(field, "Host").map(|error| error.to_string())
 }
 
-/// The same refusal one position further out. A `#[serde(flatten)]` field naming an item whose own
-/// published wire is no object is the shape the member-position refusal was landed to stop, with the
-/// intersection written directly rather than through a union: serde refuses the value at runtime and
-/// the JSON-schema merge refuses the declaration, so the guard names it in the words that merge uses
-/// for a source at no position of its own.
+/// The same refusal one position further out: a `#[serde(flatten)]` field naming an item whose own
+/// published wire is no object, the intersection written directly rather than through a union.
+/// serde refuses the value at runtime and the JSON-schema merge refuses the declaration, so the
+/// guard names it in the words that merge uses for a source at no position of its own.
 #[cfg(all(feature = "serde", feature = "zod"))]
 #[test]
 fn flattening_a_registered_scalar_wire_is_refused_where_the_field_was_written() {
@@ -8998,8 +8914,7 @@ fn flattening_a_registered_string_boolean_or_array_wire_is_refused_by_its_own_ke
 }
 
 /// The three the direct position leaves exactly as they stand: an item the registry says publishes
-/// an object, a name it has never seen — the declaration-order fallback, which answers for a source
-/// written below the object no differently than for a foreign type — and an array of a proved
+/// an object, a name it has never seen (the declaration-order fallback), and an array of a proved
 /// scalar, where the array is what the field wrote rather than anything the name proves.
 #[cfg(all(feature = "serde", feature = "zod"))]
 #[test]
@@ -9021,9 +8936,8 @@ fn a_direct_flatten_of_an_object_an_unregistered_name_or_an_array_stays_admitted
 }
 
 /// A plain enum proves the same `string` and keeps the refusal written for it: those words name the
-/// variant key serde writes into the object, which is what the author of that declaration acts on.
-/// Two guards firing on one field would put two diagnostics on one line, each answering for the same
-/// thing in different words.
+/// variant key serde writes into the object, which is what the author of that declaration acts on —
+/// two guards firing on one field would put two diagnostics on one line, saying the same thing twice.
 #[cfg(all(feature = "serde", feature = "zod"))]
 #[test]
 fn a_direct_flatten_of_a_plain_enum_is_left_to_the_guard_written_for_it() {
@@ -9090,9 +9004,7 @@ fn a_nullable_registration_is_refused_by_the_keyword_its_value_side_proves() {
 
 /// And a registration whose value side is an object keeps the absence multiplication it was landed
 /// with: nothing beside the `null` is proved to be no object, so both branches are ones serde writes
-/// and reads back. A name publishing a `null` at no top level of its own is not this shape at all —
-/// there the `null` sits under a choice serde matched a member on, which the member position already
-/// answers for.
+/// and reads back. A name publishing a `null` at no top level of its own is not this shape at all.
 #[cfg(all(feature = "serde", feature = "zod"))]
 #[test]
 fn a_direct_flatten_of_a_nullable_object_registration_stays_admitted() {
@@ -9134,8 +9046,7 @@ fn seed_brand_registration(item: &syn::ItemStruct) {
 
 /// One `u32` is one wire, and every spelling of it publishes the one JSON type keyword that wire
 /// describes as. A field, the slot of a one-slot tuple struct and a brand all reach the same value,
-/// so a keyword read off one of them and not the others is the same wire named twice — and the
-/// merge that repeats the keyword cannot pick between two producers that disagree.
+/// so a merge repeating that keyword cannot pick between two producers that disagree.
 #[cfg(feature = "jsonschema")]
 #[test]
 fn every_spelling_of_one_value_publishes_one_json_type_keyword() {
@@ -9163,9 +9074,8 @@ fn every_spelling_of_one_value_publishes_one_json_type_keyword() {
 }
 
 /// A member naming a brand over an integer is recorded as the `integer` that brand publishes, and
-/// one naming a brand over a float as the `number` its own publishes. The two are one word to the
-/// shape vocabulary and two documents on the wire, which is the disagreement that left both
-/// unanswered.
+/// one naming a brand over a float as the `number` its own publishes — one word to the shape
+/// vocabulary but two documents on the wire, the disagreement that left both unanswered.
 #[cfg(all(feature = "serde", feature = "zod"))]
 #[test]
 fn a_union_member_naming_a_numeric_registration_is_recorded_by_its_own_keyword() {
@@ -9356,10 +9266,9 @@ fn flattening_a_union_with_a_named_nullable_member_is_refused_naming_the_trail()
 }
 
 /// A member naming an externally tagged enum carries one leaf per variant, at the positions the
-/// JSON-schema merge names the same variants by. serde writes a data-carrying variant as the
-/// single-key object its name tags and writes a unit variant as that name alone — a bare string —
-/// so the choice behind the member holds a leaf no object can be merged with, one level in from
-/// where the member stands.
+/// JSON-schema merge names the same variants by: serde writes a data-carrying variant as the
+/// single-key object its name tags and a unit variant as that name alone — a bare string, one
+/// level in from where the member stands.
 #[cfg(all(feature = "serde", feature = "zod"))]
 #[test]
 fn a_union_member_naming_a_tagged_enum_carries_one_leaf_per_variant() {
@@ -9385,9 +9294,8 @@ fn a_union_member_naming_a_tagged_enum_carries_one_leaf_per_variant() {
 }
 
 /// And a tagged enum whose every variant carries data keeps the one unmarked leaf it always had.
-/// Every branch of that choice is an object the merge joins, and the operand it would join is the
-/// name whichever branch matched — so writing one member per branch would put three where one stood
-/// and say nothing the single leaf did not.
+/// Every branch of that choice is an object the merge joins under the name whichever branch
+/// matched — writing one member per branch would say nothing the single leaf did not.
 #[cfg(all(feature = "serde", feature = "zod"))]
 #[test]
 fn a_union_member_naming_an_all_object_tagged_enum_keeps_its_one_leaf() {
@@ -9505,8 +9413,7 @@ fn a_word_boundary_pattern_keeps_its_regex() {
 
 /// A flattened source that is one of the item's own parameters contributes the document its
 /// filling describes as, read through the one binding every other position holding that parameter
-/// reads it through — not the placeholder that stands for a value the expansion cannot name, which
-/// carries no member and multiplies nothing into the object being written.
+/// reads it through — not the placeholder standing for a value the expansion cannot name.
 #[cfg(feature = "jsonschema")]
 #[test]
 fn a_flattened_type_parameter_is_merged_at_the_document_its_filling_binds() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -101,11 +101,9 @@ pub enum AliasKind {
 }
 
 /// The `str` method call a `pattern` says the same thing as, for the patterns a regex engine is
-/// avoidable work for.
-///
-/// Each variant carries the needle in the spelling the check takes it, which is the literal the
-/// pattern's own escapes already resolved to and not the pattern text: `^foo\.bar` starts with
-/// `foo.bar`, five bytes shorter than what was written.
+/// avoidable work for. Each variant carries the needle in the spelling the check takes it — the
+/// literal the pattern's own escapes already resolved to, not the pattern text: `^foo\.bar` starts
+/// with `foo.bar`, five bytes shorter than what was written.
 #[cfg(feature = "serde")]
 #[derive(Debug, PartialEq, Eq)]
 pub enum TrivialPattern {
@@ -174,11 +172,9 @@ impl WireLeaf {
 }
 
 /// What an object flattening an externally tagged enum joins for one of that enum's variants, on
-/// each surface that writes a merge of its own.
-///
-/// The two spellings are recorded together, from one reading of the rendered variant, because they
-/// answer one question — what serde writes for this variant into the object being merged — and a
-/// surface that answered it on its own would be free to drift from the other.
+/// each surface that writes a merge of its own. The two spellings are recorded together, from one
+/// reading of the rendered variant, since they answer one question — what serde writes for this
+/// variant into the object being merged — and answering it twice would let the two drift apart.
 #[cfg(all(feature = "serde", any(feature = "typescript", feature = "zod")))]
 #[derive(Clone)]
 pub struct FlattenVariant {
@@ -590,20 +586,17 @@ thread_local! {
 }
 
 /// Keeps a constrained brand's unanswered consult for whichever expansion registers the name it
-/// asked about.
-///
-/// Recorded once the brand has passed its own guards, so a brand that publishes nothing leaves no
-/// question behind for a later item to refuse it over.
+/// asked about. Recorded once the brand has passed its own guards, so a brand that publishes
+/// nothing leaves no question behind for a later item to refuse it over.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 pub fn record_shape_question(question: ShapeQuestion) {
     SHAPE_QUESTIONS.with(|questions| questions.borrow_mut().push(question));
 }
 
-/// Every question asked about a name, in the order the brands asking them expanded.
-///
-/// The questions are left in place rather than taken: a name is registered by one expansion, and
-/// leaving them makes reading them an observation rather than a move — nothing downstream has to
-/// know whether something else read first.
+/// Every question asked about a name, in the order the brands asking them expanded. The questions
+/// are left in place rather than taken: a name is registered by one expansion, and leaving them
+/// makes reading them an observation rather than a move — nothing downstream has to know whether
+/// something else read first.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 pub fn shape_questions_for(rust_ident: &str) -> Vec<ShapeQuestion> {
     SHAPE_QUESTIONS.with(|questions| {
@@ -789,11 +782,9 @@ pub fn ident_schema_module_name(rust_ident: &str) -> String {
 }
 
 /// The export name is what `register_alias_info` stores and what the alias's TypeScript, zod, and
-/// JSON-schema surfaces are written under, so every feature that references an alias needs it —
-/// not just `typescript`.
-///
-/// An override is taken verbatim: the parser has already refused a value no surface can carry, so
-/// what arrives here is the name the author wrote.
+/// JSON-schema surfaces are written under, so every feature that references an alias needs it, not
+/// just `typescript`. An override is taken verbatim: the parser has already refused a value no
+/// surface can carry.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 pub fn compute_alias_export_name(rust_ident: &str, override_name: Option<&str>) -> String {
     override_name.map_or_else(
@@ -856,12 +847,10 @@ pub fn ident_reexport_zod(rust_ident: &str, export_name: &str, binding_suffix: &
     })
 }
 
-/// The identifier a factory binds one type parameter's schema argument to — `idType` for `IdType`.
-///
-/// A Zod schema is a value and a `const` cannot be parameterised, so a generic type publishes a
-/// function of one argument per parameter rather than a schema, and a field written with a
-/// parameter composes that argument. Lower-camel of the declared name, so the argument reads as
-/// the parameter it fills while staying a name of its own beside it.
+/// The identifier a factory binds one type parameter's schema argument to — `idType` for `IdType`,
+/// lower-camel of the declared name. A Zod schema is a value and a `const` cannot be
+/// parameterised, so a generic type publishes a function of one argument per parameter instead,
+/// and a field written with a parameter composes that argument.
 #[cfg(feature = "zod")]
 pub fn zod_factory_argument(parameter: &str) -> String {
     let mut characters = parameter.chars();
@@ -1092,12 +1081,10 @@ fn raw_statement_groups(lines: &[DocLine]) -> Vec<(String, proc_macro2::Span)> {
     groups
 }
 
-/// The example's tokens, each respanned onto the `///` line — or, for a value split across
-/// lines, the first line of the run — it was written on.
-///
-/// `transform_example_code`'s `println!`/`let _` unwrapping only ever matches a whole example's
-/// trailing statement (its regexes anchor on the end of the input), so it is applied to the last
-/// group alone; every earlier group keeps its own raw tokens, respanned but otherwise untouched.
+/// The example's tokens, each respanned onto the `///` line it was written on — or, for a value
+/// split across lines, the first line of the run. `transform_example_code`'s `println!`/`let _`
+/// unwrapping only matches a whole example's trailing statement, so it is applied to the last group
+/// alone; every earlier group keeps its own raw tokens, respanned but otherwise untouched.
 #[cfg(feature = "zod")]
 fn respan_example_tokens(lines: &[DocLine]) -> proc_macro2::TokenStream {
     let content: Vec<DocLine> = lines
@@ -1126,13 +1113,9 @@ fn respan_example_tokens(lines: &[DocLine]) -> proc_macro2::TokenStream {
 }
 
 /// The example's tokens, respanned line-by-line onto the `///` lines that wrote them, or `None`
-/// where there is no ` ```rust example ` fence.
-///
-/// `str::parse::<TokenStream>()` alone stamps every token with `Span::call_site()` — for an
-/// attribute macro, the whole `#[model_schema(...)]` invocation — so a typo or a type mismatch
-/// inside the example used to be reported there instead of on the line the author wrote. Each
-/// `///` line lowers to its own `#[doc = "..."]` attribute with a real span, which is enough to
-/// point the diagnostic at that line (or, where a value spans several lines, the first of them).
+/// where there is no ` ```rust example ` fence. `str::parse::<TokenStream>()` alone stamps every
+/// token with `Span::call_site()` — the whole `#[model_schema(...)]` invocation — so a typo or type
+/// mismatch inside the example used to be reported there instead of on the line the author wrote.
 #[cfg(feature = "zod")]
 pub fn extract_example_tokens(attrs: &[Attribute]) -> Option<proc_macro2::TokenStream> {
     let lines = doc_lines_with_spans(attrs);
@@ -1171,11 +1154,9 @@ fn transform_example_code(code: &str) -> String {
     result.trim().to_owned()
 }
 
-/// Strips example code blocks from documentation lines.
-///
 /// Every doc body the crate writes — an item's, an alias's, a field's, an enum variant's, and the
-/// descriptions spelled from the same lines — passes through here, so the block is dropped once
-/// rather than at each surface.
+/// descriptions spelled from the same lines — passes through here, so example blocks are dropped
+/// once rather than at each surface.
 pub fn strip_examples_from_docs(docs: &[String]) -> Vec<String> {
     let mut result = Vec::new();
     let mut in_example_block = false;
@@ -1326,12 +1307,11 @@ fn matches_every_haystack(hir: &hir::Hir) -> bool {
     }
 }
 
-/// Whether a concatenation matches at a position every haystack has.
-///
-/// Every part that asks the haystack for nothing can be tried anywhere, so a run of them matches
-/// anywhere; one whole-text anchor among them fixes that anywhere to a position every haystack
-/// still has. A second anchor is what breaks it -- `^$` requires the start and the end to be the
-/// same position -- and so is any part that consumes a character.
+/// Whether a concatenation matches at a position every haystack has. Every part that asks the
+/// haystack for nothing can be tried anywhere, so a run of them matches anywhere; one whole-text
+/// anchor among them fixes that anywhere to a position every haystack still has — a second anchor
+/// breaks it (`^$` requires the start and end to be the same position), and so does any part that
+/// consumes a character.
 fn concat_matches_every_haystack(parts: &[hir::Hir]) -> bool {
     parts.iter().filter(|part| is_text_anchor(part)).count() <= 1
         && parts
@@ -1387,12 +1367,10 @@ pub fn trivial_pattern(pattern: &str) -> Option<TrivialPattern> {
     }
 }
 
-/// A concatenation's equivalent check, decided by what sits at its two ends.
-///
-/// The arms are in the lint's order, and the fall-through it relies on is not reachable from any
-/// of them: a concatenation that starts or ends with an anchor holds something that is not a
-/// literal, so the all-literals reading is already ruled out by the time an anchored arm's needle
-/// comes back missing.
+/// A concatenation's equivalent check, decided by what sits at its two ends. The arms are in the
+/// lint's order; the fall-through they rely on is unreachable from any of them, since a
+/// concatenation that starts or ends with an anchor is not a literal, ruling out the all-literals
+/// reading before an anchored arm's needle can come back missing.
 #[cfg(feature = "serde")]
 fn trivial_concat(parts: &[hir::Hir]) -> Option<TrivialPattern> {
     let opens_at_text_start = is_anchor(parts.first()?, hir::Look::Start);
@@ -1420,11 +1398,10 @@ fn is_anchor(part: &hir::Hir, anchor: hir::Look) -> bool {
     matches!(*part.kind(), hir::HirKind::Look(look) if look == anchor)
 }
 
-/// The non-empty `str` a run of parts spells, or `None` where any of them is not a literal.
-///
-/// An empty needle would name a check that always passes, which is a different statement than any
-/// of these variants makes; bytes that are not UTF-8 name no `str` at all. Neither is reachable
-/// through a `pattern` parsed in UTF-8 mode, and both keep the regex rather than guess.
+/// The non-empty `str` a run of parts spells, or `None` where any of them is not a literal. An
+/// empty needle would name a check that always passes — a different statement than any of these
+/// variants makes — and bytes that are not UTF-8 name no `str` at all; neither is reachable through
+/// a `pattern` parsed in UTF-8 mode, so both keep the regex rather than guess.
 #[cfg(feature = "serde")]
 fn literal_needle(parts: &[hir::Hir]) -> Option<String> {
     let mut bytes: Vec<u8> = Vec::new();

--- a/src/utils/tests.rs
+++ b/src/utils/tests.rs
@@ -19,11 +19,10 @@ const PORTABLE_PATTERNS: [&str; 9] = [
     r"[a\]b]",
 ];
 
-/// Every construct the guard refuses, beside the words the refusal has to name it by.
-///
-/// The list is the inventory of what `regex::Regex::new` accepts and a JavaScript regex literal
-/// either fails to parse or reads as something else, so it doubles as the record of what was
-/// checked against both grammars.
+/// Every construct the guard refuses, beside the words the refusal has to name it by — the
+/// inventory of what `regex::Regex::new` accepts and a JavaScript regex literal either fails to
+/// parse or reads as something else, so it doubles as the record of what was checked against both
+/// grammars.
 const UNPORTABLE_PATTERNS: [(&str, &str); 34] = [
     ("(?i)abc", "inline flag directive"),
     ("abc(?i)def", "inline flag directive"),
@@ -340,11 +339,9 @@ const NEGATED_CLASS_PATTERNS: [&str; 6] = [
 ];
 
 /// Every regex this crate writes into a generated schema itself, rather than carrying over from an
-/// author's `pattern`.
-///
-/// An author's pattern reaches the three surfaces through the guard, which equalises what it can
-/// and refuses the rest. One the crate writes reaches them directly, so without this list there
-/// are two contracts and only one of them is enforced.
+/// author's `pattern`. An author's pattern reaches the three surfaces through the guard, which
+/// equalises what it can and refuses the rest; one the crate writes reaches them directly, so
+/// without this list there are two contracts and only one of them is enforced.
 #[cfg(feature = "object_id")]
 const CRATE_EMITTED_PATTERNS: [&str; 1] = [OBJECT_ID_HEX_PATTERN];
 
@@ -725,9 +722,8 @@ fn test_escape_js_regex_literal_rewrites_an_identity_escaped_line_terminator() {
 }
 
 /// The module name a reference assumes for a name it has not seen and the one an alias goes on to
-/// publish are the same call, so nothing the alias is written with can pull them apart: the `Type`
-/// suffix an alias exports under and a `name = "…"` override both land on the export name only.
-/// The `Json` suffix is still read through, that being what every reference already spells.
+/// publish are the same call: the `Type` suffix an alias exports under and a `name = "…"` override
+/// both land on the export name only, and the `Json` suffix is still read through either way.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
 fn ident_schema_module_name_is_derived_from_the_ident_alone() {
@@ -772,9 +768,8 @@ fn an_unrenamed_item_publishes_the_same_module_under_either_derivation() {
 }
 
 /// The ident re-export answers at the same spelling the module seam answers at: whatever a
-/// reference falls back to when the registry cannot help it, which is the ident with the `Json`
-/// suffix read through. An item exported under that spelling already answers there and publishes
-/// nothing.
+/// reference falls back to when the registry cannot help it, the ident with the `Json` suffix read
+/// through. An item already exported under that spelling publishes nothing.
 #[cfg(feature = "typescript")]
 #[test]
 fn a_ts_reexport_is_written_only_where_the_export_moved_off_the_ident() {
@@ -896,10 +891,9 @@ fn test_portable_pattern_admits_the_boundary_both_grammars_agree_on() {
 }
 
 /// `\d`, `\w` and `\s` are in both grammars under one spelling and cover different characters by
-/// it: the `regex` crate reads them as Unicode classes, and a flagless JavaScript literal reads
-/// the narrower ASCII ones. Neither engine can be told to mean the other, so the guard writes the
-/// set out in the members both engines do agree on and hands that one string to all three
-/// surfaces.
+/// it — Unicode classes in the `regex` crate, narrower ASCII ones in a flagless JavaScript literal
+/// — so the guard writes the set out in the members both engines agree on and hands that one
+/// string to all three surfaces.
 #[test]
 fn test_portable_pattern_equalises_the_classes_the_engines_cover_differently() {
     for (written, equalised) in EQUALISED_PATTERNS {
@@ -908,9 +902,8 @@ fn test_portable_pattern_equalises_the_classes_the_engines_cover_differently() {
 }
 
 /// The whole point, asserted end to end: the string the guard emits picks out the same haystacks
-/// in the `regex` crate — which is what the generated Rust validator runs it through — as in a
-/// flagless JavaScript regex literal, which is what the Zod schema and the JSON Schema `pattern`
-/// keyword are. Run over the constructs that used to diverge and over the ones that never did.
+/// in the `regex` crate — what the generated Rust validator runs it through — as in a flagless
+/// JavaScript regex literal — what the Zod schema and JSON Schema `pattern` keyword are.
 #[test]
 fn test_the_emitted_pattern_picks_out_the_same_haystacks_in_both_engines() {
     for (written, _) in EQUALISED_PATTERNS
@@ -951,11 +944,10 @@ fn test_every_pattern_the_crate_emits_is_a_fixed_point_of_the_guard() {
     }
 }
 
-/// The `$oid` hex, run over the haystacks that tell the engines apart, on the same recorded-
-/// JavaScript discipline as the table above: twenty-four ARABIC-INDIC digits are what a `\d` in
-/// that class admits in the `regex` crate and a flagless literal refuses, so they are the case the
-/// spelling turns on. The real `ObjectId` and the uppercase hex are there to say the value set the
-/// constant is *for* did not move.
+/// The `$oid` hex, run over the haystacks that tell the engines apart: twenty-four ARABIC-INDIC
+/// digits are what a `\d` admits in the `regex` crate and a flagless literal refuses, the case the
+/// spelling turns on. The real `ObjectId` and the uppercase hex say the value set the constant is
+/// *for* did not move.
 #[test]
 #[cfg(feature = "object_id")]
 fn test_the_emitted_object_id_hex_agrees_with_javascript_over_every_hex_shaped_haystack() {
@@ -973,10 +965,9 @@ fn test_the_emitted_object_id_hex_agrees_with_javascript_over_every_hex_shaped_h
     }
 }
 
-/// The constructs with no equalising spelling at all, and why: a flagless JavaScript literal
-/// matches one UTF-16 code unit where the `regex` crate matches one character, so anything that
-/// can match a character outside the Basic Multilingual Plane parts ways over every one of them.
-/// `[^0-9]` is no better than `\D` here, which is why these are refused rather than rewritten.
+/// The constructs with no equalising spelling at all: a flagless JavaScript literal matches one
+/// UTF-16 code unit where the `regex` crate matches one character, so any construct that can match
+/// a character outside the Basic Multilingual Plane parts ways over every one of them.
 #[test]
 fn test_portable_pattern_refuses_what_no_spelling_equalises() {
     for pattern in ["^.$", r"^\D$", r"^\W$", r"^\S$", r"[a\D]", r"[\s\S]"] {
@@ -989,9 +980,8 @@ fn test_portable_pattern_refuses_what_no_spelling_equalises() {
 }
 
 /// A negated class is the last construct that was admitted while covering different characters in
-/// the two engines, and it is refused the same way `\D`, `\W` and `\S` already are — which are the
-/// same class negated, so admitting the bracketed spelling was refusing a construct under one name
-/// and taking it under another.
+/// the two engines; it is refused the same way `\D`, `\W` and `\S` already are, since those are the
+/// same class negated under another spelling.
 #[test]
 fn test_portable_pattern_refuses_a_negated_class_whatever_its_members() {
     for pattern in NEGATED_CLASS_PATTERNS {

--- a/tests/alias_reference_tests/tests.rs
+++ b/tests/alias_reference_tests/tests.rs
@@ -57,10 +57,10 @@ pub type DocumentIdsByName = HashMap<String, ReferencedDocumentId>;
 #[model_schema()]
 pub type DocumentIdsBySlot = HashMap<DocumentSlot, ReferencedDocumentId>;
 
-/// Declaration order, taken both ways round. This struct names aliases that have not expanded yet,
-/// so the module each reference resolves to is derived from the alias's Rust ident and nothing
-/// else; [`NamesAliasesDeclaredEarlier`] names the same two once they are registered. Both have to
-/// reach the same modules, or one of the two orders names a module that was never emitted.
+/// Declaration order, taken both ways round: this struct names aliases that have not expanded
+/// yet, so the module each reference resolves to is derived from the alias's Rust ident alone;
+/// [`NamesAliasesDeclaredEarlier`] names the same two once registered. Both have to reach the
+/// same modules.
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct NamesAliasesDeclaredLater {
@@ -332,8 +332,7 @@ fn aliases_declared_under_their_reference_expand_in_this_feature_combination() {
 
 /// A struct naming an alias declared under it used to refuse the whole crate: the reference
 /// assumed `later_declared_id_schema` while the alias published `later_declared_id_type_schema`,
-/// and rustc reported an `E0433` for a module the author never wrote. One spelling now answers on
-/// both sides, so which side of the alias the reference is written on changes nothing.
+/// an `E0433` for a module never written. One spelling now answers on both sides.
 #[cfg(feature = "jsonschema")]
 #[test]
 fn an_alias_reference_describes_the_same_on_either_side_of_the_alias() {
@@ -375,10 +374,9 @@ fn a_renamed_alias_exports_under_the_override_from_the_module_named_for_its_iden
     assert!(ts.contains("RenamedLaterDeclaredCount"), "got: {ts}");
 }
 
-/// An alias is never exported under its Rust ident — it is given the `Type` suffix, or whatever an
-/// override moves it to — so a forward reference to one always writes a name the alias's own
-/// `export type` line does not. The alias answers at that name too, and every name a reference
-/// writes is defined by the emission the author collects.
+/// An alias is never exported under its Rust ident — it's given the `Type` suffix, or whatever an
+/// override moves it to — so a forward reference always writes a name the alias's own
+/// `export type` line does not. The alias answers at that name too.
 #[cfg(feature = "typescript")]
 #[test]
 fn every_name_a_forward_alias_reference_writes_is_defined_by_the_emission() {

--- a/tests/branded_newtype_tests/tests.rs
+++ b/tests/branded_newtype_tests/tests.rs
@@ -45,10 +45,9 @@ mod zod_ts_tests {
         );
     }
 
-    /// The brand lands on the schema the caller supplied rather than on a value that admits
-    /// anything whatever it was filled with. Only `$SchemaDefault`, called at the declared
-    /// default, has a concrete filling to annotate with `$ZodBranded`; the builder's own bound
-    /// stays the plain `IdType extends ZodType`.
+    /// The brand lands on the caller's supplied schema, not a value that admits anything. Only
+    /// `$SchemaDefault` has a concrete filling to annotate with `$ZodBranded`; the builder's own
+    /// bound stays `IdType extends ZodType`.
     #[test]
     fn test_branded_newtype_zod_schema() {
         let zod = RoleId::<String>::zod_schema();
@@ -63,10 +62,9 @@ mod zod_ts_tests {
         assert!(!zod[..builder_end].contains("$ZodBranded"), "Got: {zod}");
     }
 
-    /// An *unconstrained* generic brand — no `minLength`/`maxLength`/`pattern` at all — still has
-    /// its `$SchemaDefault` annotated `$ZodBranded<ZodString, "RoleId">` rather than
-    /// `ZodType<RoleId<string>>`: the factory's chain ends in `.brand()` whether or not there is a
-    /// check to route.
+    /// An unconstrained generic brand still has its `$SchemaDefault` annotated
+    /// `$ZodBranded<ZodString, "RoleId">` rather than `ZodType<RoleId<string>>` — the factory's
+    /// chain ends in `.brand()` regardless.
     #[test]
     fn an_unconstrained_generic_brands_default_is_still_branded() {
         let zod = RoleId::<String>::zod_schema();
@@ -206,9 +204,8 @@ mod constrained_branded_tests {
     #[serde(transparent)]
     pub struct SlugId(pub String);
 
-    /// A pattern simple enough that a regex engine is avoidable work — the brand-side spelling of
-    /// what a consumer denying `clippy::nursery` cannot compile if the validator builds a regex
-    /// for it anyway.
+    /// A pattern simple enough that building a regex for it would fail a consumer denying
+    /// `clippy::nursery`.
     #[model_schema(pattern = "^/")]
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     #[serde(transparent)]
@@ -402,10 +399,10 @@ mod objectid_branded_surface_tests {
     pub struct HexObjectId(pub ObjectId);
 
     /// A brand whose pattern is wider than the hex the type holds — the shape that tells layering
-    /// from replacement, since a surface holding only the brand's admits strings no `ObjectId` can
-    /// ever be. Spelled as a class rather than with `.`, which the pattern guard refuses for its
-    /// cross-engine divergence; `[a-z0-9]` still admits every lowercase letter, so the `zzz…` probe
-    /// passes the brand's pattern and only the hex turns it away.
+    /// from replacement, since a surface holding only the brand's would admit strings no
+    /// `ObjectId` can be. `[a-z0-9]` (a class, since `.` is refused for cross-engine divergence)
+    /// admits every lowercase letter, so the `zzz…` probe passes the brand's pattern and only the
+    /// hex turns it away.
     #[model_schema(pattern = "^[a-z0-9]{24}$")]
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     #[serde(transparent)]
@@ -450,11 +447,9 @@ mod objectid_branded_surface_tests {
         );
     }
 
-    /// A brand's string constraints measure the inner's `Display` — the bare hex — which on the
-    /// wire is the `$oid` member, so both schema surfaces carry them there. The brand's own
-    /// `pattern` is layered rather than written over the hex the type always holds: one JSON
-    /// Schema string carries one `pattern`, and writing the brand's into that slot dropped the
-    /// type's.
+    /// A brand's string constraints measure the inner's `Display` — the bare hex, which on the
+    /// wire is the `$oid` member. The brand's own `pattern` is layered rather than written over
+    /// the hex's, since one JSON Schema string carries only one `pattern`.
     #[test]
     fn a_constrained_objectid_brand_carries_its_constraints_on_the_oid_member() {
         let zod = HexObjectId::zod_schema();
@@ -516,9 +511,8 @@ mod objectid_branded_surface_tests {
             .all(|pattern| regex::Regex::new(pattern).unwrap().is_match(hex))
     }
 
-    /// The two surfaces read the same probe payloads the same way. A brand pattern wider than the
-    /// hex is where they came apart: Zod ran the type's own regex before the brand's check, while
-    /// the JSON schema had only the brand's left and admitted a `$oid` of 24 arbitrary characters.
+    /// A brand pattern wider than the hex is where the two surfaces come apart: Zod runs the
+    /// type's own regex before the brand's check, while the JSON schema has only the brand's left.
     #[test]
     fn a_brand_pattern_wider_than_the_hex_still_narrows_to_the_hex_on_both_surfaces() {
         let zod = WideObjectId::zod_schema();
@@ -818,10 +812,9 @@ mod branded_constrained_json_schema_tests {
     #[serde(transparent)]
     pub struct ShortId(pub String);
 
-    /// A generic brand's bare-parameter inner has no type of its own to describe, so its document
-    /// is the declared default's — `{"type": "string"}` for `default_types(IdType = String)` —
-    /// narrowed by the brand's own bounds through the same `allOf` a named inner is narrowed
-    /// through. Not the inert `{}` a parameter with no default at all would describe as.
+    /// A generic brand's bare-parameter inner has no type of its own, so its document is the
+    /// declared default's — narrowed by the brand's own bounds through the same `allOf` a named
+    /// inner is narrowed through, not the inert `{}` a parameter with no default would describe as.
     #[model_schema(
         minLength = 24,
         maxLength = 24,
@@ -876,9 +869,8 @@ mod branded_constrained_json_schema_tests {
 }
 
 /// A generic branded newtype whose inner is a bare type parameter, carrying string constraints.
-/// The constraints have nowhere to land on the parameter itself, so they land on the parameter's
-/// *declared default* instead: `StrictDocumentId$SchemaDefault` enforces the 24-hex bounds,
-/// `StrictDocumentId$SchemaFactory` stays unconstrained for every other filling.
+/// The constraints land on the parameter's declared default: `$SchemaDefault` enforces the
+/// 24-hex bounds, `$SchemaFactory` stays unconstrained for every other filling.
 #[cfg(all(feature = "zod", feature = "typescript", feature = "serde"))]
 mod constrained_generic_branded_tests {
     use super::*;
@@ -893,10 +885,9 @@ mod constrained_generic_branded_tests {
     #[serde(transparent)]
     pub struct StrictDocumentId<IdType>(pub IdType);
 
-    /// The generated `validate()` sits on `impl StrictDocumentId<String>` — the declared default —
-    /// not on a blanket `impl<IdType> StrictDocumentId<IdType>`, so a second inherent impl at a
-    /// different instantiation is not a duplicate-definition error. `u32` satisfies the `Display`
-    /// bound the generic brand's declaration carries.
+    /// The generated `validate()` sits on `impl StrictDocumentId<String>` — the declared default,
+    /// not a blanket `impl<IdType>` — so a second inherent impl at a different instantiation is
+    /// not a duplicate-definition error.
     impl StrictDocumentId<u32> {
         pub fn validate(&self) -> Result<(), Vec<String>> {
             if self.0 == 0 {
@@ -915,9 +906,9 @@ mod constrained_generic_branded_tests {
     }
 
     /// A second constrained generic brand whose declared default names `StrictDocumentId` at
-    /// exactly its own declared default, so the fold defers to
-    /// `z.lazy(() => StrictDocumentId$SchemaDefault)` and `OuterId`'s own checks have to compose
-    /// *inside* that thunk rather than after it.
+    /// exactly its own default, so the fold defers to
+    /// `z.lazy(() => StrictDocumentId$SchemaDefault)` — `OuterId`'s own checks compose inside that
+    /// thunk.
     #[model_schema(minLength = 10, default_types(WrapType = StrictDocumentId<String>))]
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     #[serde(transparent)]
@@ -982,11 +973,10 @@ mod constrained_generic_branded_tests {
         );
     }
 
-    /// `OuterId`'s declared default folds onto `StrictDocumentId$SchemaDefault` — the deferred,
-    /// checks-carrying binding — and `OuterId`'s own `minLength` composes *inside* the
-    /// `z.lazy(...)` thunk, over `.check(...)`'s base spelling: the deferred target's annotation is
-    /// not guaranteed to carry `ZodString`'s chain methods, only the `.check(...)` every schema
-    /// exposes.
+    /// `OuterId`'s declared default folds onto `StrictDocumentId$SchemaDefault`, and its own
+    /// `minLength` composes inside the `z.lazy(...)` thunk over `.check(...)` — the deferred
+    /// target's annotation is not guaranteed to carry `ZodString`'s chain methods, only
+    /// `.check(...)`.
     #[test]
     fn a_constrained_brands_default_naming_another_constrained_brands_default_composes_the_checks_inside_the_thunk()
      {
@@ -1031,11 +1021,9 @@ mod constrained_generic_branded_tests {
     }
 }
 
-/// A constrained generic brand whose declared default names an ordinary (non-generic)
-/// `#[model_schema]` sibling. Held apart from
-/// `constrained_generic_branded_tests` above (whose fixtures all name a *generic* sibling) so each
-/// module pins one of the two spellings `default_zod_rendering` can defer to — a bare `$Schema`
-/// here, a folded `$SchemaDefault` there.
+/// A constrained generic brand whose declared default names an ordinary (non-generic) sibling —
+/// held apart from `constrained_generic_branded_tests` above (generic siblings) so each module
+/// pins one of the two spellings `default_zod_rendering` can defer to.
 #[cfg(all(feature = "zod", feature = "typescript", feature = "serde"))]
 mod constrained_default_names_a_sibling_tests {
     use super::*;
@@ -1048,21 +1036,18 @@ mod constrained_default_names_a_sibling_tests {
     #[serde(transparent)]
     pub struct InnerString(pub String);
 
-    /// A constrained generic brand whose declared default names `InnerString` — a non-generic
-    /// sibling, so `default_zod_rendering` defers to its bare `$Schema` binding (never a
-    /// `$SchemaDefault`, which only a generic sibling publishes) rather than reconstructing it
-    /// eagerly.
+    /// A constrained generic brand whose declared default names `InnerString` — non-generic, so
+    /// `default_zod_rendering` defers to its bare `$Schema` binding (never `$SchemaDefault`, which
+    /// only a generic sibling publishes).
     #[model_schema(minLength = 3, default_types(T = InnerString))]
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     #[serde(transparent)]
     pub struct OuterBrand<T>(pub T);
 
-    /// The check composes inside the thunk, over `InnerString$Schema`'s own base `.check(...)`
-    /// surface — `.min` after the thunk closed would land on `ZodLazy`, which does not have it.
-    ///
-    /// Annotated `$ZodBranded<ZodLazy<typeof InnerString$Schema>, "OuterBrand">` for the same
-    /// `.brand()`-vs-`ZodType` mismatch, with the deferred target's own type spelled through
-    /// `typeof`.
+    /// The check composes inside the thunk, over `InnerString$Schema`'s own base `.check(...)` —
+    /// `.min` after the thunk closed would land on `ZodLazy`, which lacks it. Annotated
+    /// `$ZodBranded<ZodLazy<typeof InnerString$Schema>, "OuterBrand">` for the same
+    /// `.brand()`-vs-`ZodType` mismatch.
     #[test]
     fn a_constrained_brands_default_naming_a_non_generic_sibling_composes_the_check_inside_the_thunk()
      {
@@ -1631,9 +1616,8 @@ mod branded_generic_inner_tests {
     }
 
     /// A parameter on its own carries no shape of its own, so each surface writes for it what it
-    /// writes for a bare generic field — which is the alias asserted beside it. On the JSON surface
-    /// that is the type the brand declared for the parameter, a document being written at one
-    /// filling and the declaration naming it.
+    /// writes for a bare generic field — the alias asserted beside it. On JSON that's the type the
+    /// brand declared for the parameter.
     #[test]
     fn a_bare_parameter_brand_matches_the_generic_field_convention() {
         assert_eq!(
@@ -1708,10 +1692,9 @@ mod branded_generic_inner_tests {
         }
     }
 
-    /// A parameter rendered as the `Name$Schema` binding every unresolved type is named after
-    /// would reference a binding no emitted module declares, and the consumer that pastes the
-    /// output gets a `ReferenceError` before any payload is read. Asserted over the brand and the
-    /// alias together, since both compose their value from the same rendering.
+    /// A parameter rendered as `Name$Schema` would reference a binding no emitted module declares
+    /// — a `ReferenceError` before any payload is read. Asserted over the brand and the alias
+    /// together.
     #[test]
     fn no_emitted_zod_value_references_a_binding_named_after_a_parameter() {
         for zod in [
@@ -1728,8 +1711,8 @@ mod branded_generic_inner_tests {
 
     /// A generic alias publishes a factory exactly as the brand beside it does, so neither has an
     /// annotation left to erase an argument out of — the `const` each used to publish claimed
-    /// `ZodType<Name<unknown>>` while the declaration beside it kept the argument, which is a type
-    /// error at any field naming either.
+    /// `ZodType<Name<unknown>>` while the declaration kept the argument, a type error at any field
+    /// naming either.
     #[test]
     fn a_generic_alias_publishes_the_factory_the_brand_beside_it_publishes() {
         for (zod, factory) in [
@@ -1793,10 +1776,8 @@ mod branded_example_arity_tests {
     }
 }
 
-/// What a build emitting no TypeScript writes for a brand: the name a brand carries is a *type*
-/// argument to `.brand` and the binding's annotation is a type — neither of which a JavaScript
-/// parser reads. Zod's runtime brand takes no argument at all, so the bare call is the same value
-/// under a spelling JavaScript does read.
+/// A build emitting no TypeScript writes a brand as a bare `.brand()` call — the name is a type
+/// argument and the annotation is a type, neither of which a JavaScript parser reads.
 #[cfg(all(feature = "zod", not(feature = "typescript")))]
 mod branded_javascript_flavour_tests {
     use super::*;
@@ -2092,10 +2073,9 @@ mod branded_sibling_inner_tests {
         );
     }
 
-    /// A brand reaching a name before the named item has expanded asks a registry that has nothing
-    /// recorded for it, and keeps its emission rather than being refused for where its inner
-    /// happens to be written: that absence is the same one an unresolved user type leaves, so
-    /// refusing on it would refuse the second for the sake of the first.
+    /// A brand reaching a name before the named item has expanded asks a registry with nothing
+    /// recorded for it, and keeps its emission rather than being refused — that absence is the
+    /// same one an unresolved user type leaves.
     #[test]
     fn a_constrained_brand_over_a_forward_declared_sibling_keeps_its_emission() {
         assert_eq!(
@@ -2113,10 +2093,9 @@ mod branded_sibling_inner_tests {
         );
     }
 
-    /// A fixed argument is not a parameter, so the refusal beside it leaves this declaration where
-    /// it was: the checks are appended to the factory call, and every surface holds the string the
-    /// declaration fixed. This is the admission the guard makes for a name the registry has no
-    /// answer for, reached by a name that carries an argument.
+    /// A fixed argument is not a parameter, so the refusal beside it leaves this declaration
+    /// untouched — the checks append to the factory call, and every surface holds the string the
+    /// declaration fixed.
     #[test]
     fn a_constrained_brand_over_a_fixed_instantiation_carries_its_checks() {
         assert_eq!(
@@ -2193,11 +2172,10 @@ mod branded_sibling_inner_tests {
 
     /// A brand's inner naming a family publisher — a generic item whose whole published value is
     /// one of its own parameters, like `LateTag<TagType>(pub TagType)` — composes to the class the
-    /// written argument itself resolves to, not the class of the sibling's own (irrelevant) name.
-    /// Guessing `ZodString` here, as the annotation once did regardless of the argument, is what
-    /// left `tsc` unable to compile the module: the runtime value is
-    /// `$ZodBranded<$ZodBranded<ZodNumber, "LateTag">, "PlainNumTag">` for the numeric filling, and
-    /// no number-shaped value is a `ZodString`.
+    /// written argument resolves to, not the sibling's own name. Guessing `ZodString` regardless
+    /// of the argument is what once left `tsc` unable to compile: the runtime value for a numeric
+    /// filling is `$ZodBranded<$ZodBranded<ZodNumber, "LateTag">, "PlainNumTag">`, and no
+    /// number-shaped value is a `ZodString`.
     #[test]
     fn a_brand_over_a_numeric_generic_instantiation_is_annotated_by_the_arguments_own_class() {
         let zod = PlainNumTag::zod_schema();
@@ -2240,9 +2218,9 @@ mod branded_sibling_inner_tests {
         );
     }
 
-    /// `FixedTag` reaches `LateTag` before it has registered (declared above it — see the comment
-    /// on `FixedTag` itself), so nothing proves what class its argument resolves to; widening to
-    /// the class every Zod schema is an instance of still compiles, where guessing would not.
+    /// `FixedTag` reaches `LateTag` before it has registered, so nothing proves what class its
+    /// argument resolves to — widening to the class every Zod schema is an instance of still
+    /// compiles, where guessing would not.
     #[test]
     fn a_forward_declared_family_publisher_widens_its_annotation() {
         let zod = FixedTag::zod_schema();
@@ -2264,10 +2242,9 @@ mod branded_sibling_inner_tests {
         );
     }
 
-    /// A generic brand's own inner naming another generic sibling (`LateTag<TagType>`) leaves
-    /// `TagType` itself unresolved at the point `$SchemaDefault`'s annotation is built — there is no
-    /// argument class to read yet, only the outer parameter — so it widens rather than guessing off
-    /// the parameter's own written name.
+    /// A generic brand's own inner naming another generic sibling leaves that sibling's parameter
+    /// unresolved at the point `$SchemaDefault`'s annotation is built — no argument class to read
+    /// yet, only the outer parameter — so it widens rather than guessing.
     #[test]
     fn a_generic_brands_default_over_a_generic_sibling_widens_its_annotation() {
         let zod = OpenTag::<String>::zod_schema();
@@ -2303,11 +2280,9 @@ mod branded_sibling_inner_tests {
 }
 
 /// The surfaces of a brand whose inner is a chrono type, pinned against what serde writes for it.
-///
 /// `#[serde(transparent)]` puts the chrono value on the wire by itself, so the brand writes the
-/// same string a field of that type writes — and carries the same `"format"` keyword saying which
-/// instant the string spells. Reaching the string through the TypeScript name every chrono type
-/// shares with `String` is what dropped the keyword.
+/// same string and carries the same `"format"` keyword — reaching it through the TypeScript name
+/// every chrono type shares with `String` is what once dropped the keyword.
 #[cfg(all(feature = "chrono", feature = "jsonschema", feature = "serde"))]
 mod branded_chrono_inner_tests {
     use super::*;
@@ -2777,9 +2752,9 @@ mod serde_tests {
 }
 
 /// Every spelling of one value publishes the one JSON type keyword its wire describes as: a brand
-/// over a `u32` writes exactly what a field, a one-slot tuple struct and an alias of the same `u32`
-/// write. Pinned against each other because a keyword taken from the rendered TypeScript name
-/// instead of from the type spelled `integer` three times and `number` once.
+/// over a `u32` writes exactly what a field, a tuple struct and an alias of the same `u32` write.
+/// Pinned against each other because a keyword once taken from the rendered TypeScript name
+/// spelled `integer` three times and `number` once.
 #[cfg(all(feature = "jsonschema", feature = "serde"))]
 mod branded_scalar_keyword_tests {
     use super::*;

--- a/tests/collection_tests/tests.rs
+++ b/tests/collection_tests/tests.rs
@@ -222,11 +222,9 @@ struct TickRef(Tick);
 #[serde(transparent)]
 struct Enabled(bool);
 
-/// A brand over a plain enum. serde writes the variant name, which is a bare string, so the brand
-/// keys a map the way a string does — under its own name, and open, the brand publishing no
-/// `enum_members()` of its own for a schema to close the object with. `no_display` is the inner's
-/// business, not the key's: a plain enum carries no `Display`, and the brand's key path never
-/// consults one.
+/// A brand over a plain enum: serde writes the variant name — a bare string — so the brand keys a
+/// map like a string does, open, since the brand publishes no `enum_members()` to close the
+/// object with. `no_display` is the inner's business, not the key's.
 #[model_schema(no_display)]
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[serde(transparent)]
@@ -380,10 +378,9 @@ struct OptionalMapValues {
     string_keyed: HashMap<String, Option<String>>,
 }
 
-// A sequence wrapper around a map is the field's array, not the map's, so each wrapped field
-// describes as the array of the map its unwrapped twin describes as — the wrap every other field
-// type applies, and the one the slot positions already apply to the same type. An `Option` is not
-// such a wrapper: field position spells optionality by leaving the name out of `required`.
+// A sequence wrapper around a map is the field's array, not the map's — each wrapped field
+// describes as the array of its unwrapped twin. An `Option` is not such a wrapper: field
+// position spells optionality by leaving the name out of `required`.
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct WrappedMapFields {
@@ -419,11 +416,10 @@ struct MetricTag {
 #[model_schema()]
 type MetricTagRef = MetricTag;
 
-// Every std wrapper serde writes as a JSON array of `T` — the criterion for covering one — puts
-// the element in charge of what the array holds. The twin structs below carry the same element
-// types under each covered spelling; the tests hold every field of one against its `Vec` twin.
-// `LinkedList` has no twin here, the crate's own lints forbidding it a value of one; it is covered
-// by name at the dispatch and in the renderers' unit tests instead.
+// Every std wrapper serde writes as a JSON array of `T` puts the element in charge of what the
+// array holds. The twin structs carry the same element types under each covered spelling.
+// `LinkedList` has no twin here — the crate's own lints forbid a value of one — so it's covered
+// by name at the dispatch instead.
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct SetElementFields {
@@ -496,9 +492,8 @@ struct VecElementFields {
 }
 
 /// A `BuildHasher` written where std implies one, so a field can name the hasher parameter both
-/// `HashMap` and `HashSet` carry past the types they write. What it hashes with is beside the
-/// point — serde writes the same bytes whichever hasher a container is built with, which is why the
-/// argument is not part of the wire form the surfaces render.
+/// `HashMap` and `HashSet` carry. serde writes the same bytes regardless, so the argument is not
+/// part of the wire form the surfaces render.
 #[derive(Clone, Default)]
 struct NamedHasher;
 
@@ -534,9 +529,8 @@ struct HasherImpliedFields {
 }
 
 // A slot — a map member, a tuple element — cannot be dropped the way an object key can, so it
-// holds whatever the value writes, and a covered wrapper writes the array its element decides. The
-// twin below carries the `Vec` spelling of the same slots, which is what each set slot is held
-// against: the key path, the element type and the nesting are the same on both.
+// holds whatever the value writes. The twin below carries the `Vec` spelling of the same slots,
+// held against each set slot with the same key path, element type, and nesting.
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct SetSlotValues {
@@ -586,10 +580,9 @@ struct SiblingSlotValues {
 #[model_schema()]
 type MetricGrid = Vec<Vec<u32>>;
 
-// A sequence holding a sequence writes an array of arrays, so it describes as one: every level the
-// field is written at is a level of the description, whichever covered wrapper spells each level.
-// A constraint still has only the innermost element to land on — the levels above hold arrays, not
-// values a `minLength` could reach.
+// A sequence holding a sequence writes an array of arrays, so it describes as one at every level,
+// whichever covered wrapper spells each level. A constraint still has only the innermost element
+// to land on — the levels above hold arrays, not values a `minLength` could reach.
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct NestedSequenceFields {
@@ -1194,12 +1187,10 @@ fn test_enum_keyed_sibling_array_member_matches_the_serialized_form() {
     );
 }
 
-/// What serde writes for a map whose key is wrapped in a sequence: nothing at all. A JSON object
-/// key is a string, a sequence has no string form, and `serde_json` refuses the whole value rather
-/// than falling back to an array of pairs — the refusal is the wrapper's, not the element's, so the
-/// fixed-size spelling earns it as squarely as the `Vec` one. The bare key beside them is the form
-/// that does write, and the one `#[model_schema()]` describes; a sequence-wrapped key describes no
-/// wire at all, which is why the expansion refuses the spelling instead of enumerating its element.
+/// What serde writes for a map whose key is wrapped in a sequence: nothing at all — `serde_json`
+/// refuses the whole value rather than falling back to an array of pairs, since a JSON object key
+/// must be a string. The refusal is the wrapper's, not the element's, so the expansion refuses the
+/// spelling instead of enumerating its element.
 #[test]
 fn test_a_sequence_wrapped_map_key_has_no_wire_form() {
     let vec_keyed = HashMap::from([(vec![MetricSlot::Daily], 1_u32)]);
@@ -2012,10 +2003,9 @@ fn test_scalar_brand_keyed_maps_match_the_serialized_form() {
     assert_eq!(read_back, maps);
 }
 
-/// A brand over a plain enum writes the variant name, which is a bare string — so it describes as
-/// the `String`-keyed twin does, keeping the value's own schema under `additionalProperties`. The
-/// enum-keyed spelling closes the object over `enum_members()`; the brand has no such method, and
-/// the object it describes is open rather than closed over members nothing can supply.
+/// A brand over a plain enum writes the variant name, a bare string — so it describes as the
+/// `String`-keyed twin does. The enum-keyed spelling closes the object over `enum_members()`; the
+/// brand has no such method, so its object stays open.
 #[test]
 #[cfg(feature = "jsonschema")]
 fn test_enum_brand_keyed_maps_describe_as_their_string_keyed_twin() {
@@ -2136,10 +2126,9 @@ fn test_scalar_alias_keyed_maps_constructible() {
     assert_eq!(twin.by_tick[&7], maps.by_tick[&tick]);
 }
 
-/// An alias is the type it names, so a map keyed by an alias of a value serde stringifies builds the
-/// object the bare target builds — field for field the bare-keyed twin's, at every depth and through
-/// either chain, the alias's name being spent on the nominal surfaces and having nothing to say on
-/// the structural one.
+/// An alias is the type it names, so a map keyed by an alias of a stringified value builds the
+/// same object the bare target builds — the alias's name is spent on the nominal surfaces and has
+/// nothing to say on the structural one.
 #[test]
 #[cfg(feature = "jsonschema")]
 fn test_scalar_alias_keyed_maps_describe_as_their_bare_target_twin() {
@@ -2735,10 +2724,9 @@ fn test_a_named_hasher_writes_what_the_implied_hasher_writes() {
     );
 }
 
-/// The reported failure: naming the hasher carried an argument more than the container arms claimed,
-/// so the type fell through to the sibling rendering and each surface published a name nothing
-/// emits — a `HashMap<…>` TypeScript type, the same string as a Zod schema, and a schema module the
-/// expansion never writes. Writing the same bytes, the two spellings describe the same.
+/// The reported failure: naming the hasher carried an argument more than the container arms
+/// claimed, so the type fell through to the sibling rendering and each surface published a name
+/// nothing emits.
 #[test]
 #[cfg(feature = "jsonschema")]
 fn test_hasher_named_fields_describe_as_the_implied_spelling() {
@@ -2832,10 +2820,8 @@ fn test_set_element_zod_generation() {
     }
 }
 
-/// Whatever a set field renders as, it is not the Rust wrapper's name: neither surface has any
-/// meaning for it, so the name surviving anywhere into the output is a syntax error in the output.
-/// The other covered wrappers name themselves in their own fixture's type name, so the equivalence
-/// with the `Vec` twin below is what says no wrapper name reached their output.
+/// Whatever a set field renders as, it is not the Rust wrapper's name — neither surface has any
+/// meaning for it, so the name surviving into the output would be a syntax error there.
 #[test]
 #[cfg(any(feature = "typescript", feature = "zod"))]
 fn test_no_sequence_wrapper_name_survives_into_generated_output() {
@@ -2902,10 +2888,9 @@ fn test_every_covered_wrapper_describes_as_the_vec_spelling() {
     }
 }
 
-/// The same holding on the TypeScript surface: with the fixture's own name set aside, a covered
-/// wrapper's field declarations are the `Vec` spelling's, so no wrapper name reached the output.
-/// Declarations rather than whole definitions, because the surrounding `JSDoc` differs for a reason
-/// of its own: a `Vec` field's doc comment is dropped where every other spelling keeps it.
+/// The same holding on TypeScript: a covered wrapper's field declarations are the `Vec` spelling's.
+/// Declarations rather than whole definitions, because the surrounding `JSDoc` differs — a `Vec`
+/// field's doc comment is dropped where every other spelling keeps it.
 #[test]
 #[cfg(feature = "typescript")]
 fn test_every_covered_wrapper_types_as_the_vec_spelling() {

--- a/tests/crate_rustdoc_tests/tests.rs
+++ b/tests/crate_rustdoc_tests/tests.rs
@@ -1,10 +1,7 @@
 //! The crate rustdoc opens with four declarations and prints, beside each, what that declaration
-//! emits. A reader takes those blocks for the crate's output — so each one is expanded here as
-//! written and held to the run: the emission the generator answers with has to still appear in
-//! `src/lib.rs` verbatim. Drift on either side fails here rather than on the docs page.
-//!
-//! Field and variant order is load-bearing, every surface being written in declaration order, so
-//! each type is declared exactly as the rustdoc declares it.
+//! emits. Each is expanded here as written and held to the run: the emission the generator
+//! answers with has to still appear in `src/lib.rs` verbatim, field and variant order included,
+//! since every surface writes in declaration order. Drift fails here rather than on the docs page.
 
 #[cfg(all(
     feature = "jsonschema",

--- a/tests/example_tests/tests.rs
+++ b/tests/example_tests/tests.rs
@@ -422,9 +422,8 @@ fn test_description_escapes_quotes() {
 }
 
 /// A doc example on a generic item is Rust the expansion has to compile, and a parameter names no
-/// type to compile it at, so every parameter the item declares is instantiated at the filling
-/// `default_types` declares for it — here `String`, which is also what an undeclared parameter
-/// falls back to, so this item is annotated exactly as it was before the filling was read.
+/// type to compile it at — so every parameter is instantiated at the filling `default_types`
+/// declares, here `String`, the same fallback an undeclared parameter uses.
 #[cfg(feature = "zod")]
 #[test]
 fn a_generic_struct_renders_its_example_at_its_declared_filling() {
@@ -468,9 +467,8 @@ fn a_generic_enum_renders_its_example_at_its_declared_fillings() {
 }
 
 /// `default_types` is the one argument that names a concrete type per parameter, so the example is
-/// annotated at what the author already declared. A parameter bounded by a trait `String` does not
-/// satisfy then compiles, and the value the example builds is the one the filling admits rather
-/// than one an annotation picked over it contradicts.
+/// annotated at what the author already declared — a parameter bounded by a trait `String` does
+/// not satisfy still compiles, since the example builds the value the filling admits.
 #[cfg(feature = "zod")]
 #[test]
 fn a_bounded_parameter_renders_its_example_at_its_declared_filling() {
@@ -538,9 +536,8 @@ fn an_unfilled_parameter_keeps_the_string_instantiation() {
 }
 
 /// A filling written as `String` is exactly what an unfilled parameter falls back to, so the two
-/// items write the same schema down to the byte once their names are read as one — reading the
-/// declaration leaves every item the convention already got right untouched. Names of equal length
-/// so nothing but the name itself differs.
+/// items write the same schema down to the byte once their names are read as one. Names of equal
+/// length so nothing but the name itself differs.
 #[cfg(all(feature = "zod", not(feature = "jsonschema")))]
 #[test]
 fn a_string_filling_and_no_filling_write_the_same_schema() {
@@ -573,9 +570,8 @@ fn a_string_filling_and_no_filling_write_the_same_schema() {
 }
 
 /// A generic item publishes a factory, whose last `;` closes its arrow function — so the example
-/// anchors on the statement binding the schema the factory caches instead. That statement is the
-/// one place on the value every call returns that also keeps two calls with the same arguments the
-/// same schema: attaching at `return schema` would hand back an instance the cache never stored.
+/// anchors on the statement binding the cached schema instead. Attaching at `return schema` would
+/// hand back an instance the cache never stored.
 #[cfg(feature = "zod")]
 #[test]
 fn a_factory_carries_its_example_on_the_schema_it_memoizes() {

--- a/tests/fixed_array_tests/tests.rs
+++ b/tests/fixed_array_tests/tests.rs
@@ -205,10 +205,10 @@ fn test_a_fixed_array_validates_its_length_in_zod() {
     }
 }
 
-/// TypeScript takes the other answer and stays `Array<T>` at every level. The fixed-length form its
-/// type system has is the N-element tuple, which has to be written out element by element and stops
-/// being readable long before `N` stops being legal; the two validating surfaces are where a
-/// wrong-length payload is caught.
+/// TypeScript takes the other answer and stays `Array<T>` at every level — its fixed-length form,
+/// the N-element tuple, has to be written out element by element and stops being readable long
+/// before `N` stops being legal. The two validating surfaces are where a wrong-length payload is
+/// caught.
 #[test]
 #[cfg(feature = "typescript")]
 fn test_a_fixed_array_types_as_an_unbounded_array_in_typescript() {

--- a/tests/flatten_tests/tests.rs
+++ b/tests/flatten_tests/tests.rs
@@ -159,10 +159,8 @@ struct FlatOverEnum {
     tone: FlatHue,
 }
 
-/// A newtype over a `String` flattened into a struct: serde writes it as the string it wraps, which
-/// is no object and which the merge has nothing to join its own keys to. The name records that wire
-/// as it expands, so a build carrying the Zod merge refuses the declaration where it was written and
-/// only a build without one gets as far as the merge.
+/// A newtype over a `String` flattened into a struct: serde writes it as a string, not an object,
+/// so the Zod merge has nothing to join keys to and refuses the declaration where it was written.
 #[cfg(not(feature = "zod"))]
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -177,10 +175,9 @@ struct FlatOverBrand {
     slug: FlatSlug,
 }
 
-/// The same newtype declared *below* the object that flattens it. The recording holds what has
-/// already expanded, so this one proves nothing about its wire and the guard keeps the
-/// declaration-order fallback — while the JSON-schema merge, which reads the document back at run
-/// time, refuses it wherever it is declared.
+/// The same newtype declared *below* the object that flattens it — the recording holds only what
+/// has already expanded, so the guard keeps the declaration-order fallback while the JSON-schema
+/// merge (reading the document at run time) refuses it regardless of order.
 #[cfg(any(feature = "jsonschema", feature = "zod"))]
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -283,10 +280,9 @@ enum FlatScalarEither {
     Text(String),
 }
 
-/// Flattening it is what no value satisfies, and the Zod surface refuses the declaration once the
-/// members it multiplies over say which of them serde writes as a scalar. So the struct exists
-/// only where nothing records those members, which is where the JSON-schema merge answers for the
-/// same declaration at run time instead.
+/// Flattening it is what no value satisfies, so the Zod surface refuses the declaration once the
+/// members it multiplies over reveal a scalar. The struct exists only where nothing records those
+/// members — where the JSON-schema merge answers instead.
 #[cfg(not(feature = "zod"))]
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -296,10 +292,9 @@ struct FlatOverScalarUntagged {
     own: String,
 }
 
-/// The same union declared *below* the object that flattens it. The recording holds what has
-/// already expanded, so this one carries no members and the Zod merge names it as the one operand
-/// it is — the fallback a forward reference already takes — while the JSON-schema merge, which
-/// reads the members back at run time, refuses it wherever it is declared.
+/// The same union declared *below* the object that flattens it — carrying no recorded members,
+/// the Zod merge falls back to naming it as a plain operand, while the JSON-schema merge
+/// (reading members at run time) refuses it regardless of order.
 #[cfg(any(feature = "jsonschema", feature = "zod"))]
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -459,10 +454,9 @@ enum LaterMemberSlugEither {
     Slug(MemberSlug),
 }
 
-/// Three more members that name another item rather than spelling a type out, all three of them one
-/// word to the shape vocabulary and three different answers to the merge: a registration whose wire
-/// is a JSON array, one whose wire is the object a map writes, and one whose own published surface
-/// is nullable. serde flattens the map and refuses the other two.
+/// Three members naming another item rather than spelling a type out, each a different wire
+/// shape: one is a JSON array, one is the object a map writes, one has a nullable published
+/// surface. serde flattens only the map and refuses the other two.
 #[cfg(any(feature = "jsonschema", feature = "zod"))]
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -574,10 +568,9 @@ enum LaterMemberMaybeEither {
     Maybe(MemberMaybeSecond),
 }
 
-/// A member naming a tagged enum. serde writes a data-carrying variant as the single-key object the
-/// variant's name tags, and writes a unit variant as that name alone — a bare string — so the choice
-/// this member stands for holds a leaf no object can be merged with, one level in from where the
-/// member stands.
+/// A member naming a tagged enum: serde writes a data-carrying variant as a single-key object but
+/// a unit variant as a bare string — a leaf no object can be merged with, one level in from the
+/// member.
 #[cfg(any(feature = "jsonschema", feature = "zod", feature = "typescript"))]
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -625,11 +618,9 @@ enum LaterMemberExtBareEither {
     Ext(MemberExtBare),
 }
 
-/// The same tagged enum flattened directly, with no union between. That position asks what the
-/// member position asks — can serde read the payload back — and answers the other way: serde writes
-/// a unit variant as its name holding `null` into the object being written rather than as the bare
-/// string it is standing alone, and reads that payload back as the variant. One declaration, both
-/// directions, so the merges owe it one branch per variant.
+/// The same tagged enum flattened directly, with no union between: flattened, serde writes a unit
+/// variant as its name holding `null` rather than the bare string it is standing alone, and reads
+/// that back as the variant — so the merges owe it one branch per variant.
 #[cfg(any(feature = "jsonschema", feature = "zod", feature = "typescript"))]
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -667,11 +658,9 @@ struct FlatOverMemberExtObjUntagged {
     own: String,
 }
 
-/// And that enum flattened directly, where the two merged surfaces multiply for different reasons. A
-/// Zod intersection recognizes exactly the keys its operands name and a `z.union` names none, so
-/// joining the object to the name admits nothing at all. TypeScript reaches every branch by
-/// distributing and needs the variants for what no branch says on its own: that it does not carry
-/// the tag its sibling carries.
+/// That enum flattened directly, where Zod and TypeScript multiply for different reasons: a Zod
+/// intersection recognizes only the keys its operands name and a `z.union` names none, so joining
+/// admits nothing; TypeScript distributes over every branch instead.
 #[cfg(any(feature = "jsonschema", feature = "zod", feature = "typescript"))]
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -681,10 +670,9 @@ struct ExtObjDirectHolder {
     own: String,
 }
 
-/// The same enum reached through an `Option`, where the absence branch reads its keys off the
-/// operand beside it. `keyof` a union is the keys its branches share, which for two variants tagging
-/// different names was none at all — an empty mapped type, and one every object passes through.
-/// Closing each variant against the other is what gives that branch the keys to leave out.
+/// The same enum through an `Option`: `keyof` a union is the keys its branches share, which for
+/// two differently-tagged variants is none — an empty mapped type every object passes through —
+/// unless each variant is closed against the other.
 #[cfg(feature = "typescript")]
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -694,10 +682,9 @@ struct OptExtObjHolder {
     own: String,
 }
 
-/// An untagged union written over the objects its members are rather than over names, and the struct
-/// that flattens it. serde matches a member on its shape and writes one member's keys at a time, and
-/// the members here are the only ones whose keys the declaration itself spells — a member written as
-/// a name is what it is written as, and the merge is told nothing it could close the others against.
+/// An untagged union written over the objects its members are, rather than over names — the only
+/// case where the declaration itself spells each member's keys, since serde matches a member by
+/// shape.
 #[cfg(any(feature = "jsonschema", feature = "zod", feature = "typescript"))]
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -888,12 +875,10 @@ enum NestCycleInner {
     Back(Box<NestCycleOuter>),
 }
 
-/// A base reached through an `Option`, and the object that flattens it. serde writes the base's
-/// members beside the object's own when the field is `Some` and writes the object alone when it is
-/// `None` — the declaration guard forces `skip_serializing_if` on the field, so the absent form is
-/// the only `None` the crate admits.
-///
-/// Two required members, so a payload carrying one of them is a base serde never writes.
+/// A base reached through an `Option`: serde writes the base's members beside the object's own
+/// when `Some`, and the object alone when `None` — the guard forces `skip_serializing_if`, so
+/// absence is the only `None` the crate admits. Two required members, so a payload carrying only
+/// one is a base serde never writes.
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct OptBase {
@@ -909,11 +894,9 @@ struct OptHolder {
     own: String,
 }
 
-/// The other spelling of reaching that same absence: a registration whose own published surface is
-/// nullable, flattened directly with no union between. serde writes the base's members beside the
-/// object's own or writes the object's own alone, exactly as the `Option`-typed field does, and
-/// reads both forms back — so the two spellings are one declaration and the merge owes them one
-/// answer.
+/// The other spelling of the same absence: a nullable-surfaced registration flattened directly, no
+/// union between. serde reads and writes both forms exactly as the `Option`-typed field does, so
+/// the merge owes both spellings one answer.
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct MaybeOptBase(Option<OptBase>);
@@ -926,12 +909,10 @@ struct NamedMaybeHolder {
     own: String,
 }
 
-/// The same two spellings over a value that is no object. A registration whose published surface is
-/// a nullable scalar writes one of its two values and refuses the other: serde writes nothing for
-/// the `None` and reads the object's own keys back as it, and refuses the `Some` outright. So one
-/// declaration carries a branch that round-trips and a branch no payload satisfies, which is the
-/// declaration the guard refuses where it was written — and only a build without the Zod surface
-/// gets as far as either merge.
+/// The same two spellings over a scalar rather than an object: serde writes nothing for `None`
+/// (reading the object's own keys back as it) but refuses `Some` outright — one branch
+/// round-trips, the other satisfies no payload, so the guard refuses the declaration where it was
+/// written.
 #[cfg(not(feature = "zod"))]
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -946,10 +927,9 @@ struct MaybeCountHolder {
     own: String,
 }
 
-/// The same registration declared *below* the object that flattens it. The recording holds what has
-/// already expanded, so this one proves nothing about its wire and the guard keeps the
-/// declaration-order fallback — while the JSON-schema merge, which reads the document back at run
-/// time, refuses it wherever it is declared.
+/// The same registration declared *below* the object that flattens it — the recording holds only
+/// what has already expanded, so the guard keeps the declaration-order fallback while the
+/// JSON-schema merge (reading the document at run time) refuses it regardless of order.
 #[cfg(any(feature = "jsonschema", feature = "zod"))]
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -1129,9 +1109,8 @@ fn test_no_flatten_zod_unchanged() {
 }
 
 /// A base's schema is a `const` the emitted module reads, and nothing orders one type's module
-/// against another's. A flattened base named straight into the intersection would be read while
-/// the const initializer runs, which fails outright for any base declared below the type that
-/// flattens it — so the operand is the deferred form and the read happens when something validates.
+/// against another's — naming it straight into the intersection would fail for a base declared
+/// below, so the operand is deferred until something validates.
 #[test]
 #[cfg(feature = "zod")]
 fn test_a_flattened_base_is_never_read_while_the_const_initializes() {
@@ -1176,10 +1155,9 @@ fn test_a_flatten_cycle_defers_both_sides_of_the_pair() {
     );
 }
 
-/// An intersection operand is written in two places — a struct's flattened base and an internally
-/// tagged newtype variant's content — and a cycle can run through both. Deferring one side alone
-/// leaves the other reading a name that a module declared below has not bound yet, so both sides
-/// carry the same deferral and the pair loads whichever order the modules are assembled in.
+/// An intersection operand is written in two places — a flattened base and an internally tagged
+/// variant's content — and a cycle can run through both, so both sides carry the same deferral
+/// regardless of module assembly order.
 #[test]
 #[cfg(feature = "zod")]
 fn test_a_flatten_cycle_through_a_variants_content_defers_both_sides() {
@@ -1630,11 +1608,9 @@ fn test_a_string_member_of_a_later_flattened_untagged_enum_is_refused_by_the_mer
     assert!(FlatOverLaterScalarUntagged::json_schema().is_object());
 }
 
-/// A member reached through an `Option` is the one shape where serde's two directions describe
-/// different payload sets. It writes the flattened `None` as the object's own keys alone, with no
-/// error, and then refuses to read those same keys back — the untagged enum matches no member for
-/// them. So there is no branch a multiplication could write: spelling the absence accepts a
-/// document `from_value` rejects, and omitting it rejects one `to_value` writes.
+/// An `Option` member is the one shape where serde's two directions describe different payload
+/// sets: it writes flattened `None` as the object's own keys alone with no error, then refuses to
+/// read those same keys back — no branch a multiplication could write covers both directions.
 #[test]
 #[cfg(any(feature = "jsonschema", feature = "zod"))]
 fn test_an_optional_flattened_union_member_is_written_and_then_not_read_back() {
@@ -2153,10 +2129,9 @@ fn test_the_optional_flatten_schema_rejects_a_partial_base() {
     }
 }
 
-/// The document that says both: the base's members joined to the object's under one branch, and the
-/// object's own alone under another. `anyOf` is what the choice is written with — the branches
-/// overlap wherever the base can write no members of its own, which is the same payload the absent
-/// branch stands for.
+/// The document says both: base members joined to the object's under one `anyOf` branch, the
+/// object's own alone under another — the branches overlap on the payload the absent branch
+/// stands for.
 #[test]
 #[cfg(feature = "jsonschema")]
 fn test_the_optional_flatten_document_offers_the_base_and_its_absence() {
@@ -2189,10 +2164,9 @@ fn test_an_optional_flattened_union_offers_every_member_and_their_absence() {
     );
 }
 
-/// The same two key sets on the TypeScript surface: the object's own members beside the base's, or
-/// the object's own beside none of them. `| undefined` said something else — that the whole value
-/// may be missing — and `&` binds tighter than `|`, so it admitted neither payload the object
-/// writes for an absent base.
+/// The same two key sets on TypeScript: `| undefined` said something else — that the whole value
+/// may be missing — and `&` binds tighter than `|`, so it admitted neither payload for an absent
+/// base.
 #[test]
 #[cfg(feature = "typescript")]
 fn test_the_optional_flatten_type_offers_the_base_and_its_absence() {
@@ -2224,11 +2198,9 @@ fn test_an_optional_flattened_union_type_offers_its_members_and_their_absence() 
     );
 }
 
-/// What Zod says about the same base: a choice between the object's own keys merged with the base
-/// and the object's own keys alone. The choice is written outside the intersection because that is
-/// the only place Zod can read it — an intersection recognizes the keys its operands name, and an
-/// operand that is itself a choice leaves each branch answering for the keys the other one carries,
-/// which rejects every payload the object writes.
+/// Zod writes the choice outside the intersection because that's the only place it can read it —
+/// an intersection recognizes only the keys its operands name, so a choice operand would leave
+/// each branch missing the other's keys.
 #[test]
 #[cfg(feature = "zod")]
 fn test_the_optional_flatten_schema_offers_the_base_and_its_absence() {
@@ -2284,10 +2256,8 @@ fn test_the_optional_flatten_schema_binds_the_objects_own_keys_once() {
     );
 }
 
-/// The same two payloads reached through a name rather than through an `Option` in the field's own
-/// type: serde writes the base's members beside the object's own or writes the object's own alone,
-/// and reads both back as the value that wrote them. One declaration, both directions — which is
-/// what says the merge owes it the two key sets rather than a refusal.
+/// The same two payloads reached through a name rather than an `Option`: serde reads and writes
+/// both forms, so the merge owes it two key sets rather than a refusal.
 #[test]
 fn test_a_named_nullable_flattened_base_writes_its_members_or_nothing() {
     let forms: [(Option<OptBase>, serde_json::Value); 2] = [
@@ -2354,10 +2324,8 @@ fn test_the_named_nullable_flatten_document_admits_the_captured_payloads() {
     }
 }
 
-/// And Zod writes the same choice around the same intersection: the object's own keys merged with
-/// the name, or the object's own keys alone. The name is left spelled as the nullable binding it is
-/// — the null side of it carries no key an intersection could take, so the branch that names it
-/// admits exactly the payload the base writes.
+/// Zod writes the same choice around the intersection, leaving the name spelled as the nullable
+/// binding it is — its null side carries no key an intersection could take.
 #[test]
 #[cfg(feature = "zod")]
 fn test_the_named_nullable_flatten_schema_offers_the_base_and_its_absence() {
@@ -2375,10 +2343,9 @@ fn test_the_named_nullable_flatten_schema_offers_the_base_and_its_absence() {
     );
 }
 
-/// And TypeScript writes the same choice over the same two key sets. The name itself carries the
-/// value branch — an intersection distributes over the choice behind it and the `null` side takes no
-/// key, so that branch is already the base's — while the branch carrying none of the base's members
-/// reads them off the value side by name, a choice having no key of its own for `keyof` to find.
+/// TypeScript writes the same choice: the name carries the value branch since the intersection
+/// distributes over it and `null` takes no key, while the other branch reads the base's members
+/// off the value side by name.
 #[test]
 #[cfg(feature = "typescript")]
 fn test_the_named_nullable_flatten_type_offers_the_base_and_its_absence() {
@@ -2393,10 +2360,9 @@ fn test_the_named_nullable_flatten_type_offers_the_base_and_its_absence() {
     );
 }
 
-/// The absence is a question about what the name published and nothing else, so a direct flatten
-/// naming an item whose surface is not nullable is spelled exactly as it was before there was a
-/// second branch to spell — one intersection on Zod, one closed object on the document, and the
-/// bare name on TypeScript.
+/// The absence is a question about what the name published — a direct flatten naming a
+/// non-nullable item is spelled exactly as before there was a second branch: one intersection on
+/// Zod, one closed object on the document, the bare name on TypeScript.
 #[test]
 #[cfg(feature = "typescript")]
 fn test_a_named_non_nullable_flatten_type_is_byte_identical() {
@@ -2614,10 +2580,8 @@ fn test_an_aliased_untagged_flatten_multiplies_over_the_same_members() {
     );
 }
 
-/// A union nested inside a union contributes its leaves and not its name: the nesting writes no key
-/// of its own, and a name standing for a union carries no key set for the intersection to read.
-/// Where every level holds one member there is one combination, so the object's own keys stay where
-/// they were and the leaf joins them directly.
+/// A union nested inside a union contributes its leaves, not its name — the nesting writes no key
+/// of its own, so the object's own keys stay where they were and the leaf joins them directly.
 #[test]
 #[cfg(feature = "zod")]
 fn test_a_nested_untagged_flatten_multiplies_over_the_leaf_members() {
@@ -2684,10 +2648,9 @@ fn test_a_standalone_union_with_a_scalar_member_is_byte_identical() {
     assert_eq!(FlatScalarEither::zod_schema(), EXPECTED);
 }
 
-/// A union holding a member reached through an `Option`, and ones holding members that name a
-/// brand or a plain enum, are unions like any other while nothing flattens them: the member is a
-/// branch of the choice, and each is spelled byte for byte as it was before the merge could tell
-/// the shapes apart.
+/// A union holding an `Option`-reached member, a brand, or a plain enum is a union like any other
+/// while nothing flattens it — each spelled byte for byte as before the merge could tell the
+/// shapes apart.
 #[test]
 #[cfg(feature = "zod")]
 fn test_standalone_unions_the_merge_now_refuses_are_byte_identical() {
@@ -2743,10 +2706,8 @@ fn test_the_unions_declared_below_the_object_are_still_named_as_one_operand() {
     );
 }
 
-/// And flattening one is refused at expansion rather than emitted — the branch that used to be
-/// written for the scalar member was the object intersected with it, which no payload satisfies and
-/// which nothing reported. The declaration that would carry it does not exist under this feature,
-/// so what the refusal is pinned against is the field it names.
+/// Flattening one is refused at expansion rather than emitted — the branch that used to be written
+/// for the scalar member intersected with it, which no payload satisfies and nothing reported.
 #[test]
 #[cfg(feature = "zod")]
 fn test_a_union_with_a_scalar_member_declared_below_is_still_named_as_one_operand() {
@@ -2802,10 +2763,9 @@ fn test_a_named_array_member_of_a_later_flattened_untagged_enum_is_refused_by_th
     assert!(FlatOverLaterMemberBagUntagged::json_schema().is_object());
 }
 
-/// A member naming a registration whose own published surface is nullable carries the same null the
-/// member written `Option<T>` carries, one name away — and serde's two directions describe
-/// different payload sets for it exactly as they do there: the absent form is written without an
-/// error and then matches no member on the way back.
+/// A member naming a nullable-surfaced registration carries the same null an `Option<T>` member
+/// carries, one name away — serde's two directions describe different payload sets exactly as
+/// there.
 #[test]
 #[cfg(any(feature = "jsonschema", feature = "zod"))]
 fn test_a_named_nullable_flattened_union_member_is_written_and_then_not_read_back() {
@@ -3028,10 +2988,9 @@ fn test_the_tagged_enums_are_byte_identical_standing_alone() {
     );
 }
 
-/// The direct position asks the round-trip question the member position asks and gets the other
-/// answer. serde writes the unit variant as its name holding `null` into the object being written —
-/// not the bare string it is standing alone — and reads that payload back as the variant, so the
-/// declaration is one serde admits in both directions.
+/// The direct position asks the same round-trip question and gets the other answer: serde writes
+/// the unit variant as its name holding `null`, not the bare string it is standing alone, and
+/// reads that back as the variant.
 #[test]
 #[cfg(any(feature = "jsonschema", feature = "zod"))]
 fn test_a_directly_flattened_tagged_enum_round_trips_every_variant() {
@@ -3180,11 +3139,9 @@ fn test_the_all_object_tagged_direct_flatten_schema_multiplies_the_object_over_t
     );
 }
 
-/// TypeScript distributes an intersection over a union of objects on its own, so the branches are
-/// ones the enum's own name already reaches. What the name does not reach is what each branch says
-/// about the other: the excess-property check reads the union of both key sets, so a payload
-/// carrying both tags satisfies either branch structurally — a payload serde writes for no value and
-/// the other three surfaces refuse. Spelling the variants is what carries that.
+/// TypeScript distributes the intersection over the union on its own, but the excess-property
+/// check reads the union of both key sets — a payload carrying both tags would satisfy either
+/// branch structurally, which no value produces. Spelling the variants is what rules that out.
 #[test]
 #[cfg(feature = "typescript")]
 fn test_an_all_object_tagged_direct_flatten_type_closes_each_variant_against_the_other() {
@@ -3205,10 +3162,9 @@ fn test_an_all_object_tagged_direct_flatten_document_is_byte_identical() {
     );
 }
 
-/// And the absence branch beside the same enum reads the closed variants' keys, where it had none to
-/// read: `keyof` a union is the keys its branches share, so before the exclusions the branch was an
-/// empty mapped type — `{}`, which every object passes through, including one carrying part of a
-/// variant's key set.
+/// The absence branch beside the same enum reads the closed variants' keys, where it had none to
+/// read: `keyof` a union is the keys its branches share, which before the exclusions was an empty
+/// mapped type `{}` that every object passes through.
 #[test]
 #[cfg(feature = "typescript")]
 fn test_the_optional_all_object_tagged_flatten_type_names_the_keys_its_absence_leaves_out() {

--- a/tests/generic_types_tests/tests.rs
+++ b/tests/generic_types_tests/tests.rs
@@ -1,21 +1,6 @@
-//! `#[model_schema()]` on an item that declares parameters.
-//!
-//! Three questions run through every fixture here. Does the emitted `impl` still name the type the
-//! author declared — every parameter it binds, lifetimes and consts included. Does the TypeScript
-//! declaration bind the parameters its fields are written under. And does a field typed with one
-//! reach, on each surface, whatever that surface fills the parameter with: the name itself on the
-//! type surface, the argument a factory binds on the value surface, and the document the filling
-//! describes as on the JSON one.
-//!
-//! A plain enum — all unit variants — cannot bind a *type* parameter at all: Rust refuses the
-//! declaration for an unused parameter before the attribute is reached. What it can bind is a
-//! const, which `PlainConst` carries, and that is the plain-enum shape of the same question: the
-//! `impl` has to repeat the const while the declaration names nothing.
-//!
-//! Every fixture binding a type parameter declares a default type for it, which is what a build
-//! generating a JSON document requires. JSON Schema has no type parameters, so a document exists
-//! only at one filling: the declared one where the document stands alone, and the reference site's
-//! where a field embeds it.
+//! `#[model_schema()]` on an item that declares parameters — the emitted `impl`'s own parameter
+//! list, what each surface fills a parameter with, and the default type every JSON-visible fixture
+//! declares, since JSON Schema has no type parameters of its own.
 
 #[cfg(feature = "typescript")]
 mod typescript {
@@ -25,12 +10,8 @@ mod typescript {
         keyed_alias_schema,
     };
 
-    /// The key states the string keys serde writes, the way the two validating surfaces already
-    /// do. `Record<K, V>` is declared `K extends keyof any`, so a declaration that hands it a
-    /// parameter it binds without bounding fails to type-check before a consumer writes a value —
-    /// and the bound that would repair it is one the parameter cannot carry, because a parameter
-    /// filled by anything serde can key a map with is filled by the string that reaches the wire.
-    /// The member gives up naming the parameter; the value beside it keeps it.
+    /// `Record<K, V>` requires `K extends keyof any`, so the key states the string keys serde
+    /// actually writes rather than naming the parameter — the value beside it keeps that.
     #[test]
     fn a_parameter_keyed_map_states_the_string_keys_serde_writes_on_the_type_surface() {
         let ts = KeyedByParameter::<String, u32>::ts_definition();
@@ -268,10 +249,8 @@ mod zod {
         );
     }
 
-    /// A record key has to produce string keys, and serde says every instantiation this map has
-    /// does: it writes a JSON object key as a string or refuses the map outright at serialization.
-    /// So the key states that guarantee rather than declining to state anything, and the member
-    /// comes out byte-identical to the concrete `String`-keyed one beside it.
+    /// serde writes every map key as a string or refuses the map at serialization, so the key
+    /// states that guarantee — coming out byte-identical to the concrete `String`-keyed member.
     #[test]
     fn a_parameter_keyed_map_states_the_string_keys_serde_writes() {
         let zod = KeyedByParameter::<String, u32>::zod_schema();
@@ -292,11 +271,8 @@ mod zod {
         assert!(!zod.contains("KeyType$Schema"), "Got: {zod}");
     }
 
-    /// The alias reaches the same two answers through the same classification, and the factory it
-    /// publishes is where they compose: the parameter written as the map's VALUE is the argument
-    /// the factory binds, while the one written as its KEY states the string guarantee and so
-    /// leaves its own argument unspent — the signature still binds it, the declaration having
-    /// written it.
+    /// The alias composes both answers in its factory: the VALUE parameter is the bound argument,
+    /// while the KEY parameter states the string guarantee and leaves its own argument unspent.
     #[test]
     fn a_parameter_keyed_map_alias_composes_the_factory_argument_with_the_string_key() {
         let zod = keyed_alias_schema::Schema::zod_schema();
@@ -337,10 +313,9 @@ mod zod {
         );
     }
 
-    /// Whether the output publishes `name` as a plain exported `const` — the binding a type that
-    /// declares no parameter writes, in either build flavour. Asked this way because
-    /// `{name}$SchemaFactory` carries `{name}$Schema` inside it, so the two names cannot be told
-    /// apart by the prefix alone.
+    /// Whether `name` publishes a plain exported `const`. Checked this way because
+    /// `{name}$SchemaFactory` contains `{name}$Schema` as a substring, so prefix matching alone
+    /// cannot tell them apart.
     fn publishes_a_schema_const(zod: &str, name: &str) -> bool {
         zod.contains(&format!("export const {name}$Schema:"))
             || zod.contains(&format!("export const {name}$Schema ="))
@@ -504,10 +479,9 @@ mod zod {
         );
     }
 
-    /// A declared default naming another generic item at exactly the arguments that item calls its
-    /// own default folds the argument onto that item's own `$SchemaDefault`, so the checks and
-    /// brand it declared are carried in by reference instead of rebuilt under a `z.string()` the
-    /// memo would not share with it.
+    /// A default naming another item at exactly that item's own default folds onto its
+    /// `$SchemaDefault`, carrying the checks and brand by reference instead of rebuilding them
+    /// under a `z.string()` the memo would not share.
     #[test]
     fn a_default_naming_a_siblings_own_default_folds_onto_its_binding() {
         let zod = EchoedDefault::<String>::zod_schema();
@@ -517,11 +491,9 @@ mod zod {
         );
     }
 
-    /// The same shape at a filling that names the sibling at an argument other than its own
-    /// default — the fold does not fire, and the reference still calls the sibling's factory
-    /// exactly as an ordinary field naming it does, deferred exactly as the fold's own reference
-    /// is: `Tagged$SchemaFactory` is a module-scope `const` this one's own `const` cannot know is
-    /// declared above it or below.
+    /// At an argument other than the sibling's own default, the fold does not fire — the call is
+    /// deferred exactly as an ordinary field reference is, since neither `const` can know whether
+    /// the other is declared above or below it in the generated module.
     #[test]
     fn a_default_naming_a_sibling_at_another_filling_still_calls_its_factory() {
         let zod = OverriddenDefault::<String>::zod_schema();
@@ -534,10 +506,8 @@ mod zod {
         );
     }
 
-    /// A `default_types` entry wrapping a sibling reference in a `Vec` is deferred exactly like a
-    /// bare one — `Tagged$SchemaFactory` inside `z.array(...)` is as much a module-scope `const`
-    /// read as `Tagged$SchemaFactory` bare — so the whole wrapped expression is what `z.lazy`
-    /// wraps, not merely the factory call sitting inside it.
+    /// A sibling reference wrapped in `Vec` defers exactly like a bare one — `z.lazy` wraps the
+    /// whole expression, not merely the factory call inside `z.array(...)`.
     #[test]
     fn a_default_wrapping_a_sibling_in_vec_defers_the_whole_expression() {
         let zod = BatchedDefault::<Vec<Tagged<String>>>::zod_schema();
@@ -579,10 +549,8 @@ mod zod {
         assert!(!zod.contains("z.lazy"), "Got: {zod}");
     }
 
-    /// Nothing else in this crate constructs `ConstrainedId` directly — every other use names it
-    /// only as a bare type argument — so this pins the same bounds-through-serde behavior
-    /// `constrained_generic_branded_tests::StrictDocumentId` in `branded_newtype_tests` covers for
-    /// the identical shape.
+    /// Pins the bounds-through-serde behavior for `ConstrainedId` directly, mirroring what
+    /// `constrained_generic_branded_tests::StrictDocumentId` covers in `branded_newtype_tests`.
     #[cfg(all(feature = "typescript", feature = "serde"))]
     #[test]
     fn a_constrained_ids_declared_default_enforces_the_bounds_through_serde() {
@@ -594,10 +562,8 @@ mod zod {
         assert!(too_short.is_err(), "Should reject a too-short id via serde");
     }
 
-    /// `validate()` itself — not only the `deserialize_with` hook — at the declared default:
-    /// `ConstrainedId<String>` is `default_types(IdType = String)`'s own filling, and the generated
-    /// `validate()` runs the same `minLength`/`maxLength`/`pattern` checks `ConstrainedId$SchemaDefault`
-    /// enforces on the Zod side.
+    /// `validate()` itself, not just the `deserialize_with` hook, at the declared default —
+    /// running the same `minLength`/`maxLength`/`pattern` checks `$SchemaDefault` enforces.
     #[cfg(all(feature = "typescript", feature = "serde"))]
     #[test]
     fn the_declared_defaults_validate_method_runs_the_same_checks_the_default_schema_enforces() {
@@ -614,10 +580,9 @@ mod zod {
         );
     }
 
-    /// The whole point of pinning `validate()` to the declared default: a hand-written inherent impl
-    /// for a *different* instantiation compiles alongside the generated one, with no
-    /// duplicate-definition error — and it is the hand-written body that runs, not the generated
-    /// one, since the two are written against different concrete types.
+    /// The point of pinning `validate()` to the declared default: a hand-written impl for a
+    /// *different* instantiation compiles alongside the generated one with no duplicate-definition
+    /// error, and it is the hand-written body that runs.
     #[cfg(all(feature = "typescript", feature = "serde"))]
     #[test]
     fn a_hand_written_impl_for_another_instantiation_compiles_and_runs_beside_the_generated_one() {
@@ -628,10 +593,9 @@ mod zod {
         );
     }
 
-    /// The fold fires for a *constrained* generic brand exactly as it does for `Tagged`: the
-    /// recorded comparison key is the plain rendering, not the `.min`/`.max`/`.check` chain
-    /// `$SchemaDefault` emits, so the two forms agree and the bounds are carried in by reference
-    /// instead of silently dropped.
+    /// The fold fires for a constrained brand exactly as for `Tagged`: the comparison key is the
+    /// plain rendering, not the `.min`/`.max`/`.check` chain `$SchemaDefault` emits — so the bounds
+    /// carry in by reference instead of being silently dropped.
     #[cfg(all(feature = "typescript", feature = "serde"))]
     #[test]
     fn a_default_naming_a_constrained_brands_own_default_folds_onto_its_binding() {
@@ -645,10 +609,8 @@ mod zod {
         );
     }
 
-    /// A downstream default naming a sibling whose own recorded fold key itself names a further
-    /// sibling at matching arguments — the fold chains two levels deep, reading
-    /// `ConstrainedEchoedDefault`'s comparison key back rather than the deferred, checks-carrying
-    /// text its own `$SchemaDefault` emits.
+    /// The fold chains two levels deep here, reading `ConstrainedEchoedDefault`'s comparison key
+    /// back rather than the deferred, checks-carrying text its own `$SchemaDefault` emits.
     #[cfg(all(feature = "typescript", feature = "serde"))]
     #[test]
     fn a_default_naming_a_siblings_default_that_itself_folds_chains_two_levels_deep() {
@@ -1007,9 +969,8 @@ mod jsonschema {
         use super::super::{Carried, FlatCarrier, FlatReferrer};
 
         /// A flattened parameter is a flattened value like any other: the object its filling
-        /// describes contributes its members to the one being written, beside the ones that object
-        /// writes itself. The filling reaches the merge through the one binding every other
-        /// position reads the parameter through, so the merge never sees which end filled it.
+        /// describes contributes its members to the one being written. The merge never sees which
+        /// end filled the parameter.
         #[test]
         fn a_flattened_parameter_merges_the_members_the_reference_site_filled_it_with() {
             assert_eq!(
@@ -1026,10 +987,9 @@ mod jsonschema {
             );
         }
 
-        /// A filling that is not an object has no members to merge, and what serde writes for it
-        /// never joins the object being written. The declaration cannot say so — which type fills
-        /// the parameter is the reference site's to name — so the merge answers where the filling
-        /// is finally known, in the words it answers for every other source in.
+        /// A non-object filling has no members to merge. The declaration cannot refuse this itself
+        /// — only the reference site names the filling — so the refusal fires where it's finally
+        /// known.
         #[test]
         #[should_panic(
             expected = "`FlatCarrier`: `#[serde(flatten)]` of `held` is not written as \
@@ -1040,10 +1000,8 @@ mod jsonschema {
             let _: serde_json::Value = FlatCarrier::<String>::json_schema();
         }
 
-        /// The declared filling reaches the merge exactly as a reference-site one does: the
-        /// standalone document is built at the default the declaration names, so an
-        /// object-writing sibling's members multiply into the base with no reference site
-        /// involved.
+        /// A declared filling reaches the merge exactly as a reference-site one does — built at
+        /// the default the declaration names, with no reference site involved.
         #[test]
         fn a_flattened_parameter_merges_the_members_its_declared_default_names() {
             assert_eq!(
@@ -1292,10 +1250,8 @@ mod jsonschema {
         );
     }
 
-    /// A filling naming another item is not a literal document but a request made of that item,
-    /// and only the frame carrying the run's two values can make it. Made there, the standalone
-    /// document holds at the parameter position exactly what the named item publishes — the same
-    /// document a reference site supplying that type as an argument would have embedded.
+    /// A filling naming another item is a request made of that item, not a literal document — the
+    /// standalone document holds at the parameter position exactly what the named item publishes.
     #[test]
     fn a_filling_naming_another_item_embeds_the_document_that_item_publishes() {
         let schema = Sealed::<Envelope>::json_schema();
@@ -1324,10 +1280,8 @@ mod jsonschema {
         );
     }
 
-    /// A cycle closing through a declared filling is the cycle every other edge closes: the name is
-    /// recognized while its own description is still running, so the filling describes as the
-    /// pointer and the frame that put the name in flight hoists the body that pointer resolves
-    /// against.
+    /// A cycle closing through a declared filling defers the same way every other edge does: the
+    /// name is recognized mid-description, so the filling describes as a pointer.
     #[test]
     fn a_cycle_closing_through_a_declared_filling_defers_the_same_way() {
         let schema = Roost::<Perch>::json_schema();
@@ -1345,12 +1299,9 @@ mod jsonschema {
         );
     }
 
-    /// A cycle written at the filling it was entered at is the one a document holding a single
-    /// definition per name and filling can describe, and it describes exactly as it always has:
-    /// the definition at that filling, and a reference into it wherever the name comes back
-    /// around. The key itself now carries the filling — a readable label off the argument's own
-    /// `"type"` keyword, plus a digest that keeps two labels alike from colliding — so the pinned
-    /// string below gained that text, and no character in it is one a URI-reference forbids.
+    /// The key now carries the filling — a readable label off the argument's own `"type"`
+    /// keyword, plus a digest keeping alike labels from colliding — so the pinned string below
+    /// gained that text, with no character a URI-reference forbids.
     #[test]
     fn a_cycle_that_keeps_its_filling_defers_through_the_one_definition() {
         let document = super::Recurring::<String>::json_schema();
@@ -1370,10 +1321,8 @@ mod jsonschema {
         }
     }
 
-    /// A reference that comes back around to a name at a filling the document is not being written
-    /// at has nowhere to put its own definition, and the pointer it would write resolves to the
-    /// other filling's body. Both fillings are named, because which one is wrong is the author's to
-    /// decide.
+    /// A reference at a filling the document is not being written at has nowhere to put its own
+    /// definition. Both fillings are named in the refusal — which one is wrong is the author's call.
     #[test]
     #[should_panic(
         expected = "`Refilled`: a reference closes a cycle at a filling the document is \
@@ -1424,9 +1373,7 @@ pub struct Wrapper<IdType> {
 }
 
 /// A `char` filling for a parameter's declared default — refused before `char` gained a
-/// `FieldDefType` arm of its own: the dispatch had no arm for it and named a `char_schema` module
-/// nothing publishes. The fixture compiling is part of the assertion; the document it renders is
-/// the rest.
+/// `FieldDefType` arm of its own. The fixture compiling is part of the assertion.
 #[cfg(feature = "jsonschema")]
 #[model_schema(default_types(InitialType = char))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1520,11 +1467,9 @@ pub struct LifetimeStruct<'label> {
     pub label: Cow<'label, str>,
 }
 
-/// A constrained field beside a type parameter that is *not* itself constrained, combined with a
-/// lifetime — the combination `default_instantiation`'s lifetime-passthrough branch exists for.
-/// The declared-default `validate()` sits on `impl<'label> AnnotatedConstrained<'label, String>`,
-/// carrying the lifetime through unchanged while substituting only the type parameter, which is
-/// what lets the hand-written `impl AnnotatedConstrained<'label, u32>` below coexist with it.
+/// A constrained field beside an unconstrained type parameter, combined with a lifetime — the
+/// combination `default_instantiation`'s lifetime-passthrough branch exists for. The lifetime
+/// carries through unchanged, letting the hand-written impl below coexist with the generated one.
 #[cfg(all(
     feature = "serde",
     any(feature = "typescript", feature = "zod", feature = "jsonschema")
@@ -1563,10 +1508,8 @@ where
     pub label: LabelType,
 }
 
-/// A parameter whose bound names the item's other parameter, which holds only where that one is
-/// filled too. Both fillings are declared, so the bound is checked at both at once — `String`
-/// implements `From<String>` through the reflexive impl — and the fixture compiling is the whole
-/// of the assertion that a satisfying joint filling is let through.
+/// A parameter whose bound names the item's other parameter — checked jointly at both declared
+/// fillings (`String` implements `From<String>` via the reflexive impl).
 #[model_schema(default_types(WideType = String, NarrowType = String))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Widened<WideType: From<NarrowType>, NarrowType: Clone> {
@@ -1574,10 +1517,8 @@ pub struct Widened<WideType: From<NarrowType>, NarrowType: Clone> {
     pub wide: WideType,
 }
 
-/// A parameter bounded both ways at once: `Clone` reads no neighbour and is checked at the filling
-/// alone, `Into<Cow<'label, str>>` reads the item's lifetime and is checked at the whole parameter
-/// list. Both hold at the declared filling, so the fixture compiling asserts the two halves are
-/// each checked and neither is checked twice.
+/// A parameter bounded both ways at once: `Clone` is checked at the filling alone,
+/// `Into<Cow<'label, str>>` at the whole parameter list — neither checked twice.
 #[model_schema(default_types(LabelType = String))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Annotated<'label, LabelType: Clone + Into<Cow<'label, str>>> {
@@ -1654,10 +1595,8 @@ pub struct Carried<IdType> {
     pub id: IdType,
 }
 
-/// A parameter with no declared default type, which only a build generating a JSON document
-/// refuses: nothing else reads the default, so there is nothing for the absence to break. The
-/// fixture compiling under the feature sets that admit it is the whole of the assertion — under
-/// the one that does not, it is not declared at all.
+/// A parameter with no declared default type — only a build generating a JSON document refuses
+/// this, so it is declared only under the feature sets that admit it.
 #[cfg(not(feature = "jsonschema"))]
 #[model_schema()]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1750,11 +1689,9 @@ pub struct Referrer {
     pub tagged: Tagged<String>,
 }
 
-/// A declared filling that names another item rather than a primitive. Such a filling is not a
-/// literal document: it is written by asking the named item for its own, which reads the names in
-/// flight and the definitions being hoisted — so which frame the argumentless forms evaluate the
-/// filling in is the whole of what makes this fixture expand. Read by the JSON surface alone,
-/// which is the only one that fills a parameter with a document.
+/// A declared filling that names another item rather than a primitive — written by asking that
+/// item for its own document, reading the names in flight and definitions being hoisted. Read
+/// by the JSON surface alone, the only one that fills a parameter with a document.
 #[cfg(feature = "jsonschema")]
 #[model_schema(default_types(BodyType = Envelope))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1782,11 +1719,9 @@ pub struct Grove<BranchType> {
     pub named: Branch,
 }
 
-/// A cycle that closes through a declared filling: the item the filling names holds the generic
-/// item back, reaching it without arguments — which is writable only because the parameter carries
-/// a Rust-level default too. That is the one shape reaching this cycle. A cycle running through two
-/// declared fillings is a cycle in the parameter defaults themselves, which rustc refuses while
-/// computing them, before the attribute is read at all.
+/// A cycle that closes through a declared filling — reachable without arguments only because
+/// the parameter also carries a Rust-level default. A cycle through two declared fillings would
+/// be a cycle in the parameter defaults themselves, which rustc refuses before the attribute runs.
 #[cfg(feature = "jsonschema")]
 #[model_schema(default_types(HostType = Perch))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1813,11 +1748,9 @@ pub struct Summarised<ValueType> {
     pub tagged: Tagged<ValueType>,
 }
 
-/// A `default_types` entry naming another generic item at exactly the arguments that item calls
-/// its own default — the fold that lets the argument read `Tagged$SchemaDefault` rather than
-/// reconstruct `Tagged$SchemaFactory(z.string())` beside it, a call the memo would not share with
-/// `Tagged`'s own binding. Read by the Zod surface alone, which is the only one that renders a
-/// declared default as an argument.
+/// A `default_types` entry naming another generic item at exactly its own default — the fold
+/// that lets the argument read `Tagged$SchemaDefault` rather than reconstruct
+/// `Tagged$SchemaFactory(z.string())`, a call the memo would not share with it.
 #[cfg(feature = "zod")]
 #[model_schema(default_types(HolderType = Tagged<String>))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1836,9 +1769,8 @@ pub struct OverriddenDefault<HolderType> {
 }
 
 /// A declared default wrapping a sibling reference in a `Vec` — the direct-sibling fold gate
-/// requires `array_depth == 0`, so this falls through to the ordinary rendering, and that
-/// rendering names `Tagged$SchemaFactory` exactly as much as a bare reference does: it just does
-/// so from inside `z.array(...)` rather than at the argument's own top level.
+/// requires `array_depth == 0`, so this falls through to the ordinary rendering, naming
+/// `Tagged$SchemaFactory` from inside `z.array(...)` rather than at the argument's top level.
 #[cfg(feature = "zod")]
 #[model_schema(default_types(Items = Vec<Tagged<String>>))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1864,10 +1796,9 @@ pub struct ListedDefault<Items> {
     pub items: Items,
 }
 
-/// A generic branded newtype whose inner is a bare type parameter, carrying string constraints —
-/// held here rather than reused from `branded_newtype_tests` because each integration test file
-/// compiles as its own crate. `$SchemaDefault` composes the checks onto the declared-default
-/// argument, exactly as `constrained_generic_branded_tests::StrictDocumentId` does there.
+/// A generic branded newtype whose inner is a bare type parameter, carrying string constraints
+/// — held here rather than reused from `branded_newtype_tests` because each integration test
+/// file compiles as its own crate.
 #[cfg(all(feature = "zod", feature = "typescript", feature = "serde"))]
 #[model_schema(
     minLength = 24,
@@ -1879,12 +1810,9 @@ pub struct ListedDefault<Items> {
 #[serde(transparent)]
 pub struct ConstrainedId<IdType>(pub IdType);
 
-/// The door the declared-default `validate()` leaves open: `ConstrainedId<String>` (the declared
-/// default) gets the generated `validate()`, so a *second* inherent impl at a different
-/// instantiation is not a duplicate-definition error — it would be, were the generated one written
-/// as a blanket `impl<IdType> ConstrainedId<IdType>`. `u32` satisfies the `Display` bound the
-/// generic brand's declaration carries, so nothing about this instantiation is special beyond not
-/// being the default.
+/// The declared default (`ConstrainedId<String>`) gets the generated `validate()`, so this
+/// second inherent impl at a different instantiation is not a duplicate-definition error — it
+/// would be if the generated one were a blanket `impl<IdType> ConstrainedId<IdType>`.
 #[cfg(all(feature = "zod", feature = "typescript", feature = "serde"))]
 impl ConstrainedId<u32> {
     pub fn validate(&self) -> Result<(), Vec<String>> {
@@ -1895,11 +1823,9 @@ impl ConstrainedId<u32> {
     }
 }
 
-/// A declared default naming a *constrained* generic brand at exactly the arguments that brand
-/// calls its own. The emitted `$SchemaDefault` text carries a `.min`/`.max`/`.check` chain the
-/// plain rendering a downstream reference computes never spells, so the fold comparison has to key
-/// on the plain form or a constrained brand can never fold — the checks would be silently dropped
-/// from every reference naming it at its own default.
+/// A declared default naming a *constrained* generic brand at exactly its own default. The fold
+/// comparison has to key on the plain rendering — not the `.min`/`.max`/`.check` chain
+/// `$SchemaDefault` emits — or a constrained brand could never fold.
 #[cfg(all(feature = "zod", feature = "typescript", feature = "serde"))]
 #[model_schema(default_types(HolderType = ConstrainedId<String>))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1907,10 +1833,8 @@ pub struct ConstrainedEchoedDefault<HolderType> {
     pub held: HolderType,
 }
 
-/// A declared default naming a sibling — `ConstrainedEchoedDefault` — whose own recorded fold key
-/// itself names a further sibling (`ConstrainedId`) at matching arguments. The fold has to chain
-/// two levels deep, reading `ConstrainedEchoedDefault`'s comparison key back rather than the
-/// deferred, checks-carrying text its own `$SchemaDefault` emits.
+/// A declared default naming a sibling whose own recorded fold key itself names a further
+/// sibling at matching arguments — the fold chains two levels deep.
 #[cfg(all(feature = "zod", feature = "typescript", feature = "serde"))]
 #[model_schema(default_types(HolderType = ConstrainedEchoedDefault<ConstrainedId<String>>))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1956,12 +1880,9 @@ pub struct Refilled<ValueType> {
     pub value: ValueType,
 }
 
-/// A struct whose flattened source is one of its own type parameters. `#[serde(flatten)]` is read
-/// only where `serde` is, and the document is built only where `jsonschema` is, so the fixture
-/// exists where both do.
-///
-/// The declared filling is a scalar, which is the filling the merge has to answer for; the object
-/// filling reaches it from the reference site below.
+/// A struct whose flattened source is one of its own type parameters, gated on both `serde`
+/// (which reads `#[serde(flatten)]`) and `jsonschema` (which builds the document). The declared
+/// filling is a scalar; the object filling reaches it from the reference site below.
 #[cfg(all(feature = "serde", feature = "jsonschema"))]
 #[model_schema(default_types(HeldType = String))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1997,10 +1918,9 @@ fn a_parameter_with_no_default_still_expands_where_no_json_document_is_built() {
     assert_eq!(Undefaulted { id: 1_u32 }.id, 1);
 }
 
-/// A declared filling is checked against the bounds its parameter carries, and every shape a bound
-/// can reach — satisfied at the filling alone, satisfied jointly with a neighbour, both at once,
-/// and beside a const that takes no filling — still expands and still holds what the author wrote
-/// into it.
+/// Every shape a bound can reach — satisfied at the filling alone, jointly with a neighbour,
+/// both at once, and beside a const that takes no filling — still expands and holds what the
+/// author wrote.
 #[test]
 fn a_bounded_parameter_filled_at_a_type_its_bound_admits_still_expands() {
     assert_eq!(
@@ -2044,11 +1964,9 @@ fn a_generic_alias_expands_to_rust_that_compiles() {
     assert_eq!(concrete["k"], 2);
 }
 
-/// The pair the attribute used to produce on any generic item: `E0107` on the emitted `impl`,
-/// which dropped the parameters the declaration binds, and `E0433` on a module named after a
-/// parameter, which names no type and so publishes none. Both are compile errors, so the suite
-/// compiling is the assertion; this names an instance of each declaration shape so no build can
-/// drop one silently.
+/// The pair of compile errors the attribute used to produce on any generic item: `E0107` on the
+/// `impl` (dropped parameters) and `E0433` on a module named after a parameter (names no type).
+/// The suite compiling is the assertion.
 #[test]
 fn a_generic_item_expands_to_rust_that_compiles() {
     let wrapper = Wrapper {
@@ -2298,11 +2216,8 @@ fn a_lifetime_struct_still_holds_its_field_to_its_bound() {
 }
 
 /// The declared-default `validate()` for a type combining a lifetime with a type parameter still
-/// enforces the constrained field's bound, and the hand-written `impl
-/// AnnotatedConstrained<'label, u32>` beside `AnnotatedConstrained`'s own declaration compiles and
-/// runs without colliding with the generated `impl<'label> AnnotatedConstrained<'label, String>` —
-/// proof that `default_instantiation` carries the lifetime through the substitution correctly
-/// rather than dropping it or mishandling the mixed parameter list.
+/// enforces the constrained field's bound, and the hand-written impl at a different
+/// instantiation compiles and runs without colliding with the generated one.
 #[cfg(all(
     feature = "serde",
     any(feature = "typescript", feature = "zod", feature = "jsonschema")

--- a/tests/generic_types_tests/whole_type_tests.rs
+++ b/tests/generic_types_tests/whole_type_tests.rs
@@ -1,21 +1,10 @@
-//! Whole generic types, read on every surface at once.
+//! Whole generic types, read on every surface at once — TypeScript declaration, Zod factory, and
+//! JSON document together, plus the wire where serde compiles, since a suite that asks one
+//! question at a time can pass while the answers disagree with each other.
 //!
-//! The fixtures beside this one each hold a single question still — what one parameter position
-//! renders as, what one cache level looks like, what one reference site supplies. A type an author
-//! actually writes holds all of them at the same time, and a suite that only ever asks one at a
-//! time passes while the answers disagree with each other: a member the TypeScript declaration
-//! binds a parameter for, whose Zod factory takes an argument the JSON document has no filling for.
-//!
-//! So each fixture here is read three times over — the TypeScript declaration, the Zod factory, the
-//! JSON document — and, where serde compiles, against the wire the value actually writes. What is
-//! asserted is that the three agree about one type, not that each is separately plausible.
-//!
-//! The recursive pair at the end is the shape none of the single-question fixtures can hold: a type
-//! that reaches itself while it is still being described. The two surfaces answer it differently
-//! and both answers are pinned — JSON writes one definition and points a `$ref` back at it, and Zod
-//! defers the read so that the factory reaches its own memo before the reference is followed. What
-//! the deferral is worth is that the emitted module loads and validates at depth; the pins below
-//! are the emitted spelling, and the depth was read off the real output under `tsc` and `zod`.
+//! The recursive pair at the end reaches itself while still being described: JSON writes one
+//! definition and points a `$ref` back at it, and Zod defers the read so the factory reaches its
+//! own memo first — pinned against the real output under `tsc` and `zod`.
 
 /// serde's `rename_all` is what turns the declared members into the keys every surface here spells,
 /// so these read the emitted declaration only where the attribute is parsed at all.
@@ -55,11 +44,9 @@ mod typescript {
     }
 
     /// A brand is a type parameter's own spelling intersected with the marker, so a generic brand
-    /// binds its parameter and spends it in the intersection — and the type holding one names the
-    /// brand with the argument it forwards, two levels from where the parameter was declared.
-    ///
-    /// Which marker is written is the value surface's business — `$brand<"Name">` is Zod's — so the
-    /// intersection is read where that surface compiles.
+    /// binds its parameter and spends it in the intersection. Which marker is written
+    /// (`$brand<"Name">`) is Zod's business, so the intersection is read only where that surface
+    /// compiles.
     #[cfg(feature = "zod")]
     #[test]
     fn a_generic_brand_is_named_with_the_argument_forwarded_to_it() {
@@ -241,11 +228,9 @@ mod zod {
     }
 
     /// A value is a value: one Zod schema cannot stand for every filling, so a recursive generic
-    /// reaches itself by calling its own factory with the argument it was handed — never by naming
-    /// a `$Schema` binding, which a generic type does not publish at all.
-    ///
-    /// The member is written as a getter so the call is made after the factory has reached its own
-    /// memo, which is what ends the recursion instead of running it to the bottom of the stack.
+    /// reaches itself by calling its own factory with the argument it was handed, never a
+    /// `$Schema` binding a generic type does not publish. Written as a getter so the call happens
+    /// after the factory reaches its own memo — what ends the recursion.
     #[test]
     fn a_self_recursive_generic_calls_its_own_factory_behind_a_deferred_read() {
         let zod = ArchiveNode::<String>::zod_schema();
@@ -258,10 +243,10 @@ mod zod {
         assert!(!zod.contains("ArchiveNode$Schema)"), "Got: {zod}");
     }
 
-    /// A cycle between two generic types is ended at the reference written *forward* — the one
-    /// naming a type declared below, which is the reference a cycle cannot be built without. That
-    /// one is deferred; the reference back at a type already declared is read as it stands, because
-    /// what is left once the forward ones are deferred cannot cycle.
+    /// A cycle between two generic types is ended at the reference written *forward* — naming a
+    /// type declared below, which a cycle cannot be built without. That one is deferred; the
+    /// backward reference is read as it stands, since what's left after deferring forward
+    /// references cannot cycle.
     #[test]
     fn a_generic_cycle_is_deferred_at_the_reference_written_forward() {
         let branch = ArchiveBranch::<String>::zod_schema();
@@ -348,8 +333,7 @@ mod json_schema {
     /// A document cannot be written to the bottom of a recursion, so the type is hoisted into
     /// `$defs` once and the recursive member points a `$ref` back at it. One definition per name
     /// *and filling* — the key carries a readable label off the filling's own `"type"` keyword
-    /// plus a digest, since a document can hold this same generic name again at a different
-    /// filling (see the sibling-fillings test below), and a bare name would let the two collide.
+    /// plus a digest, since a bare name would let two fillings of the same generic collide.
     #[test]
     fn a_recursive_generic_is_hoisted_once_and_pointed_back_at() {
         assert_eq!(
@@ -391,11 +375,10 @@ mod json_schema {
     }
 
     /// Two sibling fields naming the same recursive generic at different fillings are the shape
-    /// neither the in-flight cycle check nor a bare `$defs` key can tell apart: the frames are
-    /// sequential rather than nested, so neither reference is ever in flight while the other runs.
-    /// Each filling gets its own definition and its own `$ref`; a third field at the same filling
-    /// as the first still shares that one definition; and each definition's own recursive member
-    /// resolves back to its own filling rather than whichever filling was written last.
+    /// neither the in-flight cycle check nor a bare `$defs` key can tell apart — the frames are
+    /// sequential, not nested. Each filling gets its own definition and `$ref`; a third field at
+    /// the first filling shares that definition; each recursive member resolves back to its own
+    /// filling.
     #[test]
     fn siblings_at_different_fillings_of_one_recursive_generic_each_get_their_own_definition() {
         let document = TwoLoopedFillings::json_schema();
@@ -702,9 +685,9 @@ pub struct ArchiveTrunk<IdType> {
 }
 
 /// A recursive generic reached by two sibling fields at two different fillings — sequential rather
-/// than nested, so neither reference is ever in flight while the other runs and the in-flight
-/// filling comparison never sees the pair at all. Read by the JSON surface alone, which is the one
-/// that hoists a recursive type into a `$defs` entry a bare name could collide under.
+/// than nested, so neither reference is in flight while the other runs. Read by the JSON surface
+/// alone, the one that hoists a recursive type into a `$defs` entry a bare name could collide
+/// under.
 #[cfg(all(feature = "jsonschema", feature = "serde"))]
 #[model_schema(default_types(ValueType = String))]
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/tests/item_description_tests/tests.rs
+++ b/tests/item_description_tests/tests.rs
@@ -178,12 +178,10 @@ fn assert_jsdoc_opens_with(ts: &str, expected: &str) {
     assert!(ts.starts_with(&header), "expected {expected} to open: {ts}");
 }
 
-/// The surface with the item's ident re-export taken off.
-///
-/// That line is the one place an item's Rust ident is written on purpose: a reference standing
-/// before the item has only the ident to spell, so each nominal surface answers at it. Everything
-/// else the item publishes is written under the name it is exported as, which is what the
-/// assertions below are about.
+/// The surface with the item's ident re-export taken off. That line is the one place an item's
+/// Rust ident is written on purpose — a reference standing before the item has only the ident to
+/// spell. Everything else is written under the name it's exported as, which the assertions below
+/// are about.
 #[cfg(any(feature = "typescript", feature = "zod"))]
 fn without_ident_reexport(surface: &str, ident: &str, exported: &str) -> String {
     surface
@@ -194,12 +192,10 @@ fn without_ident_reexport(surface: &str, ident: &str, exported: &str) -> String 
         )
 }
 
-/// The ` * ` lines a definition's `JSDoc` block is written from, with the block's own delimiters and
-/// the surrounding indentation set aside — what every shape spells from one body, and the one part
-/// of the emitted `TypeScript` the shapes may be held against each other over.
-///
-/// The rendered JSON schema an item publishes under `jsonschema` is appended after that body rather
-/// than written from it, so it is read as the end of the body and not as part of it.
+/// The ` * ` lines a definition's `JSDoc` block is written from, delimiters and surrounding
+/// indentation set aside — the one part of the emitted TypeScript the shapes may be held against
+/// each other over. The rendered JSON schema under `jsonschema` is appended after that body
+/// rather than written from it.
 #[cfg(feature = "typescript")]
 fn jsdoc_body_lines(ts: &str) -> Vec<String> {
     let (block, _) = ts

--- a/tests/item_jsdoc_example_tests/tests.rs
+++ b/tests/item_jsdoc_example_tests/tests.rs
@@ -373,10 +373,9 @@ fn example_only_twins() -> Vec<(String, String, &'static str, &'static str)> {
     ]
 }
 
-/// The reported failure: an item and a member documented with nothing but an example emitted an
-/// empty `JSDoc` body, where an undocumented one names what it is documenting. The strip is what
-/// decides whether anything was said, so what it leaves empty is what falls back to the name — and
-/// the shape is then the undocumented one, byte for byte.
+/// The reported failure: an item or member documented with nothing but an example emitted an
+/// empty `JSDoc` body, where an undocumented one names what it's documenting. What the strip
+/// leaves empty falls back to the name, so the shape becomes the undocumented one, byte for byte.
 #[test]
 fn an_example_only_shape_writes_what_its_undocumented_twin_writes() {
     // The aliases publish `ts_definition` from their own modules rather than from the alias, so

--- a/tests/item_rename_tests/tests.rs
+++ b/tests/item_rename_tests/tests.rs
@@ -51,11 +51,10 @@ pub struct ReferencesRenamedItems {
     pub tree: TreeUnderRustName,
 }
 
-/// Declaration order, taken both ways round. This struct names a renamed struct and a renamed enum
-/// that have not expanded yet, so the module each reference resolves to is derived from the item's
-/// Rust ident and nothing else; [`NamesRenamedItemsDeclaredEarlier`] names the same two once they
-/// are registered. Both have to reach the same modules, or one of the two orders names a module
-/// that was never emitted.
+/// Declaration order, taken both ways round: this struct names a renamed struct and enum that
+/// have not expanded yet, so the module each reference resolves to is derived from the item's
+/// Rust ident alone; [`NamesRenamedItemsDeclaredEarlier`] names the same two once registered.
+/// Both have to reach the same modules.
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct NamesRenamedItemsDeclaredLater {
@@ -296,9 +295,8 @@ fn renamed_items_declared_under_their_reference_expand_in_this_feature_combinati
 
 /// A struct naming a renamed struct or enum declared under it used to refuse the whole crate: the
 /// reference assumed `later_renamed_gauge_schema` while the item published
-/// `renamed_later_gauge_schema`, and rustc reported an `E0433` for a module the author never
-/// wrote. One spelling now answers on both sides, so which side of the item the reference is
-/// written on changes nothing.
+/// `renamed_later_gauge_schema`, an `E0433` for a module never written. One spelling now answers
+/// on both sides.
 #[cfg(feature = "jsonschema")]
 #[test]
 fn an_item_reference_describes_the_same_on_either_side_of_the_item() {
@@ -348,9 +346,8 @@ fn a_forward_referenced_renamed_item_exports_under_the_override() {
 
 /// The two declaration orders write the reference differently and always will: a reference
 /// standing before the item has nothing but the Rust ident to spell it by, and an override is not
-/// recoverable from that ident. What has to hold is name parity — every name a reference writes is
-/// one the emission the author collects also defines — so each nominal surface answers at the
-/// ident as well as at the override.
+/// recoverable from that ident. What has to hold is name parity — each nominal surface answers at
+/// the ident as well as at the override.
 #[cfg(feature = "typescript")]
 #[test]
 fn every_name_a_forward_item_reference_writes_is_defined_by_the_emission() {

--- a/tests/jsdoc_block_tests/tests.rs
+++ b/tests/jsdoc_block_tests/tests.rs
@@ -1,10 +1,8 @@
 //! One `JSDoc` block, one shape, wherever a surface writes one.
 //!
 //! A block opens at the indent of the member it documents, carries its body at that same indent,
-//! and closes with the delimiter JavaScript closes a block comment with. Nothing between the block
-//! and what it documents, and nothing between the last member and the brace that closes the object
-//! — the emitted text is what a caller writes to a `.ts` file, so a struct, a plain enum and a
-//! tagged enum have to agree on all of it rather than each spelling its own.
+//! and closes with the delimiter JavaScript closes a block comment with — the emitted text is what
+//! a caller writes to a `.ts` file, so a struct, a plain enum and a tagged enum must all agree.
 
 #![cfg(feature = "typescript")]
 

--- a/tests/jsonschema_tests.rs
+++ b/tests/jsonschema_tests.rs
@@ -1,18 +1,6 @@
-//! Comprehensive tests for JSON Schema generation.
-//!
-//! This module tests the JSON schema generation feature of tixschema.
-//! The `jsonschema` feature generates JSON schema objects from Rust types.
-//!
-//! ## What is tested:
-//! - Basic primitive types (string, number, integer, boolean).
-//! - Optional fields (not in required array).
-//! - Arrays.
-//! - `HashMaps` (as objects with additionalProperties).
-//! - Nested structs.
-//! - Plain enums (as string enums).
-//! - All numeric types (integer vs number).
-//! - Serde rename attributes.
-//! - `ObjectId` support (when `object_id` feature enabled).
+//! Tests for JSON Schema generation — the `jsonschema` feature's JSON schema objects from Rust
+//! types, covering primitives, optional fields, arrays, maps, nested structs, enums, numeric
+//! types, serde rename attributes, and `ObjectId` support.
 
 #[cfg(test)]
 #[cfg(feature = "jsonschema")]

--- a/tests/mongodb_real_tests/tests.rs
+++ b/tests/mongodb_real_tests/tests.rs
@@ -457,11 +457,10 @@ fn test_real_objectid_serialization() {
 }
 
 /// The hex a real `ObjectId` round-trips through serde, held to both generated surfaces at once.
-///
 /// The `pattern` keyword is a flagless ECMA-262 regex, so the Zod literal's flags are read here
-/// rather than dropped: a flag on one surface and not on the other is two contracts for one member,
-/// whatever the source spelling says. Lower-case is the only case there is to pin, because
-/// `ObjectId::to_hex()` is the only thing that writes this member.
+/// rather than dropped — a flag on one surface and not the other is two contracts for one member.
+/// Lower-case is the only case to pin, since `ObjectId::to_hex()` is the only thing that writes
+/// this member.
 #[test]
 #[cfg(all(feature = "object_id", feature = "jsonschema", feature = "zod"))]
 fn a_real_object_id_hex_satisfies_the_zod_literal_and_the_json_schema_pattern_alike() {

--- a/tests/omitted_key_tests/tests.rs
+++ b/tests/omitted_key_tests/tests.rs
@@ -1,10 +1,7 @@
-//! The wire is the arbiter. serde writes two payloads for a field carrying a `skip_serializing_if`
-//! — one with the key, one without it — and each surface is held to admitting exactly those two.
-//!
-//! The payloads are asserted first, in this file, so the surface expectations below are read off
-//! them rather than off each other. What serde writes does not turn on the crate's `serde` feature,
-//! and neither do the expectations: the attribute is on the declaration in every build, so every
-//! build owes the same answer.
+//! The wire is the arbiter. serde writes two payloads for a field carrying a
+//! `skip_serializing_if` — one with the key, one without — and each surface is held to admitting
+//! exactly those two, asserted first here so the surface expectations below are read off them.
+//! The attribute is on the declaration in every build, so every build owes the same answer.
 
 use serde::{Deserialize, Serialize};
 use tixschema::model_schema;
@@ -146,8 +143,8 @@ fn zod_keeps_the_undefined_union_that_already_admits_the_absent_key() {
 
 /// A plain `z.array(...)` member rejects the payload serde writes for an empty `Vec` — recorded
 /// against zod 4.4.3 under node v26.2.0, `safeParse({ id: "1" })` failing with `invalid_type` at
-/// `roles`. `.optional()` is what admits the absent key while still rejecting `null` and still
-/// rejecting an unrecognized key under the surrounding `z.strictObject`.
+/// `roles`. `.optional()` admits the absent key while still rejecting `null` and an unrecognized
+/// key under `z.strictObject`.
 #[test]
 #[cfg(feature = "zod")]
 fn zod_marks_the_predicate_omitted_key_optional() {

--- a/tests/optional_key_flag_tests/tests.rs
+++ b/tests/optional_key_flag_tests/tests.rs
@@ -1,8 +1,8 @@
 //! `ts_optional` is the whole of what decides between `field?: T` and `field: T | undefined`.
 //!
-//! Every shape below carries a flagged member beside an unflagged control of the same type and the
-//! same serde attributes, so the flag is the only difference the two lines can come from. Held
-//! under both feature flavours, since only one of them reads an attribute at all.
+//! Every shape below carries a flagged member beside an unflagged control of the same type and
+//! attributes, so the flag is the only difference. Held under both feature flavours, since only
+//! one reads an attribute at all.
 
 #[cfg(feature = "serde")]
 mod under_the_serde_feature {
@@ -83,11 +83,9 @@ mod without_the_serde_feature {
     use tixschema::model_schema;
 
     /// An `Option<T>` no attribute says anything about. Declarable only here — under the `serde`
-    /// feature the `Option`-null guard refuses both of these fields.
-    ///
-    /// Declared with its fields alphabetically, as this crate's lints require of Rust source; the
-    /// README orders the same three for reading. Only the written order differs, so each member is
-    /// held as a whole line rather than as part of a block.
+    /// feature the `Option`-null guard refuses both of these fields. Fields are declared
+    /// alphabetically (this crate's lint requirement); the README orders them for reading, so
+    /// each member is held as a whole line.
     #[model_schema()]
     #[derive(Debug, Clone, PartialEq)]
     struct Profile {

--- a/tests/optional_nesting_tests/tests.rs
+++ b/tests/optional_nesting_tests/tests.rs
@@ -1,10 +1,9 @@
 //! An `Option` inside a covered sequence wrapper and an `Option` around one are two different
 //! values on the wire, and each surface has to say which it describes.
 //!
-//! Every expectation here is read off what serde writes, asserted first in this file and then
-//! described by the three surfaces in the same order: a `None` the wrapper holds is a `null` among
-//! the array's items, so the items admit `null` and the array itself does not; a `None` around the
-//! wrapper replaces the whole array, so the array admits `null` and its items do not.
+//! Every expectation here is read off what serde writes: a `None` the wrapper holds is a `null`
+//! among the array's items (items admit `null`, the array does not); a `None` around the wrapper
+//! replaces the whole array (the array admits `null`, its items do not).
 
 use alloc::collections::BTreeSet;
 use serde::{Deserialize, Serialize};

--- a/tests/pattern_preprocess_tests/tests.rs
+++ b/tests/pattern_preprocess_tests/tests.rs
@@ -433,7 +433,7 @@ fn test_pattern_enum_variant_serde_validation() {
 // The Zod surface splices a pattern into a JS regex literal, where `/` is the delimiter: an
 // unescaped one closes the literal early and the emitted TypeScript stops parsing. That escaping
 // belongs to the splice alone — JSON Schema and the Rust-side validator carry the pattern as a
-// plain string and must see it byte for byte as written.
+// plain string, byte for byte.
 
 #[cfg(feature = "zod")]
 #[test]
@@ -552,8 +552,8 @@ fn test_the_escaped_zod_pattern_matches_the_value_set_the_validator_enforces() {
 
 // A JS regex literal cannot carry a raw line terminator: the literal ends at the line break and
 // the emitted TypeScript stops parsing, exactly as an unescaped delimiter did. The escape form
-// denotes the same character, so the literal keeps matching what the Rust-side validator enforces,
-// and the surfaces that carry the pattern as a plain string still see it byte for byte.
+// denotes the same character, so surfaces carrying the pattern as a plain string still see it
+// byte for byte.
 
 #[cfg(feature = "zod")]
 #[test]

--- a/tests/readme_example_tests/tests.rs
+++ b/tests/readme_example_tests/tests.rs
@@ -1,22 +1,14 @@
 //! The README's `Option` examples, expanded here as the README declares them.
 //!
-//! An `Option` field serde writes as `null` for a `None` is refused where it is declared, so an
-//! example carrying one is not a declaration a reader can paste — and the block beside it, showing
-//! the key that declaration would render, describes a build the declaration cannot be written in.
-//! Each example is therefore held to two things: the README still declares it exactly as it is
-//! declared here, and the emission the README shows beside it is what the generator answers with.
-//! Drift on either side fails here rather than in someone's editor.
+//! An `Option` field serde writes as `null` for `None` is refused where declared, so an example
+//! carrying one is not a declaration a reader can paste. Each example is held to two things: the
+//! README declares it exactly as here, and the emission shown beside it is what the generator
+//! answers with — drift on either side fails here rather than in someone's editor.
 //!
-//! Each type is declared with its fields ordered alphabetically, as this crate's lints require of
-//! Rust source; the README orders its examples for reading. Only the order the members are written
-//! in differs, so every member is held as a whole line rather than as part of a block — what is
-//! pinned is the spelling of each, which is what an omitted key changes. A derive list is widened
-//! here for the same reason and to the same effect on the emission, which is none: the generator
-//! reads no derive but serde's.
-//!
-//! The README's `ts_optional` example is not here. The flag decides the key only where no serde
-//! attribute is read, so the section shows a declaration this module's build cannot compile; the
-//! same declares-and-shows pin sits in `optional_key_flag_tests`, gated the other way.
+//! Fields are declared alphabetically (this crate's lint requirement) while the README orders
+//! them for reading, so each member is held as a whole line rather than part of a block. The
+//! README's `ts_optional` example is not here — it cannot compile under this module's build — and
+//! is instead pinned in `optional_key_flag_tests`, gated the other way.
 
 #![cfg(all(feature = "serde", feature = "typescript"))]
 
@@ -348,11 +340,9 @@ fn test_the_chrono_example_is_declarable_and_shows_what_it_emits() {
     );
 }
 
-/// The README declares this, and the block beside it is the emission whole.
-///
-/// Held as one block rather than line by line, which is what a truncated paste needs: an emission
-/// shown down to its seventh line matches every line it shows and still leaves the reader without
-/// the factory the rest of the block declares.
+/// The README declares this, and the block beside it is the emission whole — held as one block
+/// rather than line by line, since a truncated paste (matching only the first several lines)
+/// would still leave the reader without the factory the rest declares.
 fn assert_readme_declares_and_shows_whole(declaration: &str, emission: &str) {
     assert!(
         readme().contains(declaration),
@@ -365,11 +355,9 @@ fn assert_readme_declares_and_shows_whole(declaration: &str, emission: &str) {
 }
 
 /// The "Branded Newtypes" example: a generic brand beside a non-generic one, and the whole of what
-/// each publishes.
-///
-/// A generic brand publishes a factory, so its emission runs well past the builder the block used
-/// to stop at — the type alias reading the builder's return back, the two-method cache interface,
-/// the cache itself and the exported factory. All of it is what a reader pastes.
+/// each publishes. A generic brand publishes a factory, so its emission runs well past the
+/// builder the block used to stop at — the alias, the cache interface, the cache itself and the
+/// exported factory, all of it what a reader pastes.
 #[test]
 #[cfg(feature = "zod")]
 fn test_the_branded_newtype_example_is_declarable_and_shows_what_it_emits() {
@@ -453,9 +441,8 @@ fn test_the_documented_branded_newtype_example_is_declarable_and_shows_what_it_e
 }
 
 /// The rejected half of the constrained-brand rule for an inner written over a parameter. Only its
-/// spelling can be held here — the declaration itself is a `compile_error!` by construction, which
-/// is what the rule says it should be — so what this pins is that the README still shows the two
-/// declarations the refusal is written about.
+/// spelling can be held here, since the declaration itself is a `compile_error!` by construction —
+/// this pins that the README still shows the two declarations the refusal is written about.
 #[test]
 fn test_the_constrained_brand_over_a_parameterised_inner_example_is_still_shown() {
     assert!(

--- a/tests/recursive_type_tests/tests.rs
+++ b/tests/recursive_type_tests/tests.rs
@@ -1,9 +1,9 @@
 /// What a self-referential type describes as on the JSON-schema and TypeScript surfaces.
 ///
-/// Each description is produced in a child copy of this test binary. A description that does not
-/// terminate overflows the stack, and a stack overflow aborts the process rather than unwinding —
-/// there is nothing to catch where it happens. Running it in a child turns that abort into an exit
-/// status the parent asserts on, so a regression fails one test instead of killing the suite.
+/// Each description runs in a child copy of this test binary: a description that doesn't
+/// terminate overflows the stack, and a stack overflow aborts the process with nothing to catch.
+/// Running it in a child turns that abort into an exit status the parent asserts on, so a
+/// regression fails one test instead of killing the suite.
 #[cfg(feature = "jsonschema")]
 mod describes {
     use super::{
@@ -28,11 +28,10 @@ mod describes {
     /// The libtest path of [`production`], which the parent names to run only it in the child.
     const CHILD_TEST: &str = "tests::describes::production";
 
-    /// The deepest object or array nesting anywhere in a description.
-    ///
-    /// A type that names itself has a description whose depth is set by its own fields. One that
-    /// terminated by unrolling itself a fixed number of times instead would be far deeper, which
-    /// is the difference this measures.
+    /// The deepest object or array nesting anywhere in a description. A type that names itself has
+    /// a description whose depth is set by its own fields — one that terminated by unrolling
+    /// itself a fixed number of times instead would be far deeper, which is the difference this
+    /// measures.
     fn depth(value: &Value) -> usize {
         match value {
             Value::Object(members) => 1 + members.values().map(depth).max().unwrap_or_default(),
@@ -463,7 +462,7 @@ pub struct Person {
 
 /// Two non-generic structs cycling through a `Vec` — `Chapter` names `Section` before `Section`
 /// is declared, and `Section` names `Chapter` back afterward. Legal Rust, no `Box` needed, since
-/// the cycle runs through a collection on both sides; this is the zero-argument counterpart of
+/// the cycle runs through a collection on both sides; the zero-argument counterpart of
 /// `CycleLeader`/`CycleFollower` in `generic_types_tests`.
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -666,9 +665,8 @@ fn test_recursive_named_struct_variant() {
 }
 
 /// Test 8b: the same recursive field, now nested under an adjacent form's content key. The field's
-/// own getter still has to defer the reference; the content key itself needs none; wrapping it in a
-/// second getter would be wrong precedent (see `render_external_variant`'s `defer_key`, which never
-/// sets it for a `Named` variant either).
+/// own getter still defers the reference; the content key needs none — a second getter would be
+/// wrong precedent (see `render_external_variant`'s `defer_key`, never set for a `Named` variant).
 #[test]
 fn test_recursive_named_struct_variant_adjacent() {
     let zod = TreeEnumAdjacent::zod_schema();
@@ -701,10 +699,10 @@ fn test_recursive_boxed_option_struct() {
     );
 }
 
-/// Test 10: A non-generic forward reference — a bare, zero-argument sibling declared BELOW the
-/// type naming it — has to defer exactly as a generic forward reference already does, or the
-/// module the pair is written into throws at import in every concatenation order: whichever half
-/// of the cycle lands first names a `const` the other half has not published yet.
+/// Test 10: a non-generic forward reference — a bare, zero-argument sibling declared BELOW the
+/// type naming it — has to defer exactly as a generic forward reference does, or the module
+/// throws at import in every concatenation order: whichever half lands first names a `const` the
+/// other has not published yet.
 #[test]
 fn test_non_generic_forward_reference_defers_through_a_getter() {
     let chapter_zod = Chapter::zod_schema();

--- a/tests/rename_all_tests/tests.rs
+++ b/tests/rename_all_tests/tests.rs
@@ -46,10 +46,10 @@ enum SandboxKind {
     PlainAdd,
 }
 
-// One struct-variant enum per tagged representation, each carrying an enum-level `rename_all` and
-// two variants: `Unmarked` has no rename of its own, so its field must stay as declared — the
+// One struct-variant enum per tagged representation, each carrying an enum-level `rename_all`
+// and two variants: `Unmarked` has no rename of its own, so its field stays as declared — the
 // container-level rule cases the discriminator alone, never a variant's fields. `Marked` carries
-// its own `rename_all`, which serde treats as the container for its own fields and does apply.
+// its own `rename_all`, which serde treats as the container for its own fields.
 #[model_schema()]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "kind", rename_all = "camelCase")]

--- a/tests/semantic_types_tests.rs
+++ b/tests/semantic_types_tests.rs
@@ -1,17 +1,6 @@
-//! Comprehensive tests for type alias support.
-//!
-//! Type aliases allow developers to create semantic types (e.g., `DocumentId`, `UserId`)
-//! that are distinct in TypeScript but use primitive types in Rust.
-//!
-//! This module tests:
-//! - Basic type aliases (String, numeric types).
-//! - Optional type aliases (Option<T>).
-//! - Generic type aliases (Pair<T, U>).
-//! - Nested type aliases (alias referencing another alias).
-//! - Type aliases used as struct fields.
-//! - Type aliases in collections (Vec, `HashMap`).
-//! - TypeScript, Zod, and JSON schema generation.
-//! - Module structure and naming.
+//! Tests for type alias support — semantic types (e.g. `DocumentId`, `UserId`) distinct in
+//! TypeScript but backed by primitives in Rust, covering basic, optional, generic and nested
+//! aliases, alias fields and collections, and module structure across all three surfaces.
 
 #[cfg(test)]
 #[path = "semantic_types_tests/tests.rs"]

--- a/tests/serde_tests.rs
+++ b/tests/serde_tests.rs
@@ -1,14 +1,6 @@
-//! Comprehensive tests for Serde attribute handling.
-//!
-//! This module tests how tixschema handles Serde attributes when the `serde` feature is enabled.
-//!
-//! ## What is tested:
-//! - `rename_all` with different case conventions (camelCase, `snake_case`, `PascalCase`, etc.).
-//! - Field-level rename attribute.
-//! - Combination of `rename_all` and field rename.
-//! - Serde attributes with optional fields.
-//! - Serde attributes in TypeScript, Zod, and JSON schema generation.
-//! - Enum `rename_all`.
+//! Tests for how tixschema handles Serde attributes under the `serde` feature — `rename_all`
+//! case conventions, field-level rename, combinations of the two, optional fields, and enum
+//! `rename_all`, across TypeScript, Zod, and JSON schema generation.
 
 #[cfg(test)]
 #[cfg(feature = "serde")]

--- a/tests/skipped_field_tests/tests.rs
+++ b/tests/skipped_field_tests/tests.rs
@@ -1,20 +1,16 @@
-//! The wire is the arbiter, and it is read in both directions before any surface is asserted.
+//! The wire is the arbiter, read in both directions before any surface is asserted.
 //!
-//! Three spellings drop a field out of one direction or both, and the payloads they produce are
-//! three different payloads. A bare `skip` — and the two halves written side by side, which is what
-//! it abbreviates — takes the key out of everything serde writes *and* throws it away out of
-//! everything serde reads, so nothing on the wire ever carries it and no surface has a member to
-//! describe. `skip_serializing` alone drops the key on the way out but still reads a supplied one,
-//! so its member is described under an optional key. `skip_deserializing` alone writes the key in
-//! every payload, so its member keeps a required one.
+//! Three spellings drop a field out of one direction or both: a bare `skip` drops the key from
+//! both read and write, so no surface has a member to describe; `skip_serializing` alone drops
+//! the key on the way out but still reads a supplied one, so its member is described under an
+//! optional key; `skip_deserializing` alone writes the key in every payload, so its member keeps
+//! a required one.
 //!
-//! Dropping the member is stricter than serde on the read side, and deliberately so. Recorded
-//! against zod 4.4.3 under node v26.2.0: `z.strictObject({ id: z.string() })` accepts
-//! `{ id: "1" }` and rejects `{ id: "1", internal: ["x"] }` with `unrecognized_keys`
-//! (`Unrecognized key: "internal"`), while serde accepts that same payload and discards the value.
-//! The surfaces describe the payload serde *writes*, and serde writes that key in no payload at
-//! all; an optional member would claim the opposite — that the key is sometimes written — and would
-//! additionally describe a value the deserializer throws away.
+//! Dropping the member is stricter than serde on the read side, deliberately. Recorded against
+//! zod 4.4.3 under node v26.2.0: `z.strictObject({ id: z.string() })` rejects
+//! `{ id: "1", internal: ["x"] }` with `unrecognized_keys`, while serde accepts that same payload
+//! and discards the value — the surfaces describe the payload serde *writes*, and serde writes
+//! that key in no payload at all.
 
 use serde::{Deserialize, Serialize};
 use tixschema::model_schema;

--- a/tests/substituted_field_type_tests/tests.rs
+++ b/tests/substituted_field_type_tests/tests.rs
@@ -1,9 +1,8 @@
 //! One declaration written twice: once through a `macro_rules!` metavariable, once by hand.
 //!
-//! The fixtures below are the same struct. The only thing that differs between them is which of
-//! the two ways the field types were spelled, and that is not something any surface describes — so
-//! every assertion here is the same assertion: the two describe identically, and neither describes
-//! a field as the opaque value.
+//! The fixtures below are the same struct — the only difference is which of the two ways the
+//! field types were spelled, which no surface describes. Every assertion here is the same
+//! assertion: the two describe identically, and neither describes a field as the opaque value.
 
 #[cfg(feature = "jsonschema")]
 mod jsonschema {
@@ -183,10 +182,9 @@ pub struct Written {
 #[serde(transparent)]
 pub struct WrittenSlug(pub String);
 
-/// The substituted item's surface under the written twin's name, so the two can be compared as the
-/// one description they are — the name is the only thing about them that differs.
-///
-/// The JSON document names nothing, so only the two rendered surfaces have a name to put back.
+/// The substituted item's surface under the written twin's name, so the two can be compared as
+/// the one description they are — the name is the only thing about them that differs. The JSON
+/// document names nothing, so only the two rendered surfaces have a name to put back.
 #[cfg(any(feature = "typescript", feature = "zod"))]
 fn as_written(rendered: &str) -> String {
     rendered.replace("Substituted", "Written")

--- a/tests/transparent_wrapper_tests/tests.rs
+++ b/tests/transparent_wrapper_tests/tests.rs
@@ -334,9 +334,8 @@ fn ts_field_declarations(definition: &str) -> Vec<String> {
         .collect()
 }
 
-/// One populated instance of every wrapper twin, serialized, beside the bare spelling's.
-///
-/// `Cell` is not among them: its fixture holds a different, reduced field set (see
+/// One populated instance of every wrapper twin, serialized, beside the bare spelling's. `Cell`
+/// is not among them: its fixture holds a different, reduced field set (see
 /// `test_cell_field_writes_its_inner_value` and its neighbors below).
 fn covered_wrapper_payloads() -> [(&'static str, serde_json::Value); 7] {
     [
@@ -525,10 +524,9 @@ fn test_every_covered_wrapper_describes_as_the_inner_spelling() {
     }
 }
 
-/// The same holding on the `TypeScript` surface, with the fixture's own name set aside.
-/// Declarations rather than whole definitions, because the surrounding `JSDoc` differs for a reason
-/// of its own: a field written under an `Option` or a `Vec` has its doc comment dropped, so the
-/// twins' `Option`- and `Vec`-inner fields carry a doc comment the bare spelling has lost.
+/// The same holding on TypeScript, fixture name set aside. Declarations rather than whole
+/// definitions, because the surrounding `JSDoc` differs: a field under `Option` or `Vec` has its
+/// doc comment dropped, so the twins' inner fields carry a doc comment the bare spelling has lost.
 #[test]
 #[cfg(feature = "typescript")]
 fn test_every_covered_wrapper_types_as_the_inner_spelling() {

--- a/tests/tuple_field_tests/tests.rs
+++ b/tests/tuple_field_tests/tests.rs
@@ -214,21 +214,16 @@ fn test_optional_tuple_field_zod() {
     );
 }
 
-// The remargin compact-row shape is `Vec<(Option<String>, Vec<usize>, String,
-// Option<String>)>`. That exact struct field trips `clippy::type_complexity`
-// (the outer `Vec` + nested `Vec<usize>` + 4 elements together clear the
-// threshold), and factoring it into a `type` alias would make the macro treat it
-// as a sibling reference rather than a tuple — so the happy path is proven in two
-// composable halves: the exact inner tuple below (all four slots, including
-// `Vec<usize>` → `Array<number>` and both `Option` → null), and the outer
-// `Vec` → `Array<[...]>` wrap in `test_tuple_element_option_array_wrap`. The wire
-// round-trip exercises the full shape through a `type` alias, which serde reads
-// natively.
+// The remargin compact-row shape is `Vec<(Option<String>, Vec<usize>, String, Option<String>)>`,
+// which trips `clippy::type_complexity` as a struct field, and factoring it into a `type` alias
+// would make the macro treat it as a sibling reference rather than a tuple — so the happy path is
+// proven in two composable halves: the exact inner tuple below, and the outer `Vec` wrap in
+// `test_tuple_element_option_array_wrap`. The wire round-trip exercises the full shape through a
+// `type` alias, which serde reads natively.
 
-/// Null-flavor happy path (TS): each `Option` element inside a tuple renders as
-/// `T | null` — a positional slot serializes `None` as JSON `null`, unlike an
-/// omittable object key. Also the scenario-5 negative guard: a required tuple
-/// field emits no `undefined` at all.
+/// Null-flavor happy path (TS): each `Option` element inside a tuple renders as `T | null` — a
+/// positional slot serializes `None` as JSON `null`, unlike an omittable object key. Also the
+/// negative guard: a required tuple field emits no `undefined` at all.
 #[test]
 fn test_tuple_element_option_null_flavor_ts() {
     #[model_schema()]
@@ -315,10 +310,9 @@ fn test_tuple_element_option_null_flavor_json_schema() {
     assert_eq!(prefix[2], serde_json::json!({ "type": "string" }));
 }
 
-/// Array-wrap composition (TS): a `Vec<(Option<Vec<usize>>, String)>` field wraps
-/// the tuple in `Array<[...]>`, and the null flavor survives the wrap. The
-/// `Option<Vec<usize>>` slot proves the array wrap happens inside the base with
-/// `null` on top: `Array<number> | null`.
+/// Array-wrap composition (TS): a `Vec<(Option<Vec<usize>>, String)>` field wraps the tuple in
+/// `Array<[...]>`, and the null flavor survives the wrap — the `Option<Vec<usize>>` slot proves
+/// the array wrap happens inside the base with `null` on top: `Array<number> | null`.
 #[test]
 fn test_tuple_element_option_array_wrap_ts() {
     #[model_schema()]

--- a/tests/tuple_variant_tests/tests.rs
+++ b/tests/tuple_variant_tests/tests.rs
@@ -17,9 +17,9 @@ pub enum Outer {
 }
 
 /// The content key of a single-element tuple variant is a slot: serde always writes the key, so a
-/// `None` at the outermost level reaches the wire as a `null` under it rather than dropping the
-/// key. The three variants below are the three answers the surfaces owe — the `Option` around the
-/// array, the `Option` among its items, and no `Option` at all.
+/// `None` at the outermost level reaches the wire as `null` rather than dropping the key. The
+/// three variants below cover the `Option` around the array, the `Option` among its items, and no
+/// `Option` at all.
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(tag = "type", content = "value")]
@@ -41,10 +41,10 @@ pub enum SlotElements {
 
 /// A struct variant of an adjacently tagged enum: serde nests its fields in an object under the
 /// content key rather than splicing them beside the tag. `Named`'s optional `y` covers key
-/// optionality at the nested depth. The empty-content case (`Empty {}`) has no way to be declared
-/// here without tripping `clippy::empty_enum_variants_with_brackets`, so it is covered by
+/// optionality at the nested depth. The empty-content case (`Empty {}`) trips
+/// `clippy::empty_enum_variants_with_brackets` here, so it's covered instead by
 /// `adjacently_tagged_empty_named_variant_nests_an_empty_content_object` in
-/// `src/model_schema/tests.rs` instead, built through `parse_quote!` rather than a real item.
+/// `src/model_schema/tests.rs`, built through `parse_quote!`.
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "kind", content = "data")]
@@ -57,10 +57,9 @@ pub enum AdjacentNamed {
     Unit,
 }
 
-/// An enum carrying no `#[serde(tag = ..., content = ...)]` is externally tagged: serde writes the
-/// variant name as the sole key of an object holding the content, and a unit variant as the bare
-/// name. The four variants below are the four contents that key can hold, plus the one that has no
-/// key at all.
+/// An externally tagged enum (no `#[serde(tag = ..., content = ...)]`): serde writes the variant
+/// name as the sole key of an object holding the content, or the bare name for a unit variant. The
+/// four variants below cover what that key can hold, plus the keyless case.
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub enum External {
@@ -103,10 +102,9 @@ pub struct TagPayload {
     pub b: bool,
 }
 
-/// An enum carrying `#[serde(tag = ...)]` and no `content` is internally tagged: there is no key
-/// for a variant's data, so what it writes are members of the object the tag is written in. The
-/// three variants are the three things that can be written there — nothing at all, a struct
-/// variant's own fields, and the members of a newtype variant's inner type.
+/// An internally tagged enum (`#[serde(tag = ...)]`, no `content`) writes a variant's data as
+/// members of the object the tag is written in. The three variants cover what can be written
+/// there: nothing, a struct variant's own fields, or a newtype variant's inner members.
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "type")]
@@ -221,10 +219,9 @@ pub enum RecursiveExternal {
     Txt(String),
 }
 
-/// The positions a dropped slot can sit in, beside the variant that drops none. A leading drop is
+/// The positions a dropped slot can sit in, beside the variant that drops none: a leading drop is
 /// the one the slots behind move up into, a trailing one only shortens the array, a middle one is
-/// where the renumbering shows, every slot dropped still writes an array, and a lone slot dropped
-/// leaves the variant a unit.
+/// where the renumbering shows, and a lone slot dropped leaves the variant a unit.
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub enum ExternalDroppedSlots {
@@ -243,10 +240,10 @@ pub enum ExternalKeptOnly {
     Kept(u8, bool),
 }
 
-/// The same drops under a content key, where the array is written under `value` rather than under
-/// the variant's own name. `Lone` is declared as the unit it would have been written as: under this
-/// tagging alone the collapse has no payload to be described by and is refused, and this is the
-/// remedy that refusal names.
+/// The same drops under a content key, where the array is written under `value` rather than the
+/// variant's own name. `Lone` is declared as the unit it would have been written as — under this
+/// tagging alone the collapse has no payload to describe and is refused; this is the remedy that
+/// refusal names.
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(tag = "type", content = "value")]
@@ -1051,10 +1048,10 @@ fn test_empty_tuple_variant() {
     );
 }
 
-/// Test 16: enum tuple variant with an `Option` element gets null flavor in the
-/// generated JSON Schema, via the same shared element builder used by struct
-/// tuple fields. A positional tuple slot serializes `None` as `null`, so the
-/// optional element renders `anyOf [<base>, null]`; arity is unchanged.
+/// Test 16: an enum tuple variant with an `Option` element gets null flavor in the generated JSON
+/// Schema, via the same shared element builder struct tuple fields use — a positional tuple slot
+/// serializes `None` as `null`, so the optional element renders `anyOf [<base>, null]`, arity
+/// unchanged.
 #[cfg(feature = "jsonschema")]
 #[test]
 fn test_optional_tuple_variant_element_json_schema_null_flavor() {
@@ -1799,7 +1796,7 @@ fn test_bare_tag_zod_intersects_the_inner_schema() {
 
 /// Test 22c2: the inner type is a `const` of its own and nothing orders one type's emitted module
 /// against another's, so naming it straight into the member would read it while the enum's own
-/// `const` initializes — which fails for any inner type declared below. The read is deferred to
+/// `const` initializes — failing for any inner type declared below. The read is deferred to
 /// whenever something validates, the same way a `#[serde(flatten)]` base's is.
 #[cfg(feature = "zod")]
 #[test]

--- a/tests/typescript_feature_tests/tests.rs
+++ b/tests/typescript_feature_tests/tests.rs
@@ -127,10 +127,8 @@ fn test_typescript_enabled_discriminated_enum_zod_schema() {
 #[test]
 #[cfg(not(feature = "typescript"))]
 fn test_typescript_disabled_struct_ts_definition_not_available() {
-    // The ts_definition method should not be available when typescript feature is disabled.
-    // This would cause a compile error if we tried to call TypeScriptTestUser::ts_definition().
-    // We can't test the compilation failure directly, but we can verify the method doesn't exist
-    // by checking that our code compiles without calling it.
+    // ts_definition() should not exist when the typescript feature is disabled — not directly
+    // testable as a compile failure, so we verify the surrounding code still compiles without it.
 }
 
 #[test]

--- a/tests/untagged_tests/tests.rs
+++ b/tests/untagged_tests/tests.rs
@@ -59,10 +59,9 @@ enum NamedUnion {
     B { y: i64 },
 }
 
-// A struct variant's own `rename_all` cases its fields — the container rule serde applies to a
-// struct variant, distinct from the enum's own `rename_all` (which cases variant names, never the
-// fields inside one). Both variants carry one so the flatten holder below closes two renamed keys
-// against each other.
+// A struct variant's own `rename_all` cases its fields — distinct from the enum's own
+// `rename_all`, which cases variant names, never fields. Both variants carry one so the flatten
+// holder below closes two renamed keys against each other.
 #[model_schema()]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -145,11 +144,10 @@ enum ShapedUnion {
     Pair { pair: (i64, String) },
 }
 
-// The std wrappers serde writes as a JSON array of their element, written in untagged members. Each
-// writes what a `Vec` of the same element writes, so each member has to describe as that field does
-// rather than as a schema module named after the wrapper. `LinkedList` is covered too and has no
-// member here, the crate's own lints forbidding it a value of one; it is covered by name at the
-// dispatch's own unit tests instead.
+// The std wrappers serde writes as a JSON array of their element, written in untagged members:
+// each describes as the `Vec` of the same element does, not as a schema module named after the
+// wrapper. `LinkedList` has no member here — the crate's own lints forbid a value of one — so
+// it's covered by name at the dispatch's own unit tests instead.
 #[model_schema()]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -931,10 +929,9 @@ fn test_untagged_wrapper_member_wire() {
     }
 }
 
-/// A member holding a covered sequence wrapper describes as the array serde writes: the element's
-/// own schema under array wrapping. Held against the struct field written from the same type, which
-/// is the rendering a member must not diverge from — and which is where the wrapper name stopped
-/// standing for a schema module of its own.
+/// A member holding a covered sequence wrapper describes as the array serde writes — the element's
+/// own schema under array wrapping. Held against the struct field written from the same type, the
+/// rendering a member must not diverge from.
 #[test]
 #[cfg(feature = "jsonschema")]
 fn test_untagged_wrapper_member_json_schema() {
@@ -1041,9 +1038,9 @@ fn test_untagged_string_array_member_wire() {
 }
 
 /// A member holding a `String` under array levels describes as the array of strings serde writes,
-/// and as the struct field written from the same type describes. The member's value used to be the
-/// one the array wrap could not carry: a Rust block landing where the wrap's `serde_json::json!`
-/// reads a JSON object, which is the expansion that never reached a compiler.
+/// matching the struct field written from the same type. This used to be the one value the array
+/// wrap could not carry — a Rust block landing where the wrap's `serde_json::json!` reads a JSON
+/// object, an expansion that never reached a compiler.
 #[test]
 #[cfg(feature = "jsonschema")]
 fn test_untagged_string_array_member_json_schema() {
@@ -1190,10 +1187,10 @@ fn test_untagged_member_constraint_is_enforced_on_deserialize() {
     );
 }
 
-/// What a bound means in this position, pinned: serde tries the variants in order and a member the
-/// bound rejects takes its variant out of the running rather than ending the read — the same thing
-/// the union member's own schema does under `anyOf` and under `z.union`. So a violating value lands
-/// on the next branch that accepts it, and errors only when none does.
+/// What a bound means in this position: serde tries the variants in order, and a member the bound
+/// rejects takes its variant out of the running rather than ending the read — the same thing the
+/// union's own schema does under `anyOf` and `z.union`. A violating value lands on the next branch
+/// that accepts it, erroring only when none does.
 #[test]
 fn test_untagged_member_constraint_decides_which_variant_is_read() {
     assert_eq!(
@@ -1241,11 +1238,10 @@ fn test_untagged_objectid_member_spells_the_one_oid_object() {
     );
 }
 
-/// What the read costs the author, pinned. serde's derived `Deserialize` for an untagged enum drops
-/// each candidate's own error as it moves to the next, so when no variant accepts, the bound that
-/// refused the value is gone and one generic sentence stands in its place. The tagged twin, whose
-/// tag names the variant before its members are read, keeps the bound's own words. A serde upgrade
-/// that rewords the sentence lands here.
+/// What the read costs the author: serde's derived `Deserialize` for an untagged enum drops each
+/// candidate's own error as it moves to the next, so when no variant accepts, the bound's own
+/// error is gone and one generic sentence stands in its place. The tagged twin, whose tag names
+/// the variant before its members are read, keeps the bound's own words.
 #[test]
 fn test_untagged_member_bound_failure_reports_serdes_generic_sentence() {
     assert_eq!(

--- a/tests/validation_tests/tests.rs
+++ b/tests/validation_tests/tests.rs
@@ -1154,9 +1154,8 @@ fn test_pattern_anchored_single_character_prefix() {
 }
 
 /// `^$` is written out of the two anchors a pattern admitting every value is written out of, and
-/// it is the one arrangement of them that still says something: both ends of the value at one
-/// position, which only the empty string has. It keeps validating, and it keeps compiling under a
-/// deny set that has no edit available at the attribute.
+/// is the one arrangement that still says something: both ends of the value at one position,
+/// which only the empty string has.
 #[cfg(all(
     feature = "serde",
     any(feature = "typescript", feature = "zod", feature = "jsonschema")
@@ -2102,9 +2101,8 @@ fn test_a_constraint_free_enum_publishes_no_validate_just_as_a_struct_does() {
 }
 
 /// The arm binds each constrained member under a name of its own, so a member spelled like
-/// something the body already reads is still checked rather than taking that name over: `errors` is
-/// the accumulator every check pushes into, and `value_0` is the head of the walk a wrapped member
-/// is reached through.
+/// something the body already reads is still checked rather than shadowing it: `errors` is the
+/// accumulator every check pushes into, `value_0` the head of a wrapped member's walk.
 #[cfg(all(
     feature = "serde",
     any(feature = "typescript", feature = "zod", feature = "jsonschema")
@@ -2180,11 +2178,10 @@ fn test_every_variant_shape_reaches_the_accessor() {
     EveryShape::Nothing.validate().unwrap();
 }
 
-/// The README's `validate()` example prints the errors a caller reads back, and a reader who greps
-/// for one of those sentences, or writes an assertion against it, is holding the crate to it. So
-/// the example is expanded here as written and held to the same two things: the generator answers
-/// with those exact sentences, and the README still shows them. Drift on either side fails here
-/// rather than in someone's editor.
+/// The README's `validate()` example prints the errors a caller reads back, and a reader who
+/// greps for one of those sentences is holding the crate to it. The example is expanded here as
+/// written and held to two things: the generator answers with those exact sentences, and the
+/// README still shows them.
 #[cfg(all(
     feature = "serde",
     any(feature = "typescript", feature = "zod", feature = "jsonschema")

--- a/tests/zod_tests.rs
+++ b/tests/zod_tests.rs
@@ -1,20 +1,6 @@
-//! Comprehensive tests for Zod v4 schema generation.
-//!
-//! This module tests the Zod schema generation feature of tixschema.
-//! The `zod` feature generates Zod v4 validation schemas from Rust types.
-//!
-//! ## What is tested:
-//! - Basic primitive types (string, number, boolean).
-//! - Optional fields using z.union([type, `z.undefined()`]).
-//! - Arrays using `z.array()`.
-//! - `HashMaps` using `z.record()`.
-//! - Nested structs.
-//! - Plain enums using `z.enum()`.
-//! - Discriminated union enums using `z.discriminatedUnion()`.
-//! - Integration with TypeScript feature (type annotations).
-//! - Serde rename attributes.
-//! - `ObjectId` support (when `object_id` feature enabled).
-//! - All numeric types (integers vs floats).
+//! Tests for Zod v4 schema generation — the `zod` feature's validation schemas from Rust types,
+//! covering primitives, optional fields, arrays, maps, nested structs, plain and discriminated
+//! union enums, TypeScript integration, serde renames, and `ObjectId` support.
 
 #[cfg(test)]
 #[cfg(feature = "zod")]


### PR DESCRIPTION
Doc comments had grown into rationale essays: a paragraph on why an approach
was chosen over its alternatives, what a sibling function establishes, what a
previous attempt measured. On a fifteen-line function that is fifteen lines of
prose, and none of it is what the next reader needs — it is commit-message
material sitting above the code.

Three kinds are gone. Comments restating what the line below already says.
Rustdoc echoing the name it sits on, which in the test suites means every
comment that spelled a test's own name back in prose, the name being the
documentation there. And every second and third paragraph of argument.

What stays is a note of one to three lines where the reason is genuinely not
visible: that `Record<K, V>` requires `K extends keyof any`, so a map key states
the string keys serde writes rather than naming the parameter; that
`{name}$SchemaFactory` contains `{name}$Schema` as a substring, so a prefix
match alone answers the wrong question. Fixture comments explaining a
`#[cfg(feature = ...)]` gate stay too — that gate is what keeps the fixture from
being dead code on the toggles that do not build it, and removing it breaks the
powerset.

Untouched: the ` ```rust example ` blocks, which the macro extracts and the
compiler checks, and the crate-level rustdoc, which is published API
documentation with pinned generated output.

Nothing but comments moved — no code, no test name, no assertion, no gate.

44 files, 811 lines net. just check, just quick, just lint-all across all 68
toggles, the test powerset across all 68 in four partitions, and private-item
rustdoc under -D warnings — all green.

