### PR TITLE
spell a self-referencing untagged map member as an index signature, where the mapped type cycled

### DIFF
--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -294,7 +294,7 @@ impl FieldDef {
             || self.parameter_shape_name().is_some()
     }
 
-    #[cfg(feature = "zod")]
+    #[cfg(any(feature = "zod", all(feature = "serde", feature = "typescript")))]
     /// Checks if this field contains a reference to the given type name.
     pub fn contains_type_reference(&self, type_name: &str) -> bool {
         match &self.field_type {
@@ -959,6 +959,36 @@ impl FieldDef {
     /// `None` in each of them.
     pub fn typescript_slot_typename(&self) -> String {
         let base = self.typescript_base();
+        if self.is_optional() {
+            format!("{base} | null")
+        } else {
+            base
+        }
+    }
+
+    /// The slot spelling of a member of the type named by `self_type_name`, with a map whose
+    /// values name that type written as an index signature. `Partial<Record<K, V>>` is a mapped
+    /// type, and TypeScript resolves those while it resolves the alias declaring the union, so a
+    /// member spelled that way makes the alias circular (TS2456); the index-signature object it is
+    /// equal to states the same type and is resolved lazily. A key the index signature has no
+    /// parameter type for keeps the mapped spelling, as does a map under an array wrap, which is
+    /// already deferred by the wrap.
+    #[cfg(all(feature = "serde", feature = "typescript"))]
+    pub fn typescript_slot_typename_deferring_self(&self, self_type_name: &str) -> String {
+        let FieldDefType::Map(key, value) = &self.field_type else {
+            return self.typescript_slot_typename();
+        };
+        let key_type = key.typescript_map_key_typename();
+        if self.array_depth > 0
+            || !matches!(key_type.as_str(), "number" | "string")
+            || !value.contains_type_reference(self_type_name)
+        {
+            return self.typescript_slot_typename();
+        }
+        let base = format!(
+            "{{ [key: {key_type}]: {} | undefined }}",
+            value.typescript_slot_typename()
+        );
         if self.is_optional() {
             format!("{base} | null")
         } else {

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -7275,6 +7275,9 @@ fn render_untagged_tuple_single(
     fld: &FieldDef,
     self_type_name: &str,
 ) -> (String, String, proc_macro2::TokenStream) {
+    #[cfg(feature = "typescript")]
+    let ts = fld.typescript_slot_typename_deferring_self(self_type_name);
+    #[cfg(not(feature = "typescript"))]
     let ts = fld.typescript_slot_typename();
 
     #[cfg(feature = "zod")]

--- a/tests/untagged_tests/tests.rs
+++ b/tests/untagged_tests/tests.rs
@@ -149,6 +149,16 @@ enum KeyedUnion {
     Labels { labels: HashMap<String, String> },
 }
 
+// A newtype member holding a map that names nothing recursive: the mapped-type spelling the
+// self-naming member of `JsonValueUnion` has to avoid is what a member like this keeps.
+#[model_schema()]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+enum LabelBagUnion {
+    Bag(HashMap<String, String>),
+    Name(String),
+}
+
 // A tuple written in an untagged member. Serde writes it as the fixed-arity array a tuple field
 // writes, so the member has to describe as that field does.
 #[model_schema()]
@@ -457,21 +467,51 @@ fn test_recursive_tuple_single_union_zod_keeps_scalar_members_eager() {
     }
 }
 
-/// A TypeScript type names itself wherever it likes, so the union is written out flat — the thunk
-/// the Zod schema needs has no counterpart here.
+/// A TypeScript type names itself from an array member wherever it likes, so the union is written
+/// out flat — the thunk the Zod schema needs has no counterpart there. The map member is the one
+/// exception: `Partial<Record<…>>` is a mapped type, resolved while the alias resolves, so a member
+/// spelled that way makes the alias circular (TS2456). It is written as the index-signature object
+/// it is equal to, which is resolved lazily.
 #[test]
 #[cfg(feature = "typescript")]
-fn test_recursive_tuple_single_union_typescript_carries_no_deferral() {
+fn test_recursive_tuple_single_union_typescript_defers_only_the_map_member() {
     let ts = JsonValueUnion::ts_definition();
     assert!(
         ts.contains(
             "export type JsonValueUnion = boolean | Array<JsonValueUnion> | \
-             Partial<Record<string, JsonValueUnion>> | number | string;"
+             { [key: string]: JsonValueUnion | undefined } | number | string;"
         ),
         "Got:\n{ts}"
     );
+    assert!(
+        !ts.contains("Partial<Record<string, JsonValueUnion>>"),
+        "the mapped-type spelling is the circularity itself. Got:\n{ts}"
+    );
     assert!(!ts.contains("z.lazy"), "Got:\n{ts}");
     assert!(!ts.contains("=>"), "Got:\n{ts}");
+}
+
+/// The lazy spelling is paid only where the cycle is: a map member naming nothing recursive keeps
+/// the `Partial<Record<…>>` every other map is written in.
+#[test]
+#[cfg(feature = "typescript")]
+fn test_non_recursive_tuple_single_map_member_keeps_mapped_type() {
+    let ts = LabelBagUnion::ts_definition();
+    assert!(
+        ts.contains("export type LabelBagUnion = Partial<Record<string, string>> | string;"),
+        "Got:\n{ts}"
+    );
+    assert!(!ts.contains("[key: string]"), "Got:\n{ts}");
+}
+
+/// The map member of a union that names nothing recursive, written and read back.
+#[test]
+fn test_serde_round_trip_non_recursive_map_member() {
+    let value = LabelBagUnion::Bag(HashMap::from([("a".to_owned(), "b".to_owned())]));
+    let json = serde_json::to_string(&value).unwrap();
+    assert_eq!(json, r#"{"a":"b"}"#);
+    let back: LabelBagUnion = serde_json::from_str(&json).unwrap();
+    assert_eq!(back, value);
 }
 
 /// The nesting the deferral exists for, written and read back through the union that describes it.


### PR DESCRIPTION
A self-recursive untagged enum whose recursive member is a map generates a TypeScript type alias that references itself through `Partial<Record<string, Self>>`. TypeScript resolves mapped types while it resolves the alias declaring them, so the alias is refused outright: `error TS2456: Type alias circularly references itself`. The array member never had this problem — only the map spelling did.

The fix is spelling-only: when the map's value type references the enclosing self type (the same test the zod renderer already applies for its `z.lazy` deferral), the member is written as the index-signature object it is equal to — `{ [key: string]: V | undefined }` — which TypeScript resolves lazily. Every other map keeps the byte-identical `Partial<Record<..>>`: non-recursive maps, array-wrapped maps (the wrap already defers), and maps whose key does not spell as `string` or `number` (an index signature has no parameter type for those; that keyed-by-enum case is tracked separately). Zod and JSON Schema surfaces are untouched.

Tests pin the new spelling on the recursive fixture, the preserved spelling on a new non-recursive one, and the negative assertions on both; verified externally with `tsc --strict`: the new alias compiles clean, the old spelling reproduces TS2456. Full feature-combination matrix green.