### PR TITLE
rename the companion-type suffix from Json to Data, and stop recognizing the old one

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -5,17 +5,17 @@ This crate provides procedural macros for generating TypeScript types and Zod sc
 
 ## Usage Rules
 
-### 1. ALWAYS use `Json` suffix for Rust types
+### 1. ALWAYS use `Data` suffix for Rust types
 ```rust
 // ✅ CORRECT
 #[model_schema()]
 #[derive(Serialize, Deserialize)]
-pub struct UserJson {
+pub struct UserData {
     pub id: String,
     pub name: String,
 }
 
-// ❌ WRONG - missing Json suffix
+// ❌ WRONG - missing Data suffix
 #[model_schema()]
 #[derive(Serialize, Deserialize)]
 pub struct User {
@@ -32,7 +32,7 @@ use serde::{Deserialize, Serialize};
 
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct MyTypeJson {
+pub struct MyTypeData {
     // fields...
 }
 ```
@@ -43,7 +43,7 @@ pub struct MyTypeJson {
 #[model_schema()]
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct UserProfileJson {
+pub struct UserProfileData {
     pub user_id: String,          // becomes userId in TypeScript
     pub first_name: String,       // becomes firstName in TypeScript
     #[serde(rename = "email")]
@@ -54,13 +54,13 @@ pub struct UserProfileJson {
 ### 4. HashMap limitations
 ```rust
 // ✅ SUPPORTED - String keys only
-pub struct ConfigJson {
+pub struct ConfigData {
     pub settings: HashMap<String, String>,
     pub metadata: HashMap<String, i32>,
 }
 
 // ❌ NOT SUPPORTED - Non-string keys
-pub struct BadConfigJson {
+pub struct BadConfigData {
     pub settings: HashMap<i32, String>,  // Will cause compilation error
 }
 ```
@@ -70,7 +70,7 @@ pub struct BadConfigJson {
 // ✅ CORRECT optional field handling
 #[model_schema()]
 #[derive(Serialize, Deserialize)]
-pub struct UserJson {
+pub struct UserData {
     pub id: String,
     pub name: String,
     pub email: Option<String>,                    // becomes email?: string
@@ -84,10 +84,10 @@ pub struct UserJson {
 // ✅ SUPPORTED collection types
 #[model_schema()]
 #[derive(Serialize, Deserialize)]
-pub struct DataJson {
+pub struct CollectionsData {
     pub tags: Vec<String>,                        // becomes Array<string>
     pub scores: Vec<u32>,                         // becomes Array<number>
-    pub nested: Vec<OtherJson>,                   // becomes Array<Other>
+    pub nested: Vec<OtherData>,                   // becomes Array<Other>
 }
 ```
 
@@ -97,7 +97,7 @@ pub struct DataJson {
 #[model_schema()]
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
-pub enum StatusJson {
+pub enum StatusData {
     Active,
     Inactive,
     Pending,
@@ -107,7 +107,7 @@ pub enum StatusJson {
 #[model_schema()]
 #[derive(Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "camelCase")]
-pub enum PaymentJson {
+pub enum PaymentData {
     CreditCard { number: String, expiry: String },
     BankTransfer { account: String, routing: String },
     PayPal { email: String },
@@ -119,17 +119,17 @@ pub enum PaymentJson {
 // ✅ CORRECT nested type usage
 #[model_schema()]
 #[derive(Serialize, Deserialize)]
-pub struct AddressJson {
+pub struct AddressData {
     pub street: String,
     pub city: String,
 }
 
 #[model_schema()]
 #[derive(Serialize, Deserialize)]
-pub struct UserJson {
+pub struct UserData {
     pub id: String,
-    pub address: AddressJson,                     // References Address in TypeScript
-    pub addresses: Vec<AddressJson>,              // Array<Address>
+    pub address: AddressData,                     // References Address in TypeScript
+    pub addresses: Vec<AddressData>,              // Array<Address>
 }
 ```
 
@@ -140,7 +140,7 @@ use tixschema::{model_schema, model_schema_prop};
 
 #[model_schema()]
 #[derive(Serialize, Deserialize)]
-pub struct ApiConfigJson {
+pub struct ApiConfigData {
     pub id: String,
     #[model_schema_prop(as = String)]
     pub custom_field: String,
@@ -160,9 +160,9 @@ impl MyEntities {
         (
             "Generated Types".to_string(),
             vec![
-                UserJson::ts_definition(),
-                AddressJson::ts_definition(),
-                StatusJson::ts_definition(),
+                UserData::ts_definition(),
+                AddressData::ts_definition(),
+                StatusData::ts_definition(),
                 // Add all your types here
             ],
         )
@@ -198,7 +198,7 @@ pub fn generate_ts_schemas(target_path: &str) -> Result<(), Box<dyn std::error::
 
 ## Common Mistakes to Avoid
 
-### 1. ❌ Forgetting Json suffix
+### 1. ❌ Forgetting Data suffix
 ```rust
 // Wrong - will not follow naming convention
 #[model_schema()]
@@ -210,13 +210,13 @@ pub struct User { ... }
 // Wrong - missing Serialize, Deserialize
 #[model_schema()]
 #[derive(Debug)]
-pub struct UserJson { ... }
+pub struct UserData { ... }
 ```
 
 ### 3. ❌ Non-string HashMap keys
 ```rust
 // Wrong - will cause compilation error
-pub struct ConfigJson {
+pub struct ConfigData {
     pub settings: HashMap<i32, String>,
 }
 ```
@@ -229,8 +229,8 @@ impl MyEntities {
         (
             "Generated Types".to_string(),
             vec![
-                UserJson::ts_definition(),
-                // Missing: NewTypeJson::ts_definition(),
+                UserData::ts_definition(),
+                // Missing: NewTypeData::ts_definition(),
             ],
         )
     }
@@ -239,12 +239,12 @@ impl MyEntities {
 
 ## Generated Output Understanding
 
-1. **Type Name Transformation**: `UserJson` in Rust becomes `User` in TypeScript
+1. **Type Name Transformation**: `UserData` in Rust becomes `User` in TypeScript
 2. **Field Names**: Respect serde rename attributes
 3. **Optional Fields**: `Option<T>` becomes `T | undefined`
 4. **Arrays**: `Vec<T>` becomes `Array<T>`
 5. **Maps**: `HashMap<String, T>` becomes `Partial<Record<string, T>>`
-6. **Nested Types**: Reference other types without Json suffix
+6. **Nested Types**: Reference other types without the `Data` suffix
 
 ## Testing Best Practices
 
@@ -260,7 +260,7 @@ impl MyEntities {
 my_project/
 ├── src/
 │   ├── types/
-│   │   ├── user.rs        # Contains UserJson, UserStatusJson, etc.
+│   │   ├── user.rs        # Contains UserData, UserStatusData, etc.
 │   │   └── mod.rs
 │   └── lib.rs
 ├── tests/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,7 +174,7 @@ The crate uses 5 optional features for minimal dependencies:
 
 ### 1. Type Naming Convention
 
-The `Json` suffix is **optional** on Rust type names. If present, it is stripped from the generated TypeScript name. If absent, the Rust name is used as-is.
+The `Data` suffix is **optional** on Rust type names. If present, it is stripped from the generated TypeScript name. If absent, the Rust name is used as-is. A type named exactly `Data` keeps that name: stripping never empties a name.
 
 ```rust
 // Both are valid:
@@ -182,10 +182,10 @@ The `Json` suffix is **optional** on Rust type names. If present, it is stripped
 pub struct User { ... }     // → TypeScript: User
 
 #[model_schema()]
-pub struct UserJson { ... } // → TypeScript: User (suffix stripped)
+pub struct UserData { ... } // → TypeScript: User (suffix stripped)
 ```
 
-The codebase convention is to use type names WITHOUT the `Json` suffix.
+The codebase convention is to use type names WITHOUT the `Data` suffix.
 
 ### 2. Required Derives and Imports
 
@@ -237,7 +237,7 @@ pub struct BadMapKey {
 - `Option<T>` → `T | undefined` (Zod: `z.union([z.null().transform(() => undefined), T, z.undefined()]).prefault(undefined)`, accepting an explicit `null` and coercing it to `undefined`; JSON Schema `anyOf: [T, {"type": "null"}]`, key left out of `required`); with `#[model_schema_prop(ts_optional)]` the TypeScript key becomes optional instead: `field?: T`; with `#[model_schema_prop(nullable)]` all three surfaces render `T | null` with the key **required** instead: Zod `z.union([T, z.null()])`, JSON Schema `anyOf: [T, {"type": "null"}]` with the key in `required`
 - `Vec<T>` → `Array<T>`
 - `HashMap<String, T>` → `Partial<Record<string, T>>`
-- Custom types → Reference by name (Json suffix stripped if present)
+- Custom types → Reference by name (`Data` suffix stripped if present)
 - `ObjectId` → `ObjectId` (with $oid validation)
 - `DateTime<Tz>` → `Date` (Zod `z.coerce.date()`); with `#[model_schema_prop(as_number)]` → `number` (inline epoch-ms coercer)
 - `NaiveTime` → `string` (Zod `z.iso.time()` wrapped in an inline preprocessor that also accepts millis-since-start-of-day)
@@ -376,7 +376,7 @@ constraints.
 
 ### 8. Branded Newtypes
 
-Single-field tuple structs with `#[serde(transparent)]` are treated as branded/opaque types. If the Rust name has a `Json` suffix, it is stripped from the TypeScript name.
+Single-field tuple structs with `#[serde(transparent)]` are treated as branded/opaque types. If the Rust name has a `Data` suffix, it is stripped from the TypeScript name.
 
 A non-generic brand publishes a `$RawSchema`/`$Schema` const pair:
 
@@ -730,12 +730,12 @@ fn test_generate_typescript() {
 
 The macro transforms Rust types to TypeScript following these rules:
 
-1. **Type Name Transformation**: If the Rust type name ends with `Json`, the suffix is stripped (e.g., `UserJson` → `User`). Otherwise, the name is used as-is (e.g., `User` → `User`).
+1. **Type Name Transformation**: If the Rust type name ends with `Data`, the suffix is stripped (e.g., `UserData` → `User`). Otherwise, the name is used as-is (e.g., `User` → `User`), and a name that is exactly `Data` is left alone.
 2. **Field Names**: Respect serde rename attributes (`#[serde(rename = "...")]`, `#[serde(rename_all = "...")]`)
 3. **Optional Fields**: `Option<T>` becomes `T | undefined` in TypeScript and `z.union([z.null().transform(() => undefined), type, z.undefined()]).prefault(undefined)` in Zod, accepting both an absent key and an explicit `null`
 4. **Arrays**: `Vec<T>` becomes `Array<T>` in TypeScript
 5. **Maps**: `HashMap<String, T>` becomes `Partial<Record<string, T>>` in TypeScript
-6. **Nested Types**: Reference other types by name (Json suffix stripped if present)
+6. **Nested Types**: Reference other types by name (`Data` suffix stripped if present)
 7. **MongoDB ObjectId**: `ObjectId` becomes `ObjectId` in TypeScript with proper JSON schema validation
 8. **ObjectId Serialization**: Uses MongoDB format `{ "$oid": "hex_string" }`
 9. **ObjectId Validation**: Includes regex validation for 24-character hexadecimal strings

--- a/README.md
+++ b/README.md
@@ -1087,7 +1087,7 @@ export type CorrelationId = string & { readonly [__brand_CorrelationId]: true };
 
 Notes:
 
-- If the Rust type name ends with `Json`, the suffix is stripped in the generated TypeScript (e.g., `UserIdJson` becomes `UserId`). Otherwise, the Rust name is used as-is.
+- If the Rust type name ends with `Data`, the suffix is stripped in the generated TypeScript (e.g., `UserIdData` becomes `UserId`). Otherwise, the Rust name is used as-is.
 - Generic parameter names (e.g., `IdType`) are preserved exactly in the TypeScript type.
 - A generic brand publishes a factory, as every other generic item does, so the brand and its inner's shape land on the argument the caller supplied rather than on a value pinned at expansion. A parameter reaches it as the factory's own argument, under the rule in [Type Parameters](#type-parameters); a brand written over that parameter still describes what its inner writes, so `TagList<T>(pub Vec<T>)` is an array on every surface — `Array<T>`, `z.array(t)`, `{"type": "array", "items": {}}` — and not the bare parameter.
 - The description is written before the brand in a factory and after it in a `const`. Inside a factory the receiver is the parameter the caller filled, and Zod's `.meta()` returns `this` — which TypeScript resolves back to that bare parameter, dropping the marker `.brand<"Name">()` had just added. Both orders build the same schema.
@@ -2159,9 +2159,9 @@ If the `serde` feature is disabled but serde attributes are present, you will se
 
 ## Important Notes
 
-1. **Naming Convention**: The `Json` suffix on Rust type names is optional. If present, it is automatically stripped in the generated TypeScript output (e.g., `UserJson` becomes `User`). If no `Json` suffix is present, the Rust type name is used as-is (e.g., `User` stays `User`).
+1. **Naming Convention**: The `Data` suffix on Rust type names is optional. If present, it is automatically stripped in the generated TypeScript output (e.g., `UserData` becomes `User`). If no `Data` suffix is present, the Rust type name is used as-is (e.g., `User` stays `User`), and a type named exactly `Data` keeps that name -- stripping never empties a name.
 
-2. **Type References**: Nested types reference each other by their TypeScript name (with the `Json` suffix stripped if present).
+2. **Type References**: Nested types reference each other by their TypeScript name (with the `Data` suffix stripped if present).
 
 3. **Map Keys**: `HashMap` and `BTreeMap` are both supported, and the key decides what the map describes as: a `String` key gives an object open to any string key, and a plain `#[model_schema()]` enum key gives one closed to the enum's members. A brand and a `#[model_schema()]` alias answer by their inner and their target, keeping their own name on the TypeScript and Zod surfaces. A key path proved to be one serde writes as no key at all, and any sequence-wrapped key, is refused at expansion; every other key describes as an open object. See [Collections and Maps](#collections-and-maps).
 

--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -110,7 +110,7 @@ pub enum FieldDefType {
     /// See `README.md` for serialization format and validation details.
     ObjectId,
     /// Reference to another struct/enum type, potentially with generics
-    /// First String is the type name (without Json suffix in TS)
+    /// First String is the type name (without the companion suffix in TS)
     /// `Vec<FieldDef>` holds generic parameters if any.
     SiblingType(String, Vec<FieldDef>),
     /// String primitive - maps to string.
@@ -1657,10 +1657,7 @@ fn get_field_def_type_or_sibling(t_name: &str) -> FieldDefType {
         "NaiveTime" => FieldDefType::NaiveTime,
         #[cfg(feature = "chrono")]
         "NaiveDateTime" => FieldDefType::NaiveDateTime,
-        type_name_json if type_name_json.ends_with("Json") => {
-            FieldDefType::SiblingType(safe_type_name(type_name_json), vec![])
-        }
-        type_name => FieldDefType::SiblingType(type_name.to_owned(), vec![]),
+        type_name => FieldDefType::SiblingType(safe_type_name(type_name), vec![]),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -646,7 +646,7 @@ pub fn model_schema(args: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// #[model_schema()]
 /// #[derive(Serialize, Deserialize)]
-/// pub struct UserJson {
+/// pub struct UserData {
 ///     #[model_schema_prop(minLength = 3, maxLength = 50, pattern = "^[a-z0-9_]+$")]
 ///     pub username: String,
 ///
@@ -688,7 +688,7 @@ pub fn model_schema(args: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// #[model_schema()]
 /// #[derive(Serialize, Deserialize)]
-/// pub struct ProductJson {
+/// pub struct ProductData {
 ///     #[model_schema_prop(minimum = 0, maximum = 120)]
 ///     pub age_restriction: u32,
 ///
@@ -710,7 +710,7 @@ pub fn model_schema(args: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// #[model_schema()]
 /// #[derive(Serialize, Deserialize)]
-/// pub struct RegistrationJson {
+/// pub struct RegistrationData {
 ///     #[model_schema_prop(minLength = 3, maxLength = 30)]
 ///     pub username: String,
 ///
@@ -723,7 +723,7 @@ pub fn model_schema(args: TokenStream, input: TokenStream) -> TokenStream {
 /// from:
 ///
 /// ```text
-/// let reg = RegistrationJson { username: "ab".to_string(), age: 150 };
+/// let reg = RegistrationData { username: "ab".to_string(), age: 150 };
 /// match reg.validate() {
 ///     Ok(()) => println!("valid"),
 ///     Err(errors) => {
@@ -749,7 +749,7 @@ pub fn model_schema(args: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// #[model_schema()]
 /// #[derive(Serialize, Deserialize)]
-/// pub struct ApiConfigJson {
+/// pub struct ApiConfigData {
 ///     #[model_schema_prop(as = String)]
 ///     pub metric: String,
 ///
@@ -770,7 +770,7 @@ pub fn model_schema(args: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// #[model_schema()]
 /// #[derive(Serialize, Deserialize)]
-/// pub struct EventJson {
+/// pub struct EventData {
 ///     // → z.preprocess(trim, z.preprocess(normalize, z.string()))
 ///     #[model_schema_prop(preprocess = ["trim", "normalize"])]
 ///     pub name: String,

--- a/src/model_schema/tests.rs
+++ b/src/model_schema/tests.rs
@@ -2312,35 +2312,35 @@ fn an_alias_violating_both_type_level_guards_earns_both_refusals() {
     );
 }
 
-/// An alias publishes under a computed export name — `SlotJson` under `SlotType`, sharing no
+/// An alias publishes under a computed export name — `SlotData` under `SlotType`, sharing no
 /// substring with what was written. Both type-level guards name the written ident, the one string
 /// the author can find in their own source.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
-fn a_json_suffixed_alias_is_named_by_its_written_ident() {
+fn a_data_suffixed_alias_is_named_by_its_written_ident() {
     register_alias_info("Tally", "Tally", "tally_schema", AliasKind::NoEnumMembers);
     let held: syn::ItemType = syn::parse_quote! {
-        pub type SlotJson = OnceLock<u32>;
+        pub type SlotData = OnceLock<u32>;
     };
     let held_def = get_field_def("SlotType", &held.ty, "");
     let held_error = alias_undescribable_std_error(&held, &held_def)
         .unwrap_or_default()
         .to_string();
     assert!(
-        held_error.contains("type alias `SlotJson`"),
+        held_error.contains("type alias `SlotData`"),
         "got: {held_error}"
     );
     assert!(!held_error.contains("SlotType"), "got: {held_error}");
 
     let keyed: syn::ItemType = syn::parse_quote! {
-        pub type CountsJson = HashMap<Tally, u32>;
+        pub type CountsData = HashMap<Tally, u32>;
     };
     let keyed_def = get_field_def("CountsType", &keyed.ty, "");
     let keyed_error = alias_map_key_guard_error(&keyed, &keyed_def)
         .unwrap_or_default()
         .to_string();
     assert!(
-        keyed_error.contains("type alias `CountsJson`"),
+        keyed_error.contains("type alias `CountsData`"),
         "got: {keyed_error}"
     );
     assert!(!keyed_error.contains("CountsType"), "got: {keyed_error}");
@@ -3881,13 +3881,13 @@ fn an_alias_rejection_points_at_the_written_target() {
     );
 }
 
-/// The rejection names the written ident, not the export name the alias publishes under: `RowsJson`
+/// The rejection names the written ident, not the export name the alias publishes under: `RowsData`
 /// exports as `RowsType`, which the author's source does not contain anywhere.
 #[cfg(feature = "jsonschema")]
 #[test]
-fn a_json_suffixed_alias_rejection_names_its_written_ident() {
+fn a_data_suffixed_alias_rejection_names_its_written_ident() {
     let alias: syn::ItemType = syn::parse_quote! {
-        pub type RowsJson = HashMap<String, (u32, u32)>;
+        pub type RowsData = HashMap<String, (u32, u32)>;
     };
     let field_def = super::get_field_def("RowsType", &alias.ty, "");
     let tokens = super::generate_alias_json_schema_method(
@@ -3897,7 +3897,7 @@ fn a_json_suffixed_alias_rejection_names_its_written_ident() {
         &super::ModelSchemaArgs::default(),
     )
     .to_string();
-    assert!(tokens.contains("type alias `RowsJson`"), "got: {tokens}");
+    assert!(tokens.contains("type alias `RowsData`"), "got: {tokens}");
     assert!(!tokens.contains("type alias `RowsType`"), "got: {tokens}");
 }
 
@@ -5159,10 +5159,10 @@ fn an_exported_name_can_carry_no_double_quote() {
         syn::Ident::new_raw("type", proc_macro2::Span::call_site()).to_string(),
         "r#type"
     );
-    // The unrenamed path takes the ident whole but for a `Json` suffix, which drops characters and
+    // The unrenamed path takes the ident whole but for a `Data` suffix, which drops characters and
     // adds none; the renamed path takes the refused-unless-identifier override verbatim.
     assert_eq!(
-        super::compute_item_export_name("PayloadJson", None),
+        super::compute_item_export_name("PayloadData", None),
         "Payload"
     );
     assert_eq!(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -60,6 +60,10 @@ const ASTRAL_DIVERGENCE: &str = "a character outside the Basic Multilingual Plan
                                  the two code units it is written from -- so the set is the same \
                                  and the count is not, and no spelling of the class closes that";
 
+/// The suffix a companion type carries, taken off every generated name so `UserData` publishes as
+/// `User`.
+const COMPANION_SUFFIX: &str = "Data";
+
 /// Why a construct cannot reach the JavaScript surfaces as the author wrote it. The three are
 /// different failures and the rejection says which one it is.
 #[derive(Clone, Copy)]
@@ -765,12 +769,13 @@ pub fn written_type(ty: &Type) -> &Type {
     current
 }
 
+/// A name with [`COMPANION_SUFFIX`] taken off, unless taking it off would leave nothing to publish
+/// under.
 pub fn safe_type_name(key: &str) -> String {
-    if key.ends_with("Json") {
-        key.strip_suffix("Json").map(str::to_owned).unwrap()
-    } else {
-        key.to_owned()
-    }
+    key.strip_suffix(COMPANION_SUFFIX)
+        .filter(|stripped| !stripped.is_empty())
+        .unwrap_or(key)
+        .to_owned()
 }
 
 /// The schema module a `#[model_schema()]` item publishes — an alias, a struct, an enum, a branded
@@ -795,7 +800,7 @@ pub fn compute_alias_export_name(rust_ident: &str, override_name: Option<&str>) 
 
 /// The spelling every reference to a `#[model_schema()]` item falls back to when the registry
 /// cannot answer for it, which is what a reference standing *before* the item expanded has and
-/// nothing else — the ident with the `Json` suffix taken off, that being what the field walk
+/// nothing else — the ident with the `Data` suffix taken off, that being what the field walk
 /// records for a sibling and what [`ident_schema_module_name`] names the module from.
 #[cfg(any(feature = "typescript", feature = "zod"))]
 fn ident_reexport_name(rust_ident: &str, export_name: &str) -> Option<String> {

--- a/src/utils/tests.rs
+++ b/src/utils/tests.rs
@@ -727,15 +727,26 @@ fn test_escape_js_regex_literal_rewrites_an_identity_escaped_line_terminator() {
     assert_eq!(escape_js_regex_literal("^a\\\\\nb$"), r"^a\\\nb$");
 }
 
+/// A name is the suffix's to take only where something is left behind: an item declared as the
+/// bare suffix has to publish under the name it was written with, there being no other.
+#[test]
+fn the_companion_suffix_never_empties_a_name() {
+    assert_eq!(safe_type_name("PayloadData"), "Payload");
+    assert_eq!(safe_type_name("Data"), "Data");
+    assert_eq!(safe_type_name("Payload"), "Payload");
+    assert_eq!(safe_type_name("PayloadJson"), "PayloadJson");
+    assert_eq!(safe_type_name("Json"), "Json");
+}
+
 /// The module name a reference assumes for a name it has not seen and the one an alias goes on to
 /// publish are the same call: the `Type` suffix an alias exports under and a `name = "…"` override
-/// both land on the export name only, and the `Json` suffix is still read through either way.
+/// both land on the export name only, and the `Data` suffix is still read through either way.
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
 fn ident_schema_module_name_is_derived_from_the_ident_alone() {
     assert_eq!(ident_schema_module_name("LaterAlias"), "later_alias_schema");
     assert_eq!(
-        ident_schema_module_name("LaterAliasJson"),
+        ident_schema_module_name("LaterAliasData"),
         "later_alias_schema"
     );
     assert_eq!(
@@ -754,7 +765,7 @@ fn ident_schema_module_name_is_derived_from_the_ident_alone() {
 #[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
 #[test]
 fn an_unrenamed_item_publishes_the_same_module_under_either_derivation() {
-    for ident in ["LaterItem", "LaterItemJson", "HTTPHeader", "A"] {
+    for ident in ["LaterItem", "LaterItemData", "HTTPHeader", "A"] {
         assert_eq!(
             ident_schema_module_name(ident),
             format!(
@@ -774,7 +785,7 @@ fn an_unrenamed_item_publishes_the_same_module_under_either_derivation() {
 }
 
 /// The ident re-export answers at the same spelling the module seam answers at: whatever a
-/// reference falls back to when the registry cannot help it, the ident with the `Json` suffix read
+/// reference falls back to when the registry cannot help it, the ident with the `Data` suffix read
 /// through. An item already exported under that spelling publishes nothing.
 #[cfg(feature = "typescript")]
 #[test]
@@ -791,7 +802,7 @@ fn a_ts_reexport_is_written_only_where_the_export_moved_off_the_ident() {
         ident_reexport_ts("Pair", "PairType", "<A, B>"),
         "\n\nexport type Pair<A, B> = PairType<A, B>;"
     );
-    for (ident, export) in [("PlainItem", "PlainItem"), ("PlainItemJson", "PlainItem")] {
+    for (ident, export) in [("PlainItem", "PlainItem"), ("PlainItemData", "PlainItem")] {
         assert_eq!(ident_reexport_ts(ident, export, ""), "", "for: {ident}");
     }
 }
@@ -803,7 +814,7 @@ fn a_zod_reexport_is_written_only_where_the_export_moved_off_the_ident() {
         ident_reexport_zod("LaterAlias", "LaterAliasType", "$Schema"),
         "\n\nexport const LaterAlias$Schema = LaterAliasType$Schema;"
     );
-    for (ident, export) in [("PlainItem", "PlainItem"), ("PlainItemJson", "PlainItem")] {
+    for (ident, export) in [("PlainItem", "PlainItem"), ("PlainItemData", "PlainItem")] {
         assert_eq!(
             ident_reexport_zod(ident, export, "$Schema"),
             "",

--- a/tests/companion_suffix_tests.rs
+++ b/tests/companion_suffix_tests.rs
@@ -1,0 +1,10 @@
+//! Tests for the companion-type suffix: a declaration named `XData` publishes every generated name
+//! as `X`, while one named `XJson` publishes as itself. The three surfaces are covered where each
+//! writes a type's own name — the `export type` line, the schema consts, and the `$defs` key a
+//! self-referential document hoists under — alongside the reference resolution that has to agree
+//! with all three.
+
+#[cfg(any(feature = "typescript", feature = "zod", feature = "jsonschema"))]
+#[cfg(test)]
+#[path = "companion_suffix_tests/tests.rs"]
+mod tests;

--- a/tests/companion_suffix_tests/tests.rs
+++ b/tests/companion_suffix_tests/tests.rs
@@ -1,0 +1,128 @@
+use serde::{Deserialize, Serialize};
+use tixschema::model_schema;
+
+// Each shape names itself so the JSON document hoists it into `$defs`, that key being the one
+// place the JSON surface writes a type's own name.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug)]
+pub struct SomethingData {
+    pub children: Vec<Self>,
+    pub label: String,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug)]
+pub struct SomethingJson {
+    pub children: Vec<Self>,
+    pub label: String,
+}
+
+// The bare suffix: stripping it would leave nothing to publish under.
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Data {
+    pub children: Vec<Self>,
+    pub label: String,
+}
+
+#[model_schema()]
+#[derive(Serialize, Deserialize, Debug)]
+pub struct SuffixHolder {
+    pub bare: Data,
+    pub kept: SomethingJson,
+    pub stripped: SomethingData,
+}
+
+#[cfg(feature = "typescript")]
+#[test]
+fn typescript_is_published_under_the_name_the_suffix_leaves() {
+    let stripped = SomethingData::ts_definition();
+    assert!(
+        stripped.contains("export type Something = {"),
+        "got: {stripped}"
+    );
+    assert!(!stripped.contains("SomethingData"), "got: {stripped}");
+
+    let kept = SomethingJson::ts_definition();
+    assert!(
+        kept.contains("export type SomethingJson = {"),
+        "got: {kept}"
+    );
+
+    let bare = Data::ts_definition();
+    assert!(bare.contains("export type Data = {"), "got: {bare}");
+}
+
+#[cfg(feature = "zod")]
+#[test]
+fn zod_consts_are_published_under_the_name_the_suffix_leaves() {
+    let stripped = SomethingData::zod_schema();
+    assert!(
+        stripped.contains("export const Something$Schema"),
+        "got: {stripped}"
+    );
+    assert!(!stripped.contains("SomethingData"), "got: {stripped}");
+
+    let kept = SomethingJson::zod_schema();
+    assert!(
+        kept.contains("export const SomethingJson$Schema"),
+        "got: {kept}"
+    );
+
+    let bare = Data::zod_schema();
+    assert!(bare.contains("export const Data$Schema"), "got: {bare}");
+}
+
+#[cfg(feature = "jsonschema")]
+#[test]
+fn the_json_definition_is_keyed_by_the_name_the_suffix_leaves() {
+    assert_eq!(
+        SomethingData::json_schema()["$ref"],
+        serde_json::json!("#/$defs/Something")
+    );
+    assert_eq!(
+        SomethingJson::json_schema()["$ref"],
+        serde_json::json!("#/$defs/SomethingJson")
+    );
+    assert_eq!(
+        Data::json_schema()["$ref"],
+        serde_json::json!("#/$defs/Data")
+    );
+}
+
+#[cfg(feature = "typescript")]
+#[test]
+fn a_typescript_reference_names_what_the_referenced_item_publishes() {
+    let ts = SuffixHolder::ts_definition();
+    assert!(ts.contains("stripped: Something;"), "got: {ts}");
+    assert!(ts.contains("kept: SomethingJson;"), "got: {ts}");
+    assert!(ts.contains("bare: Data;"), "got: {ts}");
+}
+
+#[cfg(feature = "zod")]
+#[test]
+fn a_zod_reference_names_what_the_referenced_item_publishes() {
+    let zod = SuffixHolder::zod_schema();
+    assert!(zod.contains("stripped: Something$Schema,"), "got: {zod}");
+    assert!(zod.contains("kept: SomethingJson$Schema,"), "got: {zod}");
+    assert!(zod.contains("bare: Data$Schema,"), "got: {zod}");
+}
+
+#[cfg(feature = "jsonschema")]
+#[test]
+fn a_json_reference_points_at_the_definition_the_referenced_item_hoists() {
+    let document = SuffixHolder::json_schema();
+    let properties = &document["properties"];
+    assert_eq!(
+        properties["stripped"],
+        serde_json::json!({ "$ref": "#/$defs/Something" })
+    );
+    assert_eq!(
+        properties["kept"],
+        serde_json::json!({ "$ref": "#/$defs/SomethingJson" })
+    );
+    assert_eq!(
+        properties["bare"],
+        serde_json::json!({ "$ref": "#/$defs/Data" })
+    );
+}

--- a/tests/item_description_tests.rs
+++ b/tests/item_description_tests.rs
@@ -3,7 +3,7 @@
 //!
 //! The fallback names the item as it is **exported**, so it agrees with the `export type` written
 //! one line under it. An export name parts from the Rust ident two ways: a `name = "…"` override,
-//! and the `Json` suffix stripped off a declared ident. Both are covered here, alongside the
+//! and the `Data` suffix stripped off a declared ident. Both are covered here, alongside the
 //! un-suffixed un-renamed items whose output this must leave exactly where it was.
 
 #[cfg(any(feature = "typescript", feature = "zod"))]

--- a/tests/item_description_tests/tests.rs
+++ b/tests/item_description_tests/tests.rs
@@ -11,7 +11,7 @@ pub struct PlainStruct {
 #[cfg(feature = "typescript")]
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug)]
-pub struct SuffixedStructJson {
+pub struct SuffixedStructData {
     pub label: String,
 }
 
@@ -38,7 +38,7 @@ pub struct PlainTuple(pub String, pub u32);
 #[cfg(feature = "typescript")]
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug)]
-pub struct SuffixedTupleJson(pub String, pub u32);
+pub struct SuffixedTupleData(pub String, pub u32);
 
 #[cfg(feature = "typescript")]
 #[model_schema(name = "RenamedTuple")]
@@ -56,7 +56,7 @@ pub enum PlainSlot {
 #[cfg(any(feature = "typescript", feature = "zod"))]
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
-pub enum SuffixedSlotJson {
+pub enum SuffixedSlotData {
     Primary,
     Secondary,
 }
@@ -80,7 +80,7 @@ pub enum PlainShape {
 #[cfg(feature = "typescript")]
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug)]
-pub enum SuffixedShapeJson {
+pub enum SuffixedShapeData {
     Named { side: u8 },
     Unit,
 }
@@ -106,7 +106,7 @@ pub enum PlainAdjacent {
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "kind", content = "payload")]
-pub enum SuffixedAdjacentJson {
+pub enum SuffixedAdjacentData {
     Named { side: u8 },
     Unit,
 }
@@ -133,7 +133,7 @@ pub enum PlainEither {
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(untagged)]
-pub enum SuffixedEitherJson {
+pub enum SuffixedEitherData {
     Count(u32),
     Label(String),
 }
@@ -157,7 +157,7 @@ pub struct PlainBrand(pub String);
 #[model_schema()]
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(transparent)]
-pub struct SuffixedBrandJson(pub String);
+pub struct SuffixedBrandData(pub String);
 
 #[cfg(feature = "zod")]
 #[model_schema(name = "RenamedBrand")]
@@ -220,12 +220,12 @@ fn an_undocumented_item_names_itself_in_jsdoc_as_it_is_exported() {
         (ShapeUnderRustName::ts_definition(), "RenamedShape"),
         (AdjacentUnderRustName::ts_definition(), "RenamedAdjacent"),
         (EitherUnderRustName::ts_definition(), "RenamedEither"),
-        (SuffixedStructJson::ts_definition(), "SuffixedStruct"),
-        (SuffixedTupleJson::ts_definition(), "SuffixedTuple"),
-        (SuffixedSlotJson::ts_definition(), "SuffixedSlot"),
-        (SuffixedShapeJson::ts_definition(), "SuffixedShape"),
-        (SuffixedAdjacentJson::ts_definition(), "SuffixedAdjacent"),
-        (SuffixedEitherJson::ts_definition(), "SuffixedEither"),
+        (SuffixedStructData::ts_definition(), "SuffixedStruct"),
+        (SuffixedTupleData::ts_definition(), "SuffixedTuple"),
+        (SuffixedSlotData::ts_definition(), "SuffixedSlot"),
+        (SuffixedShapeData::ts_definition(), "SuffixedShape"),
+        (SuffixedAdjacentData::ts_definition(), "SuffixedAdjacent"),
+        (SuffixedEitherData::ts_definition(), "SuffixedEither"),
     ] {
         assert_jsdoc_opens_with(&ts, exported);
         assert!(
@@ -280,15 +280,15 @@ fn an_undocumented_item_never_writes_its_rust_ident() {
         );
     }
     for (ts, ident) in [
-        (SuffixedStructJson::ts_definition(), "SuffixedStructJson"),
-        (SuffixedTupleJson::ts_definition(), "SuffixedTupleJson"),
-        (SuffixedSlotJson::ts_definition(), "SuffixedSlotJson"),
-        (SuffixedShapeJson::ts_definition(), "SuffixedShapeJson"),
+        (SuffixedStructData::ts_definition(), "SuffixedStructData"),
+        (SuffixedTupleData::ts_definition(), "SuffixedTupleData"),
+        (SuffixedSlotData::ts_definition(), "SuffixedSlotData"),
+        (SuffixedShapeData::ts_definition(), "SuffixedShapeData"),
         (
-            SuffixedAdjacentJson::ts_definition(),
-            "SuffixedAdjacentJson",
+            SuffixedAdjacentData::ts_definition(),
+            "SuffixedAdjacentData",
         ),
-        (SuffixedEitherJson::ts_definition(), "SuffixedEitherJson"),
+        (SuffixedEitherData::ts_definition(), "SuffixedEitherData"),
     ] {
         assert!(!ts.contains(ident), "rust ident reached: {ts}");
     }
@@ -362,7 +362,7 @@ fn a_documented_item_keeps_its_docs_over_either_name() {
 fn a_plain_enum_describes_itself_as_it_is_exported() {
     for (zod, exported) in [
         (SlotUnderRustName::zod_schema(), "RenamedSlot"),
-        (SuffixedSlotJson::zod_schema(), "SuffixedSlot"),
+        (SuffixedSlotData::zod_schema(), "SuffixedSlot"),
         (PlainSlot::zod_schema(), "PlainSlot"),
     ] {
         assert!(
@@ -377,7 +377,7 @@ fn a_plain_enum_describes_itself_as_it_is_exported() {
         "rust ident reached the description: {slot}"
     );
     assert!(
-        !SuffixedSlotJson::zod_schema().contains("SuffixedSlotJson"),
+        !SuffixedSlotData::zod_schema().contains("SuffixedSlotData"),
         "rust ident reached the description"
     );
 }
@@ -389,7 +389,7 @@ fn a_plain_enum_describes_itself_as_it_is_exported() {
 fn a_brand_describes_itself_as_it_is_exported() {
     for (zod, exported) in [
         (BrandUnderRustName::zod_schema(), "RenamedBrand"),
-        (SuffixedBrandJson::zod_schema(), "SuffixedBrand"),
+        (SuffixedBrandData::zod_schema(), "SuffixedBrand"),
         (PlainBrand::zod_schema(), "PlainBrand"),
     ] {
         assert!(

--- a/tests/pattern_preprocess_tests/tests.rs
+++ b/tests/pattern_preprocess_tests/tests.rs
@@ -727,12 +727,12 @@ fn test_a_rust_named_group_reaches_the_zod_literal_as_javascript_spells_it() {
 fn test_a_rust_named_group_reaches_the_json_schema_as_ecma_262_spells_it() {
     #[model_schema()]
     #[derive(Serialize, Deserialize)]
-    pub struct RustNamedGroupJson {
+    pub struct RustNamedGroupJsonSchema {
         #[model_schema_prop(pattern = "^(?P<word>[a-z]+)$")]
         pub tag: String,
     }
 
-    let schema_str = serde_json::to_string(&RustNamedGroupJson::json_schema()).unwrap();
+    let schema_str = serde_json::to_string(&RustNamedGroupJsonSchema::json_schema()).unwrap();
     assert!(
         schema_str.contains(r#""pattern":"^(?<word>[a-z]+)$""#),
         "JSON Schema `pattern` is an ECMA-262 regex: {schema_str}"

--- a/tests/validation_tests/tests.rs
+++ b/tests/validation_tests/tests.rs
@@ -2297,7 +2297,7 @@ fn test_readme_branded_validate_example_prints_what_the_generator_writes() {
 fn test_crate_rustdoc_quotes_the_messages_the_generator_writes() {
     #[model_schema()]
     #[derive(Serialize, Deserialize)]
-    pub struct RegistrationJson {
+    pub struct RegistrationData {
         #[model_schema_prop(minimum = 0, maximum = 120)]
         pub age: u32,
 
@@ -2305,7 +2305,7 @@ fn test_crate_rustdoc_quotes_the_messages_the_generator_writes() {
         pub username: String,
     }
 
-    let errors = RegistrationJson {
+    let errors = RegistrationData {
         age: 150,
         username: "ab".to_owned(),
     }


### PR DESCRIPTION
A declaration named `XJson` published every generated name as `X` — the
TypeScript type, the Zod consts, the JSON Schema id, and what a reference to it
resolves as. The recognized suffix is `Data` now, with the same mechanics:
suffix-only, exact case, and `XData` publishes as `X` everywhere a name is
read. `Json` is not recognized at all — a hard switch, taken after auditing the
consuming workspace and finding no Json-suffixed declaration to migrate.

Recognition lives in one place where it lived in two. The reference-resolution
arm was behaviourally identical to the stripping seam once the guard sits
there, so it now routes through the same function instead of repeating the
suffix, and a grep finds no other name-level suffix reading.

Stripping never empties a name: a type named exactly `Data` keeps it. The old
code lacked that guard — `Json` alone stripped to the empty string — so it is
new, not preserved.

Pinned from both directions: `SomethingData` publishes as `Something` on all
three surfaces including reference resolution, and `SomethingJson` publishes
as itself, so the old convention is provably gone rather than merely
undocumented. Eleven fixtures migrated to the new suffix; one incidental
`Json`-named fixture about JSON Schema itself was respelled to match its
siblings; the docs' naming-convention sections and worked examples move with
it.

just fmt, just check, just quick, doctests, just lint-all across all 68
toggles, and the test powerset across all 68 in four partitions — all green.

