### PR TITLE
drop LinkedList, the covered wrapper the crate's own lints forbid it a fixture for

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,9 @@ export type UserWithOptionals = {
 
 ### Collections and Maps
 
-`Vec<T>` becomes `Array<T>`, and so does every other std wrapper serde writes as a JSON array of its element: `VecDeque<T>`, `LinkedList<T>`, `BinaryHeap<T>`, `HashSet<T>`, and `BTreeSet<T>`. Each is that array on the wire, so each is typed and validated as that array — the element decides what the array holds. Nesting is kept at whatever depth it is written: a `Vec<Vec<T>>` (or `HashSet<Vec<T>>`, or any other mix of those wrappers) writes an array of arrays, so it becomes `Array<Array<T>>`, `z.array(z.array(...))`, and a JSON schema whose `items` is itself an array.
+`Vec<T>` becomes `Array<T>`, and so does every other std wrapper serde writes as a JSON array of its element: `VecDeque<T>`, `BinaryHeap<T>`, `HashSet<T>`, and `BTreeSet<T>`. Each is that array on the wire, so each is typed and validated as that array — the element decides what the array holds. Nesting is kept at whatever depth it is written: a `Vec<Vec<T>>` (or `HashSet<Vec<T>>`, or any other mix of those wrappers) writes an array of arrays, so it becomes `Array<Array<T>>`, `z.array(z.array(...))`, and a JSON schema whose `items` is itself an array.
+
+`LinkedList<T>` is the one std sequence left out. It writes that same array, so the covered spellings already describe every wire form it has, and a type written with one is refused at compile time with the rewrite named: use `Vec<T>`, or `VecDeque<T>` where values are pushed at both ends.
 
 A fixed-size array `[T; N]` is that array too, with its length described. serde writes exactly `N` items and reads one back only at that length, so the two validating surfaces say so: the JSON schema pins the level with `"minItems": N` and `"maxItems": N`, and Zod appends `.length(N)`. The bound belongs to the level it was written at, so `Vec<[T; 3]>` is an unbounded array of 3-element arrays and `[Vec<T>; 3]` is a 3-element array of unbounded ones. TypeScript stays `Array<T>`: the fixed-length form its type system has is the N-element tuple, which has to be written out element by element and stops being readable long before `N` stops being legal. A length the macro cannot read — a const generic parameter, a `const` item, any computed expression — describes as an unbounded array, the macro running before there is a value to ask for; a slice `[T]` has no length to describe at all.
 
@@ -1552,7 +1554,7 @@ Parity with structs runs both ways: an enum no member of which carries a constra
 
 #### Constraints under `Option`, wrappers, and sequences
 
-A constraint describes the value the field puts on the wire, wherever it was written. `validate()` therefore reaches through everything the parser reads through -- an `Option`, a transparent wrapper (`Box`, `Rc`, `Arc`, `Cow`), and every sequence level (`Vec`, `VecDeque`, `HashSet`, `BTreeSet`, `LinkedList`, `BinaryHeap`, arrays and slices) -- and checks the innermost value, which is the same place the Zod, TypeScript and JSON Schema surfaces put it.
+A constraint describes the value the field puts on the wire, wherever it was written. `validate()` therefore reaches through everything the parser reads through -- an `Option`, a transparent wrapper (`Box`, `Rc`, `Arc`, `Cow`), and every sequence level (`Vec`, `VecDeque`, `HashSet`, `BTreeSet`, `BinaryHeap`, arrays and slices) -- and checks the innermost value, which is the same place the Zod, TypeScript and JSON Schema surfaces put it.
 
 ```rust
 #[model_schema()]

--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -600,18 +600,25 @@ impl FieldDef {
 
     /// The name of the first `OsString`/`OsStr` this field reaches, at any depth.
     pub fn os_string_name(&self) -> Option<&str> {
+        self.reached_name(|name| matches!(name, "OsString" | "OsStr"))
+    }
+
+    /// The parameter this field is or reaches, which is what a nested position is asked for: below
+    /// the top level the two questions have one answer.
+    #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+    fn parameter_or_argument_name(&self) -> Option<&str> {
+        self.parameter_shape_name()
+            .or_else(|| self.argument_parameter_name())
+    }
+
+    /// The enclosing item's own type parameter this field renders as, when a bound spelled against
+    /// it names a value whose type the expansion never sees.
+    pub fn parameter_shape_name(&self) -> Option<&str> {
         match &self.field_type {
-            FieldDefType::SiblingType(name, generics) => {
-                if matches!(name.as_str(), "OsString" | "OsStr") {
-                    return Some(name);
-                }
-                generics.iter().find_map(Self::os_string_name)
-            }
-            FieldDefType::Map(key, value) => {
-                key.os_string_name().or_else(|| value.os_string_name())
-            }
-            FieldDefType::Tuple(elements) => elements.iter().find_map(Self::os_string_name),
-            FieldDefType::TypeParam(_)
+            FieldDefType::TypeParam(name) => Some(name),
+            FieldDefType::SiblingType(_, _)
+            | FieldDefType::Map(_, _)
+            | FieldDefType::Tuple(_)
             | FieldDefType::Unknown
             | FieldDefType::StringLiteral(_)
             | FieldDefType::BooleanLiteral(_)
@@ -641,22 +648,29 @@ impl FieldDef {
         }
     }
 
-    /// The parameter this field is or reaches, which is what a nested position is asked for: below
-    /// the top level the two questions have one answer.
-    #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
-    fn parameter_or_argument_name(&self) -> Option<&str> {
-        self.parameter_shape_name()
-            .or_else(|| self.argument_parameter_name())
-    }
-
-    /// The enclosing item's own type parameter this field renders as, when a bound spelled against
-    /// it names a value whose type the expansion never sees.
-    pub fn parameter_shape_name(&self) -> Option<&str> {
+    /// The first name this field reaches, at any depth, that `refused` answers for. A name is only
+    /// ever written where a type is, so the walk descends the positions holding written types and
+    /// stops at every value the parser resolved to something of its own.
+    fn reached_name<F>(&self, refused: F) -> Option<&str>
+    where
+        F: Fn(&str) -> bool + Copy,
+    {
         match &self.field_type {
-            FieldDefType::TypeParam(name) => Some(name),
-            FieldDefType::SiblingType(_, _)
-            | FieldDefType::Map(_, _)
-            | FieldDefType::Tuple(_)
+            FieldDefType::SiblingType(name, generics) => {
+                if refused(name.as_str()) {
+                    return Some(name);
+                }
+                generics
+                    .iter()
+                    .find_map(|argument| argument.reached_name(refused))
+            }
+            FieldDefType::Map(key, value) => key
+                .reached_name(refused)
+                .or_else(|| value.reached_name(refused)),
+            FieldDefType::Tuple(elements) => elements
+                .iter()
+                .find_map(|element| element.reached_name(refused)),
+            FieldDefType::TypeParam(_)
             | FieldDefType::Unknown
             | FieldDefType::StringLiteral(_)
             | FieldDefType::BooleanLiteral(_)
@@ -730,6 +744,11 @@ impl FieldDef {
             | FieldDefType::NaiveDateTime
             | FieldDefType::DateTime => false,
         }
+    }
+
+    /// The name of the first `is_refused_sequence_wrapper` this field reaches, at any depth.
+    pub fn refused_sequence_wrapper_name(&self) -> Option<&str> {
+        self.reached_name(is_refused_sequence_wrapper)
     }
 
     /// Rewrites any `Self` type reference to the concrete enclosing type name, at the parameters
@@ -968,47 +987,7 @@ impl FieldDef {
 
     /// The name of the first `is_unsupported_std_wrapper` this field reaches, at any depth.
     pub fn unsupported_std_wrapper_name(&self) -> Option<&str> {
-        match &self.field_type {
-            FieldDefType::SiblingType(name, generics) => {
-                if is_unsupported_std_wrapper(name.as_str()) {
-                    return Some(name);
-                }
-                generics.iter().find_map(Self::unsupported_std_wrapper_name)
-            }
-            FieldDefType::Map(key, value) => key
-                .unsupported_std_wrapper_name()
-                .or_else(|| value.unsupported_std_wrapper_name()),
-            FieldDefType::Tuple(elements) => {
-                elements.iter().find_map(Self::unsupported_std_wrapper_name)
-            }
-            FieldDefType::TypeParam(_)
-            | FieldDefType::Unknown
-            | FieldDefType::StringLiteral(_)
-            | FieldDefType::BooleanLiteral(_)
-            | FieldDefType::NumberLiteral(_)
-            | FieldDefType::Boolean
-            | FieldDefType::Char
-            | FieldDefType::String
-            | FieldDefType::U8
-            | FieldDefType::U16
-            | FieldDefType::U32
-            | FieldDefType::U64
-            | FieldDefType::I8
-            | FieldDefType::I16
-            | FieldDefType::I32
-            | FieldDefType::I64
-            | FieldDefType::Usize
-            | FieldDefType::Isize
-            | FieldDefType::F32
-            | FieldDefType::F64 => None,
-            #[cfg(feature = "object_id")]
-            FieldDefType::ObjectId => None,
-            #[cfg(feature = "chrono")]
-            FieldDefType::NaiveDate
-            | FieldDefType::NaiveTime
-            | FieldDefType::NaiveDateTime
-            | FieldDefType::DateTime => None,
-        }
+        self.reached_name(is_unsupported_std_wrapper)
     }
 
     /// The value this field's wrappers hold, as a field of its own: the same type with the
@@ -1289,8 +1268,14 @@ fn zod_factory_call(name: &str, arguments: &[FieldDef]) -> String {
 pub fn is_sequence_wrapper(name: &str) -> bool {
     matches!(
         name,
-        "BTreeSet" | "BinaryHeap" | "HashSet" | "LinkedList" | "Vec" | "VecDeque"
+        "BTreeSet" | "BinaryHeap" | "HashSet" | "Vec" | "VecDeque"
     )
+}
+
+/// The std sequence the crate refuses rather than renders. serde writes it as the array a `Vec`
+/// writes, so the covered spelling already describes every wire form it has.
+pub fn is_refused_sequence_wrapper(name: &str) -> bool {
+    name == "LinkedList"
 }
 
 /// The number of leading type arguments a std container's wire form is written from, or `None` for

--- a/src/field_type/tests.rs
+++ b/src/field_type/tests.rs
@@ -5,13 +5,7 @@ use crate::utils::{AliasKind, register_alias_info};
 
 /// The wrappers whose fields write a JSON array of their element, named here as they reach the
 /// renderers — `Vec` excluded, the parser having collapsed it long before.
-const SEQUENCE_WRAPPERS: [&str; 5] = [
-    "BTreeSet",
-    "BinaryHeap",
-    "HashSet",
-    "LinkedList",
-    "VecDeque",
-];
+const SEQUENCE_WRAPPERS: [&str; 4] = ["BTreeSet", "BinaryHeap", "HashSet", "VecDeque"];
 
 fn field(field_type: FieldDefType) -> FieldDef {
     FieldDef {
@@ -270,6 +264,19 @@ fn test_the_covered_transparent_wrappers_are_exactly_the_recorded_list() {
     }
 }
 
+/// The covered sequence list, stated once so it is a decision rather than a spelling that happened
+/// to work. `LinkedList` is on the false side deliberately: it writes the array `Vec` writes, so
+/// the covered spelling already describes it and a field written as one is refused instead.
+#[test]
+fn test_the_covered_sequence_wrappers_are_exactly_the_recorded_list() {
+    for name in ["BTreeSet", "BinaryHeap", "HashSet", "Vec", "VecDeque"] {
+        assert!(super::is_sequence_wrapper(name), "for: {name}");
+    }
+    for name in ["LinkedList", "BTreeMap", "HashMap", "Option", "Box"] {
+        assert!(!super::is_sequence_wrapper(name), "for: {name}");
+    }
+}
+
 /// The ownership/borrow split the covered list is built from: only the first four implement
 /// `Deref`, which is what a constraint's generated validator needs to reach through one.
 #[test]
@@ -496,6 +503,8 @@ fn test_a_schematizable_field_is_not_reported_as_an_unsupported_std_wrapper() {
     }
 }
 
+/// `LinkedList` is on the false side because it is refused by a list of its own: serde writes it,
+/// so the message it earns names the covered spelling rather than a missing wire form.
 #[test]
 fn test_the_unsupported_std_wrapper_list_is_exactly_the_nine_names() {
     for name in [
@@ -513,7 +522,16 @@ fn test_the_unsupported_std_wrapper_list_is_exactly_the_nine_names() {
         assert!(!super::is_transparent_wrapper(name), "for: {name}");
     }
     for name in [
-        "Arc", "Box", "Cow", "Rc", "Cell", "Mutex", "RefCell", "RwLock", "Inner",
+        "Arc",
+        "Box",
+        "Cow",
+        "Rc",
+        "Cell",
+        "Mutex",
+        "RefCell",
+        "RwLock",
+        "Inner",
+        "LinkedList",
     ] {
         assert!(!super::is_unsupported_std_wrapper(name), "for: {name}");
     }

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -446,12 +446,14 @@ enum MapKeyRejection {
     },
 }
 
-/// A std type serde has no wire form for that a written type reaches, at any depth. Every position
-/// that reads a written type asks this, and each spans and names its own subject.
+/// A std type this crate describes no schema for that a written type reaches, at any depth. Every
+/// position that reads a written type asks this, and each spans and names its own subject.
 #[derive(Debug)]
 enum UndescribableStd<'name> {
     /// `OsString`/`OsStr`: serde writes an externally tagged enum naming the target platform.
     PlatformString(&'name str),
+    /// `LinkedList`: serde writes the array a `Vec` writes, and the covered spelling is that one.
+    Sequence(&'name str),
     /// A cell/lock/lazy-init wrapper or borrow guard: serde implements neither direction.
     Wrapper(&'name str),
 }
@@ -11011,9 +11013,10 @@ fn check_as_preprocess_conflict(
     ))
 }
 
-/// The std type `written` reaches that no schema can describe, and `None` when it reaches none.
-/// The platform string is answered first, so a type reaching both keeps the message that names its
-/// actual wire form.
+/// The std type `written` reaches that this crate describes no schema for, and `None` when it
+/// reaches none. The platform string is answered first, so a type reaching both keeps the message
+/// that names its actual wire form; the sequence is answered last, its rewrite being the only one
+/// of the three that leaves the surrounding type alone.
 fn undescribable_std_rejection(written: &FieldDef) -> Option<UndescribableStd<'_>> {
     written
         .os_string_name()
@@ -11023,11 +11026,16 @@ fn undescribable_std_rejection(written: &FieldDef) -> Option<UndescribableStd<'_
                 .unsupported_std_wrapper_name()
                 .map(UndescribableStd::Wrapper)
         })
+        .or_else(|| {
+            written
+                .refused_sequence_wrapper_name()
+                .map(UndescribableStd::Sequence)
+        })
 }
 
-/// What a written type reaching a std type serde cannot write is reported as. The `subject` names
-/// where it was written — a field, an alias, a brand, a `default_types` entry — which is all that
-/// differs between the positions.
+/// What a written type reaching a std type this crate has no schema for is reported as. The
+/// `subject` names where it was written — a field, an alias, a brand, a `default_types` entry —
+/// which is all that differs between the positions.
 fn undescribable_std_message(subject: &str, rejection: &UndescribableStd<'_>) -> String {
     match *rejection {
         UndescribableStd::PlatformString(name) => format!(
@@ -11035,6 +11043,11 @@ fn undescribable_std_message(subject: &str, rejection: &UndescribableStd<'_>) ->
              the target platform (`{{\"Unix\":[u8, ...]}}` or `{{\"Windows\":[u16, ...]}}`), not a \
              string, so no schema can describe it portably. Use `String`, or `PathBuf` for a \
              filesystem path."
+        ),
+        UndescribableStd::Sequence(name) => format!(
+            "{subject} reaches `{name}`, which serde writes as the same JSON array `Vec<T>` \
+             writes, so nothing on the wire tells the two apart and this crate describes only the \
+             one spelling. Use `Vec<T>`, or `VecDeque<T>` where values are pushed at both ends."
         ),
         UndescribableStd::Wrapper(name) => format!(
             "{subject} reaches `{name}`, which serde implements neither `Serialize` nor \

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -102,14 +102,7 @@ const SLOT_OMISSION_SPELLINGS: [(&str, bool); 6] = [
 
 /// The covered wrappers, under the names a dispatch reads them by.
 #[cfg(any(feature = "jsonschema", feature = "serde"))]
-const SEQUENCE_WRAPPERS: [&str; 6] = [
-    "BTreeSet",
-    "BinaryHeap",
-    "HashSet",
-    "LinkedList",
-    "Vec",
-    "VecDeque",
-];
+const SEQUENCE_WRAPPERS: [&str; 5] = ["BTreeSet", "BinaryHeap", "HashSet", "Vec", "VecDeque"];
 
 /// The module name a generated hook is written against, standing in for the one the enum's own
 /// expansion registers.
@@ -1797,6 +1790,66 @@ fn the_field_refusal_for_an_unsupported_wrapper_reads_exactly_this() {
     );
 }
 
+#[test]
+fn the_field_refusal_for_a_linked_list_reads_exactly_this() {
+    let message = field_undescribable_std_message(&syn::parse_quote! {
+        struct Queue {
+            pending: LinkedList<String>,
+        }
+    })
+    .unwrap();
+    assert_eq!(
+        message,
+        "model_schema: field `pending` reaches `LinkedList`, which serde writes as the same JSON \
+         array `Vec<T>` writes, so nothing on the wire tells the two apart and this crate \
+         describes only the one spelling. Use `Vec<T>`, or `VecDeque<T>` where values are pushed \
+         at both ends."
+    );
+}
+
+/// The wrappers still covered are the ones a field can be written with, and each keeps rendering
+/// as the array it writes rather than earning the refusal its dropped neighbour now earns.
+#[test]
+fn the_covered_sequence_spellings_are_left_alone_by_the_std_wrapper_guard() {
+    for spelling in [
+        quote::quote! { Vec<String> },
+        quote::quote! { VecDeque<String> },
+        quote::quote! { HashSet<String> },
+        quote::quote! { BTreeSet<String> },
+        quote::quote! { BinaryHeap<String> },
+    ] {
+        let error = field_undescribable_std_error(&syn::parse_quote! {
+            struct Queue {
+                pending: #spelling,
+            }
+        });
+        assert!(error.is_none(), "for {spelling}, got: {error:?}");
+    }
+}
+
+/// The guard reads through the wrappers the parser reads through, so the refusal names the linked
+/// list rather than whatever it was written inside.
+#[test]
+fn a_wrapped_linked_list_field_is_rejected_by_its_own_name() {
+    for spelling in [
+        quote::quote! { Vec<LinkedList<String>> },
+        quote::quote! { Option<LinkedList<String>> },
+        quote::quote! { HashMap<String, LinkedList<String>> },
+        quote::quote! { (u8, LinkedList<String>) },
+    ] {
+        let error = field_undescribable_std_error(&syn::parse_quote! {
+            struct Queue {
+                pending: #spelling,
+            }
+        })
+        .unwrap();
+        assert!(
+            error.contains("`LinkedList`"),
+            "for {spelling}, got: {error}"
+        );
+    }
+}
+
 /// A positional slot has no ident to name, and the label it is refused under is the one thing the
 /// collapse could have moved.
 #[test]
@@ -2193,6 +2246,12 @@ fn an_alias_targeting_an_undescribable_std_type_is_refused() {
             "model_schema: type alias `Keyed`",
             "`OsString`",
             "externally",
+        ),
+        (
+            "pub type Pending = LinkedList<String>;",
+            "model_schema: type alias `Pending`",
+            "`LinkedList`",
+            "Vec<T>",
         ),
     ] {
         let error = alias_undescribable_std_error_text(target);
@@ -3969,6 +4028,11 @@ fn a_brand_over_an_undescribable_std_inner_is_refused() {
             "`OnceLock`",
             "Serialize",
         ),
+        (
+            quote::quote! { LinkedList<String> },
+            "`LinkedList`",
+            "Vec<T>",
+        ),
     ] {
         let errors = branded_errors(&syn::parse_quote! {
             #[serde(transparent)]
@@ -4306,7 +4370,6 @@ fn string_constraints_over_a_non_string_inner_are_rejected() {
         ("BTreeSet<String>", "container"),
         ("BinaryHeap<String>", "container"),
         ("HashSet<String>", "container"),
-        ("LinkedList<String>", "container"),
         ("VecDeque<String>", "container"),
         ("HashMap<String, String>", "container"),
         ("(String, String)", "container"),
@@ -5492,6 +5555,7 @@ fn a_filling_reaching_an_undescribable_std_type_is_refused_at_the_entry() {
         ("OsString", "`OsString`", "externally"),
         ("Vec<OnceLock<u32>>", "`OnceLock`", "Serialize"),
         ("HashMap<String, OsString>", "`OsString`", "externally"),
+        ("LinkedList<String>", "`LinkedList`", "Vec<T>"),
     ] {
         let messages = default_types_messages(
             "pub struct Probe<ValueType> { pub held: ValueType }",

--- a/tests/collection_tests/tests.rs
+++ b/tests/collection_tests/tests.rs
@@ -12,13 +12,7 @@ use tixschema::model_schema;
 /// The covered wrappers by the name a generated surface could leak. `Vec` is covered too but
 /// never arrives under its own name: the parser collapses it onto its element long before.
 #[cfg(any(feature = "typescript", feature = "zod"))]
-const SEQUENCE_WRAPPERS: [&str; 5] = [
-    "BTreeSet",
-    "BinaryHeap",
-    "HashSet",
-    "LinkedList",
-    "VecDeque",
-];
+const SEQUENCE_WRAPPERS: [&str; 4] = ["BTreeSet", "BinaryHeap", "HashSet", "VecDeque"];
 
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -418,8 +412,6 @@ type MetricTagRef = MetricTag;
 
 // Every std wrapper serde writes as a JSON array of `T` puts the element in charge of what the
 // array holds. The twin structs carry the same element types under each covered spelling.
-// `LinkedList` has no twin here — the crate's own lints forbid a value of one — so it's covered
-// by name at the dispatch instead.
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct SetElementFields {

--- a/tests/untagged_tests/tests.rs
+++ b/tests/untagged_tests/tests.rs
@@ -146,8 +146,7 @@ enum ShapedUnion {
 
 // The std wrappers serde writes as a JSON array of their element, written in untagged members:
 // each describes as the `Vec` of the same element does, not as a schema module named after the
-// wrapper. `LinkedList` has no member here — the crate's own lints forbid a value of one — so
-// it's covered by name at the dispatch's own unit tests instead.
+// wrapper.
 #[model_schema()]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]


### PR DESCRIPTION
`LinkedList` sat on the sequence-wrapper list, covered by name only: clippy's
`linkedlist` lint, denied through pedantic, forbids declaring a field of the
type in this crate's own tests, so nothing could ever exercise the macro
expanding over a real one. A support no fixture can prove is a promise the
suite cannot keep, and the lint's own rationale — use `Vec` — applies to this
crate's consumers as much as to this crate.

A `LinkedList<T>` field is refused now rather than silently unlisted, through
the same rejection seam the other refused std types answer from, so the field,
alias, brand-inner and filling positions all get the refusal spanned on their
own subject. The message is its own, not the deny-list's: that list's wording
says serde implements neither trait, which is false here — serde writes a
`LinkedList` as the same JSON array `Vec` writes, which is exactly why nothing
on the wire tells the two apart and only one spelling is described. The message
names both rewrites, `Vec<T>`, or `VecDeque<T>` where values are pushed at both
ends.

The three near-identical written-name walkers folded into one that takes the
predicate, so the new refusal did not add a fourth copy of a forty-arm match.

just check, just quick, just lint-all across all 68 toggles, and the test
powerset across all 68 in four partitions — all green.

