### PR TITLE
defer a self-naming untagged newtype member behind z.lazy, where the eager read cycled

### DIFF
--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -7266,7 +7266,10 @@ fn unsupported_untagged_variant_error(variant: &syn::Variant, shape: &str) -> sy
 
 /// Renders a `TupleSingle` (`S(T)`) untagged variant as a union member (`T` / `T$Schema` / value).
 /// The variant carries no key of its own, so a `None` inner reaches the wire as a bare `null`
-/// rather than going absent — read through the slot spellings for that reason.
+/// rather than going absent — read through the slot spellings for that reason. That same missing
+/// key is why a member naming the union itself is deferred with [`deferred_zod_operand`] rather
+/// than the getter [`render_untagged_named`] hangs off a key: read eagerly, the name lands in its
+/// own `const`'s initializer and throws on import.
 #[cfg(feature = "serde")]
 fn render_untagged_tuple_single(
     fld: &FieldDef,
@@ -7275,16 +7278,25 @@ fn render_untagged_tuple_single(
     let ts = fld.typescript_slot_typename();
 
     #[cfg(feature = "zod")]
-    let zod = fld.zod_slot_type();
+    let zod = {
+        let slot = fld.zod_slot_type();
+        if fld.contains_type_reference(self_type_name) {
+            deferred_zod_operand(&slot)
+        } else {
+            slot
+        }
+    };
     #[cfg(not(feature = "zod"))]
-    let zod = String::new();
+    let zod = {
+        let _: &str = self_type_name;
+        String::new()
+    };
 
     #[cfg(feature = "jsonschema")]
     let json_val = nullable_slot_json_schema_value(fld, field_json_schema_value(fld));
     #[cfg(not(feature = "jsonschema"))]
     let json_val = quote! {};
 
-    let _: &str = self_type_name;
     (ts, zod, json_val)
 }
 

--- a/tests/untagged_tests/tests.rs
+++ b/tests/untagged_tests/tests.rs
@@ -108,6 +108,20 @@ enum CompliantUnion {
     },
 }
 
+// The plain-JSON value shape: an untagged union naming itself from newtype variants, which carry
+// no key for a getter to defer the name behind. Its two recursive members read the union's own
+// binding, so each has to be read after the `const` declaring it finishes rather than while it runs.
+#[model_schema()]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+enum JsonValueUnion {
+    B(bool),
+    L(Vec<Self>),
+    M(HashMap<String, Self>),
+    N(f64),
+    S(String),
+}
+
 // An untagged newtype variant's content has no key to drop: it is the whole serialized value, so
 // a `None` there reaches the wire as a bare `null`. The non-`Option` member beside it carries none.
 #[model_schema()]
@@ -409,6 +423,72 @@ fn test_tuple_single_union_zod() {
         zod.contains("export const DateValue$Schema: ZodType<DateValue> = DateValue$RawSchema;"),
         "Got:\n{zod}"
     );
+}
+
+/// A newtype member naming the union itself is read through a thunk, not written straight into the
+/// `const` that declares the name — the eager spelling is a cycle the bundle throws on at import.
+#[test]
+#[cfg(feature = "zod")]
+fn test_recursive_tuple_single_union_zod_defers_self_reference() {
+    let zod = JsonValueUnion::zod_schema();
+    assert!(
+        zod.contains("z.lazy(() => z.array(JsonValueUnion$Schema))"),
+        "Got:\n{zod}"
+    );
+    assert!(
+        zod.contains("z.lazy(() => z.record(z.string(), JsonValueUnion$Schema))"),
+        "Got:\n{zod}"
+    );
+}
+
+/// The deferral is paid only where the cycle is: a member naming nothing recursive keeps the eager
+/// spelling every other tuple-single member is written in.
+#[test]
+#[cfg(feature = "zod")]
+fn test_recursive_tuple_single_union_zod_keeps_scalar_members_eager() {
+    let zod = JsonValueUnion::zod_schema();
+    assert!(zod.contains("z.union([z.boolean(), z.lazy("), "Got:\n{zod}");
+    assert!(zod.contains("z.number(), z.string()])"), "Got:\n{zod}");
+    for member in ["z.string()", "z.boolean()", "z.number()"] {
+        assert!(
+            !zod.contains(&format!("z.lazy(() => {member})")),
+            "`{member}` names nothing recursive and must stay eager. Got:\n{zod}"
+        );
+    }
+}
+
+/// A TypeScript type names itself wherever it likes, so the union is written out flat — the thunk
+/// the Zod schema needs has no counterpart here.
+#[test]
+#[cfg(feature = "typescript")]
+fn test_recursive_tuple_single_union_typescript_carries_no_deferral() {
+    let ts = JsonValueUnion::ts_definition();
+    assert!(
+        ts.contains(
+            "export type JsonValueUnion = boolean | Array<JsonValueUnion> | \
+             Partial<Record<string, JsonValueUnion>> | number | string;"
+        ),
+        "Got:\n{ts}"
+    );
+    assert!(!ts.contains("z.lazy"), "Got:\n{ts}");
+    assert!(!ts.contains("=>"), "Got:\n{ts}");
+}
+
+/// The nesting the deferral exists for, written and read back through the union that describes it.
+#[test]
+fn test_serde_round_trip_nested_recursive_union() {
+    let value = JsonValueUnion::M(HashMap::from([(
+        "items".to_owned(),
+        JsonValueUnion::L(vec![
+            JsonValueUnion::S("a".to_owned()),
+            JsonValueUnion::B(true),
+            JsonValueUnion::N(1.5),
+        ]),
+    )]));
+    let json = serde_json::to_string(&value).unwrap();
+    assert_eq!(json, r#"{"items":["a",true,1.5]}"#);
+    let back: JsonValueUnion = serde_json::from_str(&json).unwrap();
+    assert_eq!(back, value);
 }
 
 #[test]


### PR DESCRIPTION
`render_untagged_tuple_single` took `self_type_name` and discarded it, so a newtype member naming the union itself was written straight into the `const` that declares that name. A self-recursive untagged union — the plain-JSON value shape, `B(bool) | L(Vec<Self>) | M(HashMap<String, Self>) | N(f64) | S(String)` — therefore emitted

```js
const V$RawSchema = z.union([z.boolean(), z.array(V$Schema), z.record(z.string(), V$Schema), z.number(), z.string()]);
export const V$Schema: ZodType<V> = V$RawSchema;
```

which reads `V$Schema` inside its own initializer. Importing the generated bundle throws `ReferenceError: Cannot access 'V$Schema' before initialization` before a single value is ever parsed.

## The fix

The sibling `render_untagged_named` already defers such a member, with a `get key() { … }` getter hung off the key its struct variant spells. A newtype variant carries no key to hang one off, so the deferral is the thunk the rest of the crate already answers the same problem with: the member's zod slot is wrapped by `deferred_zod_operand` — `z.lazy(() => …)` — whenever the member's type names the union itself, and left eager whenever it does not, so the indirection is paid only where the cycle is.

```js
const V$RawSchema = z.union([z.boolean(), z.lazy(() => z.array(V$Schema)), z.lazy(() => z.record(z.string(), V$Schema)), z.number(), z.string()]);
```

TypeScript and the JSON document do not move: a TypeScript type names itself wherever it likes, and JSON Schema defers through `$ref`. The externally tagged form was never affected either — its recursion already sat inside a `z.strictObject({ get … })`, which is exactly the deferral a bare union member had no place to write. The `#[cfg(not(feature = "zod"))]` branch keeps discarding `self_type_name`, the way the named renderer's already does.

## Coverage

A new `JsonValueUnion` fixture in `tests/untagged_tests/tests.rs` — the plain-JSON value shape — with four tests asserting:

- both recursive members render behind `z.lazy` (the array and the record);
- the three scalar members stay eager, with no `z.lazy(() => z.string())` and friends anywhere;
- the TypeScript definition is the flat union and carries no trace of the thunk;
- a nested value (`{"items":["a",true,1.5]}`) round-trips through serde.

The two zod assertions were confirmed to fail with the deferral disabled and pass with it on.

## Gates

`just fmt`, `just check`, `just lint-all` across all 68 toggles, and `just test` across the full feature powerset — all green. No suppressions.
