### PR TITLE
refuse a pattern that is one look-around and nothing else, the shape no surface can emit warning-free

### DIFF
--- a/README.md
+++ b/README.md
@@ -1462,10 +1462,15 @@ The verdict is read off the parsed pattern rather than off its text, so the same
 | `a*`, `a?`, `a\|`, `^a*`, `a*$` | Refused -- the repeated part may run zero times, or the alternative may be skipped |
 | `^$` | Accepted -- both ends at one position, which only the empty string has |
 | `^a*$` | Accepted -- both ends pinned around a run of `a` |
-| `\b`, `\B` | Accepted -- the empty string holds no word boundary |
+| `\b`, `\B` | Constraining -- the empty string holds no word boundary -- and refused by the next rule |
+| `\b\w+`, `\Ba` | Accepted -- a boundary with something beside it |
 | `a+`, `^[a-z]+$` | Accepted -- a character has to be there |
 
-One case is left standing. `clippy::trivial_regex`, which a consumer denying `clippy::nursery` gets, also flags `\b` -- as "the regex is unlikely to be useful as it is", naming no replacement -- and reports it against the `#[model_schema]` attribute, where there is no edit available. `\b` keeps its regex anyway: it is a real constraint, and answering the lint would mean dropping a check the author asked for.
+#### A `pattern` cannot be one assertion and nothing else
+
+`\b` and `\B` are refused for a third reason, and it is not about what they accept. The generated Rust validator builds the pattern with `regex::Regex::new`, and `clippy::trivial_regex` -- which a consumer denying `clippy::nursery` gets -- calls a lone assertion "unlikely to be useful as it is" and reports it against the `#[model_schema]` attribute, where the author has no edit to make. For the shapes that lint does name a replacement for -- `^abc`, `abc$`, `^abc$`, `^$`, `abc` -- this crate emits the `str` call instead of a regex, so they compile clean; for a lone boundary it names none, so there is nothing to put in the regex's place.
+
+Write the boundary beside what has to sit next to it: `\b\w+` rather than `\b`, `\B\w` rather than `\B`. That keeps the regex, keeps the boundary check, and is no longer trivial to the lint. Only the lone assertion is refused -- `\ba`, `^\bfoo` and every other pattern with a boundary somewhere in it are untouched.
 
 ### Numeric Constraints (minimum, maximum)
 

--- a/src/features/model_schema_prop.rs
+++ b/src/features/model_schema_prop.rs
@@ -6,7 +6,7 @@
 use syn::meta::ParseNestedMeta;
 use syn::{Attribute, Lit, LitStr, Type};
 
-use crate::utils::{constraining_pattern, portable_pattern};
+use crate::utils::{constraining_pattern, emittable_pattern, portable_pattern};
 
 /// Every key the parser reads, in the order the unknown-key rejection names them. Add a new key to
 /// [`parse_prop_key`], add it here too, or `no_key_the_parser_reads_is_rejected` fails.
@@ -135,8 +135,9 @@ pub struct ModelSchemaPropMeta {
     /// earned a [`Self::pattern_rejection`].
     pub pattern: Option<String>, // e.g., "^[0-9a-fA-F]{24}$" from pattern = "^[0-9a-fA-F]{24}$"
     /// What keeps `pattern` off the surfaces it was written for -- a regex the `regex` crate
-    /// cannot parse, a construct a JavaScript regex literal cannot carry, or a shape that admits
-    /// every value and so says nothing on any of them -- spanned on the literal it was written as.
+    /// cannot parse, a construct a JavaScript regex literal cannot carry, a shape that admits
+    /// every value and so says nothing on any of them, or a lone look-around the emitted regex
+    /// cannot carry lint-free -- spanned on the literal it was written as.
     pub pattern_rejection: Option<syn::Error>,
     pub preprocess: Vec<String>, // e.g., ["epoch_to_date", "trim"] from preprocess = ["epoch_to_date", "trim"]
     pub ts_optional: bool,
@@ -177,7 +178,10 @@ fn parse_prop_key(nested: &ParseNestedMeta, meta: &mut ModelSchemaPropMeta) -> s
         let lit: LitStr = nested.value()?.parse()?;
         // A refused pattern is recorded as written: the guards that answer for what a `pattern`
         // may sit on read that one was given, not what it says.
-        match portable_pattern(&lit).and_then(|portable| constraining_pattern(&lit, portable)) {
+        match portable_pattern(&lit)
+            .and_then(|portable| constraining_pattern(&lit, portable))
+            .and_then(|constraining| emittable_pattern(&lit, constraining))
+        {
             Ok(pattern) => meta.pattern = Some(pattern),
             Err(rejection) => {
                 meta.pattern_rejection = Some(rejection);

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -52,8 +52,9 @@ use crate::features::object_id::OBJECT_ID_HEX_PATTERN;
 
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 use crate::utils::{
-    AliasKind, PublishedShape, ShapeQuestion, constraining_pattern, lookup_alias_info,
-    portable_pattern, record_shape_question, record_value_shape, shape_questions_for,
+    AliasKind, PublishedShape, ShapeQuestion, constraining_pattern, emittable_pattern,
+    lookup_alias_info, portable_pattern, record_shape_question, record_value_shape,
+    shape_questions_for,
 };
 
 #[cfg(feature = "serde")]
@@ -486,8 +487,9 @@ struct ModelSchemaArgs {
     /// earned a `pattern_rejection`.
     pattern: Option<String>,
     /// What keeps `pattern` off the surfaces it was written for: an unparseable regex, a construct
-    /// a JavaScript regex literal cannot carry, or a shape that admits every value — spanned on
-    /// the literal it was written as.
+    /// a JavaScript regex literal cannot carry, a shape that admits every value, or a lone
+    /// look-around the emitted regex cannot carry lint-free — spanned on the literal it was
+    /// written as.
     #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
     pattern_rejection: Option<syn::Error>,
 }
@@ -1003,7 +1005,10 @@ fn unknown_arg_rejection(meta: &Meta) -> syn::Error {
 /// what it says.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 fn record_pattern(result: &mut ModelSchemaArgs, lit_str: &syn::LitStr) {
-    match portable_pattern(lit_str).and_then(|portable| constraining_pattern(lit_str, portable)) {
+    match portable_pattern(lit_str)
+        .and_then(|portable| constraining_pattern(lit_str, portable))
+        .and_then(|constraining| emittable_pattern(lit_str, constraining))
+    {
         Ok(pattern) => result.pattern = Some(pattern),
         Err(rejection) => {
             result.pattern_rejection = Some(rejection);

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -2568,11 +2568,39 @@ fn a_field_pattern_admitting_every_value_names_the_field_and_says_so() {
     }
 }
 
+/// A lone word boundary says something about the value and still cannot be emitted: the regex the
+/// validator builds from it draws `clippy::trivial_regex` at this very attribute, where the author
+/// has no edit to make. The refusal names the field and the rewrite that keeps the check.
+#[test]
+fn a_field_pattern_that_is_one_assertion_and_nothing_else_names_the_field_and_says_so() {
+    for pattern in [r"\b", r"\B"] {
+        let errors = field_prop_guard_errors(&syn::parse_quote! {
+            struct Report {
+                #[model_schema_prop(pattern = #pattern)]
+                name: String,
+            }
+        });
+        assert_eq!(errors.len(), 1, "for {pattern:?}, got: {errors:?}");
+        for needle in [
+            "compile_error",
+            "field `name`",
+            "one look-around assertion and nothing else",
+            "clippy::trivial_regex",
+        ] {
+            assert!(
+                errors[0].contains(needle),
+                "{needle} missing for {pattern:?}: {}",
+                errors[0]
+            );
+        }
+    }
+}
+
 /// The shapes written out of the same pieces that still turn a value away clear the guard: `^$`
-/// asks for the empty string, `^a*$` for a run of `a`, and `\b` for a word boundary.
+/// asks for the empty string, `^a*$` for a run of `a`, and `\b\w+` for a word at a boundary.
 #[test]
 fn a_field_pattern_written_out_of_the_same_pieces_that_still_constrains_clears_the_guard() {
-    for pattern in ["^$", "^a*$", r"\b"] {
+    for pattern in ["^$", "^a*$", r"\b\w+"] {
         let errors = field_prop_guard_errors(&syn::parse_quote! {
             struct Report {
                 #[model_schema_prop(pattern = #pattern)]
@@ -3950,10 +3978,33 @@ fn a_brand_pattern_admitting_every_value_names_the_type_and_says_so() {
     }
 }
 
+/// The brand's `pattern` reaches the same `regex::Regex::new` a field's does, so the shape that
+/// cannot be emitted without a lint at the attribute is refused here too, naming the type.
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[test]
+fn a_brand_pattern_that_is_one_assertion_and_nothing_else_names_the_type_and_says_so() {
+    for pattern in [r"\b", r"\B"] {
+        let errors = brand_pattern_errors(pattern);
+        assert_eq!(errors.len(), 1, "for {pattern:?}, got: {errors:?}");
+        for needle in [
+            "compile_error",
+            "type `UserId`",
+            "one look-around assertion and nothing else",
+            "clippy::trivial_regex",
+        ] {
+            assert!(
+                errors[0].contains(needle),
+                "{needle} missing for {pattern:?}: {}",
+                errors[0]
+            );
+        }
+    }
+}
+
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
 fn a_brand_pattern_that_still_constrains_clears_the_guard() {
-    for pattern in ["^$", "^a*$", r"\b"] {
+    for pattern in ["^$", "^a*$", r"\b\w+"] {
         let errors = brand_pattern_errors(pattern);
         assert!(errors.is_empty(), "for {pattern:?}, got: {errors:?}");
     }
@@ -10384,18 +10435,19 @@ fn the_empty_string_pattern_keeps_the_call_it_was_already_emitted_as() {
     );
 }
 
-/// `\b` is trivial to `clippy::trivial_regex` and names no `str` call, so it keeps the regex — and
-/// the lint keeps firing on it in the consumer, which is the one case left standing here.
+/// A boundary with something beside it is the rewrite the lone-assertion refusal names. It is not
+/// trivial to `clippy::trivial_regex` and names no `str` call either, so it keeps the regex and
+/// compiles clean at the consumer.
 #[cfg(feature = "serde")]
 #[test]
 fn a_word_boundary_pattern_keeps_its_regex() {
     assert_eq!(
-        emitted_pattern_validator(r"\b"),
+        emitted_pattern_validator(r"\b[0-9A-Za-z_]+"),
         "pub fn validate_field_value (value : & str) -> Result < () , String > \
          { { use std :: sync :: LazyLock ; \
-         static RE : LazyLock < regex :: Regex > = LazyLock :: new (|| { regex :: Regex :: new (\"\\\\b\") . unwrap () }) ; \
+         static RE : LazyLock < regex :: Regex > = LazyLock :: new (|| { regex :: Regex :: new (\"\\\\b[0-9A-Za-z_]+\") . unwrap () }) ; \
          if ! RE . is_match (value) { \
-         return Err (format ! (\"'{}' does not match pattern '{}'\" , \"field\" , \"\\\\b\")) ; } } Ok (()) } "
+         return Err (format ! (\"'{}' does not match pattern '{}'\" , \"field\" , \"\\\\b[0-9A-Za-z_]+\")) ; } } Ok (()) } "
     );
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1281,6 +1281,39 @@ pub fn constraining_pattern(lit: &LitStr, pattern: String) -> Result<String, syn
     Ok(pattern)
 }
 
+/// The `pattern` handed back when the regex built from it draws no lint at the line that wrote it,
+/// or the refusal it earns for being one look-around and nothing else -- spanned on the literal the
+/// author wrote.
+pub fn emittable_pattern(lit: &LitStr, pattern: String) -> Result<String, syn::Error> {
+    if is_lone_look_around(&pattern) {
+        return Err(syn::Error::new_spanned(
+            lit,
+            "`pattern` is one look-around assertion and nothing else, which no surface can be \
+             handed without a warning at the line that wrote it: the generated validator builds \
+             the pattern with `regex::Regex::new`, and `clippy::trivial_regex` -- which a consumer \
+             denying `clippy::nursery` gets -- calls a lone assertion unlikely to be useful and \
+             reports it against the `model_schema` attribute, where there is no edit to make. The \
+             shapes that lint names a `str` call for are emitted as that call instead; for this \
+             one it names none, so there is nothing to put in the regex's place. Write the \
+             boundary beside what has to sit next to it -- `\\b\\w+` rather than `\\b`, `\\B\\w` \
+             rather than `\\B` -- which keeps the regex and stops it being trivial.",
+        ));
+    }
+    Ok(pattern)
+}
+
+/// Whether the whole pattern is a single look-around, read off the HIR the way the verdict above
+/// is. The text anchors reach this shape too and are refused before it for admitting every value,
+/// and every boundary flavour but `\b` and `\B` is unportable, so what is left here is those two.
+fn is_lone_look_around(pattern: &str) -> bool {
+    regex_syntax::ParserBuilder::new()
+        .unicode(true)
+        .utf8(true)
+        .build()
+        .parse(pattern)
+        .is_ok_and(|parsed| matches!(*parsed.kind(), hir::HirKind::Look(_)))
+}
+
 /// Whether a search for `pattern` succeeds in every haystack, read off the HIR rather than off the
 /// pattern text: `^` and `(^)` and `^|a` are one verdict written three ways, and `^$` is written
 /// out of the same two anchors as `^` and `$` yet admits only the empty string.

--- a/src/utils/tests.rs
+++ b/src/utils/tests.rs
@@ -321,9 +321,15 @@ const UNCONSTRAINING_PATTERNS: [&str; 12] = [
 
 /// Patterns that turn some value away, kept beside [`UNCONSTRAINING_PATTERNS`] as the near misses
 /// that decide where the line sits.
-const CONSTRAINING_PATTERNS: [&str; 8] = [
-    "^$", "^a*$", r"\b", r"\B", "a+", "(?:ab)+", "^[a-z]+$", r"^\s*$",
-];
+const CONSTRAINING_PATTERNS: [&str; 6] = ["^$", "^a*$", "a+", "(?:ab)+", "^[a-z]+$", r"^\s*$"];
+
+/// The look-arounds that survive the other two guards -- the text anchors admit every value and
+/// every other boundary flavour is unportable -- and so are the whole of what the third refuses.
+const LONE_ASSERTION_PATTERNS: [&str; 2] = [r"\b", r"\B"];
+
+/// The same boundaries with something beside them: what the refusal tells the author to write, and
+/// what the lint stops calling trivial.
+const BOUNDED_ASSERTION_PATTERNS: [&str; 4] = [r"\ba", r"\Ba", r"^\bfoo", r"\b[0-9A-Za-z_]+"];
 
 /// The negated classes the verdict was decided over: a single member, the ranges an author reaches
 /// for to bound one to ASCII, an escape, and the `\d` the guard writes out to `0-9` on its way in.
@@ -1185,12 +1191,13 @@ fn test_trivial_pattern_accepts_exactly_what_its_regex_accepts() {
     }
 }
 
-/// Runs both `pattern` guards the way the attribute parsers run them, and hands back the refusal
-/// as the author reads it.
-fn constraining(pattern: &str) -> Result<String, String> {
+/// Runs the three `pattern` guards the way the attribute parsers run them, and hands back the
+/// refusal as the author reads it.
+fn guarded(pattern: &str) -> Result<String, String> {
     let lit = LitStr::new(pattern, proc_macro2::Span::call_site());
     portable_pattern(&lit)
         .and_then(|portable| constraining_pattern(&lit, portable))
+        .and_then(|constraining| emittable_pattern(&lit, constraining))
         .map_err(|rejection| rejection.to_string())
 }
 
@@ -1209,7 +1216,10 @@ fn test_the_unconstraining_verdict_is_the_regex_crate_s_own() {
             );
         }
     }
-    for pattern in CONSTRAINING_PATTERNS {
+    for pattern in CONSTRAINING_PATTERNS
+        .into_iter()
+        .chain(LONE_ASSERTION_PATTERNS)
+    {
         let regex = regex::Regex::new(pattern).unwrap();
         assert!(
             haystacks.iter().any(|haystack| !regex.is_match(haystack)),
@@ -1223,7 +1233,7 @@ fn test_the_unconstraining_verdict_is_the_regex_crate_s_own() {
 #[test]
 fn test_a_pattern_admitting_every_value_is_refused() {
     for pattern in UNCONSTRAINING_PATTERNS {
-        let rejection = constraining(pattern).unwrap_err();
+        let rejection = guarded(pattern).unwrap_err();
         for needle in ["pattern", "admits every value", "constrains nothing"] {
             assert!(
                 rejection.contains(needle),
@@ -1233,14 +1243,49 @@ fn test_a_pattern_admitting_every_value_is_refused() {
     }
 }
 
-/// A pattern that turns some value away keeps its place, `\b` included.
+/// A pattern that turns some value away keeps its place.
 #[test]
 fn test_a_pattern_turning_some_value_away_clears_the_guard() {
     for pattern in CONSTRAINING_PATTERNS {
         assert!(
-            constraining(pattern).is_ok(),
+            guarded(pattern).is_ok(),
             "{pattern} constrains something and was refused: {:?}",
-            constraining(pattern)
+            guarded(pattern)
+        );
+    }
+}
+
+/// A lone look-around says something about the value and still cannot be emitted: the regex the
+/// validator builds from it draws `clippy::trivial_regex` at the attribute that wrote it, and the
+/// lint names no `str` call to put in the regex's place. The refusal names the rewrite that keeps
+/// the check.
+#[test]
+fn test_a_pattern_that_is_one_assertion_and_nothing_else_is_refused() {
+    for pattern in LONE_ASSERTION_PATTERNS {
+        let rejection = guarded(pattern).unwrap_err();
+        for needle in [
+            "one look-around assertion and nothing else",
+            "clippy::trivial_regex",
+            r"`\b\w+` rather than `\b`",
+            r"`\B\w` rather than `\B`",
+        ] {
+            assert!(
+                rejection.contains(needle),
+                "{needle} missing for {pattern}: {rejection}"
+            );
+        }
+    }
+}
+
+/// The rewrite the refusal names is accepted, and so is every other pattern with a boundary in it:
+/// one assertion beside anything at all is more than the lint calls trivial.
+#[test]
+fn test_a_boundary_beside_something_clears_the_guard() {
+    for pattern in BOUNDED_ASSERTION_PATTERNS {
+        assert_eq!(
+            guarded(pattern).as_deref(),
+            Ok(pattern),
+            "{pattern} was refused, or came back in a different spelling"
         );
     }
 }
@@ -1252,7 +1297,7 @@ fn test_a_pattern_turning_some_value_away_clears_the_guard() {
 fn test_the_shapes_already_classified_still_clear_the_guard() {
     for pattern in TRIVIAL_PATTERNS.into_iter().chain(PORTABLE_PATTERNS) {
         assert_eq!(
-            constraining(pattern).as_deref(),
+            guarded(pattern).as_deref(),
             Ok(pattern),
             "{pattern} was refused, or came back in a different spelling"
         );

--- a/tests/validation_tests/tests.rs
+++ b/tests/validation_tests/tests.rs
@@ -1185,6 +1185,38 @@ fn test_pattern_pinning_both_ends_to_one_position() {
     );
 }
 
+/// The rewrite a lone `\b` is refused in favour of. It reaches the emitter as a regex, and this
+/// crate's own lints deny `clippy::nursery`, so compiling this fixture is what proves the emitted
+/// `Regex::new` draws no `trivial_regex` at the attribute that wrote it.
+#[cfg(all(
+    feature = "serde",
+    any(feature = "typescript", feature = "zod", feature = "jsonschema")
+))]
+#[test]
+fn test_pattern_boundary_with_a_word_beside_it() {
+    #[model_schema()]
+    #[derive(Serialize, Deserialize, Debug)]
+    pub struct PatternBoundedWord {
+        #[model_schema_prop(pattern = r"\b\w+")]
+        pub caption: String,
+    }
+
+    PatternBoundedWord {
+        caption: "hello there".to_owned(),
+    }
+    .validate()
+    .unwrap();
+
+    let rejected = PatternBoundedWord {
+        caption: "...".to_owned(),
+    };
+    let errors = rejected.validate().unwrap_err();
+    assert_eq!(
+        errors[0], r"'caption' does not match pattern '\b[0-9A-Za-z_]+'",
+        "Rejection should quote the pattern in the spelling every surface receives: {errors:?}"
+    );
+}
+
 #[cfg(all(
     feature = "serde",
     any(feature = "typescript", feature = "zod", feature = "jsonschema")


### PR DESCRIPTION
A field written `pattern = r"\b"` compiled, and the generated validator's
`Regex::new(r"\b")` then failed the consumer's own clippy under a denied
nursery: `trivial_regex` calls a lone assertion unlikely to be useful and
reports it against the `model_schema` attribute, where no edit exists. The two
shipped answers reach every neighbouring shape but not this one — the shapes
that lint names a `str` call for are emitted as that call, and a shape that
admits every value is refused for that — but `\b` turns a value away and clippy
names nothing to put in its place, so there was no call to emit and no check to
drop.

It is refused now, before expansion, in the same chain the other two pattern
verdicts run in and delivered by the same rejection machinery, so it fires
wherever they fire and reads in their voice. The message names the rewrite:
write the boundary beside what has to sit next to it — `\b\w+` rather than
`\b` — which keeps the regex and stops it being trivial.

The rule is the shape, not the spelling: a whole pattern parsing to a single
look-around. Read off the HIR, that is exactly what clippy calls trivial while
naming no replacement, and everything else in the class is already answered —
the text anchors by the admits-every-value refusal, every boundary flavour but
`\b` and `\B` by portability. A boundary with anything beside it is untouched
and byte-identical, and an integration fixture compiling under this crate's own
nursery-denying lints is what proves the emitted regex draws nothing.

just check, just quick, just lint-all across all 68 toggles, and the test
powerset across all 68 in four partitions — all green.

