### PR TITLE
merge a flattened variant field into its variant's object, where serde writes it

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -86,16 +86,13 @@ use crate::features::model_schema_prop::{
 
 #[cfg(feature = "jsonschema")]
 use crate::features::jsonschema::{
-    MergedSource, SchemaParameter,
+    MergeDiagnostic, MergedSource, SchemaParameter,
     generate_plain_enum_json_schema_method as generate_plain_enum_json_schema_method_impl,
     generate_struct_json_schema_method as generate_struct_json_schema_method_impl, in_flight_type,
-    json_schema_methods,
+    json_schema_methods, merged_object_value,
 };
 #[cfg(feature = "jsonschema")]
 use crate::utils::json_argument_binding;
-
-#[cfg(all(feature = "serde", feature = "jsonschema"))]
-use crate::features::jsonschema::{MergeDiagnostic, merged_object_value};
 
 #[cfg(any(
     feature = "typescript",
@@ -174,6 +171,10 @@ struct DiscriminatedVariant {
     discriminator_value: String,
     docs: String,
     field_defs: Vec<FieldDef>,
+    /// The variant's own `#[serde(flatten)]` sources, held apart from `field_defs` the way
+    /// [`collect_struct_fields`] holds a struct's apart: they write no key of their own, so every
+    /// surface joins them onto the object the rest of the fields close.
+    flattened_fields: Vec<FieldDef>,
     kind: VariantKind,
 }
 
@@ -3153,6 +3154,48 @@ fn flatten_edge_guard_error(
     Some(syn::Error::new_spanned(&field.ty, message).to_compile_error())
 }
 
+/// The `compile_error!` tokens for a `#[serde(flatten)]` field of an enum variant whose source
+/// writes more than one key set, or `None` for every source that writes exactly one. A variant's
+/// members are a fragment of a larger literal, with nowhere to bind them to the `$OwnSchema` const
+/// [`zod_merged_statements`] hoists once it counts more than one combination.
+#[cfg(all(feature = "serde", feature = "zod"))]
+fn variant_flatten_branch_guard_error(
+    field: &syn::Field,
+    type_name: &str,
+    variant_name: &str,
+) -> Option<proc_macro2::TokenStream> {
+    let inner = get_field_def("_flattened", &field.ty, "");
+    let written = if flattened_zod_branches(&inner).is_empty() {
+        if SourceAbsence::written(&inner).offered() {
+            "writes its members or no members at all"
+        } else {
+            return None;
+        }
+    } else {
+        "writes one key set per branch of the choice it names"
+    };
+    let field_name = field_label(
+        &field
+            .ident
+            .as_ref()
+            .map_or_else(String::new, ToString::to_string),
+    );
+    Some(
+        syn::Error::new_spanned(
+            &field.ty,
+            format!(
+                "model_schema: {field_name} of variant `{variant_name}` of `{type_name}` carries \
+                 `#[serde(flatten)]` over a source that {written}, which a variant cannot merge: \
+                 the variant's own members are written inside the union member that carries them, \
+                 leaving nowhere to bind them to a name each alternative could join. Flatten the \
+                 source into a struct of its own and write that struct as the variant's content, \
+                 or write the field as a named member so the value gets a key of its own."
+            ),
+        )
+        .to_compile_error(),
+    )
+}
+
 /// The JSON type keyword the item a flattened field names publishes, where the name is the whole of
 /// what the field writes and the registry proves that wire is no object — and `None` everywhere the
 /// declaration is left as it stands.
@@ -3210,12 +3253,9 @@ fn collect_struct_fields(
     let mut deferred_attrs: Vec<Vec<syn::Attribute>> = Vec::new();
 
     for field in fields.iter_mut() {
-        #[cfg(feature = "serde")]
-        let is_flatten = parse_serde_field_attributes(&field.attrs).flatten;
-        #[cfg(not(feature = "serde"))]
-        let is_flatten = false;
-
         // Read before the field is processed, which strips the attributes the declaration carried.
+        let is_flatten = is_flattened_field(field);
+
         #[cfg(all(
             feature = "serde",
             any(feature = "typescript", feature = "zod", feature = "jsonschema")
@@ -5499,6 +5539,72 @@ fn check_variant_slot_wire_is_readable(
     ))
 }
 
+/// The two name overrides a variant declares: its own `#[serde(rename)]`, and the `rename_all` its
+/// own fields are read against. serde treats a struct variant as the container for its fields, so
+/// the enum's container-level `rename_all` never reaches them — that one renames variant names only.
+#[cfg(feature = "serde")]
+fn variant_serde_names(attrs: &[syn::Attribute]) -> (Option<String>, Option<String>) {
+    (
+        parse_serde_field_attributes(attrs).rename,
+        parse_serde_type_attributes(attrs).rename_all,
+    )
+}
+
+/// No declaration is read where nothing parses serde's attributes.
+#[cfg(not(feature = "serde"))]
+const fn variant_serde_names(_attrs: &[syn::Attribute]) -> (Option<String>, Option<String>) {
+    (None, None)
+}
+
+/// Whether a field's members join the object being written rather than sitting under a key of their
+/// own.
+#[cfg(feature = "serde")]
+fn is_flattened_field(field: &syn::Field) -> bool {
+    parse_serde_field_attributes(&field.attrs).flatten
+}
+
+/// No field flattens where nothing parses serde's attributes.
+#[cfg(not(feature = "serde"))]
+const fn is_flattened_field(_field: &syn::Field) -> bool {
+    false
+}
+
+/// The `compile_error!` tokens a variant's `#[serde(flatten)]` field is refused with: the two the
+/// struct-level split already reads a flattened field against, plus the branching a variant's own
+/// position cannot compose.
+fn variant_flatten_guard_errors(
+    field: &syn::Field,
+    enum_type_name: &str,
+    variant_ident: &str,
+) -> Vec<proc_macro2::TokenStream> {
+    #[cfg(all(
+        feature = "serde",
+        any(feature = "typescript", feature = "zod", feature = "jsonschema")
+    ))]
+    let named = [flattened_field_guard_error(field, enum_type_name)];
+    #[cfg(not(all(
+        feature = "serde",
+        any(feature = "typescript", feature = "zod", feature = "jsonschema")
+    )))]
+    let named = {
+        let _: (&_, &_) = (&field, &enum_type_name);
+        [None]
+    };
+
+    #[cfg(all(feature = "serde", feature = "zod"))]
+    let edges = [
+        flatten_edge_guard_error(field, enum_type_name),
+        variant_flatten_branch_guard_error(field, enum_type_name, variant_ident),
+    ];
+    #[cfg(not(all(feature = "serde", feature = "zod")))]
+    let edges = {
+        let _: &_ = &variant_ident;
+        [None, None]
+    };
+
+    named.into_iter().chain(edges).flatten().collect()
+}
+
 /// Processes each variant of a discriminated enum, returning per-variant field defs, doc strings,
 /// and variant kinds in declaration order, plus the collected serde validation functions and the
 /// `validate()` arms those functions are run from.
@@ -5517,18 +5623,7 @@ fn collect_discriminated_variants(
     let enum_type_name = item_enum.ident.to_string();
 
     for item in &mut item_enum.variants {
-        #[cfg(feature = "serde")]
-        let field_rename = parse_serde_field_attributes(&item.attrs).rename;
-        #[cfg(not(feature = "serde"))]
-        let field_rename: Option<String> = None;
-        // serde treats a struct variant as the container for its own fields: its own
-        // `rename_all` (if any) reaches them, the enum's container-level `rename_all` never does
-        // — that one renames variant names only.
-        #[cfg(feature = "serde")]
-        let variant_rename_all = parse_serde_type_attributes(&item.attrs).rename_all;
-        #[cfg(not(feature = "serde"))]
-        let variant_rename_all: Option<String> = None;
-
+        let (field_rename, variant_rename_all) = variant_serde_names(&item.attrs);
         let variant_ident = item.ident.to_string();
         let final_name =
             get_final_variant_name(&variant_ident, field_rename.as_deref(), rename_all);
@@ -5541,6 +5636,7 @@ fn collect_discriminated_variants(
         let variant_defaulted = has_serde_default(&item.attrs);
 
         let mut field_defs: Vec<FieldDef> = Vec::new();
+        let mut flattened_fields: Vec<FieldDef> = Vec::new();
         let mut bound: Vec<(proc_macro2::Ident, proc_macro2::Ident)> = Vec::new();
         let mut checks: Vec<proc_macro2::TokenStream> = Vec::new();
         let total_fields = item.fields.len();
@@ -5556,6 +5652,18 @@ fn collect_discriminated_variants(
             ) {
                 guard_errors.push(rejection.to_compile_error());
             }
+
+            // Read before the field is processed, which strips the attributes the declaration
+            // carried.
+            let is_flatten = is_flattened_field(field);
+            if is_flatten {
+                guard_errors.extend(variant_flatten_guard_errors(
+                    field,
+                    &enum_type_name,
+                    &variant_ident,
+                ));
+            }
+
             let (f_def, validation_fn, validate_body, field_guard_errors) = process_field(
                 &FieldContext {
                     container_defaulted: variant_defaulted,
@@ -5568,6 +5676,14 @@ fn collect_discriminated_variants(
                 field,
                 &mut deferred_attrs,
             );
+            guard_errors.extend(field_guard_errors);
+
+            if is_flatten {
+                let _: (&_, &_) = (&validation_fn, &validate_body);
+                flattened_fields.push(f_def);
+                continue;
+            }
+
             if let Some(vfn) = validation_fn {
                 enum_validation_fns.push(vfn);
             }
@@ -5578,7 +5694,6 @@ fn collect_discriminated_variants(
                 bound.push((ident.clone(), binding));
                 checks.push(body);
             }
-            guard_errors.extend(field_guard_errors);
             if positional && omission.absent_from_wire() {
                 continue;
             }
@@ -5594,6 +5709,7 @@ fn collect_discriminated_variants(
             discriminator_value: final_name,
             docs: discriminator_docs,
             field_defs,
+            flattened_fields,
             kind: wire_kind,
         });
     }
@@ -5630,15 +5746,7 @@ fn render_discriminated_variants(
 
     for variant in variants {
         let (variant_type_code, variant_schema_code, optional_fields, json_schema_variant) =
-            generate_variant_code(
-                tag_name,
-                content_name,
-                &variant.discriminator_value,
-                &variant.field_defs,
-                &variant.kind,
-                &variant.docs,
-                item_name,
-            );
+            generate_variant_code(tag_name, content_name, variant, item_name);
         type_code_items.push(variant_type_code);
         schema_code_items.push((variant_schema_code, optional_fields));
         json_schema_variants.push(json_schema_variant);
@@ -5857,23 +5965,54 @@ fn process_discriminated_enum(
 }
 
 /// The object schema a struct variant's fields sit in when they are written under a key of their
-/// own rather than beside a discriminator. Used by both the externally tagged form and the
-/// adjacently tagged form's own struct variant.
+/// own rather than beside a discriminator, with the members of every `#[serde(flatten)]` source the
+/// variant carries merged beside them. Used by both the externally tagged form and the adjacently
+/// tagged form's own struct variant.
 #[cfg(feature = "jsonschema")]
-fn named_content_json_value(json_fields: &[proc_macro2::TokenStream]) -> proc_macro2::TokenStream {
-    quote! {
+fn named_content_json_value(
+    json_fields: &[proc_macro2::TokenStream],
+    flattened_fields: &[FieldDef],
+    self_type_name: &str,
+    variant_name: &str,
+) -> proc_macro2::TokenStream {
+    let object = quote! {
         {
+            let mut schema_obj = serde_json::Map::new();
+            schema_obj.insert("type".to_string(), serde_json::Value::String("object".to_string()));
             let mut properties = serde_json::Map::new();
             let mut required: Vec<serde_json::Value> = Vec::new();
             #(#json_fields)*
-            serde_json::json!({
-                "type": "object",
-                "properties": serde_json::Value::Object(properties),
-                "required": serde_json::Value::Array(required),
-                "additionalProperties": false
-            })
+            schema_obj.insert("properties".to_string(), serde_json::Value::Object(properties));
+            schema_obj.insert("required".to_string(), serde_json::Value::Array(required));
+            schema_obj.insert("additionalProperties".to_string(), serde_json::Value::Bool(false));
+            schema_obj
         }
+    };
+    variant_merged_json_value(&object, flattened_fields, self_type_name, variant_name)
+}
+
+/// A variant's own object with the members of every `#[serde(flatten)]` source it carries merged
+/// beside them, and the object exactly as it stands where the variant flattens nothing.
+#[cfg(feature = "jsonschema")]
+fn variant_merged_json_value(
+    base: &proc_macro2::TokenStream,
+    flattened_fields: &[FieldDef],
+    self_type_name: &str,
+    variant_name: &str,
+) -> proc_macro2::TokenStream {
+    if flattened_fields.is_empty() {
+        return quote! { serde_json::Value::Object(#base) };
     }
+    merged_object_value(
+        base,
+        &flatten_merged_sources(flattened_fields),
+        &MergeDiagnostic {
+            cycle_remedy: "write the field as a named member so the cycle defers through a reference",
+            edge: &format!("`#[serde(flatten)]` in variant `{variant_name}` of"),
+            non_object_remedy: "write the field as a named member so the value gets a key of its own",
+            subject: self_type_name,
+        },
+    )
 }
 
 /// The diagnostic a variant whose content has no rendering produces, in the value position the
@@ -5891,15 +6030,15 @@ fn external_content_rejection_value(
 /// Renders what one variant of an externally tagged enum writes under its key.
 #[cfg(feature = "serde")]
 fn render_external_content(
-    kind: &VariantKind,
-    field_defs: &[FieldDef],
-    discriminator_value: &str,
+    variant: &DiscriminatedVariant,
     self_type_name: &str,
 ) -> (String, String, proc_macro2::TokenStream) {
+    let field_defs = &variant.field_defs;
+    let discriminator_value = &variant.discriminator_value;
     #[cfg(not(feature = "jsonschema"))]
     let _: &str = discriminator_value;
 
-    match kind {
+    match &variant.kind {
         VariantKind::Unit => (String::new(), String::new(), quote! {}),
         VariantKind::TupleSingle => {
             // `classify_variant` names this kind only for a variant of exactly one unnamed field.
@@ -5958,18 +6097,24 @@ fn render_external_content(
                 type_code: String::new(),
             };
             write_named_variant_fields(field_defs, None, self_type_name, &mut parts);
+            let flatten = variant_flatten_intersections(&variant.flattened_fields);
 
             #[cfg(feature = "zod")]
-            let zod = format!("z.strictObject({{\n{}}})", parts.schema_code);
+            let zod = format!("z.strictObject({{\n{}}}){}", parts.schema_code, flatten.1);
             #[cfg(not(feature = "zod"))]
             let zod = String::new();
 
             #[cfg(feature = "jsonschema")]
-            let json = named_content_json_value(&parts.json_fields);
+            let json = named_content_json_value(
+                &parts.json_fields,
+                &variant.flattened_fields,
+                self_type_name,
+                discriminator_value,
+            );
             #[cfg(not(feature = "jsonschema"))]
             let json = quote! {};
 
-            (format!("{{\n{}}}", parts.type_code), zod, json)
+            (format!("{{\n{}}}{}", parts.type_code, flatten.0), zod, json)
         }
     }
 }
@@ -5996,8 +6141,7 @@ fn render_external_variant(
         );
     }
 
-    let (content_ts, content_zod, content_json) =
-        render_external_content(&variant.kind, &variant.field_defs, key, self_type_name);
+    let (content_ts, content_zod, content_json) = render_external_content(variant, self_type_name);
 
     #[cfg(feature = "zod")]
     let zod = {
@@ -6500,16 +6644,23 @@ fn render_internal_variant(
         .flatten();
 
     let Some(inner) = flattened else {
+        let flatten = variant_flatten_intersections(&variant.flattened_fields);
+
         #[cfg(feature = "jsonschema")]
-        let json = quote! { serde_json::Value::Object(#tag_object) };
+        let json = variant_merged_json_value(
+            &tag_object,
+            &variant.flattened_fields,
+            self_type_name,
+            &variant.discriminator_value,
+        );
         #[cfg(not(feature = "jsonschema"))]
         let json = quote! {};
 
         return (
-            parts.type_code,
-            format!("z.strictObject({})", parts.schema_code),
+            format!("{}{}", parts.type_code, flatten.0),
+            format!("z.strictObject({}){}", parts.schema_code, flatten.1),
             json,
-            false,
+            !variant.flattened_fields.is_empty(),
         );
     };
 
@@ -7772,27 +7923,21 @@ fn tagged_variant_json_object(
 fn generate_variant_code(
     tag_name: &str,
     content_name: &str,
-    discriminator_value: &str,
-    field_defs: &[FieldDef],
-    variant_kind: &VariantKind,
-    discriminator_docs: &str,
+    variant: &DiscriminatedVariant,
     self_type_name: &str,
 ) -> (String, String, Vec<String>, proc_macro2::TokenStream) {
-    let mut parts = tagged_variant_parts(tag_name, discriminator_value, discriminator_docs);
+    let discriminator_value = &variant.discriminator_value;
+    let field_defs = &variant.field_defs;
+    let mut parts = tagged_variant_parts(tag_name, discriminator_value, &variant.docs);
 
-    match variant_kind {
+    match &variant.kind {
         VariantKind::Unit => {
             // Unit variant: no additional fields beyond the discriminator
             // TypeScript: { type: "Variant" }
             // Zod: { type: z.literal("Variant") }
         }
         VariantKind::Named => {
-            write_adjacent_named_variant_fields(
-                field_defs,
-                content_name,
-                self_type_name,
-                &mut parts,
-            );
+            write_adjacent_named_variant_fields(variant, content_name, self_type_name, &mut parts);
         }
         VariantKind::TupleSingle => {
             write_tuple_single_variant_fields(field_defs, content_name, self_type_name, &mut parts);
@@ -7832,7 +7977,7 @@ fn generate_variant_code(
 /// serde actually writes for it (`{"tag":"Variant","content":{...fields}}`). Reuses
 /// [`write_named_variant_fields`]'s own `None`-tag rendering rather than a second nesting mechanism.
 fn write_adjacent_named_variant_fields(
-    field_defs: &[FieldDef],
+    variant: &DiscriminatedVariant,
     content_name: &str,
     self_type_name: &str,
     parts: &mut VariantParts,
@@ -7843,24 +7988,31 @@ fn write_adjacent_named_variant_fields(
         schema_code: String::new(),
         type_code: String::new(),
     };
-    write_named_variant_fields(field_defs, None, self_type_name, &mut inner);
+    write_named_variant_fields(&variant.field_defs, None, self_type_name, &mut inner);
+    let flatten = variant_flatten_intersections(&variant.flattened_fields);
 
     let content_key = ts_member_key(content_name);
     let _ = writeln!(
         parts.type_code,
-        "  {content_key}: {{\n{}}};",
-        inner.type_code
+        "  {content_key}: {{\n{}}}{};",
+        inner.type_code, flatten.0
     );
 
     #[cfg(feature = "zod")]
     let _ = writeln!(
         parts.schema_code,
-        "  {content_key}: z.strictObject({{\n{}}}),",
-        inner.schema_code
+        "  {content_key}: z.strictObject({{\n{}}}){},",
+        inner.schema_code, flatten.1
     );
 
     #[cfg(feature = "jsonschema")]
-    push_named_content_json_field(&mut parts.json_fields, content_name, &inner.json_fields);
+    push_named_content_json_field(
+        &mut parts.json_fields,
+        content_name,
+        &inner.json_fields,
+        variant,
+        self_type_name,
+    );
 }
 
 /// Pushes the JSON-schema property/required entries for an adjacently tagged struct variant's
@@ -7870,9 +8022,16 @@ fn push_named_content_json_field(
     json_schema_variant_fields: &mut Vec<proc_macro2::TokenStream>,
     content_name: &str,
     inner_json_fields: &[proc_macro2::TokenStream],
+    variant: &DiscriminatedVariant,
+    self_type_name: &str,
 ) {
     let content_name_str = content_name.to_owned();
-    let inner = named_content_json_value(inner_json_fields);
+    let inner = named_content_json_value(
+        inner_json_fields,
+        &variant.flattened_fields,
+        self_type_name,
+        &variant.discriminator_value,
+    );
     json_schema_variant_fields.push(quote! {
         properties.insert(#content_name_str.to_string(), #inner);
         required.push(serde_json::Value::String(#content_name_str.to_string()));
@@ -10840,6 +10999,52 @@ fn flatten_merged_source(fld: &FieldDef) -> MergedSource {
     }
 }
 
+/// The ` & A & B` an object's own block is closed with, one operand per merged source.
+#[cfg(feature = "typescript")]
+fn ts_intersection_suffix(operands: &[MergedOperand]) -> String {
+    operands.iter().fold(String::new(), |mut acc, operand| {
+        let _ = write!(acc, " & {}", ts_merged_operand(operand));
+        acc
+    })
+}
+
+/// The `.and(...)` chain an object's own `z.strictObject` is closed with. Every source reaching
+/// here contributes exactly one key set, so the chain is the whole merge — the struct-level
+/// [`zod_merged_statements`] is what multiplies the sources that contribute more.
+#[cfg(feature = "zod")]
+fn zod_intersection_suffix(operands: &[MergedOperand]) -> String {
+    operands.iter().fold(String::new(), |mut acc, operand| {
+        let _ = write!(acc, ".and({})", deferred_zod_operand(&operand.spelling));
+        acc
+    })
+}
+
+/// What a variant's `#[serde(flatten)]` sources are joined onto its own object with: the TypeScript
+/// intersection first, the Zod chain second, each empty where its surface is off or the variant
+/// flattens nothing.
+#[cfg(any(feature = "typescript", feature = "zod"))]
+fn variant_flatten_intersections(flattened_fields: &[FieldDef]) -> (String, String) {
+    let operands = compute_flatten_outputs(flattened_fields);
+
+    #[cfg(feature = "typescript")]
+    let typescript = ts_intersection_suffix(&operands.0);
+    #[cfg(not(feature = "typescript"))]
+    let typescript = String::new();
+
+    #[cfg(feature = "zod")]
+    let zod = zod_intersection_suffix(&operands.1);
+    #[cfg(not(feature = "zod"))]
+    let zod = String::new();
+
+    (typescript, zod)
+}
+
+/// Nothing is joined where neither surface writes an intersection.
+#[cfg(not(any(feature = "typescript", feature = "zod")))]
+const fn variant_flatten_intersections(_flattened_fields: &[FieldDef]) -> (String, String) {
+    (String::new(), String::new())
+}
+
 /// What one merged source is written as inside the intersection.
 #[cfg(feature = "typescript")]
 fn ts_merged_operand(operand: &MergedOperand) -> String {
@@ -10868,10 +11073,7 @@ fn generate_ts_definition_method(
     let has_flatten = !flatten_types.is_empty();
     let operands: Vec<String> = flatten_types.iter().map(ts_merged_operand).collect();
     let intersection_only = operands.join(" & ");
-    let intersection_suffix: String = operands.iter().fold(String::new(), |mut acc, t| {
-        let _ = write!(acc, " & {t}");
-        acc
-    });
+    let intersection_suffix = ts_intersection_suffix(flatten_types);
 
     let typescript_type_gen = if fields_empty {
         if has_flatten {

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -9496,3 +9496,184 @@ fn an_untagged_sibling_exclusion_writes_a_non_identifier_key_as_a_string() {
         "{ subject: string; \"reply-to\"?: never; sent_at?: never }"
     );
 }
+
+/// Collects a discriminated enum's guard failures as rendered `compile_error!` token strings.
+#[cfg(feature = "serde")]
+fn discriminated_guard_errors(mut item: syn::ItemEnum) -> Vec<String> {
+    collect_discriminated_variants(&mut item, None, Some("probe_schema"))
+        .2
+        .iter()
+        .map(ToString::to_string)
+        .collect()
+}
+
+/// The field defs one variant of a discriminated enum collected, beside the ones it flattens.
+#[cfg(feature = "serde")]
+fn collected_variant_fields(mut item: syn::ItemEnum) -> (Vec<String>, Vec<String>) {
+    let variants = collect_discriminated_variants(&mut item, None, Some("probe_schema")).0;
+    let variant = variants.first().unwrap();
+    (
+        variant.field_defs.iter().map(|f| f.name.clone()).collect(),
+        variant
+            .flattened_fields
+            .iter()
+            .map(|f| f.name.clone())
+            .collect(),
+    )
+}
+
+/// A variant's `#[serde(flatten)]` field is held apart from the members that write a key, exactly
+/// as a struct's own is.
+#[cfg(feature = "serde")]
+#[test]
+fn a_flattened_variant_field_is_split_out_of_the_variants_members() {
+    let (written, flattened) = collected_variant_fields(syn::parse_quote! {
+        enum Probe {
+            Named {
+                #[serde(flatten)]
+                extra: PlainBase,
+                x: String,
+            },
+        }
+    });
+    assert_eq!(written, vec!["x".to_owned()]);
+    assert_eq!(flattened, vec!["extra".to_owned()]);
+}
+
+/// And an unregistered source is left to the merge, which is what the struct-level split does with
+/// a name the expansion has not seen either.
+#[cfg(feature = "serde")]
+#[test]
+fn a_flattened_variant_field_over_an_unrecorded_name_is_not_refused() {
+    assert!(
+        discriminated_guard_errors(syn::parse_quote! {
+            enum Probe {
+                Named {
+                    #[serde(flatten)]
+                    extra: NeverRecordedBase,
+                    x: String,
+                },
+            }
+        })
+        .is_empty()
+    );
+}
+
+/// The guards a struct's own flattened field is read against reach a variant's too: a plain enum
+/// writes its variant name as a key holding null, which no closed object admits.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn a_flattened_variant_field_over_a_plain_enum_is_refused() {
+    register_alias_info(
+        "VariantHue",
+        "VariantHue",
+        &ident_schema_module_name("VariantHue"),
+        AliasKind::EnumMembers,
+    );
+    let errors = discriminated_guard_errors(syn::parse_quote! {
+        enum Probe {
+            Named {
+                #[serde(flatten)]
+                tone: VariantHue,
+                x: String,
+            },
+        }
+    });
+    assert_eq!(errors.len(), 1, "got: {errors:?}");
+    assert!(errors[0].contains("compile_error"), "got: {}", errors[0]);
+    assert!(
+        errors[0].contains("carries `#[serde(flatten)]` over `VariantHue`"),
+        "got: {}",
+        errors[0]
+    );
+}
+
+/// A source that writes one key set per branch is refused where a variant flattens it: the
+/// variant's own members are written inside the union member carrying them, so there is nowhere to
+/// bind them to a name each alternative could join.
+#[cfg(all(feature = "serde", feature = "zod"))]
+#[test]
+fn a_flattened_variant_field_over_a_multi_branch_source_is_refused() {
+    let mut choice: syn::ItemEnum = syn::parse_quote! {
+        enum VariantChoice {
+            First(Holder),
+            Second(Other),
+        }
+    };
+    let (_, _, _, merge_parts, _, errors, _, _) =
+        collect_untagged_members(&mut choice, UNTAGGED_MODULE);
+    assert!(errors.is_empty(), "got: {errors:?}");
+    register_alias_info(
+        "VariantChoice",
+        "VariantChoice",
+        &ident_schema_module_name("VariantChoice"),
+        AliasKind::NoEnumMembers,
+    );
+    record_zod_union_members("VariantChoice", &merge_parts);
+
+    let refusals = discriminated_guard_errors(syn::parse_quote! {
+        enum Probe {
+            Named {
+                #[serde(flatten)]
+                either: VariantChoice,
+                x: String,
+            },
+        }
+    });
+    assert_eq!(refusals.len(), 1, "got: {refusals:?}");
+    assert!(
+        refusals[0].contains("writes one key set per branch of the choice it names"),
+        "got: {}",
+        refusals[0]
+    );
+    assert!(
+        refusals[0].contains("variant `Named` of `Probe`"),
+        "got: {}",
+        refusals[0]
+    );
+}
+
+/// So is a source serde writes all the members of or none of: that is two key sets as well.
+#[cfg(all(feature = "serde", feature = "zod"))]
+#[test]
+fn an_optional_flattened_variant_field_is_refused() {
+    let refusals = discriminated_guard_errors(syn::parse_quote! {
+        enum Probe {
+            Named {
+                #[serde(flatten, skip_serializing_if = "Option::is_none", default)]
+                extra: Option<PlainBase>,
+                x: String,
+            },
+        }
+    });
+    assert_eq!(refusals.len(), 1, "got: {refusals:?}");
+    assert!(
+        refusals[0].contains("writes its members or no members at all"),
+        "got: {}",
+        refusals[0]
+    );
+}
+
+/// And each refusal names a way out the author can act on.
+#[cfg(all(feature = "serde", feature = "zod"))]
+#[test]
+fn the_variant_flatten_refusal_names_the_remedy() {
+    let refusals = discriminated_guard_errors(syn::parse_quote! {
+        enum Probe {
+            Named {
+                #[serde(flatten, skip_serializing_if = "Option::is_none", default)]
+                extra: Option<PlainBase>,
+                x: String,
+            },
+        }
+    });
+    assert!(
+        refusals[0]
+            .contains("write the field as a named member so the value gets a key of its own"),
+        "got: {}",
+        refusals[0]
+    );
+}

--- a/tests/flatten_tests/tests.rs
+++ b/tests/flatten_tests/tests.rs
@@ -970,6 +970,115 @@ struct OptUnionHolder {
     own: String,
 }
 
+/// The source an enum's own struct variants flatten, and one form of the enum per tagging: serde
+/// writes the source's members into the variant's own content object, wherever that object sits.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct VariantExtra {
+    note: String,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct VariantRank {
+    rank: i64,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+enum ExternalFlatVariant {
+    Named {
+        #[serde(flatten)]
+        extra: VariantExtra,
+        x: String,
+    },
+    Plain {
+        y: String,
+    },
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(tag = "kind")]
+enum InternalFlatVariant {
+    Named {
+        #[serde(flatten)]
+        extra: VariantExtra,
+        x: String,
+    },
+    Plain {
+        y: String,
+    },
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(tag = "kind", content = "data")]
+enum AdjacentFlatVariant {
+    Named {
+        #[serde(flatten)]
+        extra: VariantExtra,
+        x: String,
+    },
+    Plain {
+        y: String,
+    },
+}
+
+/// Two sources flattened into one variant: both sets of members join the same content object.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+enum TwiceFlatVariant {
+    Named {
+        #[serde(flatten)]
+        extra: VariantExtra,
+        #[serde(flatten)]
+        rank: VariantRank,
+        x: String,
+    },
+}
+
+/// The content object of `variant` in `document`, whichever of the three taggings put it there.
+#[cfg(feature = "jsonschema")]
+fn variant_content(document: &serde_json::Value, variant: &str) -> serde_json::Value {
+    let branches = document["oneOf"].as_array().unwrap();
+    let member = branches
+        .iter()
+        .find(|branch| {
+            let properties = branch["properties"].as_object().unwrap();
+            properties.contains_key(variant)
+                || properties
+                    .get("kind")
+                    .is_some_and(|tag| tag["const"] == variant)
+        })
+        .unwrap();
+    let properties = member["properties"].as_object().unwrap();
+    for key in [variant, "data"] {
+        if let Some(content) = properties.get(key) {
+            return content.clone();
+        }
+    }
+    member.clone()
+}
+
+/// The keys a content object names, and the keys it requires.
+#[cfg(feature = "jsonschema")]
+fn described_keys(content: &serde_json::Value) -> (Vec<String>, Vec<String>) {
+    let named = content["properties"]
+        .as_object()
+        .unwrap()
+        .keys()
+        .cloned()
+        .collect();
+    let required = content["required"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|key| key.as_str().unwrap().to_owned())
+        .collect();
+    (named, required)
+}
+
 /// Whether `payload` is accepted by a document every leaf of which is an object closed by
 /// `additionalProperties: false`: a leaf accepts when it names every key the payload carries and
 /// requires no key it does not.
@@ -3271,4 +3380,237 @@ fn test_the_inline_untagged_direct_flatten_document_is_unchanged() {
         serde_json::to_string(&InlineUntagDirectHolder::json_schema()).unwrap(),
         r#"{"type":"object","anyOf":[{"type":"object","properties":{"own":{"type":"string"},"left":{"type":"string"}},"required":["own","left"],"additionalProperties":false},{"type":"object","properties":{"own":{"type":"string"},"right":{"type":"boolean"}},"required":["own","right"],"additionalProperties":false}]}"#
     );
+}
+
+/// What serde writes for a `#[serde(flatten)]` field of an enum's own struct variant: the source's
+/// members sit in the variant's content object, under no key of their own — the same merge a
+/// struct's own flattened field gets, one level deeper.
+#[test]
+fn test_a_flattened_variant_field_writes_its_members_into_the_variants_content() {
+    assert_eq!(
+        serde_json::to_value(ExternalFlatVariant::Named {
+            extra: VariantExtra {
+                note: "n".to_owned()
+            },
+            x: "y".to_owned(),
+        })
+        .unwrap(),
+        serde_json::json!({ "Named": { "note": "n", "x": "y" } })
+    );
+    assert_eq!(
+        serde_json::to_value(InternalFlatVariant::Named {
+            extra: VariantExtra {
+                note: "n".to_owned()
+            },
+            x: "y".to_owned(),
+        })
+        .unwrap(),
+        serde_json::json!({ "kind": "Named", "note": "n", "x": "y" })
+    );
+    assert_eq!(
+        serde_json::to_value(AdjacentFlatVariant::Named {
+            extra: VariantExtra {
+                note: "n".to_owned()
+            },
+            x: "y".to_owned(),
+        })
+        .unwrap(),
+        serde_json::json!({ "kind": "Named", "data": { "note": "n", "x": "y" } })
+    );
+    assert_eq!(
+        serde_json::to_value(TwiceFlatVariant::Named {
+            extra: VariantExtra {
+                note: "n".to_owned()
+            },
+            rank: VariantRank { rank: 3 },
+            x: "y".to_owned(),
+        })
+        .unwrap(),
+        serde_json::json!({ "Named": { "note": "n", "rank": 3_i64, "x": "y" } })
+    );
+}
+
+/// And reads them back the same way, so the merged shape is what a payload must carry in both
+/// directions.
+#[test]
+fn test_a_flattened_variant_field_reads_back_from_the_merged_shape() {
+    let external: ExternalFlatVariant =
+        serde_json::from_value(serde_json::json!({ "Named": { "note": "n", "x": "y" } })).unwrap();
+    assert_eq!(
+        external,
+        ExternalFlatVariant::Named {
+            extra: VariantExtra {
+                note: "n".to_owned()
+            },
+            x: "y".to_owned(),
+        }
+    );
+    let internal: InternalFlatVariant =
+        serde_json::from_value(serde_json::json!({ "kind": "Named", "note": "n", "x": "y" }))
+            .unwrap();
+    assert_eq!(
+        internal,
+        InternalFlatVariant::Named {
+            extra: VariantExtra {
+                note: "n".to_owned()
+            },
+            x: "y".to_owned(),
+        }
+    );
+}
+
+/// So the TypeScript the variant describes as is an intersection at the content's own position,
+/// never a key holding the source.
+#[test]
+#[cfg(feature = "typescript")]
+fn test_a_flattened_variant_field_is_a_typescript_intersection_inside_the_variant() {
+    let external = ExternalFlatVariant::ts_definition();
+    assert!(external.contains("} & VariantExtra;"), "Got: {external}");
+    assert!(!external.contains("extra:"), "Got: {external}");
+    assert!(external.contains("y: string;"), "Got: {external}");
+
+    let internal = InternalFlatVariant::ts_definition();
+    assert!(internal.contains("} & VariantExtra"), "Got: {internal}");
+    assert!(!internal.contains("extra:"), "Got: {internal}");
+
+    let adjacent = AdjacentFlatVariant::ts_definition();
+    assert!(adjacent.contains("} & VariantExtra;"), "Got: {adjacent}");
+    assert!(!adjacent.contains("extra:"), "Got: {adjacent}");
+}
+
+#[test]
+#[cfg(feature = "typescript")]
+fn test_two_flattened_variant_fields_join_the_same_content_object() {
+    let ts = TwiceFlatVariant::ts_definition();
+    assert!(ts.contains("} & VariantExtra & VariantRank;"), "Got: {ts}");
+    assert!(!ts.contains("rank:"), "Got: {ts}");
+}
+
+/// And the Zod schema joins the source through the same deferred operand a struct's own flattened
+/// base joins through, so a source declared below the enum is still read when something validates.
+#[test]
+#[cfg(feature = "zod")]
+fn test_a_flattened_variant_field_is_a_zod_intersection_inside_the_variant() {
+    for zod in [
+        ExternalFlatVariant::zod_schema(),
+        InternalFlatVariant::zod_schema(),
+        AdjacentFlatVariant::zod_schema(),
+    ] {
+        assert!(
+            zod.contains("}).and(z.lazy(() => VariantExtra$Schema))"),
+            "Got: {zod}"
+        );
+        assert!(!zod.contains("extra:"), "Got: {zod}");
+        assert!(
+            !zod.contains(".and(VariantExtra$Schema)"),
+            "the source is read while the const initializes: {zod}"
+        );
+    }
+}
+
+#[test]
+#[cfg(feature = "zod")]
+fn test_two_flattened_variant_fields_chain_their_zod_operands() {
+    let zod = TwiceFlatVariant::zod_schema();
+    assert!(
+        zod.contains(
+            "}).and(z.lazy(() => VariantExtra$Schema)).and(z.lazy(() => VariantRank$Schema))"
+        ),
+        "Got: {zod}"
+    );
+}
+
+/// An internally tagged member that flattens is an intersection rather than an object, and Zod
+/// discriminates only between objects — so the union carrying it is a plain one.
+#[test]
+#[cfg(feature = "zod")]
+fn test_an_internally_tagged_flattened_variant_forces_a_plain_zod_union() {
+    let zod = InternalFlatVariant::zod_schema();
+    assert!(zod.contains("z.union(["), "Got: {zod}");
+    assert!(!zod.contains("z.discriminatedUnion("), "Got: {zod}");
+}
+
+/// The JSON document names the source's members where the variant's own members are named, and
+/// requires them beside its own — no key stands for the flattened field itself.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_a_flattened_variant_field_merges_into_the_variants_json_content() {
+    for document in [
+        ExternalFlatVariant::json_schema(),
+        InternalFlatVariant::json_schema(),
+        AdjacentFlatVariant::json_schema(),
+    ] {
+        let content = variant_content(&document, "Named");
+        let (named, required) = described_keys(&content);
+        assert!(named.contains(&"note".to_owned()), "Got: {content}");
+        assert!(named.contains(&"x".to_owned()), "Got: {content}");
+        assert!(!named.contains(&"extra".to_owned()), "Got: {content}");
+        assert!(required.contains(&"note".to_owned()), "Got: {content}");
+        assert!(required.contains(&"x".to_owned()), "Got: {content}");
+        assert_eq!(content["additionalProperties"], serde_json::json!(false));
+    }
+}
+
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_two_flattened_variant_fields_merge_into_one_json_content() {
+    let content = variant_content(&TwiceFlatVariant::json_schema(), "Named");
+    let (named, required) = described_keys(&content);
+    for key in ["note", "rank", "x"] {
+        assert!(named.contains(&key.to_owned()), "Got: {content}");
+        assert!(required.contains(&key.to_owned()), "Got: {content}");
+    }
+}
+
+/// And the document accepts exactly the payload serde writes.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_the_flattened_variant_document_accepts_what_serde_writes() {
+    let cases = [
+        (
+            ExternalFlatVariant::json_schema(),
+            serde_json::to_value(ExternalFlatVariant::Named {
+                extra: VariantExtra {
+                    note: "n".to_owned(),
+                },
+                x: "y".to_owned(),
+            })
+            .unwrap(),
+        ),
+        (
+            InternalFlatVariant::json_schema(),
+            serde_json::to_value(InternalFlatVariant::Named {
+                extra: VariantExtra {
+                    note: "n".to_owned(),
+                },
+                x: "y".to_owned(),
+            })
+            .unwrap(),
+        ),
+    ];
+    for (document, payload) in cases {
+        assert!(
+            closed_document_accepts(&document, &payload),
+            "{document} rejected {payload}"
+        );
+    }
+}
+
+/// A variant carrying no flattened field is untouched: its content stays the object it always was,
+/// with a key per declared field and no intersection anywhere.
+#[test]
+#[cfg(feature = "typescript")]
+fn test_a_variant_without_a_flattened_field_keeps_its_typescript_object() {
+    let ts = ExternalFlatVariant::ts_definition();
+    let declared = &ts[ts.find("export type").unwrap()..];
+    let plain = &declared[declared.find("\"Plain\"").unwrap()..];
+    assert!(!plain.contains(" & "), "Got: {plain}");
+}
+
+#[test]
+#[cfg(feature = "zod")]
+fn test_a_variant_without_a_flattened_field_keeps_its_zod_object() {
+    let zod = AdjacentFlatVariant::zod_schema();
+    let plain = &zod[zod.find("z.literal(\"Plain\")").unwrap()..];
+    assert!(!plain.contains(".and("), "Got: {plain}");
 }


### PR DESCRIPTION
`#[serde(flatten)]` on a struct-variant field of a tagged enum was never read.
The field went into the variant's member list like any other, so every surface
described a key holding a nested object serde never writes:

    #[serde(tag = "kind")]
    enum Probe { Named { #[serde(flatten)] extra: Extra, x: String } }

    serde writes   {"kind":"Named","note":"n","x":"y"}
    described      { kind: "Named"; extra: Extra; x: string }

Measured with a real safeParse before the fix: the schema rejected the payload
serde produced, on all three tagged forms.

The split mirrors what the struct level already does, one level deeper.
`collect_discriminated_variants` now separates a variant's flattened sources
from its own members through the same predicate the struct path reads, and runs
the two struct-level guards those fields previously skipped. The three surfaces
join the sources onto the object the variant already builds: TypeScript and Zod
through the same intersection suffixes the struct path renders — extracted, so
the two paths share the join — and the JSON document through the same merge the
struct path runs, reached at the external and adjacent forms through the
content object.

An internally tagged member that flattens is an intersection rather than an
object, so its union drops from z.discriminatedUnion to z.union — a
discriminated union requires each member to name the key statically, and an
intersection does not.

What a variant cannot merge is refused rather than mis-described, spanned on the
field's type: a source that writes one key set per branch of a choice, and one
that offers its own absence — an Option-wrapped source, or a surface with an
absent form. Both multiply the member's shape, and the variant's members are
written inside the union member that carries them, leaving no name to bind the
alternatives to. The refusal names the rewrite: flatten into a struct of its
own, or give the value a key.

Wire shapes verified against zod 4.4.3 and ajv from real serde_json output —
external, internal and adjacent forms, two sources in one variant, unit
variants untouched, and the stale nested shape now rejected by both validators.

just check, just quick, just lint-all across all 68 toggles, and the test
powerset across all 68 in four partitions — all green.

