### PR TITLE
read the one name a list-form serde rename agrees on, and refuse the pair that names two

### DIFF
--- a/src/features/serde.rs
+++ b/src/features/serde.rs
@@ -53,6 +53,14 @@ impl SerdeKeyOmission {
     }
 }
 
+/// What a list-form `rename(...)` or `rename_all(...)` names in each of serde's two directions.
+#[cfg(feature = "serde")]
+#[derive(Default)]
+struct RenameDirections {
+    deserialize: Option<String>,
+    serialize: Option<String>,
+}
+
 /// Metadata for serde attributes applied to a struct or enum.
 #[cfg(feature = "serde")]
 #[derive(Clone, Debug, Default)]
@@ -116,8 +124,9 @@ pub fn parse_serde_key_omission(attrs: &[Attribute]) -> SerdeKeyOmission {
 
 /// Consumes the value of a `key = value` or the group of a `key(...)` list the walk had no use
 /// for, so an unread value doesn't end the walk early and drop every attribute written after it.
-/// The list is consumed whole rather than parsed — nothing here reads into `bound(...)`,
-/// `rename(...)`, or `rename_all(...)`, only steps past them.
+/// The list is consumed whole rather than parsed. `bound(...)` is the one list form worth naming
+/// here: it replaces the trait bounds serde's derive writes on its own impls and leaves the JSON
+/// byte-identical, so no surface generated from this walk has anything to read out of it.
 fn consume_unread_value(nested: &ParseNestedMeta<'_>) -> syn::Result<()> {
     if nested.input.peek(Token![=]) {
         nested.value()?.parse::<syn::Expr>()?;
@@ -133,6 +142,129 @@ fn consume_unread_value(nested: &ParseNestedMeta<'_>) -> syn::Result<()> {
 /// (`default` and `default = "path"`).
 pub fn has_serde_default(attrs: &[Attribute]) -> bool {
     parse_serde_key_omission(attrs).defaulted
+}
+
+/// Reads the `serialize` and `deserialize` sub-keys out of a list-form `rename(...)` /
+/// `rename_all(...)`, stepping past any other sub-key the same way the outer walk does.
+#[cfg(feature = "serde")]
+fn parse_rename_directions(nested: &ParseNestedMeta<'_>) -> syn::Result<RenameDirections> {
+    let mut directions = RenameDirections::default();
+    nested.parse_nested_meta(|inner| {
+        if inner.path.is_ident("serialize") {
+            directions.serialize = Some(inner.value()?.parse::<LitStr>()?.value());
+        } else if inner.path.is_ident("deserialize") {
+            directions.deserialize = Some(inner.value()?.parse::<LitStr>()?.value());
+        } else {
+            consume_unread_value(&inner)?;
+        }
+        Ok(())
+    })?;
+    Ok(directions)
+}
+
+/// The one name both of serde's directions agree on, or the refusal a pair naming two earns. A
+/// direction the list leaves out keeps the name it would otherwise have had, which serde was
+/// measured to do, so writing one direction alone splits the two apart just as writing two
+/// different values does.
+#[cfg(feature = "serde")]
+fn agreed_rename(
+    key: &str,
+    path: &syn::Path,
+    directions: &RenameDirections,
+) -> Result<Option<String>, Error> {
+    match (&directions.serialize, &directions.deserialize) {
+        (Some(serialize), Some(deserialize)) if serialize == deserialize => {
+            Ok(Some(serialize.clone()))
+        }
+        (Some(serialize), Some(deserialize)) => Err(Error::new_spanned(
+            path,
+            format!(
+                "serde `{key}` names `{serialize}` when serializing and `{deserialize}` when \
+                 deserializing, so the payload serde writes is not one serde reads. A schema \
+                 describes one key per member, so no schema can be written for the pair. Write \
+                 both directions at one value, or use the single-value spelling `{key} = \"...\"`."
+            ),
+        )),
+        (Some(serialize), None) => Err(one_direction_only(key, path, serialize, "serializing")),
+        (None, Some(deserialize)) => {
+            Err(one_direction_only(key, path, deserialize, "deserializing"))
+        }
+        (None, None) => Ok(None),
+    }
+}
+
+/// The refusal a list form writing one of serde's two directions and not the other earns.
+#[cfg(feature = "serde")]
+fn one_direction_only(key: &str, path: &syn::Path, written: &str, direction: &str) -> Error {
+    Error::new_spanned(
+        path,
+        format!(
+            "serde `{key}` names `{written}` when {direction} only, and leaves the other \
+             direction at the name it would otherwise use, so the payload serde writes is not one \
+             serde reads. A schema describes one key per member, so no schema can be written for \
+             the pair. Write both directions at one value, or use the single-value spelling \
+             `{key} = \"...\"`."
+        ),
+    )
+}
+
+/// The name a `rename` / `rename_all` key carries, in either spelling: the value of `key = "..."`,
+/// or the one name a list form's two directions agree on. A list form the directions disagree over
+/// names nothing a surface could render, and is answered by [`rename_direction_rejection`].
+#[cfg(feature = "serde")]
+fn read_renaming(nested: &ParseNestedMeta<'_>, key: &str) -> syn::Result<Option<String>> {
+    if nested.input.peek(Token![=]) {
+        let lit: LitStr = nested.value()?.parse()?;
+        Ok(Some(lit.value()))
+    } else if nested.input.peek(Paren) {
+        let directions = parse_rename_directions(nested)?;
+        Ok(agreed_rename(key, &nested.path, &directions).ok().flatten())
+    } else {
+        Ok(None)
+    }
+}
+
+/// The refusal the item's own list-form `rename(...)` / `rename_all(...)` earns when its two
+/// directions do not name one key, or `None` when every renaming written here names exactly one.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+pub fn rename_direction_rejection(attrs: &[Attribute]) -> Option<Error> {
+    let mut rejection: Option<Error> = None;
+
+    for attr in attrs {
+        if !attr.path().is_ident("serde") {
+            continue;
+        }
+        attr.parse_nested_meta(|nested| {
+            let renaming = if nested.path.is_ident("rename") {
+                Some("rename")
+            } else if nested.path.is_ident("rename_all") {
+                Some("rename_all")
+            } else {
+                None
+            };
+            if let Some(key) = renaming
+                && nested.input.peek(Paren)
+            {
+                let directions = parse_rename_directions(&nested)?;
+                if let Err(refusal) = agreed_rename(key, &nested.path, &directions)
+                    && rejection.is_none()
+                {
+                    rejection = Some(refusal);
+                }
+                return Ok(());
+            }
+            consume_unread_value(&nested)?;
+            Ok(())
+        })
+        .unwrap_or_else(|e| {
+            log::trace!("Failed to parse serde rename attribute: {e}");
+        });
+    }
+
+    rejection
 }
 
 /// The rejection for a `cfg_attr` carrying a `serde(...)` attribute, or `None` for every other
@@ -179,13 +311,10 @@ pub fn parse_serde_type_attributes(attrs: &[Attribute]) -> SerdeTypeMeta {
                     let lit: LitStr = value.parse()?;
                     meta.content = Some(lit.value());
                 }
-                // Handle `rename_all = "value"`. The list form `rename_all(serialize = "...",
-                // deserialize = "...")` is left to fall through to `consume_unread_value` below,
-                // the same as any other key this walk has no use for.
-                else if nested.path.is_ident("rename_all") && nested.input.peek(Token![=]) {
-                    let value = nested.value()?;
-                    let lit: LitStr = value.parse()?;
-                    meta.rename_all = Some(lit.value());
+                // Handle `rename_all = "value"` and `rename_all(serialize = "...",
+                // deserialize = "...")`
+                else if nested.path.is_ident("rename_all") {
+                    meta.rename_all = read_renaming(&nested, "rename_all")?;
                 }
                 // Handle `untagged`
                 else if nested.path.is_ident("untagged") {
@@ -217,13 +346,9 @@ pub fn parse_serde_field_attributes(attrs: &[Attribute]) -> SerdeFieldMeta {
             meta.cfg_attr_rejection = cfg_attr_serde_rejection(attr);
         } else if attr.path().is_ident("serde") {
             attr.parse_nested_meta(|nested| {
-                // Handle `rename = "value"`. The list form `rename(serialize = "...",
-                // deserialize = "...")` is left to fall through to `consume_unread_value` below,
-                // the same as any other key this walk has no use for.
-                if nested.path.is_ident("rename") && nested.input.peek(Token![=]) {
-                    let value = nested.value()?;
-                    let lit: LitStr = value.parse()?;
-                    meta.rename = Some(lit.value());
+                // Handle `rename = "value"` and `rename(serialize = "...", deserialize = "...")`
+                if nested.path.is_ident("rename") {
+                    meta.rename = read_renaming(&nested, "rename")?;
                 }
                 // Handle the whole `skip` lump
                 else if nested.path.is_ident("skip")

--- a/src/features/serde/tests.rs
+++ b/src/features/serde/tests.rs
@@ -324,8 +324,9 @@ fn test_tag_after_a_list_form_bound_is_still_read() {
     );
 }
 
-/// `rename_all` has a dedicated branch, but list-form syntax leaves this crate nothing to read —
-/// only the tag written after it must survive, the same as the `bound(...)` case above.
+/// `rename_all` has a dedicated branch, and a list form only one direction is written in names no
+/// single rule — only the tag written after it must survive, the same as the `bound(...)` case
+/// above.
 #[test]
 fn test_tag_after_a_list_form_rename_all_is_still_read() {
     let item: syn::ItemEnum = syn::parse_quote! {
@@ -337,7 +338,7 @@ fn test_tag_after_a_list_form_rename_all_is_still_read() {
     let meta = parse_serde_type_attributes(&item.attrs);
     assert_eq!(
         meta.rename_all, None,
-        "list-form rename_all carries a value this crate does not read"
+        "one direction alone leaves the other at the name it would otherwise use"
     );
     assert_eq!(
         meta.tag.as_deref(),
@@ -359,10 +360,140 @@ fn test_flatten_after_a_list_form_rename_is_still_read() {
     let meta = field_meta(&item);
     assert_eq!(
         meta.rename, None,
-        "list-form rename carries a value this crate does not read"
+        "two directions naming two keys leave no single name to record"
     );
     assert!(
         meta.flatten,
         "flatten is written after a list-form rename(...)"
     );
+}
+
+#[test]
+fn test_list_form_rename_reads_the_name_both_directions_share() {
+    let item: syn::ItemStruct = syn::parse_quote! {
+        struct S {
+            #[serde(rename(serialize = "same_name", deserialize = "same_name"))]
+            value: u32,
+        }
+    };
+    assert_eq!(field_meta(&item).rename.as_deref(), Some("same_name"));
+}
+
+/// The two sub-keys are a set, not a sequence: the deserialize-first spelling names the same key.
+#[test]
+fn test_list_form_rename_reads_its_directions_in_either_order() {
+    let item: syn::ItemStruct = syn::parse_quote! {
+        struct S {
+            #[serde(rename(deserialize = "same_name", serialize = "same_name"))]
+            value: u32,
+        }
+    };
+    assert_eq!(field_meta(&item).rename.as_deref(), Some("same_name"));
+}
+
+#[test]
+fn test_list_form_rename_all_reads_the_rule_both_directions_share() {
+    let item: syn::ItemStruct = syn::parse_quote! {
+        #[serde(rename_all(serialize = "camelCase", deserialize = "camelCase"))]
+        struct S {
+            my_field: u32,
+        }
+    };
+    let meta = parse_serde_type_attributes(&item.attrs);
+    assert_eq!(meta.rename_all.as_deref(), Some("camelCase"));
+}
+
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn test_list_form_rename_naming_two_keys_is_refused() {
+    let item: syn::ItemStruct = syn::parse_quote! {
+        struct S {
+            #[serde(rename(serialize = "out_name", deserialize = "in_name"))]
+            value: u32,
+        }
+    };
+    let message = rename_direction_rejection(field_attrs(&item))
+        .unwrap()
+        .to_string();
+    assert!(message.contains("`out_name` when serializing"), "{message}");
+    assert!(
+        message.contains("`in_name` when deserializing"),
+        "{message}"
+    );
+    assert!(field_meta(&item).rename.is_none());
+}
+
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn test_list_form_rename_all_naming_two_rules_is_refused() {
+    let item: syn::ItemStruct = syn::parse_quote! {
+        #[serde(rename_all(serialize = "camelCase", deserialize = "snake_case"))]
+        struct S {
+            my_field: u32,
+        }
+    };
+    let message = rename_direction_rejection(&item.attrs).unwrap().to_string();
+    assert!(
+        message.contains("`camelCase` when serializing"),
+        "{message}"
+    );
+    assert!(
+        message.contains("`snake_case` when deserializing"),
+        "{message}"
+    );
+    assert!(
+        parse_serde_type_attributes(&item.attrs)
+            .rename_all
+            .is_none()
+    );
+}
+
+/// serde was measured to leave the unwritten direction at the name it would otherwise use, so one
+/// direction alone splits the two apart exactly as two different values do.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn test_list_form_rename_written_for_one_direction_only_is_refused() {
+    let serializing: syn::ItemStruct = syn::parse_quote! {
+        struct S {
+            #[serde(rename(serialize = "out_name"))]
+            value: u32,
+        }
+    };
+    let written_out = rename_direction_rejection(field_attrs(&serializing))
+        .unwrap()
+        .to_string();
+    assert!(
+        written_out.contains("`out_name` when serializing only"),
+        "{written_out}"
+    );
+
+    let deserializing: syn::ItemStruct = syn::parse_quote! {
+        struct S {
+            #[serde(rename(deserialize = "in_name"))]
+            value: u32,
+        }
+    };
+    let read_in = rename_direction_rejection(field_attrs(&deserializing))
+        .unwrap()
+        .to_string();
+    assert!(
+        read_in.contains("`in_name` when deserializing only"),
+        "{read_in}"
+    );
+}
+
+/// `bound(...)` writes the same two sub-keys and says nothing about the wire, so the walk that
+/// reads them out of a renaming must not read them out of it.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn test_list_form_bound_earns_no_rename_refusal() {
+    let item: syn::ItemStruct = syn::parse_quote! {
+        #[serde(bound(serialize = "T: Clone", deserialize = "T: Clone"))]
+        struct S<T> {
+            #[serde(bound(serialize = "T: Clone", deserialize = "T: Clone"))]
+            value: T,
+        }
+    };
+    assert!(rename_direction_rejection(&item.attrs).is_none());
+    assert!(rename_direction_rejection(field_attrs(&item)).is_none());
 }

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -59,6 +59,11 @@ use crate::utils::{
 #[cfg(feature = "serde")]
 use crate::utils::{TrivialPattern, trivial_pattern};
 
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+use crate::features::serde::rename_direction_rejection;
 #[cfg(feature = "serde")]
 use crate::features::serde::{SerdeFieldMeta, SerdeTypeMeta};
 use crate::features::serde::{has_serde_default, parse_serde_key_omission};
@@ -1004,6 +1009,16 @@ pub fn exec_model_schema(args: TokenStream, input: TokenStream) -> TokenStream {
     ) {
         return output;
     }
+    // A list-form serde rename whose two directions name two keys leaves what serde writes and
+    // what serde reads two different payloads, so it is refused here — ahead of every shape, and
+    // at the one seam a container, a variant and a member are all reachable from.
+    if let Some(output) = guard_failure_output(
+        &item,
+        item_schema_ident(&item),
+        &rename_direction_guard_errors(&item),
+    ) {
+        return output;
+    }
     // A doc example is compiled at one instantiation, and a const parameter takes no filling from
     // the convention that names one, so an item writing both is refused here — ahead of every
     // shape, and of the branded split inside the struct path.
@@ -1832,9 +1847,9 @@ fn pattern_guard_error(rejection: &syn::Error, subject: &str) -> proc_macro2::To
     .to_compile_error()
 }
 
-/// Turns this crate's own attribute parser's refusal — of a `model_schema` argument or of a
-/// `model_schema_prop` key — into `compile_error!` tokens naming what carries it, keeping the
-/// refusal's span so the diagnostic points at the argument, key or value as written.
+/// Turns an attribute parser's refusal — of a `model_schema` argument, a `model_schema_prop` key,
+/// or a serde renaming that names two keys — into `compile_error!` tokens naming what carries it,
+/// keeping the refusal's span so the diagnostic points at the argument, key or value as written.
 fn attr_guard_error(rejection: &syn::Error, subject: &str) -> proc_macro2::TokenStream {
     syn::Error::new(
         rejection.span(),
@@ -1912,6 +1927,89 @@ const fn item_generics(item: &Item) -> Option<&syn::Generics> {
     } else {
         None
     }
+}
+
+/// The attribute lists an item's own serde renames can be written on, each beside the name a guard
+/// message calls it by.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+fn renamable_attribute_lists(item: &Item) -> Vec<(String, &[syn::Attribute])> {
+    let mut lists: Vec<(String, &[syn::Attribute])> = vec![(item_label(item), item_attrs(item))];
+    if let Item::Struct(item_struct) = item {
+        lists.extend(field_attribute_lists(&item_struct.fields));
+    } else if let Item::Enum(item_enum) = item {
+        for variant in &item_enum.variants {
+            lists.push((format!("variant `{}`", variant.ident), &variant.attrs));
+            lists.extend(field_attribute_lists(&variant.fields));
+        }
+    } else {
+        // An alias declares no member of its own to rename.
+    }
+    lists
+}
+
+/// The attributes each of `fields` carries, beside the name a guard message calls the field by.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+fn field_attribute_lists(fields: &syn::Fields) -> Vec<(String, &[syn::Attribute])> {
+    fields
+        .iter()
+        .map(|field| {
+            let ident = field
+                .ident
+                .as_ref()
+                .map_or_else(String::new, ToString::to_string);
+            (field_label(&ident), field.attrs.as_slice())
+        })
+        .collect()
+}
+
+/// The attributes written on the item itself; a shape this macro does not expand carries none it
+/// reads.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+fn item_attrs(item: &Item) -> &[syn::Attribute] {
+    if let Item::Struct(item_struct) = item {
+        &item_struct.attrs
+    } else if let Item::Enum(item_enum) = item {
+        &item_enum.attrs
+    } else if let Item::Type(item_type) = item {
+        &item_type.attrs
+    } else {
+        &[]
+    }
+}
+
+/// The `compile_error!` tokens every list-form `rename(...)` / `rename_all(...)` the item carries
+/// earns whose two directions do not name one key.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+fn rename_direction_guard_errors(item: &Item) -> Vec<proc_macro2::TokenStream> {
+    renamable_attribute_lists(item)
+        .into_iter()
+        .filter_map(|(subject, attrs)| {
+            rename_direction_rejection(attrs)
+                .map(|rejection| attr_guard_error(&rejection, &subject))
+        })
+        .collect()
+}
+
+/// Nothing, where no rename is read at all: without the `serde` feature every surface writes the
+/// Rust ident, and without a schema feature there is no surface to write.
+#[cfg(not(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+)))]
+const fn rename_direction_guard_errors(_item: &Item) -> Vec<proc_macro2::TokenStream> {
+    Vec::new()
 }
 
 /// The `compile_error!` tokens a `default_types` declaration earns against the item it was written

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -1267,6 +1267,100 @@ fn cfg_attr_wrapped_serde_on_a_variant_is_rejected() {
     assert!(errors[0].contains("variant `Active`"), "got: {}", errors[0]);
 }
 
+/// Collects an item's rename-direction guard failures as rendered `compile_error!` token strings.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+fn rename_direction_errors(item: &syn::Item) -> Vec<String> {
+    super::rename_direction_guard_errors(item)
+        .iter()
+        .map(ToString::to_string)
+        .collect()
+}
+
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn a_container_renaming_naming_two_keys_is_rejected() {
+    let errors = rename_direction_errors(&syn::parse_quote! {
+        #[serde(rename_all(serialize = "camelCase", deserialize = "snake_case"))]
+        struct Profile {
+            my_field: u32,
+        }
+    });
+    assert_eq!(errors.len(), 1, "got: {errors:?}");
+    assert!(errors[0].contains("compile_error"), "got: {}", errors[0]);
+    assert!(errors[0].contains("type `Profile`"), "got: {}", errors[0]);
+    assert!(errors[0].contains("camelCase"), "got: {}", errors[0]);
+    assert!(errors[0].contains("snake_case"), "got: {}", errors[0]);
+}
+
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn a_field_renaming_naming_two_keys_is_rejected() {
+    let errors = rename_direction_errors(&syn::parse_quote! {
+        struct Profile {
+            #[serde(rename(serialize = "out_name", deserialize = "in_name"))]
+            value: u32,
+        }
+    });
+    assert_eq!(errors.len(), 1, "got: {errors:?}");
+    assert!(errors[0].contains("field `value`"), "got: {}", errors[0]);
+    assert!(errors[0].contains("out_name"), "got: {}", errors[0]);
+    assert!(errors[0].contains("in_name"), "got: {}", errors[0]);
+}
+
+/// A variant carries both spellings of its own, and its members carry theirs, so the walk reaches
+/// three levels down an enum.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn a_variant_and_its_member_are_both_reached() {
+    let errors = rename_direction_errors(&syn::parse_quote! {
+        enum Event {
+            #[serde(rename(serialize = "created", deserialize = "made"))]
+            Created {
+                #[serde(rename(serialize = "at", deserialize = "when"))]
+                moment: u32,
+            },
+        }
+    });
+    assert_eq!(errors.len(), 2, "got: {errors:?}");
+    assert!(
+        errors.iter().any(|e| e.contains("variant `Created`")),
+        "got: {errors:?}"
+    );
+    assert!(
+        errors.iter().any(|e| e.contains("field `moment`")),
+        "got: {errors:?}"
+    );
+}
+
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn renamings_naming_one_key_are_left_alone() {
+    let errors = rename_direction_errors(&syn::parse_quote! {
+        #[serde(rename_all(serialize = "camelCase", deserialize = "camelCase"))]
+        #[serde(bound(serialize = "T: Clone", deserialize = "T: Clone"))]
+        struct Profile<T> {
+            #[serde(rename(serialize = "same_name", deserialize = "same_name"))]
+            my_field: T,
+        }
+    });
+    assert!(errors.is_empty(), "got: {errors:?}");
+}
+
 #[cfg(feature = "serde")]
 #[test]
 fn cfg_attr_without_serde_leaves_an_enum_alone() {

--- a/tests/serde_tests/tests.rs
+++ b/tests/serde_tests/tests.rs
@@ -141,6 +141,44 @@ struct PlainKeys {
     user_id: String,
 }
 
+/// The list form of `rename`, with one name in both of serde's directions.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct ListFormRename {
+    #[serde(rename(serialize = "same_name", deserialize = "same_name"))]
+    value: u32,
+}
+
+/// The list form of `rename_all`, with one rule in both of serde's directions.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all(serialize = "camelCase", deserialize = "camelCase"))]
+struct ListFormRenameAll {
+    my_field: u32,
+}
+
+/// `bound(...)` in both places serde accepts it. It replaces the trait bounds serde's derive
+/// writes on its own impls, which no generated surface describes.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(bound(serialize = "", deserialize = ""))]
+struct BoundCarrying {
+    #[serde(bound(serialize = "", deserialize = ""))]
+    reading: u32,
+    writing: u32,
+}
+
+/// The rendered line naming `key`, with the key itself removed, so two members rendered the same
+/// way compare equal whatever they are called.
+#[cfg(any(feature = "typescript", feature = "zod"))]
+fn member_rendering(surface: &str, key: &str) -> String {
+    let member = surface
+        .lines()
+        .find(|line| line.trim_start().starts_with(&format!("{key}:")));
+    assert!(member.is_some(), "no member `{key}` in:\n{surface}");
+    member.unwrap().replacen(key, "", 1)
+}
+
 #[test]
 fn test_serde_types_constructible() {
     let color = Color::Red;
@@ -626,5 +664,190 @@ fn test_identifier_legal_renamed_keys_stay_bare() {
     assert!(
         ts.lines().any(|line| line == "  user_id2: string;"),
         "expected a bare `user_id2`:\n{ts}"
+    );
+}
+
+/// The key serde writes for a list-form `rename`, which the surfaces below all describe.
+#[test]
+fn test_a_list_form_rename_writes_the_name_both_directions_share() {
+    let value = ListFormRename { value: 5 };
+    let payload = serde_json::to_value(&value).unwrap();
+    assert_eq!(payload, serde_json::json!({ "same_name": 5_u32 }));
+
+    let back: ListFormRename = serde_json::from_value(payload).unwrap();
+    assert_eq!(back, value);
+}
+
+#[test]
+#[cfg(feature = "typescript")]
+fn test_a_list_form_rename_reaches_the_typescript_type() {
+    let ts = ListFormRename::ts_definition();
+
+    assert!(
+        ts.lines().any(|line| line == "  same_name: number;"),
+        "expected the renamed key:\n{ts}"
+    );
+    assert!(
+        !ts.contains("value:"),
+        "the Rust ident leaked into the type:\n{ts}"
+    );
+}
+
+#[test]
+#[cfg(feature = "zod")]
+fn test_a_list_form_rename_reaches_the_zod_schema() {
+    let zod = ListFormRename::zod_schema();
+
+    assert!(
+        zod.contains("same_name: z.number().int()"),
+        "expected the renamed key:\n{zod}"
+    );
+    assert!(
+        !zod.contains("value:"),
+        "the Rust ident leaked into the schema:\n{zod}"
+    );
+}
+
+/// The closed document, read against the payload serde actually writes: every key written is named,
+/// and every key required is written.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_a_list_form_rename_document_accepts_what_serde_writes() {
+    let payload = serde_json::to_value(ListFormRename { value: 5 }).unwrap();
+    let schema = ListFormRename::json_schema();
+    let named = schema["properties"].as_object().unwrap();
+    let required = schema["required"].as_array().unwrap();
+    let written = payload.as_object().unwrap();
+
+    assert!(named.contains_key("same_name"), "{schema}");
+    assert!(
+        written.keys().all(|key| named.contains_key(key)),
+        "{schema}"
+    );
+    assert!(
+        required
+            .iter()
+            .all(|key| written.contains_key(key.as_str().unwrap())),
+        "{schema}"
+    );
+}
+
+/// The same, for the rule a list-form `rename_all` names.
+#[test]
+fn test_a_list_form_rename_all_writes_the_rule_both_directions_share() {
+    let value = ListFormRenameAll { my_field: 5 };
+    let payload = serde_json::to_value(&value).unwrap();
+    assert_eq!(payload, serde_json::json!({ "myField": 5_u32 }));
+
+    let back: ListFormRenameAll = serde_json::from_value(payload).unwrap();
+    assert_eq!(back, value);
+}
+
+#[test]
+#[cfg(feature = "typescript")]
+fn test_a_list_form_rename_all_reaches_the_typescript_type() {
+    let ts = ListFormRenameAll::ts_definition();
+
+    assert!(
+        ts.lines().any(|line| line == "  myField: number;"),
+        "expected the transformed key:\n{ts}"
+    );
+    assert!(
+        !ts.contains("my_field"),
+        "the Rust ident leaked into the type:\n{ts}"
+    );
+}
+
+#[test]
+#[cfg(feature = "zod")]
+fn test_a_list_form_rename_all_reaches_the_zod_schema() {
+    let zod = ListFormRenameAll::zod_schema();
+
+    assert!(
+        zod.contains("myField: z.number().int()"),
+        "expected the transformed key:\n{zod}"
+    );
+    assert!(
+        !zod.contains("my_field"),
+        "the Rust ident leaked into the schema:\n{zod}"
+    );
+}
+
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_a_list_form_rename_all_document_accepts_what_serde_writes() {
+    let payload = serde_json::to_value(ListFormRenameAll { my_field: 5 }).unwrap();
+    let schema = ListFormRenameAll::json_schema();
+    let named = schema["properties"].as_object().unwrap();
+    let required = schema["required"].as_array().unwrap();
+    let written = payload.as_object().unwrap();
+
+    assert!(named.contains_key("myField"), "{schema}");
+    assert!(
+        written.keys().all(|key| named.contains_key(key)),
+        "{schema}"
+    );
+    assert!(
+        required
+            .iter()
+            .all(|key| written.contains_key(key.as_str().unwrap())),
+        "{schema}"
+    );
+}
+
+/// `bound(...)` names trait bounds, not keys, so the member carrying it is on the wire exactly as
+/// its plain sibling is.
+#[test]
+fn test_a_bound_carrying_member_is_on_the_wire_as_its_plain_sibling_is() {
+    let value = BoundCarrying {
+        reading: 1,
+        writing: 2,
+    };
+    let payload = serde_json::to_value(&value).unwrap();
+    assert_eq!(
+        payload,
+        serde_json::json!({ "reading": 1_u32, "writing": 2_u32 })
+    );
+
+    let back: BoundCarrying = serde_json::from_value(payload).unwrap();
+    assert_eq!(back, value);
+}
+
+#[test]
+#[cfg(feature = "typescript")]
+fn test_a_bound_carrying_member_is_typed_as_its_plain_sibling_is() {
+    let ts = BoundCarrying::ts_definition();
+
+    assert_eq!(
+        member_rendering(&ts, "reading"),
+        member_rendering(&ts, "writing"),
+        "{ts}"
+    );
+}
+
+#[test]
+#[cfg(feature = "zod")]
+fn test_a_bound_carrying_member_is_validated_as_its_plain_sibling_is() {
+    let zod = BoundCarrying::zod_schema();
+
+    assert_eq!(
+        member_rendering(&zod, "reading"),
+        member_rendering(&zod, "writing"),
+        "{zod}"
+    );
+}
+
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_a_bound_carrying_member_is_described_as_its_plain_sibling_is() {
+    let schema = BoundCarrying::json_schema();
+
+    assert_eq!(
+        schema["properties"]["reading"], schema["properties"]["writing"],
+        "{schema}"
+    );
+    assert_eq!(
+        schema["required"],
+        serde_json::json!(["reading", "writing"])
     );
 }


### PR DESCRIPTION
`rename(serialize = "x", deserialize = "x")` and its `rename_all` sibling were
stepped over as unread keys, so a member carrying one was described at its raw
Rust ident while serde wrote the renamed key on both directions of the wire.

Both walks now read a renaming through one seam, in either spelling: the value
of `key = "..."`, or the one name a list form's two directions agree on. The
sub-keys are read in either order, and unknown sub-keys are stepped past the
same way the outer walk steps past unknown keys.

What cannot be read is refused rather than guessed, at `exec_model_schema`,
spanned on the key and naming both directions. Two shapes earn it:

- two directions naming two values — the payload serde writes is not one serde
  reads, and a schema describes one key per member, so no schema exists for the
  pair;
- one direction written and the other left out. serde was measured, not
  assumed: the unwritten direction keeps the name it would otherwise have used,
  so `rename(serialize = "out_name")` writes `out_name` and reads `value` — the
  same split as naming two values, spelled differently.

`bound(...)` stays an unread key in both its forms. It replaces the trait
bounds serde's derive writes on its own impls and leaves the JSON
byte-identical, so no surface generated from these walks has anything to read
out of it.

The guard walks every attribute list an item owns — the container, each variant,
each field including variant fields — so a struct, a tuple struct, a branded
newtype, an enum and an alias are all answered at one place.

just check, just quick, just lint-all across all 68 toggles, and the test
powerset across all 68 in four partitions — all green. A probe crate confirmed
the agreeing forms emit the renamed key on all three surfaces, matching
serde_json output, and the three disagreeing forms fail to compile with
correctly spanned diagnostics.

