### PR TITLE
stamp every guard diagnostic with the one prefix, and span the alias rejection on its written target

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -1077,9 +1077,12 @@ pub fn exec_model_schema(args: TokenStream, input: TokenStream) -> TokenStream {
     } else if let Item::Type(item_type) = item {
         process_type_alias(item_type, &parsed_args)
     } else {
-        syn::Error::new_spanned(item, "Unsupported target for model_schema")
-            .to_compile_error()
-            .into()
+        syn::Error::new_spanned(
+            item,
+            prefixed_guard_message("unsupported target for this attribute"),
+        )
+        .to_compile_error()
+        .into()
     };
     let answered = with_prefixed_tokens(expanded, &deferred_shape_refusals(registering.as_ref()));
     with_prefixed_tokens(answered, &filling_bound_checks)
@@ -1108,7 +1111,7 @@ fn alias_map_key_guard_error(
 ) -> Option<proc_macro2::TokenStream> {
     let rejection = map_key_rejection(alias_field_def)?;
     let subject = format!("type alias `{}`", alias.ident);
-    let message = map_key_rejection_message(&subject, &rejection);
+    let message = prefixed_guard_message(&map_key_rejection_message(&subject, &rejection));
     Some(syn::Error::new_spanned(&alias.ty, message).to_compile_error())
 }
 
@@ -1121,7 +1124,7 @@ fn alias_undescribable_std_error(
 ) -> Option<proc_macro2::TokenStream> {
     let rejection = undescribable_std_rejection(alias_field_def)?;
     let subject = format!("type alias `{}`", alias.ident);
-    let message = undescribable_std_message(&subject, &rejection);
+    let message = prefixed_guard_message(&undescribable_std_message(&subject, &rejection));
     Some(syn::Error::new_spanned(&alias.ty, message).to_compile_error())
 }
 
@@ -1866,7 +1869,7 @@ where
 fn cfg_attr_guard_error(rejection: &syn::Error, item: &str) -> proc_macro2::TokenStream {
     syn::Error::new(
         rejection.span(),
-        format!("model_schema: {item}: {rejection}"),
+        prefixed_guard_message(&format!("{item}: {rejection}")),
     )
     .to_compile_error()
 }
@@ -1876,9 +1879,15 @@ fn cfg_attr_guard_error(rejection: &syn::Error, item: &str) -> proc_macro2::Toke
 fn pattern_guard_error(rejection: &syn::Error, subject: &str) -> proc_macro2::TokenStream {
     syn::Error::new(
         rejection.span(),
-        format!("model_schema: {subject}: {rejection}"),
+        prefixed_guard_message(&format!("{subject}: {rejection}")),
     )
     .to_compile_error()
+}
+
+/// The macro's own name, in front of every diagnostic it emits — the one thing that separates this
+/// crate's refusal from rustc's on a screen full of errors.
+fn prefixed_guard_message(message: &str) -> String {
+    format!("model_schema: {message}")
 }
 
 /// Turns an attribute parser's refusal — of a `model_schema` argument, a `model_schema_prop` key,
@@ -1887,7 +1896,7 @@ fn pattern_guard_error(rejection: &syn::Error, subject: &str) -> proc_macro2::To
 fn attr_guard_error(rejection: &syn::Error, subject: &str) -> proc_macro2::TokenStream {
     syn::Error::new(
         rejection.span(),
-        format!("model_schema: {subject}: {rejection}"),
+        prefixed_guard_message(&format!("{subject}: {rejection}")),
     )
     .to_compile_error()
 }
@@ -3184,7 +3193,10 @@ fn branded_undescribable_std_error(
 ) -> Option<proc_macro2::TokenStream> {
     let inner = get_field_def("", &inner_field.ty, "");
     let rejection = undescribable_std_rejection(&inner)?;
-    let message = undescribable_std_message(&format!("type `{name}`"), &rejection);
+    let message = prefixed_guard_message(&undescribable_std_message(
+        &format!("type `{name}`"),
+        &rejection,
+    ));
     Some(syn::Error::new_spanned(&inner_field.ty, message).to_compile_error())
 }
 
@@ -3194,7 +3206,10 @@ fn branded_undescribable_std_error(
 fn branded_map_key_error(name: &Ident, inner_field: &Field) -> Option<proc_macro2::TokenStream> {
     let inner = get_field_def("", &inner_field.ty, "");
     let rejection = map_key_rejection(&inner)?;
-    let message = map_key_rejection_message(&format!("type `{name}`"), &rejection);
+    let message = prefixed_guard_message(&map_key_rejection_message(
+        &format!("type `{name}`"),
+        &rejection,
+    ));
     Some(syn::Error::new_spanned(&inner_field.ty, message).to_compile_error())
 }
 
@@ -3855,7 +3870,10 @@ fn tuple_struct_json_body(item_name: &str, shape: &TupleStructShape) -> proc_mac
     match described {
         Ok(value) => value,
         Err(rejection) => {
-            let message = map_member_rejection_message(&format!("`{item_name}`"), &rejection);
+            let message = prefixed_guard_message(&map_member_rejection_message(
+                &format!("`{item_name}`"),
+                &rejection,
+            ));
             quote! { compile_error!(#message) }
         }
     }
@@ -4248,7 +4266,10 @@ fn branded_slot_json_schema(
     match build_tuple_element_json_schema(inner) {
         Ok(value) => branded_layered_over(args, &value),
         Err(rejection) => {
-            let message = map_member_rejection_message(&format!("`{def_name}`"), &rejection);
+            let message = prefixed_guard_message(&map_member_rejection_message(
+                &format!("`{def_name}`"),
+                &rejection,
+            ));
             quote! { compile_error!(#message) }
         }
     }
@@ -6195,8 +6216,10 @@ fn external_content_rejection_value(
     discriminator_value: &str,
     rejection: &MapMemberRejection,
 ) -> proc_macro2::TokenStream {
-    let message =
-        map_member_rejection_message(&format!("variant `{discriminator_value}`"), rejection);
+    let message = prefixed_guard_message(&map_member_rejection_message(
+        &format!("variant `{discriminator_value}`"),
+        rejection,
+    ));
     quote! { compile_error!(#message) }
 }
 
@@ -7426,7 +7449,10 @@ fn member_rejection_value(
     field_name: &str,
     rejection: &MapMemberRejection,
 ) -> proc_macro2::TokenStream {
-    let message = map_member_rejection_message(&field_label(field_name), rejection);
+    let message = prefixed_guard_message(&map_member_rejection_message(
+        &field_label(field_name),
+        rejection,
+    ));
     quote! { compile_error!(#message) }
 }
 
@@ -8702,7 +8728,10 @@ fn sibling_json_schema_value(
 #[cfg(feature = "jsonschema")]
 fn argument_json_schema_value(name: &str, argument: &FieldDef) -> proc_macro2::TokenStream {
     build_tuple_element_json_schema(argument).unwrap_or_else(|rejection| {
-        let message = map_member_rejection_message(&format!("`{name}`"), &rejection);
+        let message = prefixed_guard_message(&map_member_rejection_message(
+            &format!("`{name}`"),
+            &rejection,
+        ));
         quote! { compile_error!(#message) }
     })
 }
@@ -9062,7 +9091,7 @@ fn check_map_key(field: &Field, field_def: &FieldDef, label: &str) -> Result<(),
     };
     Err(syn::Error::new_spanned(
         field,
-        map_key_rejection_message(label, &rejection),
+        prefixed_guard_message(&map_key_rejection_message(label, &rejection)),
     ))
 }
 
@@ -9237,7 +9266,10 @@ fn map_member_rejection_error(
     field_name_str: &str,
     rejection: &MapMemberRejection,
 ) -> proc_macro2::TokenStream {
-    let message = map_member_rejection_message(&format!("field `{field_name_str}`"), rejection);
+    let message = prefixed_guard_message(&map_member_rejection_message(
+        &format!("field `{field_name_str}`"),
+        rejection,
+    ));
     quote! { compile_error!(#message); }
 }
 
@@ -10606,9 +10638,12 @@ fn model_schema_prop_guard_errors(
 /// validator keeps its message — the one place the misuse is spelled — so a caller doesn't
 /// maintain the same sentence twice.
 fn flag_guard_error(field: &Field, label: &str, result: Result<(), String>) -> Option<syn::Error> {
-    result
-        .err()
-        .map(|message| syn::Error::new_spanned(field, format!("model_schema: {label}: {message}")))
+    result.err().map(|message| {
+        syn::Error::new_spanned(
+            field,
+            prefixed_guard_message(&format!("{label}: {message}")),
+        )
+    })
 }
 
 /// The bound keys a `model_schema_prop` meta carries, named as they were written, so a guard
@@ -10842,10 +10877,7 @@ fn check_undescribable_std_field(
     };
     Err(syn::Error::new_spanned(
         field,
-        format!(
-            "model_schema: {}",
-            undescribable_std_message(label, &rejection)
-        ),
+        prefixed_guard_message(&undescribable_std_message(label, &rejection)),
     ))
 }
 
@@ -12181,15 +12213,15 @@ fn generate_ts_alias_method(
 }
 
 /// The diagnostic an alias whose target the dispatch cannot render emits, in place of the whole
-/// `json_schema()` body.
+/// `json_schema()` body. Spanned on the target, which is where the unrenderable value was written.
 #[cfg(feature = "jsonschema")]
 fn alias_json_schema_rejection(
-    rust_ident: &syn::Ident,
+    alias: &ItemType,
     rejection: &MapMemberRejection,
 ) -> proc_macro2::TokenStream {
-    let subject = format!("type alias `{rust_ident}`");
-    let message = map_member_rejection_message(&subject, rejection);
-    quote! { compile_error!(#message) }
+    let subject = format!("type alias `{}`", alias.ident);
+    let message = prefixed_guard_message(&map_member_rejection_message(&subject, rejection));
+    syn::Error::new_spanned(&alias.ty, message).to_compile_error()
 }
 
 /// Builds the alias module's `json_schema()`, or nothing when `jsonschema` is off.
@@ -12203,7 +12235,7 @@ fn generate_alias_json_schema_method(
     #[cfg(feature = "jsonschema")]
     {
         let body = build_tuple_element_json_schema(&surface_field_def(&alias.generics, field_def))
-            .unwrap_or_else(|rejection| alias_json_schema_rejection(&alias.ident, &rejection));
+            .unwrap_or_else(|rejection| alias_json_schema_rejection(alias, &rejection));
         json_schema_methods(
             export_name,
             &body,

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -1020,9 +1020,8 @@ fn untagged_member_holding_an_unsupported_map_value_emits_only_the_compile_error
         "got: {}",
         values[0]
     );
-    assert!(values[0].contains("field `rows`"), "got: {}", values[0]);
     assert!(
-        values[0].contains("a tuple is not supported as a map value"),
+        values[0].contains("model_schema: field `rows`: a tuple is not supported as a map value"),
         "got: {}",
         values[0]
     );
@@ -1030,6 +1029,21 @@ fn untagged_member_holding_an_unsupported_map_value_emits_only_the_compile_error
         !values[0].contains("additionalProperties\" :"),
         "got: {}",
         values[0]
+    );
+}
+
+/// An externally tagged variant whose content has no rendering puts the diagnostic where the
+/// content would have stood, naming the key serde writes the variant under.
+#[cfg(all(feature = "serde", feature = "jsonschema"))]
+#[test]
+fn an_external_variant_holding_an_unrenderable_content_is_refused() {
+    let rendered =
+        super::external_content_rejection_value("rows", &super::MapMemberRejection::Tuple)
+            .to_string();
+    assert!(rendered.starts_with("compile_error !"), "got: {rendered}");
+    assert!(
+        rendered.contains("model_schema: variant `rows`: a tuple is not supported as a map value"),
+        "got: {rendered}"
     );
 }
 
@@ -1650,11 +1664,7 @@ fn a_map_key_proved_to_lack_enum_members_is_refused_wherever_it_is_written() {
         let error = field_map_key_error(&field_type);
         assert!(error.contains("compile_error"), "for {field_type}: {error}");
         assert!(
-            error.contains("field `counts`"),
-            "for {field_type}: {error}"
-        );
-        assert!(
-            error.contains("a map key must be a plain"),
+            error.contains("model_schema: field `counts`: a map key must be a plain"),
             "for {field_type}: {error}"
         );
         assert!(error.contains("Doc"), "for {field_type}: {error}");
@@ -1692,11 +1702,9 @@ fn a_sequence_wrapped_map_key_is_refused_wherever_it_is_written() {
         let error = field_map_key_error(&field_type);
         assert!(error.contains("compile_error"), "for {field_type}: {error}");
         assert!(
-            error.contains("field `counts`"),
-            "for {field_type}: {error}"
-        );
-        assert!(
-            error.contains("a map key must be a value serde writes as a string"),
+            error.contains(
+                "model_schema: field `counts`: a map key must be a value serde writes as a string"
+            ),
             "for {field_type}: {error}"
         );
         assert!(error.contains(element), "for {field_type}: {error}");
@@ -1711,11 +1719,9 @@ fn assert_unwritable_map_key(field_type: &proc_macro2::TokenStream, key_name: &s
     let error = field_map_key_error(field_type);
     assert!(error.contains("compile_error"), "for {field_type}: {error}");
     assert!(
-        error.contains("field `counts`"),
-        "for {field_type}: {error}"
-    );
-    assert!(
-        error.contains("a map key must be a value serde writes as a string"),
+        error.contains(
+            "model_schema: field `counts`: a map key must be a value serde writes as a string"
+        ),
         "for {field_type}: {error}"
     );
     assert!(error.contains(key_name), "for {field_type}: {error}");
@@ -1820,11 +1826,9 @@ fn an_optional_map_key_is_refused_wherever_it_is_written() {
         let error = field_map_key_error(&field_type);
         assert!(error.contains("compile_error"), "for {field_type}: {error}");
         assert!(
-            error.contains("field `counts`"),
-            "for {field_type}: {error}"
-        );
-        assert!(
-            error.contains("a map key must be a value serde writes as a string"),
+            error.contains(
+                "model_schema: field `counts`: a map key must be a value serde writes as a string"
+            ),
             "for {field_type}: {error}"
         );
         assert!(
@@ -1942,9 +1946,11 @@ fn an_alias_targeting_a_map_key_with_no_members_is_refused() {
         .unwrap_or_default()
         .to_string();
     assert!(error.contains("compile_error"), "got: {error}");
-    assert!(error.contains("type alias `CountsByDoc`"), "got: {error}");
+    assert!(
+        error.contains("model_schema: type alias `CountsByDoc`: a map key must be a plain"),
+        "got: {error}"
+    );
     assert!(!error.contains("CountsByDocType"), "got: {error}");
-    assert!(error.contains("a map key must be a plain"), "got: {error}");
     assert!(error.contains("Doc"), "got: {error}");
 }
 
@@ -1968,25 +1974,25 @@ fn an_alias_targeting_an_undescribable_std_type_is_refused() {
     for (target, subject, named, wire) in [
         (
             "pub type Slot = OnceLock<u32>;",
-            "type alias `Slot`",
+            "model_schema: type alias `Slot`",
             "`OnceLock`",
             "Serialize",
         ),
         (
             "pub type Location = OsString;",
-            "type alias `Location`",
+            "model_schema: type alias `Location`",
             "`OsString`",
             "externally",
         ),
         (
             "pub type Nested = Vec<OnceLock<u32>>;",
-            "type alias `Nested`",
+            "model_schema: type alias `Nested`",
             "`OnceLock`",
             "Serialize",
         ),
         (
             "pub type Keyed = HashMap<String, OsString>;",
-            "type alias `Keyed`",
+            "model_schema: type alias `Keyed`",
             "`OsString`",
             "externally",
         ),
@@ -3312,6 +3318,26 @@ fn branded_json_schema_method_carries_no_cfg_attribute() {
     }
 }
 
+/// A brand publishes its inner's document, so an inner the dispatch cannot render replaces that
+/// document with the diagnostic, naming the brand as it is exported.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_brand_over_an_unrenderable_slot_is_refused() {
+    let inner = get_field_def(
+        "_inner",
+        &syn::parse_str("HashMap<String, (u32, u32)>").unwrap(),
+        "",
+    );
+    let rendered =
+        super::branded_slot_json_schema(&super::ModelSchemaArgs::default(), &inner, "DocumentId")
+            .to_string();
+    assert!(rendered.starts_with("compile_error !"), "got: {rendered}");
+    assert!(
+        rendered.contains("model_schema: `DocumentId`: a tuple is not supported as a map value"),
+        "got: {rendered}"
+    );
+}
+
 /// Every shape [`super::branded_json_inner`] resolves to, so the dispatch is covered whole. The
 /// `Slot` and `Chrono` shapes build their bodies through [`super::branded_slot_json_schema`] and
 /// [`super::branded_chrono_schema`], which is where a stray `cfg` attribute would land unseen.
@@ -3461,7 +3487,9 @@ fn an_alias_of_an_unrenderable_target_emits_only_the_compile_error() {
             "for {alias_source}, got: {tokens}"
         );
         assert!(
-            tokens.contains("type alias `Rows`"),
+            tokens.contains(
+                "model_schema: type alias `Rows`: a tuple is not supported as a map value"
+            ),
             "for {alias_source}, got: {tokens}"
         );
         assert!(
@@ -3469,11 +3497,7 @@ fn an_alias_of_an_unrenderable_target_emits_only_the_compile_error() {
             "for {alias_source}, got: {tokens}"
         );
         assert!(
-            tokens.contains("a tuple is not supported as a map value"),
-            "for {alias_source}, got: {tokens}"
-        );
-        assert!(
-            tokens.contains("= compile_error !"),
+            tokens.contains("= :: core :: compile_error !"),
             "the description is the diagnostic, not a schema: for {alias_source}, got: {tokens}"
         );
         assert!(
@@ -3482,6 +3506,28 @@ fn an_alias_of_an_unrenderable_target_emits_only_the_compile_error() {
              for {alias_source}, got: {tokens}"
         );
     }
+}
+
+/// The caret has to land on the tokens the author edits. The tuple sits inside the written target,
+/// and a diagnostic carrying no location of its own falls back to the attribute — a line no edit to
+/// it can fix.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn an_alias_rejection_points_at_the_written_target() {
+    let alias: syn::ItemType =
+        syn::parse_str("pub type Rows = HashMap<String, (u32, u32)>;").unwrap();
+    let field_def = super::get_field_def("RowsType", &alias.ty, "");
+    let tokens = super::generate_alias_json_schema_method(
+        &alias,
+        "RowsType",
+        &field_def,
+        &super::ModelSchemaArgs::default(),
+    );
+    let located = located_source_texts(&tokens);
+    assert!(
+        located.iter().any(|text| text == "HashMap"),
+        "got: {located:?}"
+    );
 }
 
 /// The rejection names the written ident, not the export name the alias publishes under: `RowsJson`
@@ -3640,7 +3686,7 @@ fn a_brand_over_an_undescribable_std_inner_is_refused() {
             struct SlotId(pub #inner);
         });
         assert_eq!(errors.len(), 1, "for {inner}, got: {errors:?}");
-        for needle in ["compile_error", "type `SlotId`", named, wire] {
+        for needle in ["compile_error", "model_schema: type `SlotId`", named, wire] {
             assert!(
                 errors[0].contains(needle),
                 "{needle} missing for {inner}: {}",
@@ -3814,7 +3860,7 @@ fn a_brand_over_a_map_with_an_unwritable_key_is_refused() {
             errors[0]
         );
         assert!(
-            errors[0].contains("type `Wrap`"),
+            errors[0].contains("model_schema: type `Wrap`"),
             "for {inner}: {}",
             errors[0]
         );
@@ -6151,11 +6197,7 @@ fn an_unsupported_enum_keyed_map_value_emits_only_the_compile_error() {
             "for {map_type}, got: {tokens}"
         );
         assert!(
-            tokens.contains("field `m`"),
-            "for {map_type}, got: {tokens}"
-        );
-        assert!(
-            tokens.contains("a tuple is not supported as a map value"),
+            tokens.contains("model_schema: field `m`: a tuple is not supported as a map value"),
             "for {map_type}, got: {tokens}"
         );
     }
@@ -6765,9 +6807,8 @@ fn an_unsupported_string_keyed_map_value_emits_only_the_compile_error() {
     let tokens = map_field_schema("HashMap<String, (String, u32)>").to_string();
     assert!(tokens.starts_with("compile_error !"), "got: {tokens}");
     assert!(!tokens.contains("properties . insert"), "got: {tokens}");
-    assert!(tokens.contains("field `m`"), "got: {tokens}");
     assert!(
-        tokens.contains("a tuple is not supported as a map value"),
+        tokens.contains("model_schema: field `m`: a tuple is not supported as a map value"),
         "got: {tokens}"
     );
 }
@@ -7174,7 +7215,7 @@ fn an_unsupported_nested_map_value_emits_only_the_compile_error() {
             "for {map_type}, got: {tokens}"
         );
         assert!(
-            tokens.contains("a tuple is not supported as a map value"),
+            tokens.contains("model_schema: field `m`: a tuple is not supported as a map value"),
             "for {map_type}, got: {tokens}"
         );
     }
@@ -7263,6 +7304,24 @@ fn a_generic_sibling_string_keyed_map_value_emits_the_sibling_schema() {
              :: Schema :: json_schema_within_with (in_flight , hoisted_defs , & arguments)"
         ),
         "got: {tokens}"
+    );
+}
+
+/// An argument the dispatch cannot render replaces the document filling the parameter, naming the
+/// parameter it stands at — the reference site is where the filling was written.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_reference_site_argument_the_dispatch_cannot_render_is_refused() {
+    let argument = get_field_def(
+        "",
+        &syn::parse_str("HashMap<String, (u32, u32)>").unwrap(),
+        "",
+    );
+    let rendered = super::argument_json_schema_value("IdType", &argument).to_string();
+    assert!(rendered.starts_with("compile_error !"), "got: {rendered}");
+    assert!(
+        rendered.contains("model_schema: `IdType`: a tuple is not supported as a map value"),
+        "got: {rendered}"
     );
 }
 
@@ -7672,11 +7731,7 @@ fn a_tuple_element_holding_an_unrenderable_map_emits_only_the_compile_error() {
             "for {field_type}, got: {tokens}"
         );
         assert!(
-            tokens.contains("field `t`"),
-            "for {field_type}, got: {tokens}"
-        );
-        assert!(
-            tokens.contains("a tuple is not supported as a map value"),
+            tokens.contains("model_schema: field `t`: a tuple is not supported as a map value"),
             "for {field_type}, got: {tokens}"
         );
     }
@@ -8488,6 +8543,26 @@ fn a_tuple_struct_describes_as_its_arity_in_json_schema() {
     let pair = tuple_struct_json_body("Pair", &whole_tuple(&["String", "u32"])).to_string();
     assert!(pair.contains("prefixItems"), "Got: {pair}");
     assert!(pair.contains("maxItems"), "Got: {pair}");
+}
+
+/// A slot the dispatch cannot render replaces the whole body with the diagnostic, at either arity:
+/// the bare value a one-slot struct writes and the fixed array every other arity writes reach the
+/// same rejection, and both name the type the author declared.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_tuple_struct_slot_the_dispatch_cannot_render_is_refused() {
+    for shape in [
+        whole_tuple(&["HashMap<String, (u32, u32)>"]),
+        whole_tuple(&["String", "HashMap<String, (u32, u32)>"]),
+    ] {
+        let rendered = tuple_struct_json_body("Pair", &shape).to_string();
+        assert!(rendered.starts_with("compile_error !"), "Got: {rendered}");
+        assert!(
+            rendered.contains("model_schema: `Pair`: a tuple is not supported as a map value"),
+            "Got: {rendered}"
+        );
+        assert!(!rendered.contains("prefixItems"), "Got: {rendered}");
+    }
 }
 
 /// The bare value is the *declared* arity's, not the described list's. Captured from serde: a


### PR DESCRIPTION
Thirteen guard sinks emitted with no `model_schema:` prefix while thirty-four
spellings carried one, so a single item could be told about itself in two
voices — the same message family was prefixed at the field and `default_types`
positions and bare at the alias and brand ones.

The prefix now comes from one helper at the token-building seam, which is where
every already-compliant site put it. The three shared message builders stay
subject-first and unprefixed: the `default_types` filling path routes one of
them through the attribute guard, which prefixes on its own, so prefixing the
builders would double up there. The reroute of the existing spellings was
verified byte-identical before any new sink was stamped.

Separately, the alias `json_schema()` rejection was spanned on the attribute —
its builder took only the ident, never held the target, and fell back to
call-site spans — while its two sibling guards point at the written target. It
takes the alias item now and spans the same way they do:

    before    --> src/main.rs:11:1   #[model_schema()]
              = note: this error originates in the attribute macro
    after     --> src/main.rs:12:21  pub type RowsJson = HashMap<String, (u32, u32)>;

No emitted surface moves in either change; one pinned token-shape assertion
follows the `new_spanned` construction, and the extended tests each pin the
prefix present so a bare sink cannot creep back.

just check, just quick, just lint-all across all 68 toggles, and the test
powerset across all 68 in four partitions — all green.

