### PR TITLE
refuse a field reaching a std type serde cannot write, instead of referencing a module that never exists

### DIFF
--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -966,6 +966,51 @@ impl FieldDef {
         }
     }
 
+    /// The name of the first `is_unsupported_std_wrapper` this field reaches, at any depth.
+    pub fn unsupported_std_wrapper_name(&self) -> Option<&str> {
+        match &self.field_type {
+            FieldDefType::SiblingType(name, generics) => {
+                if is_unsupported_std_wrapper(name.as_str()) {
+                    return Some(name);
+                }
+                generics.iter().find_map(Self::unsupported_std_wrapper_name)
+            }
+            FieldDefType::Map(key, value) => key
+                .unsupported_std_wrapper_name()
+                .or_else(|| value.unsupported_std_wrapper_name()),
+            FieldDefType::Tuple(elements) => {
+                elements.iter().find_map(Self::unsupported_std_wrapper_name)
+            }
+            FieldDefType::TypeParam(_)
+            | FieldDefType::Unknown
+            | FieldDefType::StringLiteral(_)
+            | FieldDefType::BooleanLiteral(_)
+            | FieldDefType::NumberLiteral(_)
+            | FieldDefType::Boolean
+            | FieldDefType::Char
+            | FieldDefType::String
+            | FieldDefType::U8
+            | FieldDefType::U16
+            | FieldDefType::U32
+            | FieldDefType::U64
+            | FieldDefType::I8
+            | FieldDefType::I16
+            | FieldDefType::I32
+            | FieldDefType::I64
+            | FieldDefType::Usize
+            | FieldDefType::Isize
+            | FieldDefType::F32
+            | FieldDefType::F64 => None,
+            #[cfg(feature = "object_id")]
+            FieldDefType::ObjectId => None,
+            #[cfg(feature = "chrono")]
+            FieldDefType::NaiveDate
+            | FieldDefType::NaiveTime
+            | FieldDefType::NaiveDateTime
+            | FieldDefType::DateTime => None,
+        }
+    }
+
     /// The value this field's wrappers hold, as a field of its own: the same type with the
     /// `Option`s and the array levels dropped. The wrappers are the field's to declare and the
     /// value under them is what a type name stands for, so this is what an `as = Type` is compared
@@ -1280,6 +1325,25 @@ pub fn is_ownership_wrapper(name: &str) -> bool {
 /// ownership wrapper — see `generic_wrap` in `model_schema.rs`.
 pub fn is_interior_mutability_wrapper(name: &str) -> bool {
     matches!(name, "Cell" | "Mutex" | "RefCell" | "RwLock")
+}
+
+/// The std cell/lock/lazy-init types and borrow guards serde implements neither `Serialize` nor
+/// `Deserialize` for: unlike `is_transparent_wrapper`'s members there is no wire form to describe.
+/// Matched on the bare name, as `os_string_name` matches its two — a user item named `Ref` or
+/// `RefMut` is refused with them.
+pub fn is_unsupported_std_wrapper(name: &str) -> bool {
+    matches!(
+        name,
+        "OnceLock"
+            | "OnceCell"
+            | "LazyLock"
+            | "LazyCell"
+            | "Ref"
+            | "RefMut"
+            | "MutexGuard"
+            | "RwLockReadGuard"
+            | "RwLockWriteGuard"
+    )
 }
 
 /// Classifies a `syn::Variant` into its `VariantKind`.

--- a/src/field_type/tests.rs
+++ b/src/field_type/tests.rs
@@ -437,6 +437,88 @@ fn test_a_schematizable_field_is_not_reported_as_an_os_string() {
     }
 }
 
+/// The cell/lock/lazy-init types and the borrow guards serde writes nothing for: the parse leaves
+/// each a sibling, and the report names it from wherever it was written.
+#[test]
+fn test_an_unsupported_std_wrapper_is_reported_wherever_it_was_written() {
+    for (spelling, expected) in [
+        ("OnceLock<u32>", "OnceLock"),
+        ("OnceCell<u32>", "OnceCell"),
+        ("LazyLock<u32>", "LazyLock"),
+        ("LazyCell<u32>", "LazyCell"),
+        ("Ref<'a, u32>", "Ref"),
+        ("RefMut<'a, u32>", "RefMut"),
+        ("MutexGuard<'a, u32>", "MutexGuard"),
+        ("RwLockReadGuard<'a, u32>", "RwLockReadGuard"),
+        ("RwLockWriteGuard<'a, u32>", "RwLockWriteGuard"),
+        ("Option<OnceLock<u32>>", "OnceLock"),
+        ("Vec<LazyCell<u32>>", "LazyCell"),
+        ("HashMap<String, OnceCell<u32>>", "OnceCell"),
+        ("(String, MutexGuard<'a, u32>)", "MutexGuard"),
+        ("Box<Ref<'a, u32>>", "Ref"),
+        ("Wrapper<RefMut<'a, u32>>", "RefMut"),
+    ] {
+        let ty: syn::Type = syn::parse_str(spelling).unwrap();
+        let parsed = super::get_field_def("guarded", &ty, "");
+        assert_eq!(
+            parsed.unsupported_std_wrapper_name(),
+            Some(expected),
+            "for: {spelling}"
+        );
+    }
+}
+
+/// The report is for those nine names alone: the wrappers the crate reads straight through, and a
+/// user type that merely carries one of the names inside its own, all describe a wire form.
+#[test]
+fn test_a_schematizable_field_is_not_reported_as_an_unsupported_std_wrapper() {
+    for spelling in [
+        "String",
+        "Box<u32>",
+        "Rc<u32>",
+        "Arc<u32>",
+        "Cow<'a, str>",
+        "RefCell<u32>",
+        "Cell<u32>",
+        "Mutex<u32>",
+        "RwLock<u32>",
+        "OnceLockHolder",
+        "RefHolder",
+        "Wrapper<String>",
+    ] {
+        let ty: syn::Type = syn::parse_str(spelling).unwrap();
+        let parsed = super::get_field_def("guarded", &ty, "");
+        assert_eq!(
+            parsed.unsupported_std_wrapper_name(),
+            None,
+            "for: {spelling}"
+        );
+    }
+}
+
+#[test]
+fn test_the_unsupported_std_wrapper_list_is_exactly_the_nine_names() {
+    for name in [
+        "OnceLock",
+        "OnceCell",
+        "LazyLock",
+        "LazyCell",
+        "Ref",
+        "RefMut",
+        "MutexGuard",
+        "RwLockReadGuard",
+        "RwLockWriteGuard",
+    ] {
+        assert!(super::is_unsupported_std_wrapper(name), "for: {name}");
+        assert!(!super::is_transparent_wrapper(name), "for: {name}");
+    }
+    for name in [
+        "Arc", "Box", "Cow", "Rc", "Cell", "Mutex", "RefCell", "RwLock", "Inner",
+    ] {
+        assert!(!super::is_unsupported_std_wrapper(name), "for: {name}");
+    }
+}
+
 /// An `Option` written inside a sequence wrapper and one written around it are two different
 /// values on the wire — `[null]` against `null` — so the parse keeps them apart: each is recorded
 /// at the level it was written at, the element's below the array and the field's own at the top.

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -10394,9 +10394,10 @@ fn field_guard_errors(
         .collect()
 }
 
-/// Every guard error the field violates: the two the type earns — the `OsString` guard and the
-/// map-key guard, neither of which any attribute can hide — then everything the
-/// `model_schema_prop` attribute earned, then the serde-side guards when any fired.
+/// Every guard error the field violates: the three the type earns — the `OsString` guard, the
+/// unsupported-std-wrapper guard and the map-key guard, none of which any attribute can hide —
+/// then everything the `model_schema_prop` attribute earned, then the serde-side guards when any
+/// fired.
 fn collect_field_guard_errors(
     field: &Field,
     field_def: &FieldDef,
@@ -10418,6 +10419,11 @@ fn collect_field_guard_errors(
         .err()
         .map(|err| err.to_compile_error())
         .into_iter()
+        .chain(
+            check_unsupported_std_wrapper_field(field, field_def, &label)
+                .err()
+                .map(|err| err.to_compile_error()),
+        )
         .chain(map_key_error)
         .chain(model_schema_prop_guard_errors(
             field,
@@ -10695,6 +10701,27 @@ fn check_os_string_field(
              enum naming the target platform (`{{\"Unix\":[u8, ...]}}` or \
              `{{\"Windows\":[u16, ...]}}`), not a string, so no schema can describe it portably. \
              Use `String`, or `PathBuf` for a filesystem path."
+        ),
+    ))
+}
+
+/// Rejects a field that reaches a std cell/lock/lazy-init wrapper or borrow guard, at any depth:
+/// left unrefused the name falls through to `FieldDefType::SiblingType`, and the expansion
+/// references a schema module nothing publishes rather than naming the unsupported type.
+fn check_unsupported_std_wrapper_field(
+    field: &Field,
+    field_def: &FieldDef,
+    label: &str,
+) -> Result<(), syn::Error> {
+    let Some(name) = field_def.unsupported_std_wrapper_name() else {
+        return Ok(());
+    };
+    Err(syn::Error::new_spanned(
+        field,
+        format!(
+            "model_schema: {label} reaches `{name}`, which serde implements neither `Serialize` \
+             nor `Deserialize` for, so there is no wire form for a schema to describe. Store the \
+             value `{name}` holds directly, or leave this field out of the serialized shape."
         ),
     ))
 }

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -1,7 +1,8 @@
 use super::{
     FieldDefType, ModelSchemaPropMeta, check_nullable_ts_optional_conflict, check_os_string_field,
-    collect_discriminated_variants, field_label, get_field_def, render_discriminated_variants,
-    validate_as_number_flag, validate_nullable_flag, validate_ts_optional_flag,
+    check_unsupported_std_wrapper_field, collect_discriminated_variants, field_label,
+    get_field_def, render_discriminated_variants, validate_as_number_flag, validate_nullable_flag,
+    validate_ts_optional_flag,
 };
 
 #[cfg(feature = "serde")]
@@ -1458,6 +1459,90 @@ fn a_path_field_is_left_alone() {
         let error = field_os_string_error(&syn::parse_quote! {
             struct Report {
                 location: #ty,
+            }
+        });
+        assert!(error.is_none(), "for {ty}, got: {error:?}");
+    }
+}
+
+/// Runs the field walk the way [`process_field`] does and renders the std-wrapper guard failure.
+fn field_unsupported_std_wrapper_error(item: &syn::ItemStruct) -> Option<String> {
+    let field = item.fields.iter().next()?;
+    let name = field
+        .ident
+        .as_ref()
+        .map(ToString::to_string)
+        .unwrap_or_default();
+    let field_def = get_field_def(&name, &field.ty, "");
+    check_unsupported_std_wrapper_field(field, &field_def, &field_label(&name))
+        .err()
+        .map(|err| err.to_compile_error().to_string())
+}
+
+#[test]
+fn a_once_lock_field_is_rejected_by_name() {
+    let error = field_unsupported_std_wrapper_error(&syn::parse_quote! {
+        struct Probe {
+            guarded: OnceLock<u32>,
+        }
+    })
+    .unwrap();
+    assert!(error.contains("compile_error"), "got: {error}");
+    assert!(error.contains("field `guarded`"), "got: {error}");
+    assert!(error.contains("`OnceLock`"), "got: {error}");
+    assert!(error.contains("Serialize"), "got: {error}");
+}
+
+/// The guard reads through the wrappers the parser reads through, so the refusal names the
+/// unsupported type rather than the sequence or option it was written inside.
+#[test]
+fn a_wrapped_once_lock_field_is_rejected_by_its_own_name() {
+    let error = field_unsupported_std_wrapper_error(&syn::parse_quote! {
+        struct Probe {
+            guarded: Vec<Option<OnceLock<u32>>>,
+        }
+    })
+    .unwrap();
+    assert!(error.contains("`OnceLock`"), "got: {error}");
+    assert!(!error.contains("`Vec`"), "got: {error}");
+}
+
+/// A borrow guard writes a lifetime ahead of its type parameter, which the argument filter drops
+/// before the walk ever sees it.
+#[test]
+fn a_lifetime_parameterized_guard_field_is_rejected_by_name() {
+    for (spelling, expected) in [
+        (quote::quote! { MutexGuard<'a, u32> }, "`MutexGuard`"),
+        (quote::quote! { Ref<'a, u32> }, "`Ref`"),
+        (
+            quote::quote! { RwLockReadGuard<'a, u32> },
+            "`RwLockReadGuard`",
+        ),
+    ] {
+        let error = field_unsupported_std_wrapper_error(&syn::parse_quote! {
+            struct Probe {
+                guarded: #spelling,
+            }
+        })
+        .unwrap();
+        assert!(error.contains(expected), "for {spelling}, got: {error}");
+    }
+}
+
+/// A sibling type and the wrappers the crate reads straight through both describe a wire form, so
+/// neither is what this guard answers for.
+#[test]
+fn a_schematizable_field_is_left_alone_by_the_std_wrapper_guard() {
+    for ty in [
+        quote::quote! { Inner },
+        quote::quote! { Box<u32> },
+        quote::quote! { RefCell<u32> },
+        quote::quote! { Arc<Inner> },
+        quote::quote! { String },
+    ] {
+        let error = field_unsupported_std_wrapper_error(&syn::parse_quote! {
+            struct Probe {
+                guarded: #ty,
             }
         });
         assert!(error.is_none(), "for {ty}, got: {error:?}");


### PR DESCRIPTION
A field typed at a std cell, lock, lazy-init or borrow-guard type — `OnceLock`,
`OnceCell`, `LazyLock`, `LazyCell`, `Ref`, `RefMut`, `MutexGuard`,
`RwLockReadGuard`, `RwLockWriteGuard` — fell through to a sibling reference, and
the expansion named a schema module after it:

    struct Probe { guarded: OnceLock<String> }
    error[E0433]: cannot find module or crate `once_lock_schema`

serde implements neither `Serialize` nor `Deserialize` for any of the nine, so
there is no wire form for a schema to describe, and the module-not-found error
named generated plumbing instead of the actual problem.

The guard mirrors the `OsString` one exactly and chains beside it in the field
walk, which already serves struct fields and variant members alike. The walk
reaches the name at any depth — a sibling's arguments, a map's key and value, a
tuple's elements — and the refusal is spanned on the field, naming the type and
the rewrite:

    error: model_schema: field `guarded` reaches `OnceLock`, which serde
    implements neither `Serialize` nor `Deserialize` for, so there is no wire
    form for a schema to describe. Store the value `OnceLock` holds directly,
    or leave this field out of the serialized shape.

serde's own bound errors are left as they are — they name the real constraint.

The match is on the bare name, the same shape the `OsString` guard and the
undescribable-primitive refusal use: by the time the walk runs the parser has
dropped lifetimes and collapsed transparent wrappers, so an arity check would
read a normalized list rather than what was written. The stated cost is that a
user item named `Ref` or `RefMut` is refused with the std ones.

just check, just quick, just lint-all across all 68 toggles, and the test
powerset across all 68 in four partitions — all green, on the state merged with
the dead-plumbing removal.

