### PR TITLE
take the macro's whole body off proc_macro, so the fallthrough refusal is finally testable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -616,7 +616,7 @@ export const Document$Schema: ZodType<Document> = Document$RawSchema;
 ///
 #[proc_macro_attribute]
 pub fn model_schema(args: TokenStream, input: TokenStream) -> TokenStream {
-    exec_model_schema(args, input)
+    exec_model_schema(args.into(), input.into()).into()
 }
 
 /// # `model_schema_prop`

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -3,11 +3,11 @@ extern crate alloc;
 use alloc::borrow::ToOwned;
 use core::fmt::Write as _;
 
-use proc_macro::TokenStream;
+use proc_macro2::TokenStream;
 use quote::quote;
 use syn::parse::{Parse, ParseStream, Parser as _};
 use syn::punctuated::Punctuated;
-use syn::{Field, Item, ItemType, Meta, Token, parse_macro_input};
+use syn::{Field, Item, ItemType, Meta, Token};
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 use quote::quote_spanned;
@@ -1020,8 +1020,13 @@ fn record_pattern(result: &mut ModelSchemaArgs, lit_str: &syn::LitStr) {
 }
 
 pub fn exec_model_schema(args: TokenStream, input: TokenStream) -> TokenStream {
-    let parsed_args = parse_model_schema_args(args.into());
-    let item = parse_macro_input!(input as Item);
+    let parsed_args = parse_model_schema_args(args);
+    // Written out rather than `parse_macro_input!`, which returns from the enclosing function and
+    // so forces its return type to be `proc_macro::TokenStream`. This is the match it expands to.
+    let item = match syn::parse2::<Item>(input) {
+        Ok(item) => item,
+        Err(rejection) => return rejection.to_compile_error(),
+    };
     // An argument the parser refused describes a surface no expansion below can honour, so the
     // item is refused before it is dispatched to its shape.
     if let Some(rejection) = parsed_args.arg_rejection.as_ref()
@@ -1098,7 +1103,6 @@ pub fn exec_model_schema(args: TokenStream, input: TokenStream) -> TokenStream {
             prefixed_guard_message("unsupported target for this attribute"),
         )
         .to_compile_error()
-        .into()
     };
     let answered = with_prefixed_tokens(expanded, &deferred_shape_refusals(registering.as_ref()));
     with_prefixed_tokens(answered, &filling_bound_checks)
@@ -1210,7 +1214,7 @@ fn process_type_alias(item_type: ItemType, args: &ModelSchemaArgs) -> TokenStrea
         &args.default_types,
     );
 
-    let output = quote! {
+    quote! {
         #alias
 
         pub mod #module_ident {
@@ -1225,9 +1229,7 @@ fn process_type_alias(item_type: ItemType, args: &ModelSchemaArgs) -> TokenStrea
                 #zod_method
             }
         }
-    };
-
-    TokenStream::from(output)
+    }
 }
 
 #[cfg(not(any(feature = "typescript", feature = "zod", feature = "jsonschema")))]
@@ -1236,7 +1238,7 @@ fn process_type_alias(item_type: ItemType, _args: &ModelSchemaArgs) -> TokenStre
     alias
         .attrs
         .retain(|attr| !attr.path().is_ident("model_schema"));
-    TokenStream::from(quote! { #alias })
+    quote! { #alias }
 }
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
@@ -1465,7 +1467,7 @@ where
 
     log::trace!("{output}");
 
-    TokenStream::from(output)
+    output
 }
 
 /// The type-level `validate()` a struct publishes: the aggregate of its per-field validators, or
@@ -1876,7 +1878,7 @@ where
         #absorbing_module
     };
     log::trace!("{output}");
-    Some(TokenStream::from(output))
+    Some(output)
 }
 
 /// Turns a `cfg_attr` rejection into `compile_error!` tokens naming the item it was found on,
@@ -2451,12 +2453,10 @@ fn with_prefixed_tokens(expanded: TokenStream, prefix: &[proc_macro2::TokenStrea
     if prefix.is_empty() {
         return expanded;
     }
-    let item_and_surface: proc_macro2::TokenStream = expanded.into();
     quote! {
         #(#prefix)*
-        #item_and_surface
+        #expanded
     }
-    .into()
 }
 
 /// The `compile_error!` tokens an item earns for carrying a ` ```rust example ` block while
@@ -3800,7 +3800,7 @@ fn process_struct(mut item_struct: syn::ItemStruct, args: &ModelSchemaArgs) -> T
             #item_struct
         };
         log::trace!("{output}");
-        TokenStream::from(output)
+        output
     }
 }
 
@@ -5094,7 +5094,7 @@ fn assemble_branded_output(parts: &BrandedNewtypeOutput) -> TokenStream {
 
     log::trace!("{output}");
 
-    TokenStream::from(output)
+    output
 }
 
 /// The output a branded newtype its guards refused is replaced by, or `None` when it earns none.
@@ -5751,7 +5751,7 @@ fn process_plain_enum(
 
     log::trace!("{output}");
 
-    TokenStream::from(output)
+    output
 }
 
 /// The kind a variant publishes, which is not always the kind it declares.
@@ -6233,7 +6233,7 @@ fn process_discriminated_enum(
             #item_enum
         };
         log::trace!("{output}");
-        TokenStream::from(output)
+        output
     }
 }
 
@@ -6754,7 +6754,7 @@ fn process_externally_tagged_enum(
             #item_enum
         };
         log::trace!("{output}");
-        TokenStream::from(output)
+        output
     }
 }
 
@@ -7154,7 +7154,7 @@ fn process_internally_tagged_enum(
             #item_enum
         };
         log::trace!("{output}");
-        TokenStream::from(output)
+        output
     }
 }
 
@@ -8170,7 +8170,7 @@ fn process_untagged_enum(
             #item_enum
         };
         log::trace!("{output}");
-        TokenStream::from(output)
+        output
     }
 }
 

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -6132,7 +6132,6 @@ fn display_assertion(source: &str) -> proc_macro2::TokenStream {
 
 /// Collects the source text each token in `tokens` points at, skipping the macro-synthesized
 /// tokens that carry no location.
-#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn located_source_texts(tokens: &proc_macro2::TokenStream) -> Vec<String> {
     let mut texts = Vec::new();
     for tree in tokens.clone() {
@@ -10826,4 +10825,60 @@ fn a_flattened_untagged_variant_field_over_a_single_key_set_source_is_not_refuse
         })
         .is_empty()
     );
+}
+
+/// Runs the whole attribute expansion over `source`, the way the `#[proc_macro_attribute]` does
+/// either side of its `proc_macro` conversion.
+fn expansion_over(source: &str) -> proc_macro2::TokenStream {
+    super::exec_model_schema(
+        proc_macro2::TokenStream::new(),
+        syn::parse_str(source).unwrap(),
+    )
+}
+
+/// The seam's fallthrough, the one sink no item that compiles can reach: an item whose shape the
+/// macro has no expansion for earns the refusal, spanned on the item so the caret lands on the
+/// declaration rather than on the attribute.
+#[test]
+fn an_item_with_no_shape_is_refused_on_the_item() {
+    for (source, first_token) in [
+        ("pub fn unsupported_shape() {}", "pub"),
+        ("impl Unsupported {}", "impl"),
+        ("pub trait Unsupported {}", "pub"),
+        ("pub mod unsupported {}", "pub"),
+        ("pub const UNSUPPORTED: u8 = 0;", "pub"),
+        ("pub static UNSUPPORTED: u8 = 0;", "pub"),
+        ("pub union Unsupported { pub a: u8 }", "pub"),
+    ] {
+        let tokens = expansion_over(source);
+        assert!(
+            tokens
+                .to_string()
+                .contains("model_schema: unsupported target for this attribute"),
+            "for {source}, got: {tokens}"
+        );
+        let located = located_source_texts(&tokens);
+        assert_eq!(
+            located.first().map(String::as_str),
+            Some(first_token),
+            "for {source}, got: {located:?}"
+        );
+    }
+}
+
+/// The arm answers for what is left over, not for everything: the three shapes the macro does
+/// expand pass the dispatch without earning it.
+#[test]
+fn the_shapes_the_macro_expands_are_not_refused() {
+    for source in [
+        "pub struct DispatchedShape { pub name: String }",
+        "pub enum DispatchedChoice { One, Two }",
+        "pub type DispatchedAlias = String;",
+    ] {
+        let tokens = expansion_over(source);
+        assert!(
+            !tokens.to_string().contains("unsupported target"),
+            "for {source}, got: {tokens}"
+        );
+    }
 }


### PR DESCRIPTION
The unsupported-shape fallthrough — the diagnostic an `fn`, `impl`, `trait` or
any other non-expandable item earns — was pinned by no test and could not be:
`exec_model_schema` took `proc_macro::TokenStream`, which is unconstructible
outside an expansion, and the item that triggers the arm does not compile, so
no integration fixture can hold one.

The entry type was incidental, not structural. It came from one `use` and one
`parse_macro_input!`, whose macro is what forced the return type. Both are
swapped for `proc_macro2` and `syn::parse2`, the exported macro in lib.rs now
holding the crate's only compiler tokens as two `.into()` conversions at the
boundary. Clippy then names every conversion made redundant by the swap, and
all of them are deleted rather than kept as noise.

The payoff is the test the arm never had: the expansion called directly over
seven refused shapes, asserting the diagnostic's text and that its span carries
a real source location — the located-token probe's first entry is the item's
own first written token, not a call-site fallback — beside the three shapes
the macro does expand, pinned as not earning the refusal, which is what makes
the arm a fallthrough rather than an unconditional answer.

No dependency added, no emitted output changed, no signature outside the two
files moved. The one thing this cannot pin is rustc's rendered caret, which
only a compile-fail harness sees; that is a stated limit, not a gap this
pretends to close.

just check, just quick, just lint-all across all 68 toggles, and the test
powerset across all 68 in four partitions — all green.

