### PR TITLE
refuse ts_optional where it can decide nothing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -326,7 +326,7 @@ compile error naming both the literal's kind and the field's declared type. A nu
 stored as `f64` and rendered without a trailing `.0` on TypeScript and Zod; the JSON Schema `const`
 is always written under `"type": "number"`, never `"integer"`.
 
-`ts_optional` is a bare flag (no value): it renders an `Option<T>` field as the optional TypeScript key `field?: T` instead of the default `field: T | undefined`. Zod and JSON Schema output are unchanged. It is only valid on `Option<T>` fields (non-`Option` is a compile error) and composes with `as = Type`.
+`ts_optional` is a bare flag (no value): it renders an `Option<T>` field as the optional TypeScript key `field?: T` instead of the default `field: T | undefined`. Zod and JSON Schema output are unchanged. It is only valid on `Option<T>` fields (non-`Option` is a compile error) and composes with `as = Type`. The member must also have a key for the flag to make optional, and `validate_ts_optional_flag` refuses both positions where it has none, in every build: a positional slot writes no key at all, and one a serde attribute takes off the wire in both directions (`skip`, or `skip_serializing` and `skip_deserializing` together) is described on no surface. An attribute that drops the key one way only (`skip_serializing_if`, `skip_serializing`) leaves the member standing, and the flag still decides its spelling.
 
 `as_number` is a bare flag (no value): it renders a `DateTime<Tz>` field as a `number` (epoch milliseconds) with an inline self-contained Zod coercer, instead of the default native `Date` (`z.coerce.date()`). It is only valid on `DateTime<Tz>` fields (anything else is a compile error) and is honored on a tuple-variant `DateTime<Tz>` enum payload.
 

--- a/README.md
+++ b/README.md
@@ -1713,7 +1713,9 @@ pub struct Event {
 
 The bare `ts_optional` flag asks for the optional key (`field?: T` rather than `field: T | undefined`) on the author's word. It is the only thing that writes that spelling.
 
-**Read the condition before reaching for it.** An `Option<T>` field whose serde attributes drop the key for a `None` already renders as an optional key, off the wire and in every build ([Optional Fields](#optional-fields)) — on such a field the flag changes nothing, because the attribute has already said it. What is left over is an `Option<T>` carrying no key-dropping attribute at all, and with the `serde` feature on that field does not compile: the field's declared shape is `T | undefined`, so its key has to be dropped for a `None`, not written as `null` the way serde writes it absent an attribute saying otherwise — and the guard refuses the declaration and names the attribute to add (or, if the wire really does carry `null` here, points at [`nullable`](#nullable-object-keys-nullable) instead). So the flag decides the key in exactly one place — a build with the `serde` feature **off**, where no attribute is read and no such guard runs:
+**Two positions have no key for it to make optional, and writing it on either is a compile error, in every build.** A positional slot writes no key at all, so the flag names a spelling the tuple line has no room for. A member a serde attribute takes off the wire in *both* directions (`skip`, or `skip_serializing` and `skip_deserializing` together) is described on no surface, so there is no line for the flag to write its key on. An attribute that drops the key one way only (`skip_serializing_if`, `skip_serializing`) leaves the member standing and the flag decides its spelling as usual.
+
+With the `serde` feature on, an `Option<T>` field must carry a key-dropping attribute anyway: its declared shape is `T | undefined`, so its key has to be dropped for a `None`, not written as `null` the way serde writes it absent an attribute saying otherwise — the guard refuses the declaration and names the attribute to add (or, if the wire really does carry `null` here, points at [`nullable`](#nullable-object-keys-nullable) instead). The example below is a build with the feature **off**, where no attribute is read and no such guard runs:
 
 ```rust
 #[model_schema()]
@@ -1737,7 +1739,7 @@ export type Profile = {
 
 `nick_handle` is the same field without the flag, so the flag is the whole of the difference between those two lines.
 
-This is a TypeScript-only knob -- the Zod schema and JSON Schema are unchanged (the field is already optional in both, flagged or not). The flag is only valid on `Option<T>` fields; applying it to a non-`Option` field is a compile error. It composes with `as = Type`, which names the type the field already renders. On a field the flag has no say over — one already carrying an omission attribute, or a positional slot, which has no key to make optional — writing it is accepted and inert.
+This is a TypeScript-only knob -- the Zod schema and JSON Schema are unchanged (the field is already optional in both, flagged or not). The flag is only valid on `Option<T>` fields; applying it to a non-`Option` field is a compile error. It composes with `as = Type`, which names the type the field already renders.
 
 ### Nullable Object Keys (`nullable`)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -778,7 +778,9 @@ pub fn model_schema(args: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// - `ts_optional` — on an `Option<T>` field, writes the optional TypeScript key `field?: T`
 ///   instead of the default `field: T | undefined`. TypeScript-only; Zod and JSON Schema are
-///   unchanged.
+///   unchanged. The field must have a key for it to make optional: a positional slot writes none,
+///   and a member a serde attribute takes off the wire in both directions is described nowhere, so
+///   the flag is refused on either.
 /// - `as_number` — on a `DateTime<Tz>` field, renders an epoch-millisecond `number` with an
 ///   inline Zod coercer instead of the default `Date`.
 /// - `nullable` — on an `Option<T>` field, renders `T | null` with the key **required** on

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -10461,9 +10461,34 @@ fn validate_as_number_flag(field_type: &FieldDefType, flag_set: bool) -> Result<
     Ok(())
 }
 
-fn validate_ts_optional_flag(field_optional: bool, flag_set: bool) -> Result<(), String> {
-    if flag_set && !field_optional {
+/// Rejects `ts_optional` where the member has no key for it to make optional. A positional slot
+/// writes no key at all, and one a serde attribute takes out of both of serde's directions is
+/// described on no surface, so on either the flag asks for a spelling nothing emits.
+fn validate_ts_optional_flag(
+    field: &Field,
+    field_def: &FieldDef,
+    flag_set: bool,
+) -> Result<(), String> {
+    if !flag_set {
+        return Ok(());
+    }
+    if field.ident.is_none() {
+        return Err(
+            "#[model_schema_prop(ts_optional)] requires a named field: a positional slot writes \
+             no key for the flag to make optional"
+                .into(),
+        );
+    }
+    if !field_def.is_optional() {
         return Err("#[model_schema_prop(ts_optional)] requires an Option<T> field".into());
+    }
+    if field_def.absent_from_wire {
+        return Err(
+            "#[model_schema_prop(ts_optional)] requires a field the wire carries: a serde \
+             attribute takes this one out of both directions, so no member is written for the \
+             flag to make optional"
+                .into(),
+        );
     }
     Ok(())
 }
@@ -10683,7 +10708,7 @@ fn model_schema_prop_guard_errors(
         flag_guard_error(
             field,
             label,
-            validate_ts_optional_flag(field_def.is_optional(), prop_meta.ts_optional),
+            validate_ts_optional_flag(field, field_def, prop_meta.ts_optional),
         ),
         flag_guard_error(
             field,

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -1,8 +1,8 @@
 use super::{
-    EnumCasing, FieldDefType, ModelSchemaPropMeta, check_nullable_ts_optional_conflict,
-    check_undescribable_std_field, collect_discriminated_variants, field_label, get_field_def,
-    render_discriminated_variants, validate_as_number_flag, validate_nullable_flag,
-    validate_ts_optional_flag,
+    EnumCasing, FieldDefType, ModelSchemaPropMeta, apply_serde_key_omission,
+    check_nullable_ts_optional_conflict, check_undescribable_std_field,
+    collect_discriminated_variants, field_label, get_field_def, render_discriminated_variants,
+    validate_as_number_flag, validate_nullable_flag, validate_ts_optional_flag,
 };
 
 #[cfg(feature = "serde")]
@@ -122,22 +122,85 @@ const UNCASED: EnumCasing<'static> = EnumCasing {
     variants: None,
 };
 
+/// The flag's verdict on a declaration's sole member, read the way `process_field` reads it: the
+/// omission the field declares is on the def before the guard asks its question of it.
+fn ts_optional_verdict(item: &syn::ItemStruct, flag_set: bool) -> Result<(), String> {
+    let field = item.fields.iter().next().unwrap();
+    let mut rendered = get_field_def("", &field.ty, "");
+    apply_serde_key_omission(&mut rendered, field);
+    validate_ts_optional_flag(field, &rendered, flag_set)
+}
+
 #[test]
 fn ts_optional_ok_on_option_field() {
-    validate_ts_optional_flag(true, true).unwrap();
+    ts_optional_verdict(
+        &syn::parse_quote! { struct Report { name: Option<String> } },
+        true,
+    )
+    .unwrap();
+}
+
+/// A field carrying an attribute that drops its key on the way out still writes a member, and the
+/// flag is what decides which of the two spellings that member takes.
+#[test]
+fn ts_optional_ok_on_an_option_field_whose_key_is_dropped_one_way() {
+    for item in [
+        syn::parse_quote! {
+            struct Report { #[serde(skip_serializing_if = "Option::is_none")] name: Option<String> }
+        },
+        syn::parse_quote! { struct Report { #[serde(skip_serializing)] name: Option<String> } },
+    ] {
+        ts_optional_verdict(&item, true).unwrap();
+    }
 }
 
 #[test]
 fn ts_optional_ok_when_flag_unset() {
-    validate_ts_optional_flag(true, false).unwrap();
-    validate_ts_optional_flag(false, false).unwrap();
+    for item in [
+        syn::parse_quote! { struct Report { name: Option<String> } },
+        syn::parse_quote! { struct Report { name: String } },
+        syn::parse_quote! { struct Report(Option<String>); },
+        syn::parse_quote! { struct Report { #[serde(skip)] name: Option<String> } },
+    ] {
+        ts_optional_verdict(&item, false).unwrap();
+    }
 }
 
 #[test]
 fn ts_optional_err_on_non_option_field() {
-    let err = validate_ts_optional_flag(false, true).unwrap_err();
+    let err = ts_optional_verdict(&syn::parse_quote! { struct Report { name: String } }, true)
+        .unwrap_err();
     assert!(err.contains("ts_optional"));
     assert!(err.contains("Option<T>"));
+}
+
+/// A positional slot writes no key, so the flag names a spelling the tuple line has no room for.
+#[test]
+fn ts_optional_err_on_a_positional_slot() {
+    let err = ts_optional_verdict(&syn::parse_quote! { struct Report(Option<String>); }, true)
+        .unwrap_err();
+    assert_eq!(
+        err,
+        "#[model_schema_prop(ts_optional)] requires a named field: a positional slot writes no \
+         key for the flag to make optional"
+    );
+}
+
+/// A member serde takes out of both directions is described on no surface, so the flag has no line
+/// to write its key on.
+#[test]
+fn ts_optional_err_on_a_member_off_the_wire() {
+    let err = ts_optional_verdict(
+        &syn::parse_quote! { struct Report { #[serde(skip)] name: Option<String> } },
+        true,
+    )
+    .unwrap_err();
+    assert_eq!(
+        err,
+        "#[model_schema_prop(ts_optional)] requires a field the wire carries: a serde attribute \
+         takes this one out of both directions, so no member is written for the flag to make \
+         optional"
+    );
 }
 
 #[cfg(feature = "chrono")]
@@ -2441,6 +2504,7 @@ fn field_prop_guard_errors_in_scope(item: &syn::ItemStruct, parameters: &[String
     let written = get_field_def(&name, &field.ty, "");
     let mut rendered = written.clone();
     rendered.erase_type_parameters(parameters);
+    apply_serde_key_omission(&mut rendered, field);
     let meta = super::parse_model_schema_prop_attributes(&field.attrs);
     super::collect_field_guard_errors(field, &rendered, &written, &name, &meta, Vec::new())
         .iter()
@@ -3099,11 +3163,54 @@ fn the_field_prop_misuses_leave_by_the_guard_channel() {
     }
 }
 
+/// The two positions the flag has no key to make optional, refused on the same channel and spanned
+/// on what carries them: a slot the tuple line writes without a key, and a member serde takes out
+/// of both directions.
+#[test]
+fn the_flag_leaves_by_the_guard_channel_where_it_has_no_key_to_make_optional() {
+    let slot = field_prop_guard_errors(&syn::parse_quote! {
+        struct Report(#[model_schema_prop(ts_optional)] Option<String>);
+    });
+    assert_eq!(slot.len(), 1, "{slot:?}");
+    for expected in ["compile_error", "tuple field", "requires a named field"] {
+        assert!(
+            slot[0].contains(expected),
+            "{expected} missing: {}",
+            slot[0]
+        );
+    }
+
+    let off_the_wire = field_prop_guard_errors(&syn::parse_quote! {
+        struct Report {
+            #[model_schema_prop(ts_optional)]
+            #[serde(skip)]
+            name: Option<String>,
+        }
+    });
+    assert_eq!(off_the_wire.len(), 1, "{off_the_wire:?}");
+    for expected in [
+        "compile_error",
+        "field `name`",
+        "requires a field the wire carries",
+    ] {
+        assert!(
+            off_the_wire[0].contains(expected),
+            "{expected} missing: {}",
+            off_the_wire[0]
+        );
+    }
+}
+
 /// The valid spellings of the same three keys stay valid.
 #[test]
 fn the_field_prop_flags_on_the_shapes_they_fit_are_accepted() {
     for field in [
         quote::quote! { #[model_schema_prop(ts_optional)] name: Option<String> },
+        quote::quote! {
+            #[model_schema_prop(ts_optional)]
+            #[serde(skip_serializing_if = "Option::is_none")]
+            name: Option<String>
+        },
         quote::quote! { #[model_schema_prop(preprocess = ["trim"])] name: String },
         quote::quote! { #[model_schema_prop(as = String, minLength = 1)] name: String },
     ] {

--- a/tests/optional_key_flag_tests/tests.rs
+++ b/tests/optional_key_flag_tests/tests.rs
@@ -3,6 +3,10 @@
 //! Every shape below carries a flagged member beside an unflagged control of the same type and
 //! attributes, so the flag is the only difference. Held under both feature flavours, since only
 //! one reads an attribute at all.
+//!
+//! A member with no key for the flag to make optional — a positional slot, or one a serde
+//! attribute takes off the wire in both directions — is refused at expansion, so no shape here
+//! can carry that spelling.
 
 #[cfg(feature = "serde")]
 mod under_the_serde_feature {
@@ -32,19 +36,6 @@ mod under_the_serde_feature {
         b: Option<String>,
     }
 
-    /// The key is dropped in both directions, which takes both members off the surface entirely —
-    /// the flag has no member left to spell.
-    #[model_schema()]
-    #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-    struct UnderSkip {
-        #[model_schema_prop(ts_optional)]
-        #[serde(skip)]
-        a: Option<String>,
-        #[serde(skip)]
-        b: Option<String>,
-        id: String,
-    }
-
     #[test]
     fn the_flag_decides_the_spelling_the_omission_attribute_leaves_open() {
         let predicate = UnderAPredicate::ts_definition();
@@ -63,17 +54,6 @@ mod under_the_serde_feature {
             member(&skip_serializing, "b: string | undefined;"),
             "Got: {skip_serializing}"
         );
-    }
-
-    /// A key the wire carries in neither direction has no member for the flag to spell, flagged or
-    /// not.
-    #[test]
-    fn a_key_off_the_wire_entirely_leaves_the_flag_nothing_to_spell() {
-        let ts = UnderSkip::ts_definition();
-
-        assert!(!ts.contains("a?"), "Got: {ts}");
-        assert!(!ts.contains("b?"), "Got: {ts}");
-        assert!(member(&ts, "id: string;"), "Got: {ts}");
     }
 }
 


### PR DESCRIPTION
The flag was accepted and inert in two positions. A positional slot writes no
key, so there is nothing for the flag to make optional; a field a serde
attribute takes off the wire entirely has no member described on any surface.
Both are compile errors now, answered by the same validator that already
refuses the flag on a non-Option field and delivered in its voice:

    #[model_schema_prop(ts_optional)] requires a named field: a positional
    slot writes no key for the flag to make optional

    #[model_schema_prop(ts_optional)] requires a field the wire carries: a
    serde attribute takes this one out of both directions, so no member is
    written for the flag to make optional

Both refusals are ungated. The key-omission attributes are read in every build
by design, and a tuple slot has no key in any build, so a serde-gated refusal
would refuse a shape the emission rejects identically in the other build.

The set of inert positions is smaller than it was when this was reported. Since
the flag alone decides the spelling, a field carrying `skip_serializing_if` or
`skip_serializing` renders `a?: string` under the flag and stays required
without it — the flag is live there and stays accepted, byte-identical. Only a
member off the wire in both directions has nothing for it to decide. The README
and crate docs said the flag was inert on any omission-attribute field and
claimed one live position; both statements were stale and now say what holds.

just check, just quick, just lint-all across all 68 toggles, and the test
powerset across all 68 in four partitions — all green.

