### PR TITLE
refuse a brand's unrenderable slot and a filling's unwritable map key as guards, before anything else expands

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -387,8 +387,11 @@ enum MapMemberRejection {
 
 #[cfg(feature = "jsonschema")]
 impl MapMemberRejection {
-    /// The written tokens the diagnostic points at. A key under a sequence wrapper points at the
-    /// element rather than the wrapper, `get_field_def` having collapsed the wrapper onto it.
+    /// The written tokens the diagnostic points at, behind the guards rather than in front of
+    /// them: every authoring position a map key is written in is refused upstream by a guard of its
+    /// own, spanned on the type as written. A key under a sequence wrapper still carries the
+    /// element's span here, `get_field_def` having collapsed the wrapper onto it, and no reachable
+    /// position draws that caret.
     const fn span(&self) -> proc_macro2::Span {
         match *self {
             Self::Key(_, span) | Self::Tuple(span) => span,
@@ -2097,6 +2100,8 @@ fn default_types_guard_errors(
     rejections.extend(fillings_no_document_can_be_built_from(args));
     #[cfg(feature = "jsonschema")]
     rejections.extend(fillings_reaching_an_undescribable_std_type(args));
+    #[cfg(feature = "jsonschema")]
+    rejections.extend(fillings_reaching_an_unwritable_map_key(args));
 
     rejections
         .iter()
@@ -2204,6 +2209,23 @@ fn fillings_reaching_an_undescribable_std_type(args: &ModelSchemaArgs) -> Vec<sy
             let rejection = undescribable_std_rejection(&written)?;
             let message =
                 undescribable_std_message(&format!("`default_types` entry `{name}`"), &rejection);
+            Some(syn::Error::new_spanned(filling, message))
+        })
+        .collect()
+}
+
+/// The refusal every `default_types` entry earns whose filling reaches a map key no surface can
+/// write, at any depth, spanned on the filling as written. Gated with the JSON surface because it
+/// is the only one that reads a declared filling at all.
+#[cfg(feature = "jsonschema")]
+fn fillings_reaching_an_unwritable_map_key(args: &ModelSchemaArgs) -> Vec<syn::Error> {
+    args.default_types
+        .iter()
+        .filter_map(|(name, filling)| {
+            let written = get_field_def("_filling", filling, "");
+            let rejection = map_key_rejection(&written)?;
+            let message =
+                map_key_rejection_message(&format!("`default_types` entry `{name}`"), &rejection);
             Some(syn::Error::new_spanned(filling, message))
         })
         .collect()
@@ -3226,11 +3248,50 @@ fn branded_map_key_error(name: &Ident, inner_field: &Field) -> Option<proc_macro
     Some(syn::Error::new_spanned(&inner_field.ty, message).to_compile_error())
 }
 
+/// The `compile_error!` tokens for a branded newtype whose inner the JSON slot dispatch cannot
+/// render, or `None` when it renders. Gated on `jsonschema` because that is the only surface the
+/// rejection stands on: a tuple map value renders as a Zod tuple and a TypeScript tuple, and an
+/// ungated guard would newly refuse brands every jsonschema-off build accepts today.
+#[cfg(feature = "jsonschema")]
+fn branded_slot_value_error(
+    generics: &syn::Generics,
+    name: &Ident,
+    inner_field: &Field,
+) -> Option<proc_macro2::TokenStream> {
+    let inner = branded_inner_value_surface(generics, inner_field);
+    let BrandedJsonInner::Slot(slot) = branded_json_inner(&inner) else {
+        return None;
+    };
+    let rejection = build_tuple_element_json_schema(&slot).err()?;
+    // Every key reason this walk can reach is already worded by `branded_map_key_error`, at every
+    // depth, so reporting one here would refuse the same inner twice.
+    if matches!(rejection, MapMemberRejection::Key(..)) {
+        return None;
+    }
+    let message = prefixed_guard_message(&map_member_rejection_message(
+        &format!("type `{name}`"),
+        &rejection,
+    ));
+    Some(syn::Error::new(rejection.span(), message).to_compile_error())
+}
+
+#[cfg(all(
+    not(feature = "jsonschema"),
+    any(feature = "typescript", feature = "zod")
+))]
+const fn branded_slot_value_error(
+    _generics: &syn::Generics,
+    _name: &Ident,
+    _inner_field: &Field,
+) -> Option<proc_macro2::TokenStream> {
+    None
+}
+
 /// The `compile_error!` tokens for every guard a branded newtype violates: a `cfg_attr`-wrapped
 /// serde attribute on the type or on its inner slot, an `Option` inner type, string constraints
 /// over an inner type that cannot carry them, a `pattern` that is not a regex, a std type the inner
-/// reaches that serde has no wire form for, and a map key the inner reaches that no surface can
-/// write.
+/// reaches that serde has no wire form for, a map key the inner reaches that no surface can write,
+/// and an inner the JSON slot dispatch cannot render.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn branded_guard_errors(
     item_struct: &syn::ItemStruct,
@@ -3252,6 +3313,11 @@ fn branded_guard_errors(
             inner_field,
         ))
         .chain(branded_map_key_error(&item_struct.ident, inner_field))
+        .chain(branded_slot_value_error(
+            &item_struct.generics,
+            &item_struct.ident,
+            inner_field,
+        ))
         .collect()
 }
 

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -4021,6 +4021,71 @@ fn a_brand_over_a_writable_map_key_clears_the_guard() {
     }
 }
 
+/// A brand whose inner the slot dispatch cannot render is refused here rather than inside the
+/// `json_schema()` body, so the expansion stops instead of carrying on to emit a `Display` impl
+/// whose `where` clause reports a second, unasked-for error beside the refusal.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_brand_over_a_map_with_a_tuple_value_is_refused() {
+    for inner in [
+        quote::quote! { HashMap<String, (u32, u32)> },
+        quote::quote! { Vec<HashMap<String, (u32, u32)>> },
+        quote::quote! { (String, HashMap<String, (u32, u32)>) },
+    ] {
+        let errors = branded_errors(&syn::parse_quote! {
+            #[serde(transparent)]
+            struct Wrap(pub #inner);
+        });
+        assert_eq!(errors.len(), 1, "for {inner}, got: {errors:?}");
+        for needle in [
+            "compile_error",
+            "model_schema: type `Wrap`",
+            "a tuple is not supported as a map value",
+        ] {
+            assert!(
+                errors[0].contains(needle),
+                "{needle} missing for {inner}: {}",
+                errors[0]
+            );
+        }
+    }
+}
+
+/// The refusal points at the tuple that earned it, not at the map or the whole inner.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_brand_slot_value_refusal_is_spanned_on_the_tuple() {
+    let item: syn::ItemStruct =
+        syn::parse_str("#[serde(transparent)] struct Wrap(pub HashMap<String, (u32, u32)>);")
+            .unwrap();
+    let refusals = branded_guard_errors(&item, &super::ModelSchemaArgs::default());
+    assert_eq!(refusals.len(), 1, "got: {}", refusals.len());
+    assert_eq!(
+        refusals[0].span().source_text().as_deref(),
+        Some("(u32, u32)")
+    );
+}
+
+/// The guard is a filter here too: a tuple written in its own right is a fixed-arity array every
+/// surface describes, and only a tuple reached through a slot is not.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_brand_over_a_renderable_slot_clears_the_guard() {
+    for inner in [
+        quote::quote! { (String, u32) },
+        quote::quote! { HashMap<String, u32> },
+        quote::quote! { Vec<Vec<i32>> },
+        quote::quote! { Vec<Option<String>> },
+        quote::quote! { [u8; 4] },
+    ] {
+        let errors = branded_errors(&syn::parse_quote! {
+            #[serde(transparent)]
+            struct Wrap(pub #inner);
+        });
+        assert!(errors.is_empty(), "for {inner}, got: {errors:?}");
+    }
+}
+
 /// Every constraint the guard reacts to, applied one at a time: `has_string_constraints` is an
 /// or over three independent fields, so a guard wired to only one of them would still pass a
 /// pattern-only probe.
@@ -5282,6 +5347,102 @@ fn an_undescribable_std_filling_refusal_is_spanned_on_the_filling() {
         refusals[0].span().source_text().as_deref(),
         Some("OsString")
     );
+}
+
+/// A declared filling is the one map-key position no guard of its own covered, so a key no surface
+/// can write reached the rendering sink and drew its caret on whatever `get_field_def` had
+/// collapsed the key onto. Refused at the entry, at whatever depth it was written.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_filling_reaching_an_unwritable_map_key_is_refused_at_the_entry() {
+    for (written, reason) in [
+        ("HashMap<Vec<String>, u32>", "is a sequence of `String`"),
+        ("HashMap<Option<String>, u32>", "an `Option<String>`"),
+        ("HashMap<[String; 2], u32>", "is a sequence of `String`"),
+        (
+            "HashMap<String, HashMap<Vec<String>, u32>>",
+            "is a sequence of `String`",
+        ),
+        (
+            "Holder<HashMap<Vec<String>, u32>>",
+            "is a sequence of `String`",
+        ),
+        ("HashMap<(u8, u8), u32>", "serde writes `(_, _)`"),
+    ] {
+        let messages = default_types_messages(
+            "pub struct Probe<ValueType> { pub held: ValueType }",
+            &format!("default_types(ValueType = {written})"),
+        );
+        assert_eq!(messages.len(), 1, "for {written}: {messages:?}");
+        for needle in [
+            "compile_error",
+            "`default_types` entry `ValueType`",
+            "a map key must be",
+            reason,
+            "type `Probe`",
+        ] {
+            assert!(
+                messages[0].contains(needle),
+                "{needle} missing for {written}: {}",
+                messages[0]
+            );
+        }
+    }
+}
+
+/// The refusal points at the filling as written, the tokens the author can change — never at the
+/// element a sequence wrapper was collapsed onto, which is what the rendering sink underlined. Every
+/// collapsing spelling moves the same way, and the span is the one the entry's other filling guard
+/// already draws in this position.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn an_unwritable_map_key_filling_refusal_is_spanned_on_the_filling() {
+    for written in [
+        "HashMap<Vec<String>, u32>",
+        "HashMap<Vec<Vec<String>>, u32>",
+        "HashMap<Option<String>, u32>",
+        "HashMap<[String; 2], u32>",
+    ] {
+        let refusals = default_types_refusals(
+            "pub struct Probe<IdType, HeldType> { pub id: IdType, pub held: HeldType }",
+            &format!("default_types(IdType = String, HeldType = {written})"),
+        );
+        assert_eq!(refusals.len(), 1, "for {written}: {refusals:?}");
+        assert_eq!(
+            refusals[0].span().source_text().as_deref(),
+            Some(written),
+            "for {written}"
+        );
+    }
+
+    let undescribable = default_types_refusals(
+        "pub struct Probe<IdType, HeldType> { pub id: IdType, pub held: HeldType }",
+        "default_types(IdType = String, HeldType = HashMap<String, OsString>)",
+    );
+    assert_eq!(
+        undescribable[0].span().source_text().as_deref(),
+        Some("HashMap<String, OsString>")
+    );
+}
+
+/// The guard is a filter: a filling whose map key can be written, and one that is no map at all,
+/// earn nothing.
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_filling_with_a_writable_map_key_clears_the_guard() {
+    register_alias_info("Slot", "Slot", "slot_schema", AliasKind::EnumMembers);
+    for written in [
+        "HashMap<String, u32>",
+        "HashMap<Slot, u32>",
+        "Vec<HashMap<String, u32>>",
+        "String",
+    ] {
+        let messages = default_types_messages(
+            "pub struct Probe<ValueType> { pub held: ValueType }",
+            &format!("default_types(ValueType = {written})"),
+        );
+        assert!(messages.is_empty(), "for {written}: {messages:?}");
+    }
 }
 
 /// The refusal points at the filling as written — the token the author can change — rather than at

--- a/tests/branded_newtype_tests/tests.rs
+++ b/tests/branded_newtype_tests/tests.rs
@@ -703,6 +703,29 @@ mod branded_in_struct_no_jsonschema_tests {
     }
 }
 
+/// A tuple in a map slot is unrenderable on the JSON surface alone, which is why the guard refusing
+/// it is gated with that surface — with `jsonschema` off the same brand still writes its record.
+#[cfg(all(not(feature = "jsonschema"), feature = "zod"))]
+mod branded_tuple_map_value_no_jsonschema_tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[model_schema(no_display)]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct SpanMap(pub HashMap<String, (u32, u32)>);
+
+    #[test]
+    fn a_tuple_map_value_still_renders_without_the_json_surface() {
+        let zod = SpanMap::zod_schema();
+        assert!(
+            zod.contains("z.record(z.string(), z.tuple([z.number().int(), z.number().int()]))"),
+            "Got:\n{zod}"
+        );
+        assert!(zod.contains(&brand_marker("SpanMap")), "Got:\n{zod}");
+    }
+}
+
 #[cfg(all(
     feature = "jsonschema",
     not(feature = "zod"),

--- a/tests/generic_types_tests/tests.rs
+++ b/tests/generic_types_tests/tests.rs
@@ -1604,6 +1604,15 @@ pub struct Undefaulted<IdType> {
     pub id: IdType,
 }
 
+/// A filling holding a map serde cannot key. Only the JSON surface reads a declared filling deeply
+/// enough to refuse one, so with `jsonschema` off the entry is declared and rendered as any other.
+#[cfg(all(not(feature = "jsonschema"), feature = "zod"))]
+#[model_schema(default_types(HeldType = HashMap<Vec<String>, u32>))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SequenceKeyedHolder<HeldType> {
+    pub held: HeldType,
+}
+
 /// The item the reference-site fixtures below point at. A generic type publishes a factory rather
 /// than a schema, so a field naming it has nothing to name — it has to call that factory with what
 /// fills each parameter.
@@ -1910,6 +1919,16 @@ pub struct FlatDefaulted<HeldType> {
     #[serde(flatten)]
     pub held: HeldType,
     pub tag: String,
+}
+
+#[cfg(all(not(feature = "jsonschema"), feature = "zod"))]
+#[test]
+fn a_sequence_keyed_map_filling_still_renders_its_default() {
+    let zod = SequenceKeyedHolder::<HashMap<Vec<String>, u32>>::zod_schema();
+    assert!(
+        zod.contains("SequenceKeyedHolder$SchemaDefault"),
+        "Got:\n{zod}"
+    );
 }
 
 #[cfg(not(feature = "jsonschema"))]


### PR DESCRIPTION
Two positions produced a refusal without stopping the expansion around it.

A brand over a map with a tuple value had its rejection written inline into the
`json_schema()` body, so the `Display` impl kept expanding and its `where`
clause raised a second error naming a trait the author never asked for. The
rejection is now a guard chained beside the brand's map-key guard, so the item
refuses early and the one error is the whole answer. A `Key` rejection is
declined there — the map-key guard already words every key refusal at every
depth, and taking it too would report the same defect twice. A bare tuple slot
still renders; only the map-value position refuses.

A `default_types` filling was the one authoring position with no map-key guard
of its own, so an unwritable key reached the JSON argument renderer and was
spanned on the collapsed element — the inner `String` of a `Vec<String>` key —
rather than on anything the author could act on. A guard mirroring the
undescribable-std filling guard now refuses at the entry, spanned on the
filling's head, for exactly the four spellings the collapse erases. The
tuple-map-value refusal in that same position keeps its precise caret.

Both guards are jsonschema-gated, and the gating is asserted rather than
assumed: fixtures under zod-without-jsonschema pin that the same declarations
still render there.

just check, just quick, just lint-all across all 68 toggles, and the test
powerset across all 68 in four partitions — all green.

