### PR TITLE
carry the refused member's span in the rejection, so all six sinks point at the offending tokens

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -370,17 +370,30 @@ enum MapMemberItem {
     Value(proc_macro2::TokenStream),
 }
 
-/// Why a value in a slot has no rendering. Each shape carries its own diagnostic, and the field
-/// name the message needs belongs to the caller rather than to the dispatch, so the reason travels
-/// out and the message is formatted once at the top.
+/// Why a value in a slot has no rendering, and where it was written. Each shape carries its own
+/// diagnostic, and the field name the message needs belongs to the caller rather than to the
+/// dispatch, so the reason travels out and the message is formatted once at the top. The span
+/// travels with it because the callers that format it hold a slice of slots and cannot tell which
+/// one the dispatch refused.
 #[cfg(feature = "jsonschema")]
 #[derive(Debug)]
 enum MapMemberRejection {
     /// A map key with no rendering, whatever reason it has and at whatever depth the value walk
     /// reached it. The reason is the same value the field guard refuses on, so a key is worded
     /// once however the expansion arrives at it.
-    Key(MapKeyRejection),
-    Tuple,
+    Key(MapKeyRejection, proc_macro2::Span),
+    Tuple(proc_macro2::Span),
+}
+
+#[cfg(feature = "jsonschema")]
+impl MapMemberRejection {
+    /// The written tokens the diagnostic points at. A key under a sequence wrapper points at the
+    /// element rather than the wrapper, `get_field_def` having collapsed the wrapper onto it.
+    const fn span(&self) -> proc_macro2::Span {
+        match *self {
+            Self::Key(_, span) | Self::Tuple(span) => span,
+        }
+    }
 }
 
 /// What a map key opens: an open member set, the members it enumerates, nothing this expansion can
@@ -3874,7 +3887,7 @@ fn tuple_struct_json_body(item_name: &str, shape: &TupleStructShape) -> proc_mac
                 &format!("`{item_name}`"),
                 &rejection,
             ));
-            quote! { compile_error!(#message) }
+            syn::Error::new(rejection.span(), message).to_compile_error()
         }
     }
 }
@@ -4270,7 +4283,7 @@ fn branded_slot_json_schema(
                 &format!("`{def_name}`"),
                 &rejection,
             ));
-            quote! { compile_error!(#message) }
+            syn::Error::new(rejection.span(), message).to_compile_error()
         }
     }
 }
@@ -6220,7 +6233,7 @@ fn external_content_rejection_value(
         &format!("variant `{discriminator_value}`"),
         rejection,
     ));
-    quote! { compile_error!(#message) }
+    syn::Error::new(rejection.span(), message).to_compile_error()
 }
 
 /// Renders what one variant of an externally tagged enum writes under its key.
@@ -7453,7 +7466,7 @@ fn member_rejection_value(
         &field_label(field_name),
         rejection,
     ));
-    quote! { compile_error!(#message) }
+    syn::Error::new(rejection.span(), message).to_compile_error()
 }
 
 /// One untagged member's field def in the two readings the guards need: as the surfaces will
@@ -8732,7 +8745,7 @@ fn argument_json_schema_value(name: &str, argument: &FieldDef) -> proc_macro2::T
             &format!("`{name}`"),
             &rejection,
         ));
-        quote! { compile_error!(#message) }
+        syn::Error::new(rejection.span(), message).to_compile_error()
     })
 }
 
@@ -9133,7 +9146,9 @@ fn build_nested_map_member_item(
             )
         }
         MapKeyPath::Unnarrowed => MapMemberItem::Fragment(unnarrowed_key_map_json_schema_item()),
-        MapKeyPath::Refused(rejection) => return Err(MapMemberRejection::Key(rejection)),
+        MapKeyPath::Refused(rejection) => {
+            return Err(MapMemberRejection::Key(rejection, inner_key.type_span));
+        }
     })
 }
 
@@ -9233,7 +9248,7 @@ fn build_map_member_item(value: &FieldDef) -> Result<MapMemberItem, MapMemberRej
 /// inline rendering — every other type the scalar mapping names renders there.
 #[cfg(feature = "jsonschema")]
 fn scalar_slot_item(fld: &FieldDef) -> Result<proc_macro2::TokenStream, MapMemberRejection> {
-    scalar_field_json_schema_item(fld).ok_or(MapMemberRejection::Tuple)
+    scalar_field_json_schema_item(fld).ok_or(MapMemberRejection::Tuple(fld.type_span))
 }
 
 /// The `additionalProperties` schema every member of a `String`-keyed map carries, or the rejection
@@ -9252,8 +9267,10 @@ fn build_map_member_schema(
 #[cfg(feature = "jsonschema")]
 fn map_member_rejection_message(subject: &str, rejection: &MapMemberRejection) -> String {
     match rejection {
-        MapMemberRejection::Key(key_rejection) => map_key_rejection_message(subject, key_rejection),
-        MapMemberRejection::Tuple => format!(
+        MapMemberRejection::Key(key_rejection, _) => {
+            map_key_rejection_message(subject, key_rejection)
+        }
+        MapMemberRejection::Tuple(_) => format!(
             "{subject}: a tuple is not supported as a map value — give the value a `#[model_schema()]` struct instead"
         ),
     }
@@ -9270,7 +9287,7 @@ fn map_member_rejection_error(
         &format!("field `{field_name_str}`"),
         rejection,
     ));
-    quote! { compile_error!(#message); }
+    syn::Error::new(rejection.span(), message).to_compile_error()
 }
 
 /// The object a `String`-keyed map describes as, as a standalone `serde_json::Value` expression, or
@@ -9300,9 +9317,10 @@ fn enum_key_map_json_schema_value(
     value: &FieldDef,
 ) -> Result<proc_macro2::TokenStream, MapMemberRejection> {
     if proves_no_enum_members(key_type_name) {
-        return Err(MapMemberRejection::Key(MapKeyRejection::NoEnumMembers(
-            key_type_name.to_owned(),
-        )));
+        return Err(MapMemberRejection::Key(
+            MapKeyRejection::NoEnumMembers(key_type_name.to_owned()),
+            key_span,
+        ));
     }
 
     let normalized = normalized_slot_value(value);
@@ -9339,7 +9357,7 @@ fn map_json_schema_value(
         }
         MapKeyPath::Open => string_key_map_json_schema_value(value),
         MapKeyPath::Unnarrowed => Ok(unnarrowed_key_map_json_schema_value(key)),
-        MapKeyPath::Refused(rejection) => Err(MapMemberRejection::Key(rejection)),
+        MapKeyPath::Refused(rejection) => Err(MapMemberRejection::Key(rejection, key.type_span)),
     }
 }
 

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -1037,14 +1037,128 @@ fn untagged_member_holding_an_unsupported_map_value_emits_only_the_compile_error
 #[cfg(all(feature = "serde", feature = "jsonschema"))]
 #[test]
 fn an_external_variant_holding_an_unrenderable_content_is_refused() {
-    let rendered =
-        super::external_content_rejection_value("rows", &super::MapMemberRejection::Tuple)
-            .to_string();
-    assert!(rendered.starts_with("compile_error !"), "got: {rendered}");
+    let rendered = super::external_content_rejection_value(
+        "rows",
+        &super::MapMemberRejection::Tuple(proc_macro2::Span::call_site()),
+    )
+    .to_string();
+    assert!(
+        rendered.starts_with(":: core :: compile_error !"),
+        "got: {rendered}"
+    );
     assert!(
         rendered.contains("model_schema: variant `rows`: a tuple is not supported as a map value"),
         "got: {rendered}"
     );
+}
+
+/// The field defs one variant of `source` declares, parsed from text so each carries the span of
+/// the tokens it was written with.
+#[cfg(feature = "jsonschema")]
+fn variant_field_defs(source: &str, variant_name: &str) -> Vec<super::FieldDef> {
+    let item: syn::ItemEnum = syn::parse_str(source).unwrap();
+    item.variants
+        .iter()
+        .filter(|variant| variant.ident == variant_name)
+        .flat_map(|variant| variant.fields.iter())
+        .map(|field| {
+            let name = field
+                .ident
+                .as_ref()
+                .map(ToString::to_string)
+                .unwrap_or_default();
+            get_field_def(&name, &field.ty, "")
+        })
+        .collect()
+}
+
+/// The content sink's caret, at both contents an externally tagged variant can carry. The
+/// multi-content variant offends in its second element, which the sink cannot pick out of the slot
+/// list it is handed.
+#[cfg(all(feature = "serde", feature = "jsonschema"))]
+#[test]
+fn a_refused_external_content_points_at_the_written_content() {
+    const SOURCE: &str = "enum Tagged { \
+        Rows(HashMap<String, (u32, u32)>), \
+        Multi(String, HashMap<String, (u32, u32)>) }";
+
+    let single = variant_field_defs(SOURCE, "Rows");
+    let single_rejection = super::build_tuple_element_json_schema(&single[0]).unwrap_err();
+    assert_points_only_at(
+        &super::external_content_rejection_value("Rows", &single_rejection),
+        "(u32, u32)",
+        "a single-content variant",
+    );
+
+    let multi = variant_field_defs(SOURCE, "Multi");
+    let multi_rejection = super::tuple_json_schema_value(&multi).unwrap_err();
+    assert_points_only_at(
+        &super::external_content_rejection_value("Multi", &multi_rejection),
+        "(u32, u32)",
+        "a multi-content variant",
+    );
+}
+
+/// The adjacently tagged content sink's caret, at both contents a variant can carry: the single
+/// value writes its own key, and the multi one writes the fixed array, and neither knows which slot
+/// the dispatch refused.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_refused_adjacent_content_points_at_the_written_content() {
+    const SOURCE: &str = "enum Tagged { \
+        Rows(HashMap<String, (u32, u32)>), \
+        Multi(String, HashMap<String, (u32, u32)>) }";
+
+    let mut single_fields = Vec::new();
+    super::push_single_tuple_json_field(
+        &mut single_fields,
+        "value",
+        &variant_field_defs(SOURCE, "Rows")[0],
+    );
+    assert_points_only_at(
+        &single_fields[0],
+        "(u32, u32)",
+        "an adjacent single content",
+    );
+
+    let mut parts = super::VariantParts {
+        json_fields: Vec::new(),
+        schema_code: String::new(),
+        type_code: String::new(),
+    };
+    super::write_tuple_multiple_variant_fields(
+        &variant_field_defs(SOURCE, "Multi"),
+        "value",
+        "Tagged",
+        &mut parts,
+    );
+    assert_points_only_at(
+        &parts.json_fields[0],
+        "(u32, u32)",
+        "an adjacent multi content",
+    );
+}
+
+/// The untagged member sink's caret, on both paths a member reaches it by: a map written straight
+/// into the member, and a map reached through a tuple element.
+#[cfg(all(feature = "serde", feature = "jsonschema"))]
+#[test]
+fn a_refused_untagged_member_points_at_the_written_value() {
+    for (member_type, context) in [
+        ("HashMap<String, (u32, u32)>", "an untagged map member"),
+        (
+            "(String, HashMap<String, (u32, u32)>)",
+            "an untagged tuple member",
+        ),
+    ] {
+        let source = format!("enum Untagged {{ Rows {{ rows: {member_type} }} }}");
+        let member = &variant_field_defs(&source, "Rows")[0];
+        assert_points_only_at(
+            &super::field_json_schema_value(member),
+            "(u32, u32)",
+            context,
+        );
+    }
 }
 
 /// Collects the internally tagged path's guard failures as rendered `compile_error!` token strings.
@@ -3331,10 +3445,29 @@ fn a_brand_over_an_unrenderable_slot_is_refused() {
     let rendered =
         super::branded_slot_json_schema(&super::ModelSchemaArgs::default(), &inner, "DocumentId")
             .to_string();
-    assert!(rendered.starts_with("compile_error !"), "got: {rendered}");
+    assert!(
+        rendered.starts_with(":: core :: compile_error !"),
+        "got: {rendered}"
+    );
     assert!(
         rendered.contains("model_schema: `DocumentId`: a tuple is not supported as a map value"),
         "got: {rendered}"
+    );
+}
+
+/// [`a_brand_over_an_unrenderable_slot_is_refused`]'s caret, which belongs on the inner the brand
+/// was declared over rather than on the attribute that declared it.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_refused_brand_inner_points_at_the_written_inner() {
+    let item: syn::ItemStruct =
+        syn::parse_str("pub struct DocumentId(pub HashMap<String, (u32, u32)>);").unwrap();
+    let field = item.fields.iter().next().unwrap();
+    let inner = get_field_def("_inner", &field.ty, "");
+    assert_points_only_at(
+        &super::branded_slot_json_schema(&super::ModelSchemaArgs::default(), &inner, "DocumentId"),
+        "(u32, u32)",
+        "a brand's inner",
     );
 }
 
@@ -5854,6 +5987,19 @@ fn located_source_texts(tokens: &proc_macro2::TokenStream) -> Vec<String> {
     texts
 }
 
+/// Asserts that every located token in `tokens` points at `expected` and that at least one does —
+/// what a diagnostic spanned on one written value looks like, and what one falling back to the
+/// attribute does not.
+#[cfg(feature = "jsonschema")]
+fn assert_points_only_at(tokens: &proc_macro2::TokenStream, expected: &str, context: &str) {
+    let located = located_source_texts(tokens);
+    assert!(!located.is_empty(), "for {context}, nothing located");
+    assert!(
+        located.iter().all(|text| text == expected),
+        "for {context}, got: {located:?}"
+    );
+}
+
 /// Without a span carried over from the user's source there is no source text to report, which is
 /// what the assertion below would silently degrade into.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
@@ -6185,7 +6331,7 @@ fn an_unsupported_enum_keyed_map_value_emits_only_the_compile_error() {
     ] {
         let tokens = map_field_schema(map_type).to_string();
         assert!(
-            tokens.starts_with("compile_error !"),
+            tokens.starts_with(":: core :: compile_error !"),
             "for {map_type}, got: {tokens}"
         );
         assert!(
@@ -6719,7 +6865,10 @@ fn a_map_key_known_to_lack_enum_members_names_the_requirement() {
         !tokens.contains("KeyAlias :: enum_members"),
         "got: {tokens}"
     );
-    assert!(tokens.starts_with("compile_error !"), "got: {tokens}");
+    assert!(
+        tokens.starts_with(":: core :: compile_error !"),
+        "got: {tokens}"
+    );
     assert!(
         tokens.contains("a map key must be a plain"),
         "got: {tokens}"
@@ -6805,12 +6954,35 @@ fn an_opaque_string_keyed_map_value_stays_permissive() {
 #[test]
 fn an_unsupported_string_keyed_map_value_emits_only_the_compile_error() {
     let tokens = map_field_schema("HashMap<String, (String, u32)>").to_string();
-    assert!(tokens.starts_with("compile_error !"), "got: {tokens}");
+    assert!(
+        tokens.starts_with(":: core :: compile_error !"),
+        "got: {tokens}"
+    );
     assert!(!tokens.contains("properties . insert"), "got: {tokens}");
     assert!(
         tokens.contains("model_schema: field `m`: a tuple is not supported as a map value"),
         "got: {tokens}"
     );
+}
+
+/// The caret has to land on the tokens the author edits. A field's refused map value is written
+/// inside the field's type, and a diagnostic carrying no location of its own falls back to the
+/// attribute — a line no edit to it can fix.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_refused_map_value_points_at_the_written_value() {
+    let tokens = sole_field_json_schema("pub struct Rows { pub m: HashMap<String, (u32, u32)> }");
+    assert_points_only_at(&tokens, "(u32, u32)", "a map value");
+}
+
+/// [`a_refused_map_value_points_at_the_written_value`] for a map reached through a tuple element,
+/// where the offending value sits two levels inside the written field type.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_refused_tuple_element_map_value_points_at_the_written_value() {
+    let tokens =
+        sole_field_json_schema("pub struct Rows { pub t: (String, HashMap<String, (u32, u32)>) }");
+    assert_points_only_at(&tokens, "(u32, u32)", "a tuple element map value");
 }
 
 /// The value types the branch already rendered keep the tokens they have always produced: the
@@ -7119,7 +7291,7 @@ fn a_nested_map_key_known_to_lack_enum_members_names_the_requirement() {
             "for {map_type}, got: {tokens}"
         );
         assert!(
-            tokens.starts_with("compile_error !"),
+            tokens.starts_with(":: core :: compile_error !"),
             "for {map_type}, got: {tokens}"
         );
         assert!(
@@ -7145,7 +7317,10 @@ fn a_tuple_element_map_key_known_to_lack_enum_members_names_the_requirement() {
         AliasKind::NoEnumMembers,
     );
     let tokens = tuple_field_schema("(String, HashMap<KeyAlias, String>)");
-    assert!(tokens.starts_with("compile_error !"), "got: {tokens}");
+    assert!(
+        tokens.starts_with(":: core :: compile_error !"),
+        "got: {tokens}"
+    );
     assert!(
         tokens.contains("a map key must be a plain"),
         "got: {tokens}"
@@ -7207,7 +7382,7 @@ fn an_unsupported_nested_map_value_emits_only_the_compile_error() {
     ] {
         let tokens = map_field_schema(map_type).to_string();
         assert!(
-            tokens.starts_with("compile_error !"),
+            tokens.starts_with(":: core :: compile_error !"),
             "for {map_type}, got: {tokens}"
         );
         assert!(
@@ -7318,10 +7493,54 @@ fn a_reference_site_argument_the_dispatch_cannot_render_is_refused() {
         "",
     );
     let rendered = super::argument_json_schema_value("IdType", &argument).to_string();
-    assert!(rendered.starts_with("compile_error !"), "got: {rendered}");
+    assert!(
+        rendered.starts_with(":: core :: compile_error !"),
+        "got: {rendered}"
+    );
     assert!(
         rendered.contains("model_schema: `IdType`: a tuple is not supported as a map value"),
         "got: {rendered}"
+    );
+}
+
+/// The arguments a reference site writes, read off the sole field of `source` so each one carries
+/// the span of the tokens it was written with.
+#[cfg(feature = "jsonschema")]
+fn sole_field_arguments(source: &str) -> Vec<super::FieldDef> {
+    let item: syn::ItemStruct = syn::parse_str(source).unwrap();
+    let field = item.fields.iter().next().unwrap();
+    let FieldDefType::SiblingType(_, arguments) = get_field_def("", &field.ty, "").field_type
+    else {
+        return Vec::new();
+    };
+    arguments
+}
+
+/// [`a_reference_site_argument_the_dispatch_cannot_render_is_refused`]'s caret, which belongs on
+/// the argument inside the reference rather than on the whole field or the attribute.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_refused_reference_site_argument_points_at_the_written_argument() {
+    let arguments =
+        sole_field_arguments("pub struct Holder { pub boxed: Boxed<HashMap<String, (u32, u32)>> }");
+    assert_points_only_at(
+        &super::argument_json_schema_value("Boxed", &arguments[0]),
+        "(u32, u32)",
+        "a reference-site argument",
+    );
+}
+
+/// The same argument sink reached through a declared filling, where the offending tokens sit inside
+/// the attribute: the caret narrows to the filling rather than underlining the whole attribute.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_refused_declared_filling_points_at_the_written_filling() {
+    let parameter: syn::Ident = syn::parse_str("IdType").unwrap();
+    let filling: syn::Type = syn::parse_str("HashMap<String, (u32, u32)>").unwrap();
+    assert_points_only_at(
+        &super::declared_filling_json_schema_value("IdType", &[(parameter, filling)]),
+        "(u32, u32)",
+        "a declared filling",
     );
 }
 
@@ -7723,7 +7942,7 @@ fn a_tuple_element_holding_an_unrenderable_map_emits_only_the_compile_error() {
     ] {
         let tokens = tuple_field_schema(field_type);
         assert!(
-            tokens.starts_with("compile_error !"),
+            tokens.starts_with(":: core :: compile_error !"),
             "for {field_type}, got: {tokens}"
         );
         assert!(
@@ -8556,13 +8775,36 @@ fn a_tuple_struct_slot_the_dispatch_cannot_render_is_refused() {
         whole_tuple(&["String", "HashMap<String, (u32, u32)>"]),
     ] {
         let rendered = tuple_struct_json_body("Pair", &shape).to_string();
-        assert!(rendered.starts_with("compile_error !"), "Got: {rendered}");
+        assert!(
+            rendered.starts_with(":: core :: compile_error !"),
+            "Got: {rendered}"
+        );
         assert!(
             rendered.contains("model_schema: `Pair`: a tuple is not supported as a map value"),
             "Got: {rendered}"
         );
         assert!(!rendered.contains("prefixItems"), "Got: {rendered}");
     }
+}
+
+/// The caret lands on the slot that offends, not on the first one the body walks: the sink holds
+/// the whole slot list and can only know which one was refused from the rejection itself.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_refused_tuple_struct_slot_points_at_that_slot_alone() {
+    let item: syn::ItemStruct =
+        syn::parse_str("pub struct Pair(pub String, pub HashMap<String, (u32, u32)>);").unwrap();
+    let slots: Vec<super::FieldDef> = item
+        .fields
+        .iter()
+        .map(|field| get_field_def("", &field.ty, ""))
+        .collect();
+    let shape = tuple_struct_shape(slots.len(), slots);
+    assert_points_only_at(
+        &tuple_struct_json_body("Pair", &shape),
+        "(u32, u32)",
+        "a tuple struct's second slot",
+    );
 }
 
 /// The bare value is the *declared* arity's, not the described list's. Captured from serde: a


### PR DESCRIPTION
Six member-rejection sinks built their `compile_error!` through bare `quote!`,
which stamps call-site spans — the whole `#[model_schema(...)]` attribute, with
rustc's "originates in the attribute macro" note under each one. The map value,
the tuple-struct slot, the declared filling, both external content shapes, the
untagged member and the brand inner all blamed the attribute instead of the
member that earned the refusal.

Spanning at the sink cannot work for three of them: their callers hold a slice
and no longer know which element was refused, so the caret would land on the
first element whatever the offender was. The span rides in the rejection value
itself instead — every construction site still holds the offending value at the
moment it refuses it — and each sink reads it back:

    before    --> src/main.rs:29:1   #[model_schema()]
              = note: this error originates in the attribute macro
    after     --> src/main.rs:33:34  Rows { rows: HashMap<String, (u32, u32)> }
                                                               ^^^^^^^^^^

Every message is byte-identical; only the location moves, including onto the
second slot of a tuple struct and inside the attribute for a declared filling.
The caret tests pin the location through the located-token probe, and they are
red before the fix by construction: an unspanned stream locates no tokens at
all. No location-free sink remains in the file.

just check, just quick, just lint-all across all 68 toggles, and the test
powerset across all 68 in four partitions — all green.

