### PR TITLE
merge a flattened field into an untagged variant's member, where serde writes it

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -549,6 +549,9 @@ struct UntaggedVariantMembers {
     checks: Vec<proc_macro2::TokenStream>,
     deferred_attrs: Vec<Vec<syn::Attribute>>,
     field_defs: Vec<FieldDef>,
+    /// The variant's own `#[serde(flatten)]` sources, held apart from `field_defs`: they write no
+    /// key of their own, so every surface joins them onto the object the rest of the fields close.
+    flattened_fields: Vec<FieldDef>,
     guard_errors: Vec<proc_macro2::TokenStream>,
     validation_fns: Vec<proc_macro2::TokenStream>,
 }
@@ -6981,12 +6984,16 @@ fn process_internally_tagged_enum(
 fn render_untagged_variant(
     kind: &VariantKind,
     variant: &syn::Variant,
-    field_defs: &[FieldDef],
+    members: &UntaggedVariantMembers,
     self_type_name: &str,
 ) -> Result<(String, String, proc_macro2::TokenStream), syn::Error> {
-    match (kind, field_defs) {
+    match (kind, members.field_defs.as_slice()) {
         (VariantKind::TupleSingle, [fld]) => Ok(render_untagged_tuple_single(fld, self_type_name)),
-        (VariantKind::Named, _) => Ok(render_untagged_named(field_defs, self_type_name)),
+        (VariantKind::Named, _) => Ok(render_untagged_named(
+            members,
+            self_type_name,
+            &variant.ident.to_string(),
+        )),
         (VariantKind::Unit, _) if lone_slot_off_wire(variant) => {
             Err(collapsed_untagged_variant_error(variant))
         }
@@ -7063,12 +7070,19 @@ fn render_untagged_tuple_single(
 }
 
 /// Renders a `Named` (`{ a: A }`) untagged variant as a union member (object type / strictObject /
-/// object schema).
+/// object schema), with the members of every `#[serde(flatten)]` source it carries joined onto that
+/// object.
 #[cfg(feature = "serde")]
 fn render_untagged_named(
-    field_defs: &[FieldDef],
+    members: &UntaggedVariantMembers,
     self_type_name: &str,
+    variant_name: &str,
 ) -> (String, String, proc_macro2::TokenStream) {
+    let field_defs = &members.field_defs;
+    let flatten = variant_flatten_intersections(&members.flattened_fields);
+    #[cfg(not(feature = "jsonschema"))]
+    let _: &str = variant_name;
+
     let ts_fields = field_defs
         .iter()
         .map(|fld| {
@@ -7081,7 +7095,7 @@ fn render_untagged_named(
         })
         .collect::<Vec<_>>()
         .join("; ");
-    let ts = format!("{{ {ts_fields} }}");
+    let ts = format!("{{ {ts_fields} }}{}", flatten.0);
 
     #[cfg(feature = "zod")]
     let zod = {
@@ -7096,6 +7110,7 @@ fn render_untagged_named(
             }
         }
         body.push_str("})");
+        body.push_str(&flatten.1);
         body
     };
     #[cfg(not(feature = "zod"))]
@@ -7105,7 +7120,12 @@ fn render_untagged_named(
     };
 
     #[cfg(feature = "jsonschema")]
-    let json_val = untagged_named_json_value(field_defs);
+    let json_val = untagged_named_json_value(
+        field_defs,
+        &members.flattened_fields,
+        self_type_name,
+        variant_name,
+    );
     #[cfg(not(feature = "jsonschema"))]
     let json_val = quote! {};
 
@@ -7114,10 +7134,15 @@ fn render_untagged_named(
 
 /// The keys one untagged member names, and `None` where nothing here proves them. A `Named`
 /// variant's keys are the ones it already spells; every other member is written as the type it
-/// names, and its key list is not something a registry lookup can answer.
+/// names, and its key list is not something a registry lookup can answer — nor is a `Named`
+/// variant's once it flattens, since the source's keys belong to a type this expansion cannot read.
 #[cfg(all(feature = "serde", feature = "typescript"))]
-fn untagged_member_keys(kind: &VariantKind, field_defs: &[FieldDef]) -> Option<Vec<String>> {
-    matches!(kind, VariantKind::Named)
+fn untagged_member_keys(
+    kind: &VariantKind,
+    field_defs: &[FieldDef],
+    flattened_fields: &[FieldDef],
+) -> Option<Vec<String>> {
+    (matches!(kind, VariantKind::Named) && flattened_fields.is_empty())
         .then(|| field_defs.iter().map(|fld| fld.name.clone()).collect())
 }
 
@@ -7144,9 +7169,15 @@ fn close_untagged_flatten_member(member: &str, excluded: &[String]) -> String {
 }
 
 /// Builds the `{ type: object, properties, required, additionalProperties: false }` JSON-schema
-/// value token for a `Named` untagged variant.
+/// value token for a `Named` untagged variant, with the members of every `#[serde(flatten)]` source
+/// the variant carries merged beside its own.
 #[cfg(all(feature = "serde", feature = "jsonschema"))]
-fn untagged_named_json_value(field_defs: &[FieldDef]) -> proc_macro2::TokenStream {
+fn untagged_named_json_value(
+    field_defs: &[FieldDef],
+    flattened_fields: &[FieldDef],
+    self_type_name: &str,
+    variant_name: &str,
+) -> proc_macro2::TokenStream {
     let property_inserts = field_defs.iter().map(|fld| {
         let name_str = fld.name.clone();
         let value = nullable_slot_json_schema_value(fld, field_json_schema_value(fld));
@@ -7162,7 +7193,7 @@ fn untagged_named_json_value(field_defs: &[FieldDef]) -> proc_macro2::TokenStrea
             #required_insert
         }
     });
-    quote! {
+    let object = quote! {
         {
             let mut object_schema = serde_json::Map::new();
             object_schema.insert(
@@ -7184,9 +7215,10 @@ fn untagged_named_json_value(field_defs: &[FieldDef]) -> proc_macro2::TokenStrea
                 "additionalProperties".to_string(),
                 serde_json::Value::Bool(false),
             );
-            serde_json::Value::Object(object_schema)
+            object_schema
         }
-    }
+    };
+    variant_merged_json_value(&object, flattened_fields, self_type_name, variant_name)
 }
 
 /// Builds the `{ "type": "string", ... }` JSON-schema value token for a `String` field, including
@@ -7420,6 +7452,7 @@ fn collect_untagged_variant_members(
         checks: Vec::new(),
         deferred_attrs: Vec::new(),
         field_defs: Vec::new(),
+        flattened_fields: Vec::new(),
         guard_errors: Vec::new(),
         validation_fns: Vec::new(),
     };
@@ -7436,6 +7469,17 @@ fn collect_untagged_variant_members(
         ) {
             walked.guard_errors.push(rejection.to_compile_error());
         }
+
+        // Read before the field is processed, which strips the attributes the declaration carried.
+        let is_flatten = is_flattened_field(field);
+        if is_flatten {
+            walked.guard_errors.extend(variant_flatten_guard_errors(
+                field,
+                enum_type_name,
+                &variant_name,
+            ));
+        }
+
         let field_name = field_ident_string(field);
         let prop_meta = parse_model_schema_prop_attributes(&field.attrs);
         let serde_field_meta = parse_serde_field_attributes(&field.attrs);
@@ -7452,11 +7496,15 @@ fn collect_untagged_variant_members(
                 &mut injected_attrs,
             );
         field.attrs = new_attrs;
+        // Pushed for every field, flattened or not: `apply_deferred_field_attrs` zips this against
+        // the declaration's own fields, so a skipped push shifts every later field's attributes.
         walked.deferred_attrs.push(injected_attrs);
-        walked.validation_fns.extend(validation_fn);
-        if let (Some(body), Some(ident)) = (validate_body, field.ident.as_ref()) {
-            walked.bound.push((ident.clone(), member_binding(ident)));
-            walked.checks.push(body);
+        if !is_flatten {
+            walked.validation_fns.extend(validation_fn);
+            if let (Some(body), Some(ident)) = (validate_body, field.ident.as_ref()) {
+                walked.bound.push((ident.clone(), member_binding(ident)));
+                walked.checks.push(body);
+            }
         }
 
         let member_ctx = untagged_variant_context(
@@ -7476,6 +7524,10 @@ fn collect_untagged_variant_members(
             field_validation_guard_error,
         );
         walked.guard_errors.extend(member_guard_errors);
+        if is_flatten {
+            walked.flattened_fields.push(member_def);
+            continue;
+        }
         if positional && omission.absent_from_wire() {
             continue;
         }
@@ -7519,30 +7571,33 @@ fn collect_untagged_members(
         guard_errors.append(&mut walked.guard_errors);
         validation_fns.append(&mut walked.validation_fns);
         deferred_attrs.append(&mut walked.deferred_attrs);
-        let field_defs = walked.field_defs;
 
-        per_variant_checks.push((
-            variant_check_pattern(&variant.ident, &declared_kind, total_fields, &walked.bound),
-            walked.checks,
-        ));
-
-        match render_untagged_variant(&kind, variant, &field_defs, &enum_type_name) {
+        match render_untagged_variant(&kind, variant, &walked, &enum_type_name) {
             Ok((ts, zod, json_val)) => {
                 #[cfg(feature = "zod")]
                 zod_merge_parts.extend(zod_merge_branches(
                     &kind,
-                    &field_defs,
+                    &walked.field_defs,
                     &zod,
                     ts_parts.len() + 1,
                 ));
                 #[cfg(feature = "typescript")]
-                ts_member_keys.push(untagged_member_keys(&kind, &field_defs));
+                ts_member_keys.push(untagged_member_keys(
+                    &kind,
+                    &walked.field_defs,
+                    &walked.flattened_fields,
+                ));
                 ts_parts.push(ts);
                 zod_parts.push(zod);
                 json_parts.push(json_val);
             }
             Err(err) => guard_errors.push(err.to_compile_error()),
         }
+
+        per_variant_checks.push((
+            variant_check_pattern(&variant.ident, &declared_kind, total_fields, &walked.bound),
+            walked.checks,
+        ));
     }
 
     if guard_errors.is_empty() {

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -8462,12 +8462,31 @@ fn the_adjacent_collapse_refusal_quotes_the_declared_keys() {
     );
 }
 
+/// The collected walk a renderer probe hands one variant, holding just the members it writes.
+#[cfg(feature = "serde")]
+fn walked_members(field_defs: &[super::FieldDef]) -> super::UntaggedVariantMembers {
+    super::UntaggedVariantMembers {
+        bound: Vec::new(),
+        checks: Vec::new(),
+        deferred_attrs: Vec::new(),
+        field_defs: field_defs.to_vec(),
+        flattened_fields: Vec::new(),
+        guard_errors: Vec::new(),
+        validation_fns: Vec::new(),
+    }
+}
+
 /// The member spelling an untagged variant is refused with, run over the kind it publishes.
 #[cfg(feature = "serde")]
 fn untagged_refusal(declaration: &str, members: &[super::FieldDef]) -> String {
     let variant = declared_variant(declaration);
-    render_untagged_variant(&variant_wire_kind(&variant), &variant, members, "Wire")
-        .map_or_else(|err| err.to_string(), |_| String::new())
+    render_untagged_variant(
+        &variant_wire_kind(&variant),
+        &variant,
+        &walked_members(members),
+        "Wire",
+    )
+    .map_or_else(|err| err.to_string(), |_| String::new())
 }
 
 /// Captured from serde: an untagged variant whose lone slot is off the wire writes and reads `null`
@@ -8498,8 +8517,13 @@ fn an_untagged_variant_whose_lone_slot_is_dropped_is_refused_for_the_collapse() 
 #[test]
 fn the_untagged_collapse_refusal_points_at_the_variant() {
     let variant = declared_variant("enum Wire { One(#[serde(skip)] String) }");
-    let error =
-        render_untagged_variant(&variant_wire_kind(&variant), &variant, &[], "Wire").unwrap_err();
+    let error = render_untagged_variant(
+        &variant_wire_kind(&variant),
+        &variant,
+        &walked_members(&[]),
+        "Wire",
+    )
+    .unwrap_err();
     assert_eq!(
         error.span().source_text().as_deref(),
         Some("One(#[serde(skip)] String)")
@@ -9850,5 +9874,164 @@ fn the_variant_flatten_refusal_names_the_remedy() {
             .contains("write the field as a named member so the value gets a key of its own"),
         "got: {}",
         refusals[0]
+    );
+}
+
+/// The members one untagged variant collected, beside the ones it flattens.
+#[cfg(feature = "serde")]
+fn collected_untagged_variant_fields(mut item: syn::ItemEnum) -> (Vec<String>, Vec<String>) {
+    let variant = item.variants.first_mut().unwrap();
+    let walked = super::collect_untagged_variant_members(variant, "Probe", UNTAGGED_MODULE, &[]);
+    (
+        walked.field_defs.iter().map(|f| f.name.clone()).collect(),
+        walked
+            .flattened_fields
+            .iter()
+            .map(|f| f.name.clone())
+            .collect(),
+    )
+}
+
+/// An untagged variant's `#[serde(flatten)]` field is held apart from the members that write a key,
+/// exactly as its tagged twin's is.
+#[cfg(feature = "serde")]
+#[test]
+fn a_flattened_untagged_variant_field_is_split_out_of_the_variants_members() {
+    let (written, flattened) = collected_untagged_variant_fields(syn::parse_quote! {
+        enum Probe {
+            Named {
+                #[serde(flatten)]
+                extra: PlainBase,
+                x: String,
+            },
+        }
+    });
+    assert_eq!(written, vec!["x".to_owned()]);
+    assert_eq!(flattened, vec!["extra".to_owned()]);
+}
+
+/// And such a member proves no key list of its own: the source's keys belong to another type, and
+/// one expansion sees one type. Listing only the variant's own keys would have a sibling deny a key
+/// the member does carry.
+#[cfg(all(feature = "serde", feature = "typescript"))]
+#[test]
+fn a_flattening_untagged_member_proves_no_key_list() {
+    let mut item: syn::ItemEnum = syn::parse_quote! {
+        enum Probe {
+            Named {
+                #[serde(flatten)]
+                extra: PlainBase,
+                x: String,
+            },
+        }
+    };
+    let variant = item.variants.first_mut().unwrap();
+    let walked = super::collect_untagged_variant_members(variant, "Probe", UNTAGGED_MODULE, &[]);
+    assert_eq!(
+        super::untagged_member_keys(
+            &VariantKind::Named,
+            &walked.field_defs,
+            &walked.flattened_fields
+        ),
+        None
+    );
+    assert_eq!(
+        super::untagged_member_keys(&VariantKind::Named, &walked.field_defs, &[]),
+        Some(vec!["x".to_owned()])
+    );
+}
+
+/// The guards a tagged variant's flattened field is read against reach an untagged variant's too: a
+/// plain enum writes its own variant name as a key holding null, which no closed object admits.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn a_flattened_untagged_variant_field_over_a_plain_enum_is_refused() {
+    register_alias_info(
+        "UntaggedVariantHue",
+        "UntaggedVariantHue",
+        &ident_schema_module_name("UntaggedVariantHue"),
+        AliasKind::EnumMembers,
+    );
+    let errors = untagged_guard_errors(syn::parse_quote! {
+        enum Probe {
+            Named {
+                #[serde(flatten)]
+                tone: UntaggedVariantHue,
+                x: String,
+            },
+        }
+    });
+    assert_eq!(errors.len(), 1, "got: {errors:?}");
+    assert!(errors[0].contains("compile_error"), "got: {}", errors[0]);
+    assert!(
+        errors[0].contains("carries `#[serde(flatten)]` over `UntaggedVariantHue`"),
+        "got: {}",
+        errors[0]
+    );
+}
+
+/// And so does the branching an untagged variant's own position cannot compose, worded the way the
+/// tagged path words it.
+#[cfg(all(feature = "serde", feature = "zod"))]
+#[test]
+fn a_flattened_untagged_variant_field_over_a_multi_branch_source_is_refused() {
+    let mut choice: syn::ItemEnum = syn::parse_quote! {
+        enum UntaggedVariantChoice {
+            First(Holder),
+            Second(Other),
+        }
+    };
+    let (_, _, _, merge_parts, _, errors, _, _) =
+        collect_untagged_members(&mut choice, UNTAGGED_MODULE);
+    assert!(errors.is_empty(), "got: {errors:?}");
+    register_alias_info(
+        "UntaggedVariantChoice",
+        "UntaggedVariantChoice",
+        &ident_schema_module_name("UntaggedVariantChoice"),
+        AliasKind::NoEnumMembers,
+    );
+    record_zod_union_members("UntaggedVariantChoice", &merge_parts);
+
+    let refusals = untagged_guard_errors(syn::parse_quote! {
+        enum Probe {
+            Named {
+                #[serde(flatten)]
+                either: UntaggedVariantChoice,
+                x: String,
+            },
+        }
+    });
+    assert_eq!(refusals.len(), 1, "got: {refusals:?}");
+    assert!(
+        refusals[0].contains("writes one key set per branch of the choice it names"),
+        "got: {}",
+        refusals[0]
+    );
+    assert!(
+        refusals[0].contains("variant `Named` of `Probe`"),
+        "got: {}",
+        refusals[0]
+    );
+}
+
+/// A source that writes exactly one key set is what the merge composes, and neither guard fires on
+/// it.
+#[cfg(feature = "serde")]
+#[test]
+fn a_flattened_untagged_variant_field_over_a_single_key_set_source_is_not_refused() {
+    assert!(
+        untagged_guard_errors(syn::parse_quote! {
+            enum Probe {
+                Named {
+                    #[serde(flatten)]
+                    extra: PlainBase,
+                    x: String,
+                },
+            }
+        })
+        .is_empty()
     );
 }

--- a/tests/flatten_tests/tests.rs
+++ b/tests/flatten_tests/tests.rs
@@ -1038,6 +1038,58 @@ enum TwiceFlatVariant {
     },
 }
 
+/// The same source at an untagged enum's own member position: no discriminator stands over it, so
+/// serde writes the source's members beside the variant's own and nothing else.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(untagged)]
+enum UntaggedFlatVariant {
+    Named {
+        #[serde(flatten)]
+        extra: VariantExtra,
+        x: String,
+    },
+    Plain {
+        y: String,
+    },
+}
+
+/// Two sources flattened into one untagged member.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(untagged)]
+enum TwiceUntaggedFlatVariant {
+    Named {
+        #[serde(flatten)]
+        extra: VariantExtra,
+        #[serde(flatten)]
+        rank: VariantRank,
+        x: String,
+    },
+}
+
+/// An object that flattens such an enum. A member that flattens does not prove its own key list, so
+/// no member of this union is closed against keys the expansion cannot enumerate.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+struct UntaggedFlatVariantHolder {
+    #[serde(flatten)]
+    either: UntaggedFlatVariant,
+    own: String,
+}
+
+/// The branch of an untagged document that names `key`.
+#[cfg(feature = "jsonschema")]
+fn untagged_branch(document: &serde_json::Value, key: &str) -> serde_json::Value {
+    document["anyOf"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|branch| branch["properties"].as_object().unwrap().contains_key(key))
+        .unwrap()
+        .clone()
+}
+
 /// The content object of `variant` in `document`, whichever of the three taggings put it there.
 #[cfg(feature = "jsonschema")]
 fn variant_content(document: &serde_json::Value, variant: &str) -> serde_json::Value {
@@ -3613,4 +3665,240 @@ fn test_a_variant_without_a_flattened_field_keeps_its_zod_object() {
     let zod = AdjacentFlatVariant::zod_schema();
     let plain = &zod[zod.find("z.literal(\"Plain\")").unwrap()..];
     assert!(!plain.contains(".and("), "Got: {plain}");
+}
+
+/// What serde writes for a `#[serde(flatten)]` field of an *untagged* enum's own struct variant:
+/// the source's members sit beside the variant's own, under no key of their own and with no
+/// discriminator over them.
+#[test]
+fn test_a_flattened_untagged_variant_field_writes_its_members_beside_the_variants_own() {
+    assert_eq!(
+        serde_json::to_value(UntaggedFlatVariant::Named {
+            extra: VariantExtra {
+                note: "n".to_owned()
+            },
+            x: "y".to_owned(),
+        })
+        .unwrap(),
+        serde_json::json!({ "note": "n", "x": "y" })
+    );
+    assert_eq!(
+        serde_json::to_value(TwiceUntaggedFlatVariant::Named {
+            extra: VariantExtra {
+                note: "n".to_owned()
+            },
+            rank: VariantRank { rank: 3 },
+            x: "y".to_owned(),
+        })
+        .unwrap(),
+        serde_json::json!({ "note": "n", "rank": 3_i64, "x": "y" })
+    );
+}
+
+/// And reads them back the same way, for the flattening member and for the sibling beside it.
+#[test]
+fn test_a_flattened_untagged_variant_field_round_trips_both_members() {
+    for value in [
+        UntaggedFlatVariant::Named {
+            extra: VariantExtra {
+                note: "n".to_owned(),
+            },
+            x: "y".to_owned(),
+        },
+        UntaggedFlatVariant::Plain { y: "p".to_owned() },
+    ] {
+        let written = serde_json::to_value(&value).unwrap();
+        let back: UntaggedFlatVariant = serde_json::from_value(written).unwrap();
+        assert_eq!(back, value);
+    }
+}
+
+/// So the TypeScript the member describes as is an intersection at the member's own position, never
+/// a key holding the source.
+#[test]
+#[cfg(feature = "typescript")]
+fn test_a_flattened_untagged_variant_field_is_a_typescript_intersection_inside_the_member() {
+    let ts = UntaggedFlatVariant::ts_definition();
+    let declared = &ts[ts.find("export type").unwrap()..];
+    assert_eq!(
+        declared,
+        "export type UntaggedFlatVariant = { x: string } & VariantExtra | { y: string };"
+    );
+}
+
+#[test]
+#[cfg(feature = "typescript")]
+fn test_two_flattened_untagged_variant_fields_join_the_same_member_object() {
+    let ts = TwiceUntaggedFlatVariant::ts_definition();
+    assert!(
+        ts.contains("{ x: string } & VariantExtra & VariantRank;"),
+        "Got: {ts}"
+    );
+    assert!(!ts.contains("rank:"), "Got: {ts}");
+}
+
+/// And the Zod schema joins the source through the same deferred operand the tagged forms join
+/// through, so a source declared below the enum is still read when something validates.
+#[test]
+#[cfg(feature = "zod")]
+fn test_a_flattened_untagged_variant_field_is_a_zod_intersection_inside_the_member() {
+    let zod = UntaggedFlatVariant::zod_schema();
+    assert!(
+        zod.contains("}).and(z.lazy(() => VariantExtra$Schema))"),
+        "Got: {zod}"
+    );
+    assert!(!zod.contains("extra:"), "Got: {zod}");
+    assert!(
+        !zod.contains(".and(VariantExtra$Schema)"),
+        "the source is read while the const initializes: {zod}"
+    );
+}
+
+#[test]
+#[cfg(feature = "zod")]
+fn test_two_flattened_untagged_variant_fields_chain_their_zod_operands() {
+    let zod = TwiceUntaggedFlatVariant::zod_schema();
+    assert!(
+        zod.contains(
+            "}).and(z.lazy(() => VariantExtra$Schema)).and(z.lazy(() => VariantRank$Schema))"
+        ),
+        "Got: {zod}"
+    );
+}
+
+/// The keys `payload` carries, sorted, beside the keys `branch` names and the keys it requires.
+#[cfg(feature = "jsonschema")]
+fn written_against_described(
+    branch: &serde_json::Value,
+    payload: &serde_json::Value,
+) -> (Vec<String>, Vec<String>, Vec<String>) {
+    let mut written: Vec<String> = payload.as_object().unwrap().keys().cloned().collect();
+    written.sort();
+    let (mut named, mut required) = described_keys(branch);
+    named.sort();
+    required.sort();
+    (written, named, required)
+}
+
+/// The JSON document names exactly the keys serde writes for the member, and requires every one of
+/// them: the source's members sit where the variant's own are named, and no key stands for the
+/// flattened field itself.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_a_flattened_untagged_variant_field_merges_into_the_members_json_object() {
+    let payload = serde_json::to_value(UntaggedFlatVariant::Named {
+        extra: VariantExtra {
+            note: "n".to_owned(),
+        },
+        x: "y".to_owned(),
+    })
+    .unwrap();
+    let branch = untagged_branch(&UntaggedFlatVariant::json_schema(), "x");
+    let (written, named, required) = written_against_described(&branch, &payload);
+    assert_eq!(named, written, "Got: {branch}");
+    assert_eq!(required, written, "Got: {branch}");
+    assert_eq!(branch["additionalProperties"], serde_json::json!(false));
+}
+
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_two_flattened_untagged_variant_fields_merge_into_one_json_object() {
+    let payload = serde_json::to_value(TwiceUntaggedFlatVariant::Named {
+        extra: VariantExtra {
+            note: "n".to_owned(),
+        },
+        rank: VariantRank { rank: 3 },
+        x: "y".to_owned(),
+    })
+    .unwrap();
+    let branch = untagged_branch(&TwiceUntaggedFlatVariant::json_schema(), "x");
+    let (written, named, required) = written_against_described(&branch, &payload);
+    assert_eq!(named, written, "Got: {branch}");
+    assert_eq!(required, written, "Got: {branch}");
+}
+
+/// And exactly one branch of the union accepts each member's real payload: merging a source into
+/// one member leaves the others describing what they always described.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_the_flattened_untagged_variant_document_accepts_what_serde_writes() {
+    let document = UntaggedFlatVariant::json_schema();
+    for value in [
+        UntaggedFlatVariant::Named {
+            extra: VariantExtra {
+                note: "n".to_owned(),
+            },
+            x: "y".to_owned(),
+        },
+        UntaggedFlatVariant::Plain { y: "p".to_owned() },
+    ] {
+        let payload = serde_json::to_value(&value).unwrap();
+        assert_eq!(
+            accepting_branches(&document["anyOf"], &payload),
+            1,
+            "{document} on {payload}"
+        );
+    }
+}
+
+/// The nested shape the description named before the merge is one serde never writes, and the
+/// document turns it away.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_the_flattened_untagged_variant_document_rejects_the_stale_nested_shape() {
+    let document = UntaggedFlatVariant::json_schema();
+    assert!(
+        !closed_document_accepts(
+            &document,
+            &serde_json::json!({ "extra": { "note": "n" }, "x": "y" })
+        ),
+        "Got: {document}"
+    );
+}
+
+/// An object that flattens the enum writes the matched member's keys beside its own, in both
+/// directions.
+#[test]
+fn test_flattening_an_enum_whose_member_flattens_round_trips_every_member() {
+    let forms = [
+        (
+            UntaggedFlatVariant::Named {
+                extra: VariantExtra {
+                    note: "n".to_owned(),
+                },
+                x: "y".to_owned(),
+            },
+            serde_json::json!({ "note": "n", "x": "y", "own": "o" }),
+        ),
+        (
+            UntaggedFlatVariant::Plain { y: "p".to_owned() },
+            serde_json::json!({ "y": "p", "own": "o" }),
+        ),
+    ];
+    for (either, expected) in forms {
+        let holder = UntaggedFlatVariantHolder {
+            either,
+            own: "o".to_owned(),
+        };
+        let written = serde_json::to_value(&holder).unwrap();
+        assert_eq!(written, expected);
+        let back: UntaggedFlatVariantHolder = serde_json::from_value(written).unwrap();
+        assert_eq!(back, holder);
+    }
+}
+
+/// And no member of that union is closed against a key it cannot enumerate: the flattening member's
+/// own key list is not provable from one expansion, so its sibling is told to deny nothing and the
+/// merge falls back to the one operand the enum's name is.
+#[test]
+#[cfg(feature = "typescript")]
+fn test_a_flattening_untagged_member_closes_no_sibling_against_unprovable_keys() {
+    let ts = UntaggedFlatVariantHolder::ts_definition();
+    assert!(!ts.contains("?: never"), "Got: {ts}");
+    assert!(ts.contains("} & UntaggedFlatVariant;"), "Got: {ts}");
+    assert!(
+        UntaggedFlatVariant::ts_definition().contains("| { y: string };"),
+        "Got: {}",
+        UntaggedFlatVariant::ts_definition()
+    );
 }


### PR DESCRIPTION
The tagged paths learned to read `#[serde(flatten)]` on a struct-variant field;
the untagged path never did. `collect_untagged_variant_members` put a flattened
source into the member list like any other field, so the union member described
a key holding a nested object serde never writes — and because the split never
happened, none of the flatten guards ran either: a flattened multi-branch
choice, refused on every tagged path, compiled silently here.

The collector now runs the same split through the same predicate, and the
renderer joins the sources onto the member's own object with the same pieces
the tagged fix built — the guards, the intersection suffixes, the JSON merge —
none of them edited. What differs is what the untagged shape itself differs in:
there is no discriminator, the member's JSON value is restructured to a map the
merge can take (as the content object already was), and a flattening variant
reports no member-key list, so the sibling `?: never` exclusions are not
computed from keys the expansion cannot prove.

Two orderings carry invariants. The deferred-attribute push stays unconditional
and in declaration order, because it is zipped positionally against every
variant's fields — a skipped push would shift every later field's attributes
onto the wrong member. And the member-key change lands together with the
renderer change: the exclusion closer no longer matches a member ending in an
intersection, which is harmless only while such a member's exclusion list is
always empty.

Every generated-string assertion is paired with `serde_json::to_value` of a
real value, and the JSON tests assert the described key set equals the emitted
one. Validated against zod 4.4.3 and ajv: both accept the flattened payloads
and reject the stale nested shape. A variant that flattens nothing is
byte-identical — no existing assertion moved.

just check, just quick, just lint-all across all 68 toggles, and the test
powerset across all 68 in four partitions — all green.

