### PR TITLE
read an enum's rename_all_fields, the container rule serde applies to every struct variant's members

### DIFF
--- a/src/features/serde.rs
+++ b/src/features/serde.rs
@@ -53,7 +53,7 @@ impl SerdeKeyOmission {
     }
 }
 
-/// What a list-form `rename(...)` or `rename_all(...)` names in each of serde's two directions.
+/// What a list-form renaming names in each of serde's two directions.
 #[cfg(feature = "serde")]
 #[derive(Default)]
 struct RenameDirections {
@@ -69,8 +69,11 @@ pub struct SerdeTypeMeta {
     pub cfg_attr_rejection: Option<Error>,
     pub content: Option<String>, // e.g., "value" for adjacently tagged enums
     pub rename_all: Option<String>, // e.g., "camelCase"
-    pub tag: Option<String>,     // e.g., "behaviorType"
-    pub untagged: bool,          // Whether the enum is `#[serde(untagged)]`
+    /// The casing rule the container applies to the members of every struct variant. serde keeps
+    /// this apart from `rename_all`, which reaches variant names only.
+    pub rename_all_fields: Option<String>,
+    pub tag: Option<String>, // e.g., "behaviorType"
+    pub untagged: bool,      // Whether the enum is `#[serde(untagged)]`
 }
 
 /// Metadata for serde attributes applied to a field. Whether the field's key is omitted is not
@@ -144,8 +147,8 @@ pub fn has_serde_default(attrs: &[Attribute]) -> bool {
     parse_serde_key_omission(attrs).defaulted
 }
 
-/// Reads the `serialize` and `deserialize` sub-keys out of a list-form `rename(...)` /
-/// `rename_all(...)`, stepping past any other sub-key the same way the outer walk does.
+/// Reads the `serialize` and `deserialize` sub-keys out of a list-form renaming, stepping past any
+/// other sub-key the same way the outer walk does.
 #[cfg(feature = "serde")]
 fn parse_rename_directions(nested: &ParseNestedMeta<'_>) -> syn::Result<RenameDirections> {
     let mut directions = RenameDirections::default();
@@ -208,9 +211,9 @@ fn one_direction_only(key: &str, path: &syn::Path, written: &str, direction: &st
     )
 }
 
-/// The name a `rename` / `rename_all` key carries, in either spelling: the value of `key = "..."`,
-/// or the one name a list form's two directions agree on. A list form the directions disagree over
-/// names nothing a surface could render, and is answered by [`rename_direction_rejection`].
+/// The name a renaming key carries, in either spelling: the value of `key = "..."`, or the one name
+/// a list form's two directions agree on. A list form the directions disagree over names nothing a
+/// surface could render, and is answered by [`rename_direction_rejection`].
 #[cfg(feature = "serde")]
 fn read_renaming(nested: &ParseNestedMeta<'_>, key: &str) -> syn::Result<Option<String>> {
     if nested.input.peek(Token![=]) {
@@ -224,8 +227,8 @@ fn read_renaming(nested: &ParseNestedMeta<'_>, key: &str) -> syn::Result<Option<
     }
 }
 
-/// The refusal the item's own list-form `rename(...)` / `rename_all(...)` earns when its two
-/// directions do not name one key, or `None` when every renaming written here names exactly one.
+/// The refusal the item's own list-form renaming earns when its two directions do not name one key,
+/// or `None` when every renaming written here names exactly one.
 #[cfg(all(
     feature = "serde",
     any(feature = "typescript", feature = "zod", feature = "jsonschema")
@@ -242,6 +245,8 @@ pub fn rename_direction_rejection(attrs: &[Attribute]) -> Option<Error> {
                 Some("rename")
             } else if nested.path.is_ident("rename_all") {
                 Some("rename_all")
+            } else if nested.path.is_ident("rename_all_fields") {
+                Some("rename_all_fields")
             } else {
                 None
             };
@@ -315,6 +320,10 @@ pub fn parse_serde_type_attributes(attrs: &[Attribute]) -> SerdeTypeMeta {
                 // deserialize = "...")`
                 else if nested.path.is_ident("rename_all") {
                     meta.rename_all = read_renaming(&nested, "rename_all")?;
+                }
+                // Handle `rename_all_fields = "value"` and its list form
+                else if nested.path.is_ident("rename_all_fields") {
+                    meta.rename_all_fields = read_renaming(&nested, "rename_all_fields")?;
                 }
                 // Handle `untagged`
                 else if nested.path.is_ident("untagged") {

--- a/src/features/serde/tests.rs
+++ b/src/features/serde/tests.rs
@@ -28,6 +28,7 @@ fn test_final_field_name() {
         tag: None,
         content: None,
         rename_all: Some("camelCase".to_owned()),
+        rename_all_fields: None,
         untagged: false,
     };
 
@@ -479,6 +480,88 @@ fn test_list_form_rename_written_for_one_direction_only_is_refused() {
     assert!(
         read_in.contains("`in_name` when deserializing only"),
         "{read_in}"
+    );
+}
+
+#[test]
+fn test_rename_all_fields_is_read_in_both_spellings() {
+    let single: syn::ItemEnum = syn::parse_quote! {
+        #[serde(rename_all_fields = "camelCase")]
+        enum E { Made { my_field: u32 } }
+    };
+    assert_eq!(
+        parse_serde_type_attributes(&single.attrs)
+            .rename_all_fields
+            .as_deref(),
+        Some("camelCase")
+    );
+
+    let listed: syn::ItemEnum = syn::parse_quote! {
+        #[serde(rename_all_fields(serialize = "camelCase", deserialize = "camelCase"))]
+        enum E { Made { my_field: u32 } }
+    };
+    assert_eq!(
+        parse_serde_type_attributes(&listed.attrs)
+            .rename_all_fields
+            .as_deref(),
+        Some("camelCase")
+    );
+}
+
+/// `is_ident` matches the whole ident, so the `rename_all` arm cannot swallow `rename_all_fields`
+/// written beside it, and the two rules stay the independent pair serde treats them as.
+#[test]
+fn test_rename_all_and_rename_all_fields_are_recorded_apart() {
+    let item: syn::ItemEnum = syn::parse_quote! {
+        #[serde(rename_all = "SCREAMING_SNAKE_CASE", rename_all_fields = "camelCase")]
+        enum E { MadeVariant { my_field: u32 } }
+    };
+    let meta = parse_serde_type_attributes(&item.attrs);
+    assert_eq!(meta.rename_all.as_deref(), Some("SCREAMING_SNAKE_CASE"));
+    assert_eq!(meta.rename_all_fields.as_deref(), Some("camelCase"));
+}
+
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn test_list_form_rename_all_fields_naming_two_rules_is_refused() {
+    let item: syn::ItemEnum = syn::parse_quote! {
+        #[serde(rename_all_fields(serialize = "camelCase", deserialize = "kebab-case"))]
+        enum E { Made { my_field: u32 } }
+    };
+    let message = rename_direction_rejection(&item.attrs).unwrap().to_string();
+    assert!(message.contains("`rename_all_fields`"), "{message}");
+    assert!(
+        message.contains("`camelCase` when serializing"),
+        "{message}"
+    );
+    assert!(
+        message.contains("`kebab-case` when deserializing"),
+        "{message}"
+    );
+    assert!(
+        parse_serde_type_attributes(&item.attrs)
+            .rename_all_fields
+            .is_none()
+    );
+}
+
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn test_list_form_rename_all_fields_written_for_one_direction_only_is_refused() {
+    let item: syn::ItemEnum = syn::parse_quote! {
+        #[serde(rename_all_fields(serialize = "camelCase"))]
+        enum E { Made { my_field: u32 } }
+    };
+    let message = rename_direction_rejection(&item.attrs).unwrap().to_string();
+    assert!(message.contains("`rename_all_fields`"), "{message}");
+    assert!(
+        message.contains("`camelCase` when serializing only"),
+        "{message}"
+    );
+    assert!(
+        parse_serde_type_attributes(&item.attrs)
+            .rename_all_fields
+            .is_none()
     );
 }
 

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -566,6 +566,15 @@ struct UntaggedVariantMembers {
     validation_fns: Vec<proc_macro2::TokenStream>,
 }
 
+/// The two casing rules an enum's container declares, which reach two different things: `variants`
+/// renames the variant names, `variant_fields` the members inside every struct variant. Bundled
+/// because two loose `Option<&str>` neighbours meaning different things transpose silently.
+#[derive(Clone, Copy)]
+struct EnumCasing<'ctx> {
+    variant_fields: Option<&'ctx str>,
+    variants: Option<&'ctx str>,
+}
+
 /// What the item around a field says about it: everything [`process_field`] needs that is not the
 /// field itself, bundled so the walk hands one context down instead of six loose parameters.
 struct FieldContext<'ctx> {
@@ -5245,18 +5254,24 @@ fn process_enum(item_enum: syn::ItemEnum, args: &ModelSchemaArgs) -> TokenStream
             return process_untagged_enum(item_enum, &name, &item_name, args);
         }
 
+        #[cfg(feature = "serde")]
+        let casing = EnumCasing {
+            variant_fields: serde_type_meta.rename_all_fields.as_deref(),
+            variants: serde_type_meta.rename_all.as_deref(),
+        };
+
+        #[cfg(not(feature = "serde"))]
+        let casing = EnumCasing {
+            variant_fields: None,
+            variants: None,
+        };
+
         // Neither tagging key named, so serde writes the externally tagged form and that is what
         // the surfaces describe. Only the attributes the `serde` feature reads tell the two forms
         // apart; without it no declaration can be distinguished and the adjacent form stands.
         #[cfg(feature = "serde")]
         if serde_type_meta.tag.is_none() && serde_type_meta.content.is_none() {
-            return process_externally_tagged_enum(
-                item_enum,
-                &name,
-                serde_type_meta.rename_all.as_deref(),
-                &item_name,
-                args,
-            );
+            return process_externally_tagged_enum(item_enum, &name, casing, &item_name, args);
         }
 
         // A tag with no content is serde's internally tagged form: what a variant writes joins the
@@ -5266,18 +5281,11 @@ fn process_enum(item_enum: syn::ItemEnum, args: &ModelSchemaArgs) -> TokenStream
             serde_type_meta.tag.as_ref(),
             serde_type_meta.content.as_ref(),
         ) {
-            return process_internally_tagged_enum(
-                item_enum,
-                &name,
-                tag,
-                serde_type_meta.rename_all.as_deref(),
-                &item_name,
-                args,
-            );
+            return process_internally_tagged_enum(item_enum, &name, tag, casing, &item_name, args);
         }
 
         #[cfg(feature = "serde")]
-        let (tag_name, content_name, rename_all) = (
+        let (tag_name, content_name) = (
             serde_type_meta
                 .tag
                 .as_ref()
@@ -5286,19 +5294,17 @@ fn process_enum(item_enum: syn::ItemEnum, args: &ModelSchemaArgs) -> TokenStream
                 .content
                 .as_ref()
                 .map_or_else(|| "value".to_owned(), Clone::clone),
-            serde_type_meta.rename_all,
         );
 
         #[cfg(not(feature = "serde"))]
-        let (tag_name, content_name, rename_all): (String, String, Option<String>) =
-            ("type".to_owned(), "value".to_owned(), None);
+        let (tag_name, content_name): (String, String) = ("type".to_owned(), "value".to_owned());
 
         process_discriminated_enum(
             item_enum,
             &name,
             &tag_name,
             &content_name,
-            rename_all.as_deref(),
+            casing,
             &item_name,
             args,
         )
@@ -5701,20 +5707,29 @@ fn check_variant_slot_wire_is_readable(
     ))
 }
 
-/// The two name overrides a variant declares: its own `#[serde(rename)]`, and the `rename_all` its
-/// own fields are read against. serde treats a struct variant as the container for its fields, so
+/// The two name overrides a variant declares: its own `#[serde(rename)]`, and the rule its own
+/// fields are read against — its own `rename_all` where it writes one, the container's
+/// `rename_all_fields` otherwise. serde treats a struct variant as the container for its fields, so
 /// the enum's container-level `rename_all` never reaches them — that one renames variant names only.
 #[cfg(feature = "serde")]
-fn variant_serde_names(attrs: &[syn::Attribute]) -> (Option<String>, Option<String>) {
+fn variant_serde_names(
+    attrs: &[syn::Attribute],
+    rename_all_fields: Option<&str>,
+) -> (Option<String>, Option<String>) {
     (
         parse_serde_field_attributes(attrs).rename,
-        parse_serde_type_attributes(attrs).rename_all,
+        parse_serde_type_attributes(attrs)
+            .rename_all
+            .or_else(|| rename_all_fields.map(ToOwned::to_owned)),
     )
 }
 
 /// No declaration is read where nothing parses serde's attributes.
 #[cfg(not(feature = "serde"))]
-const fn variant_serde_names(_attrs: &[syn::Attribute]) -> (Option<String>, Option<String>) {
+const fn variant_serde_names(
+    _attrs: &[syn::Attribute],
+    _rename_all_fields: Option<&str>,
+) -> (Option<String>, Option<String>) {
     (None, None)
 }
 
@@ -5772,7 +5787,7 @@ fn variant_flatten_guard_errors(
 /// `validate()` arms those functions are run from.
 fn collect_discriminated_variants(
     item_enum: &mut syn::ItemEnum,
-    rename_all: Option<&str>,
+    casing: EnumCasing<'_>,
     enum_module_name_opt: Option<&str>,
 ) -> DiscriminatedVariantData {
     let type_parameters = type_parameters_in_scope(&item_enum.generics);
@@ -5785,10 +5800,11 @@ fn collect_discriminated_variants(
     let enum_type_name = item_enum.ident.to_string();
 
     for item in &mut item_enum.variants {
-        let (field_rename, variant_rename_all) = variant_serde_names(&item.attrs);
+        let (field_rename, variant_rename_all) =
+            variant_serde_names(&item.attrs, casing.variant_fields);
         let variant_ident = item.ident.to_string();
         let final_name =
-            get_final_variant_name(&variant_ident, field_rename.as_deref(), rename_all);
+            get_final_variant_name(&variant_ident, field_rename.as_deref(), casing.variants);
         // The Rust shape the `validate()` arm is matched by, beside the wire shape the surfaces
         // describe: a variant that publishes no slot is still declared holding one.
         let declared_kind = classify_variant(item);
@@ -5852,8 +5868,7 @@ fn collect_discriminated_variants(
             // A constrained positional slot is refused by its own guard, so a member with a body to
             // run is always one the arm can name.
             if let (Some(body), Some(ident)) = (validate_body, field.ident.as_ref()) {
-                let binding = member_binding(ident);
-                bound.push((ident.clone(), binding));
+                bound.push((ident.clone(), member_binding(ident)));
                 checks.push(body);
             }
             if positional && omission.absent_from_wire() {
@@ -5994,7 +6009,7 @@ fn process_discriminated_enum(
     name: &syn::Ident,
     tag_name: &str,
     content_name: &str,
-    rename_all: Option<&str>,
+    casing: EnumCasing<'_>,
     item_name: &str,
     args: &ModelSchemaArgs,
 ) -> TokenStream {
@@ -6027,7 +6042,7 @@ fn process_discriminated_enum(
     // Bind both result tuples whole so feature-gated field access marks them used (no per-element
     // guards): `variants` = (variants, validation_fns, guard_errors);
     // `rendered` = (ts, zod, json).
-    let variants = collect_discriminated_variants(&mut item_enum, rename_all, enum_module_name_opt);
+    let variants = collect_discriminated_variants(&mut item_enum, casing, enum_module_name_opt);
     if let Some(output) = guard_failure_output(&item_enum, Some(&item_enum.ident), &variants.2) {
         return output;
     }
@@ -6519,7 +6534,7 @@ fn join_external_union(
 fn process_externally_tagged_enum(
     mut item_enum: syn::ItemEnum,
     name: &syn::Ident,
-    rename_all: Option<&str>,
+    casing: EnumCasing<'_>,
     item_name: &str,
     args: &ModelSchemaArgs,
 ) -> TokenStream {
@@ -6542,7 +6557,7 @@ fn process_externally_tagged_enum(
     let enum_module_name_opt = None;
 
     let self_type_name = item_enum.ident.to_string();
-    let variants = collect_discriminated_variants(&mut item_enum, rename_all, enum_module_name_opt);
+    let variants = collect_discriminated_variants(&mut item_enum, casing, enum_module_name_opt);
     if let Some(output) = guard_failure_output(&item_enum, Some(&item_enum.ident), &variants.2) {
         return output;
     }
@@ -6922,7 +6937,7 @@ fn process_internally_tagged_enum(
     mut item_enum: syn::ItemEnum,
     name: &syn::Ident,
     tag_name: &str,
-    rename_all: Option<&str>,
+    casing: EnumCasing<'_>,
     item_name: &str,
     args: &ModelSchemaArgs,
 ) -> TokenStream {
@@ -6947,7 +6962,7 @@ fn process_internally_tagged_enum(
         return output;
     }
 
-    let variants = collect_discriminated_variants(&mut item_enum, rename_all, enum_module_name_opt);
+    let variants = collect_discriminated_variants(&mut item_enum, casing, enum_module_name_opt);
     if let Some(output) = guard_failure_output(&item_enum, Some(&item_enum.ident), &variants.2) {
         return output;
     }
@@ -7509,10 +7524,13 @@ fn collect_untagged_variant_members(
     enum_type_name: &str,
     schema_module_name: Option<&str>,
     type_parameters: &[String],
+    rename_all_fields: Option<&str>,
 ) -> UntaggedVariantMembers {
     let variant_name = variant.ident.to_string();
     let variant_defaulted = has_serde_default(&variant.attrs);
-    let variant_rename_all = parse_serde_type_attributes(&variant.attrs).rename_all;
+    // An untagged variant has no name on the wire, so the rename the seam also resolves is unused
+    // here.
+    let (_, variant_rename_all) = variant_serde_names(&variant.attrs, rename_all_fields);
     let mut walked = UntaggedVariantMembers {
         bound: Vec::new(),
         checks: Vec::new(),
@@ -7609,6 +7627,7 @@ fn collect_untagged_members(
 ) -> UntaggedMemberData {
     let enum_type_name = item_enum.ident.to_string();
     let type_parameters = type_parameters_in_scope(&item_enum.generics);
+    let rename_all_fields = parse_serde_type_attributes(&item_enum.attrs).rename_all_fields;
     let mut ts_parts: Vec<String> = Vec::new();
     #[cfg(feature = "typescript")]
     let mut ts_member_keys: Vec<Option<Vec<String>>> = Vec::new();
@@ -7633,6 +7652,7 @@ fn collect_untagged_members(
             &enum_type_name,
             schema_module_name,
             &type_parameters,
+            rename_all_fields.as_deref(),
         );
         guard_errors.append(&mut walked.guard_errors);
         validation_fns.append(&mut walked.validation_fns);

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -1,5 +1,5 @@
 use super::{
-    FieldDefType, ModelSchemaPropMeta, check_nullable_ts_optional_conflict,
+    EnumCasing, FieldDefType, ModelSchemaPropMeta, check_nullable_ts_optional_conflict,
     check_undescribable_std_field, collect_discriminated_variants, field_label, get_field_def,
     render_discriminated_variants, validate_as_number_flag, validate_nullable_flag,
     validate_ts_optional_flag,
@@ -115,6 +115,12 @@ const SEQUENCE_WRAPPERS: [&str; 6] = [
 /// expansion registers.
 #[cfg(feature = "serde")]
 const UNTAGGED_MODULE: Option<&str> = Some("choice_schema");
+
+/// What an enum declaring neither container-level casing rule hands its variant walk.
+const UNCASED: EnumCasing<'static> = EnumCasing {
+    variant_fields: None,
+    variants: None,
+};
 
 #[test]
 fn ts_optional_ok_on_option_field() {
@@ -2123,7 +2129,7 @@ fn a_constraint_refused_its_placement_leaves_no_hook_naming_the_dropped_module()
             },
         }
     };
-    let errors = collect_discriminated_variants(&mut item, None, Some("action_schema")).2;
+    let errors = collect_discriminated_variants(&mut item, UNCASED, Some("action_schema")).2;
     assert_eq!(errors.len(), 1, "got: {errors:?}");
     assert!(
         errors[0]
@@ -7761,7 +7767,7 @@ fn rendered_discriminated_union() -> (Vec<String>, Vec<String>, Vec<String>) {
             Archive,
         }
     };
-    let variants = collect_discriminated_variants(&mut item, None, Some("action_schema"));
+    let variants = collect_discriminated_variants(&mut item, UNCASED, Some("action_schema"));
     let rendered = render_discriminated_variants("type", "value", "Action", &variants.0);
     (
         rendered.0,
@@ -7829,7 +7835,7 @@ fn adjacently_tagged_empty_named_variant_nests_an_empty_content_object() {
             Unit,
         }
     };
-    let variants = collect_discriminated_variants(&mut item, None, Some("probe_schema"));
+    let variants = collect_discriminated_variants(&mut item, UNCASED, Some("probe_schema"));
     let rendered = render_discriminated_variants("kind", "data", "Probe", &variants.0);
 
     let ts = &rendered.0[0];
@@ -8186,7 +8192,7 @@ fn a_constrained_tuple_variant_yields_diagnostics_rather_than_helpers() {
             Three(String),
         }
     };
-    let variants = collect_discriminated_variants(&mut item, None, Some("probe_schema"));
+    let variants = collect_discriminated_variants(&mut item, UNCASED, Some("probe_schema"));
 
     let validation_fns: Vec<String> = variants.1.iter().map(ToString::to_string).collect();
     assert!(validation_fns.is_empty(), "got: {validation_fns:?}");
@@ -9933,7 +9939,7 @@ fn an_untagged_sibling_exclusion_writes_a_non_identifier_key_as_a_string() {
 /// Collects a discriminated enum's guard failures as rendered `compile_error!` token strings.
 #[cfg(feature = "serde")]
 fn discriminated_guard_errors(mut item: syn::ItemEnum) -> Vec<String> {
-    collect_discriminated_variants(&mut item, None, Some("probe_schema"))
+    collect_discriminated_variants(&mut item, UNCASED, Some("probe_schema"))
         .2
         .iter()
         .map(ToString::to_string)
@@ -9943,7 +9949,7 @@ fn discriminated_guard_errors(mut item: syn::ItemEnum) -> Vec<String> {
 /// The field defs one variant of a discriminated enum collected, beside the ones it flattens.
 #[cfg(feature = "serde")]
 fn collected_variant_fields(mut item: syn::ItemEnum) -> (Vec<String>, Vec<String>) {
-    let variants = collect_discriminated_variants(&mut item, None, Some("probe_schema")).0;
+    let variants = collect_discriminated_variants(&mut item, UNCASED, Some("probe_schema")).0;
     let variant = variants.first().unwrap();
     (
         variant.field_defs.iter().map(|f| f.name.clone()).collect(),
@@ -10115,7 +10121,8 @@ fn the_variant_flatten_refusal_names_the_remedy() {
 #[cfg(feature = "serde")]
 fn collected_untagged_variant_fields(mut item: syn::ItemEnum) -> (Vec<String>, Vec<String>) {
     let variant = item.variants.first_mut().unwrap();
-    let walked = super::collect_untagged_variant_members(variant, "Probe", UNTAGGED_MODULE, &[]);
+    let walked =
+        super::collect_untagged_variant_members(variant, "Probe", UNTAGGED_MODULE, &[], None);
     (
         walked.field_defs.iter().map(|f| f.name.clone()).collect(),
         walked
@@ -10160,7 +10167,8 @@ fn a_flattening_untagged_member_proves_no_key_list() {
         }
     };
     let variant = item.variants.first_mut().unwrap();
-    let walked = super::collect_untagged_variant_members(variant, "Probe", UNTAGGED_MODULE, &[]);
+    let walked =
+        super::collect_untagged_variant_members(variant, "Probe", UNTAGGED_MODULE, &[], None);
     assert_eq!(
         super::untagged_member_keys(
             &VariantKind::Named,

--- a/tests/rename_all_fields_tests.rs
+++ b/tests/rename_all_fields_tests.rs
@@ -1,0 +1,10 @@
+//! Tests that an enum's `#[serde(rename_all_fields = "...")]` cases the members of every struct
+//! variant on all three surfaces, exactly as serde writes them.
+//!
+//! serde keeps this rule apart from `rename_all`: the latter renames variant names only. Both are
+//! pinned here, under each of the four taggings, against what serde itself puts on the wire.
+
+#[cfg(test)]
+#[cfg(feature = "serde")]
+#[path = "rename_all_fields_tests/tests.rs"]
+mod tests;

--- a/tests/rename_all_fields_tests/tests.rs
+++ b/tests/rename_all_fields_tests/tests.rs
@@ -1,0 +1,496 @@
+use serde::{Deserialize, Serialize};
+use tixschema::model_schema;
+
+// One enum per tagging, each carrying only the container-level `rename_all_fields`, so what the
+// surfaces name for the members can come from nowhere else.
+#[model_schema()]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all_fields = "camelCase")]
+enum ExternalFieldCasing {
+    Made { another_one: u32, my_field: u32 },
+}
+
+#[model_schema()]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(tag = "kind", rename_all_fields = "camelCase")]
+enum InternalFieldCasing {
+    Made { another_one: u32, my_field: u32 },
+}
+
+#[model_schema()]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(tag = "kind", content = "payload", rename_all_fields = "camelCase")]
+enum AdjacentFieldCasing {
+    Made { another_one: u32, my_field: u32 },
+}
+
+#[model_schema()]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(untagged, rename_all_fields = "camelCase")]
+enum UntaggedFieldCasing {
+    Made { another_one: u32, my_field: u32 },
+}
+
+// The three steps of serde's precedence on one enum: `Marked` overrides the container with its own
+// rule, `Renamed` overrides both with the member's own key, and `Plain` takes the container's.
+#[model_schema()]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all_fields = "camelCase")]
+enum PrecedenceFieldCasing {
+    #[serde(rename_all = "PascalCase")]
+    Marked {
+        my_field: u32,
+    },
+    Plain {
+        my_field: u32,
+    },
+    Renamed {
+        #[serde(rename = "explicit_key")]
+        my_field: u32,
+    },
+}
+
+// The two container rules reach two different things and neither falls back to the other.
+#[model_schema()]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE", rename_all_fields = "camelCase")]
+enum IndependentCasing {
+    MadeVariant { my_field: u32 },
+}
+
+#[model_schema()]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+enum VariantNameCasingOnly {
+    MadeVariant { my_field: u32 },
+}
+
+#[model_schema()]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all_fields = "camelCase")]
+enum TupleSlotCasing {
+    Made(u32),
+}
+
+#[model_schema()]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all_fields = "camelCase")]
+enum PlainVariantCasing {
+    AlphaOne,
+    BetaTwo,
+}
+
+/// The keys serde wrote in the object at `pointer` of the document for `value`, sorted so a key
+/// set can be compared against one read off a schema.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn wire_keys<T>(value: &T, pointer: &str) -> Vec<String>
+where
+    T: Serialize,
+{
+    let payload = serde_json::to_value(value).unwrap();
+    sorted_keys(payload.pointer(pointer).unwrap())
+}
+
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+fn sorted_keys(object: &serde_json::Value) -> Vec<String> {
+    let mut keys: Vec<String> = object.as_object().unwrap().keys().cloned().collect();
+    keys.sort();
+    keys
+}
+
+#[cfg(any(feature = "typescript", feature = "zod"))]
+fn assert_renders_wire_keys(rendered: &str, keys: &[String]) {
+    for key in keys {
+        assert!(
+            rendered.contains(key.as_str()),
+            "the surface omits `{key}`, a key serde wrote:\n{rendered}"
+        );
+    }
+    assert!(
+        !rendered.contains("my_field") && !rendered.contains("another_one"),
+        "the surface names a member at its raw Rust ident:\n{rendered}"
+    );
+}
+
+/// Whether a closed document (`additionalProperties: false`) accepts `payload`: every key on the
+/// wire is named, and every required key is on the wire. A `oneOf` needs exactly one accepting
+/// branch, an `anyOf` at least one.
+#[cfg(feature = "jsonschema")]
+fn closed_document_accepts(schema: &serde_json::Value, payload: &serde_json::Value) -> bool {
+    if let Some(branches) = schema.get("oneOf") {
+        return accepting_branches(branches, payload) == 1;
+    }
+    if let Some(branches) = schema.get("anyOf") {
+        return accepting_branches(branches, payload) >= 1;
+    }
+    let written = payload.as_object().unwrap();
+    let named = schema["properties"].as_object().unwrap();
+    let required = schema["required"].as_array().unwrap();
+    written.keys().all(|key| named.contains_key(key))
+        && required
+            .iter()
+            .all(|key| written.contains_key(key.as_str().unwrap()))
+}
+
+#[cfg(feature = "jsonschema")]
+fn accepting_branches(branches: &serde_json::Value, payload: &serde_json::Value) -> usize {
+    branches
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|branch| closed_document_accepts(branch, payload))
+        .count()
+}
+
+#[cfg(feature = "jsonschema")]
+fn assert_accepts<T>(schema: &serde_json::Value, value: &T)
+where
+    T: Serialize,
+{
+    let payload = serde_json::to_value(value).unwrap();
+    assert!(
+        closed_document_accepts(schema, &payload),
+        "{payload} is rejected by {schema}"
+    );
+    assert!(
+        !serde_json::to_string(schema).unwrap().contains("my_field"),
+        "the document names a member at its raw Rust ident: {schema}"
+    );
+}
+
+fn external_value() -> ExternalFieldCasing {
+    ExternalFieldCasing::Made {
+        another_one: 2,
+        my_field: 1,
+    }
+}
+
+fn internal_value() -> InternalFieldCasing {
+    InternalFieldCasing::Made {
+        another_one: 2,
+        my_field: 1,
+    }
+}
+
+fn adjacent_value() -> AdjacentFieldCasing {
+    AdjacentFieldCasing::Made {
+        another_one: 2,
+        my_field: 1,
+    }
+}
+
+fn untagged_value() -> UntaggedFieldCasing {
+    UntaggedFieldCasing::Made {
+        another_one: 2,
+        my_field: 1,
+    }
+}
+
+#[test]
+fn externally_tagged_members_reach_the_wire_cased() {
+    let value = external_value();
+    let payload = serde_json::to_value(&value).unwrap();
+    assert_eq!(
+        payload,
+        serde_json::json!({ "Made": { "anotherOne": 2_i64, "myField": 1_i64 } })
+    );
+    assert_eq!(
+        serde_json::from_value::<ExternalFieldCasing>(payload).unwrap(),
+        value
+    );
+}
+
+#[test]
+fn internally_tagged_members_reach_the_wire_cased() {
+    assert_eq!(
+        serde_json::to_value(internal_value()).unwrap(),
+        serde_json::json!({ "kind": "Made", "anotherOne": 2_i64, "myField": 1_i64 })
+    );
+}
+
+#[test]
+fn adjacently_tagged_members_reach_the_wire_cased() {
+    assert_eq!(
+        serde_json::to_value(adjacent_value()).unwrap(),
+        serde_json::json!({ "kind": "Made", "payload": { "anotherOne": 2_i64, "myField": 1_i64 } })
+    );
+}
+
+#[test]
+fn untagged_members_reach_the_wire_cased() {
+    let value = untagged_value();
+    let payload = serde_json::to_value(&value).unwrap();
+    assert_eq!(
+        payload,
+        serde_json::json!({ "anotherOne": 2_i64, "myField": 1_i64 })
+    );
+    assert_eq!(
+        serde_json::from_value::<UntaggedFieldCasing>(payload).unwrap(),
+        value
+    );
+}
+
+#[test]
+fn precedence_reaches_the_wire_as_serde_resolves_it() {
+    assert_eq!(
+        serde_json::to_value(PrecedenceFieldCasing::Marked { my_field: 1 }).unwrap(),
+        serde_json::json!({ "Marked": { "MyField": 1_i64 } })
+    );
+    assert_eq!(
+        serde_json::to_value(PrecedenceFieldCasing::Plain { my_field: 1 }).unwrap(),
+        serde_json::json!({ "Plain": { "myField": 1_i64 } })
+    );
+    assert_eq!(
+        serde_json::to_value(PrecedenceFieldCasing::Renamed { my_field: 1 }).unwrap(),
+        serde_json::json!({ "Renamed": { "explicit_key": 1_i64 } })
+    );
+}
+
+#[test]
+fn the_two_container_rules_reach_the_wire_independently() {
+    assert_eq!(
+        serde_json::to_value(IndependentCasing::MadeVariant { my_field: 1 }).unwrap(),
+        serde_json::json!({ "MADE_VARIANT": { "myField": 1_i64 } })
+    );
+}
+
+/// The container's `rename_all` renames variant names only, which is what makes
+/// `rename_all_fields` a separate rule rather than an extension of it.
+#[test]
+fn variant_name_casing_leaves_members_at_their_idents_on_the_wire() {
+    assert_eq!(
+        serde_json::to_value(VariantNameCasingOnly::MadeVariant { my_field: 1 }).unwrap(),
+        serde_json::json!({ "madeVariant": { "my_field": 1_i64 } })
+    );
+}
+
+#[test]
+fn a_tuple_variant_carries_no_member_to_case() {
+    assert_eq!(
+        serde_json::to_value(TupleSlotCasing::Made(1)).unwrap(),
+        serde_json::json!({ "Made": 1_i64 })
+    );
+}
+
+#[test]
+fn a_plain_variant_carries_no_member_to_case() {
+    assert_eq!(
+        serde_json::to_value(PlainVariantCasing::AlphaOne).unwrap(),
+        serde_json::json!("AlphaOne")
+    );
+    assert_eq!(
+        PlainVariantCasing::enum_members(),
+        ["AlphaOne", "BetaTwo"],
+        "rename_all_fields names nothing a plain enum writes"
+    );
+}
+
+#[cfg(feature = "typescript")]
+#[test]
+fn externally_tagged_typescript_names_the_keys_serde_wrote() {
+    assert_renders_wire_keys(
+        &ExternalFieldCasing::ts_definition(),
+        &wire_keys(&external_value(), "/Made"),
+    );
+}
+
+#[cfg(feature = "typescript")]
+#[test]
+fn internally_tagged_typescript_names_the_keys_serde_wrote() {
+    assert_renders_wire_keys(
+        &InternalFieldCasing::ts_definition(),
+        &wire_keys(&internal_value(), ""),
+    );
+}
+
+#[cfg(feature = "typescript")]
+#[test]
+fn adjacently_tagged_typescript_names_the_keys_serde_wrote() {
+    assert_renders_wire_keys(
+        &AdjacentFieldCasing::ts_definition(),
+        &wire_keys(&adjacent_value(), "/payload"),
+    );
+}
+
+#[cfg(feature = "typescript")]
+#[test]
+fn untagged_typescript_names_the_keys_serde_wrote() {
+    assert_renders_wire_keys(
+        &UntaggedFieldCasing::ts_definition(),
+        &wire_keys(&untagged_value(), ""),
+    );
+}
+
+#[cfg(feature = "typescript")]
+#[test]
+fn precedence_typescript_matches_serde() {
+    let ts = PrecedenceFieldCasing::ts_definition();
+    assert!(ts.contains("MyField: number"), "Got:\n{ts}");
+    assert!(ts.contains("myField: number"), "Got:\n{ts}");
+    assert!(ts.contains("explicit_key: number"), "Got:\n{ts}");
+}
+
+#[cfg(feature = "typescript")]
+#[test]
+fn independent_typescript_matches_serde() {
+    let ts = IndependentCasing::ts_definition();
+    assert!(ts.contains("\"MADE_VARIANT\": {"), "Got:\n{ts}");
+    assert!(ts.contains("myField: number"), "Got:\n{ts}");
+    assert!(!ts.contains("my_field"), "Got:\n{ts}");
+}
+
+#[cfg(feature = "typescript")]
+#[test]
+fn variant_name_casing_typescript_leaves_members_at_their_idents() {
+    let ts = VariantNameCasingOnly::ts_definition();
+    assert!(ts.contains("\"madeVariant\": {"), "Got:\n{ts}");
+    assert!(ts.contains("my_field: number"), "Got:\n{ts}");
+}
+
+#[cfg(feature = "zod")]
+#[test]
+fn externally_tagged_zod_names_the_keys_serde_wrote() {
+    assert_renders_wire_keys(
+        &ExternalFieldCasing::zod_schema(),
+        &wire_keys(&external_value(), "/Made"),
+    );
+}
+
+#[cfg(feature = "zod")]
+#[test]
+fn internally_tagged_zod_names_the_keys_serde_wrote() {
+    assert_renders_wire_keys(
+        &InternalFieldCasing::zod_schema(),
+        &wire_keys(&internal_value(), ""),
+    );
+}
+
+#[cfg(feature = "zod")]
+#[test]
+fn adjacently_tagged_zod_names_the_keys_serde_wrote() {
+    assert_renders_wire_keys(
+        &AdjacentFieldCasing::zod_schema(),
+        &wire_keys(&adjacent_value(), "/payload"),
+    );
+}
+
+#[cfg(feature = "zod")]
+#[test]
+fn untagged_zod_names_the_keys_serde_wrote() {
+    assert_renders_wire_keys(
+        &UntaggedFieldCasing::zod_schema(),
+        &wire_keys(&untagged_value(), ""),
+    );
+}
+
+#[cfg(feature = "zod")]
+#[test]
+fn precedence_zod_matches_serde() {
+    let zod = PrecedenceFieldCasing::zod_schema();
+    assert!(zod.contains("MyField: z.number().int()"), "Got:\n{zod}");
+    assert!(zod.contains("myField: z.number().int()"), "Got:\n{zod}");
+    assert!(
+        zod.contains("explicit_key: z.number().int()"),
+        "Got:\n{zod}"
+    );
+}
+
+#[cfg(feature = "zod")]
+#[test]
+fn variant_name_casing_zod_leaves_members_at_their_idents() {
+    let zod = VariantNameCasingOnly::zod_schema();
+    assert!(zod.contains("my_field: z.number().int()"), "Got:\n{zod}");
+}
+
+#[cfg(feature = "jsonschema")]
+#[test]
+fn externally_tagged_json_schema_names_the_keys_serde_wrote() {
+    let schema = ExternalFieldCasing::json_schema();
+    let value = external_value();
+    assert_accepts(&schema, &value);
+    assert_eq!(
+        sorted_keys(&schema["oneOf"][0]["properties"]["Made"]["properties"]),
+        wire_keys(&value, "/Made")
+    );
+    assert_eq!(
+        sorted_keys(&schema["oneOf"][0]["properties"]["Made"]["properties"]),
+        {
+            let mut required: Vec<String> = schema["oneOf"][0]["properties"]["Made"]["required"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|key| key.as_str().unwrap().to_owned())
+                .collect();
+            required.sort();
+            required
+        }
+    );
+}
+
+#[cfg(feature = "jsonschema")]
+#[test]
+fn internally_tagged_json_schema_names_the_keys_serde_wrote() {
+    let schema = InternalFieldCasing::json_schema();
+    let value = internal_value();
+    assert_accepts(&schema, &value);
+    assert_eq!(
+        sorted_keys(&schema["oneOf"][0]["properties"]),
+        wire_keys(&value, "")
+    );
+}
+
+#[cfg(feature = "jsonschema")]
+#[test]
+fn adjacently_tagged_json_schema_names_the_keys_serde_wrote() {
+    let schema = AdjacentFieldCasing::json_schema();
+    let value = adjacent_value();
+    assert_accepts(&schema, &value);
+    assert_eq!(
+        sorted_keys(&schema["oneOf"][0]["properties"]["payload"]["properties"]),
+        wire_keys(&value, "/payload")
+    );
+}
+
+#[cfg(feature = "jsonschema")]
+#[test]
+fn untagged_json_schema_names_the_keys_serde_wrote() {
+    let schema = UntaggedFieldCasing::json_schema();
+    let value = untagged_value();
+    assert_accepts(&schema, &value);
+    assert_eq!(
+        sorted_keys(&schema["anyOf"][0]["properties"]),
+        wire_keys(&value, "")
+    );
+}
+
+#[cfg(feature = "jsonschema")]
+#[test]
+fn precedence_json_schema_matches_serde() {
+    let schema = PrecedenceFieldCasing::json_schema();
+    for value in [
+        PrecedenceFieldCasing::Marked { my_field: 1 },
+        PrecedenceFieldCasing::Plain { my_field: 1 },
+        PrecedenceFieldCasing::Renamed { my_field: 1 },
+    ] {
+        let payload = serde_json::to_value(&value).unwrap();
+        assert!(
+            closed_document_accepts(&schema, &payload),
+            "{payload} is rejected by {schema}"
+        );
+    }
+}
+
+#[cfg(feature = "jsonschema")]
+#[test]
+fn variant_name_casing_json_schema_leaves_members_at_their_idents() {
+    let schema = VariantNameCasingOnly::json_schema();
+    let value = VariantNameCasingOnly::MadeVariant { my_field: 1 };
+    assert!(closed_document_accepts(
+        &schema,
+        &serde_json::to_value(&value).unwrap()
+    ));
+    assert_eq!(
+        sorted_keys(&schema["oneOf"][0]["properties"]["madeVariant"]["properties"]),
+        wire_keys(&value, "/madeVariant")
+    );
+}


### PR DESCRIPTION
`#[serde(rename_all_fields = "...")]` was never read, so every variant's member
keys were described at their raw Rust idents while serde cased them on the
wire.

The precedence was measured against serde itself rather than assumed: a field's
own `rename` beats the variant's own `rename_all`, which beats the container's
`rename_all_fields`, which beats the raw ident. The two container rules are
independent — `rename_all` cases variant names, `rename_all_fields` cases the
members inside them — and the rule reaches struct variants only, under all four
taggings; tuple variants are untouched, and serde itself rejects the attribute
on a struct or a variant, so no guard is needed there.

The fallback sits in `variant_serde_names`, the one seam a variant's member
names resolve through, and both collectors now read it — the untagged one used
to parse the variant's attributes directly and now takes the container value,
discarding the variant-name half an untagged variant has no wire use for. The
three tagged entry points swap their `rename_all` parameter for an `EnumCasing`
bundle naming both rules, so the two same-typed values cannot be transposed at
a call site.

The key is read through the same seam as its siblings, in both spellings, so a
list form's two directions must agree and the one-direction form is refused
with the same message — the container's attributes were already in the guard's
walk, so the refusal fires with no new wiring.

Fifteen of the new tests failed against the unfixed macro — exactly the surface
assertions; every serde-wire assertion passed from the start, reconfirming the
measured precedence on this machine. Each schema assertion compares sorted key
sets against `serde_json::to_value` of a real value.

just check, just quick, just lint-all across all 68 toggles, and the test
powerset across all 68 in four partitions — all green.

