### PR TITLE
name an alias in its diagnostics by the ident the author wrote, not the export it computes

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -1104,11 +1104,11 @@ fn alias_target_kind(alias_field_def: &FieldDef) -> AliasKind {
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn alias_map_key_guard_error(
     alias: &ItemType,
-    export_name: &str,
     alias_field_def: &FieldDef,
 ) -> Option<proc_macro2::TokenStream> {
     let rejection = map_key_rejection(alias_field_def)?;
-    let message = map_key_rejection_message(&format!("type alias `{export_name}`"), &rejection);
+    let subject = format!("type alias `{}`", alias.ident);
+    let message = map_key_rejection_message(&subject, &rejection);
     Some(syn::Error::new_spanned(&alias.ty, message).to_compile_error())
 }
 
@@ -1117,11 +1117,11 @@ fn alias_map_key_guard_error(
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn alias_undescribable_std_error(
     alias: &ItemType,
-    export_name: &str,
     alias_field_def: &FieldDef,
 ) -> Option<proc_macro2::TokenStream> {
     let rejection = undescribable_std_rejection(alias_field_def)?;
-    let message = undescribable_std_message(&format!("type alias `{export_name}`"), &rejection);
+    let subject = format!("type alias `{}`", alias.ident);
+    let message = undescribable_std_message(&subject, &rejection);
     Some(syn::Error::new_spanned(&alias.ty, message).to_compile_error())
 }
 
@@ -1172,13 +1172,9 @@ fn process_type_alias(item_type: ItemType, args: &ModelSchemaArgs) -> TokenStrea
     // Registered above whatever the outcome, so a type naming a refused alias still resolves to the
     // export name the author wrote and the alias's own diagnostic stays the one they act on.
     let alias_guard_errors: Vec<proc_macro2::TokenStream> =
-        alias_undescribable_std_error(&alias, &export_name, &alias_field_def)
+        alias_undescribable_std_error(&alias, &alias_field_def)
             .into_iter()
-            .chain(alias_map_key_guard_error(
-                &alias,
-                &export_name,
-                &alias_field_def,
-            ))
+            .chain(alias_map_key_guard_error(&alias, &alias_field_def))
             .collect();
     if let Some(output) = guard_failure_output(&alias, Some(&alias.ident), &alias_guard_errors) {
         return output;
@@ -12188,10 +12184,11 @@ fn generate_ts_alias_method(
 /// `json_schema()` body.
 #[cfg(feature = "jsonschema")]
 fn alias_json_schema_rejection(
-    export_name: &str,
+    rust_ident: &syn::Ident,
     rejection: &MapMemberRejection,
 ) -> proc_macro2::TokenStream {
-    let message = map_member_rejection_message(&format!("type alias `{export_name}`"), rejection);
+    let subject = format!("type alias `{rust_ident}`");
+    let message = map_member_rejection_message(&subject, rejection);
     quote! { compile_error!(#message) }
 }
 
@@ -12206,7 +12203,7 @@ fn generate_alias_json_schema_method(
     #[cfg(feature = "jsonschema")]
     {
         let body = build_tuple_element_json_schema(&surface_field_def(&alias.generics, field_def))
-            .unwrap_or_else(|rejection| alias_json_schema_rejection(export_name, &rejection));
+            .unwrap_or_else(|rejection| alias_json_schema_rejection(&alias.ident, &rejection));
         json_schema_methods(
             export_name,
             &body,

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -1938,14 +1938,12 @@ fn an_alias_targeting_a_map_key_with_no_members_is_refused() {
         pub type CountsByDoc = HashMap<Doc, u32>;
     };
     let field_def = get_field_def("CountsByDocType", &alias.ty, "");
-    let error = alias_map_key_guard_error(&alias, "CountsByDocType", &field_def)
+    let error = alias_map_key_guard_error(&alias, &field_def)
         .unwrap_or_default()
         .to_string();
     assert!(error.contains("compile_error"), "got: {error}");
-    assert!(
-        error.contains("type alias `CountsByDocType`"),
-        "got: {error}"
-    );
+    assert!(error.contains("type alias `CountsByDoc`"), "got: {error}");
+    assert!(!error.contains("CountsByDocType"), "got: {error}");
     assert!(error.contains("a map key must be a plain"), "got: {error}");
     assert!(error.contains("Doc"), "got: {error}");
 }
@@ -1956,7 +1954,7 @@ fn an_alias_targeting_a_map_key_with_no_members_is_refused() {
 fn alias_undescribable_std_error_text(source: &str) -> String {
     let alias: syn::ItemType = syn::parse_str(source).unwrap();
     let field_def = get_field_def("Probe", &alias.ty, "");
-    alias_undescribable_std_error(&alias, "Probe", &field_def)
+    alias_undescribable_std_error(&alias, &field_def)
         .unwrap_or_default()
         .to_string()
 }
@@ -1967,27 +1965,43 @@ fn alias_undescribable_std_error_text(source: &str) -> String {
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
 fn an_alias_targeting_an_undescribable_std_type_is_refused() {
-    for (target, named, wire) in [
-        ("pub type Slot = OnceLock<u32>;", "`OnceLock`", "Serialize"),
-        ("pub type Location = OsString;", "`OsString`", "externally"),
+    for (target, subject, named, wire) in [
+        (
+            "pub type Slot = OnceLock<u32>;",
+            "type alias `Slot`",
+            "`OnceLock`",
+            "Serialize",
+        ),
+        (
+            "pub type Location = OsString;",
+            "type alias `Location`",
+            "`OsString`",
+            "externally",
+        ),
         (
             "pub type Nested = Vec<OnceLock<u32>>;",
+            "type alias `Nested`",
             "`OnceLock`",
             "Serialize",
         ),
         (
             "pub type Keyed = HashMap<String, OsString>;",
+            "type alias `Keyed`",
             "`OsString`",
             "externally",
         ),
     ] {
         let error = alias_undescribable_std_error_text(target);
-        for needle in ["compile_error", "type alias `Probe`", named, wire] {
+        for needle in ["compile_error", subject, named, wire] {
             assert!(
                 error.contains(needle),
                 "{needle} missing for {target}: {error}"
             );
         }
+        assert!(
+            !error.contains("Probe"),
+            "the field-def name leaked for {target}: {error}"
+        );
     }
 }
 
@@ -2023,13 +2037,47 @@ fn an_alias_violating_both_type_level_guards_earns_both_refusals() {
     };
     let field_def = get_field_def("Audited", &alias.ty, "");
     assert!(
-        alias_undescribable_std_error(&alias, "Audited", &field_def).is_some(),
+        alias_undescribable_std_error(&alias, &field_def).is_some(),
         "the std-type guard found nothing"
     );
     assert!(
-        alias_map_key_guard_error(&alias, "Audited", &field_def).is_some(),
+        alias_map_key_guard_error(&alias, &field_def).is_some(),
         "the map-key guard found nothing"
     );
+}
+
+/// An alias publishes under a computed export name — `SlotJson` under `SlotType`, sharing no
+/// substring with what was written. Both type-level guards name the written ident, the one string
+/// the author can find in their own source.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn a_json_suffixed_alias_is_named_by_its_written_ident() {
+    register_alias_info("Tally", "Tally", "tally_schema", AliasKind::NoEnumMembers);
+    let held: syn::ItemType = syn::parse_quote! {
+        pub type SlotJson = OnceLock<u32>;
+    };
+    let held_def = get_field_def("SlotType", &held.ty, "");
+    let held_error = alias_undescribable_std_error(&held, &held_def)
+        .unwrap_or_default()
+        .to_string();
+    assert!(
+        held_error.contains("type alias `SlotJson`"),
+        "got: {held_error}"
+    );
+    assert!(!held_error.contains("SlotType"), "got: {held_error}");
+
+    let keyed: syn::ItemType = syn::parse_quote! {
+        pub type CountsJson = HashMap<Tally, u32>;
+    };
+    let keyed_def = get_field_def("CountsType", &keyed.ty, "");
+    let keyed_error = alias_map_key_guard_error(&keyed, &keyed_def)
+        .unwrap_or_default()
+        .to_string();
+    assert!(
+        keyed_error.contains("type alias `CountsJson`"),
+        "got: {keyed_error}"
+    );
+    assert!(!keyed_error.contains("CountsType"), "got: {keyed_error}");
 }
 
 /// A refused item still publishes the schema module every reference to it addresses. The address
@@ -3413,7 +3461,11 @@ fn an_alias_of_an_unrenderable_target_emits_only_the_compile_error() {
             "for {alias_source}, got: {tokens}"
         );
         assert!(
-            tokens.contains("type alias `RowsType`"),
+            tokens.contains("type alias `Rows`"),
+            "for {alias_source}, got: {tokens}"
+        );
+        assert!(
+            !tokens.contains("type alias `RowsType`"),
             "for {alias_source}, got: {tokens}"
         );
         assert!(
@@ -3430,6 +3482,26 @@ fn an_alias_of_an_unrenderable_target_emits_only_the_compile_error() {
              for {alias_source}, got: {tokens}"
         );
     }
+}
+
+/// The rejection names the written ident, not the export name the alias publishes under: `RowsJson`
+/// exports as `RowsType`, which the author's source does not contain anywhere.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_json_suffixed_alias_rejection_names_its_written_ident() {
+    let alias: syn::ItemType = syn::parse_quote! {
+        pub type RowsJson = HashMap<String, (u32, u32)>;
+    };
+    let field_def = super::get_field_def("RowsType", &alias.ty, "");
+    let tokens = super::generate_alias_json_schema_method(
+        &alias,
+        "RowsType",
+        &field_def,
+        &super::ModelSchemaArgs::default(),
+    )
+    .to_string();
+    assert!(tokens.contains("type alias `RowsJson`"), "got: {tokens}");
+    assert!(!tokens.contains("type alias `RowsType`"), "got: {tokens}");
 }
 
 /// A type parameter reaches the mapping as a named type, and a name is carried by a reference to


### PR DESCRIPTION
An alias's three type-level refusals — the map-key guard, the
undescribable-std guard, and the json_schema rejection — named the computed
TypeScript export: `SlotType` for `Slot`, and for `SlotJson` too, an identifier
the author's source never contains. The brand guard and `item_label` already
name the written ident, so one alias could be told about itself under two
different names.

Each guard already receives the alias item, so the export-name parameter is
dropped rather than corrected at the call sites — passing the wrong string is
no longer possible — and the third site takes the ident:

    pub type SlotJson = OnceLock<u32>;

    before   error: type alias `SlotType` reaches `OnceLock`, …
    after    error: type alias `SlotJson` reaches `OnceLock`, …

Spans are byte-identical, and no emitted surface moves — a valid `Json`-suffixed
alias still publishes under its stripped export name everywhere. The updated
assertions each pin the export name absent, so the old spelling cannot creep
back.

just check, just quick, just lint-all across all 68 toggles, and the test
powerset across all 68 in four partitions — all green.

