### PR TITLE
spell an enum-keyed self-referencing map as the mapped type it equals, where both landed spellings fail

### DIFF
--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -966,29 +966,30 @@ impl FieldDef {
         }
     }
 
-    /// The slot spelling of a member of the type named by `self_type_name`, with a map whose
-    /// values name that type written as an index signature. `Partial<Record<K, V>>` is a mapped
-    /// type, and TypeScript resolves those while it resolves the alias declaring the union, so a
-    /// member spelled that way makes the alias circular (TS2456); the index-signature object it is
-    /// equal to states the same type and is resolved lazily. A key the index signature has no
-    /// parameter type for keeps the mapped spelling, as does a map under an array wrap, which is
-    /// already deferred by the wrap.
+    /// The slot spelling of a member of the type named by `self_type_name`, with a map whose values
+    /// name that type written so the alias declaring the union stays resolvable.
+    /// `Partial<Record<K, V>>` is `Partial` applied to `Record`, and TypeScript resolves both while
+    /// it resolves the alias, so a member spelled that way makes the alias circular (TS2456). A key
+    /// spelling as `string` or `number` is written as the index-signature object it is equal to; an
+    /// enumerated key is a literal type, which an index signature parameter cannot be (TS1337), so
+    /// it is written as the mapped type it is equal to instead. Both state the same object and
+    /// resolve their value lazily. A map under an array wrap keeps `Partial<Record<…>>`, the wrap
+    /// having deferred it already.
     #[cfg(all(feature = "serde", feature = "typescript"))]
     pub fn typescript_slot_typename_deferring_self(&self, self_type_name: &str) -> String {
         let FieldDefType::Map(key, value) = &self.field_type else {
             return self.typescript_slot_typename();
         };
-        let key_type = key.typescript_map_key_typename();
-        if self.array_depth > 0
-            || !matches!(key_type.as_str(), "number" | "string")
-            || !value.contains_type_reference(self_type_name)
-        {
+        if self.array_depth > 0 || !value.contains_type_reference(self_type_name) {
             return self.typescript_slot_typename();
         }
-        let base = format!(
-            "{{ [key: {key_type}]: {} | undefined }}",
-            value.typescript_slot_typename()
-        );
+        let key_type = key.typescript_map_key_typename();
+        let value_type = value.typescript_slot_typename();
+        let base = if matches!(key_type.as_str(), "number" | "string") {
+            format!("{{ [key: {key_type}]: {value_type} | undefined }}")
+        } else {
+            format!("{{ [key in {key_type}]?: {value_type} }}")
+        };
         if self.is_optional() {
             format!("{base} | null")
         } else {

--- a/tests/untagged_tests/tests.rs
+++ b/tests/untagged_tests/tests.rs
@@ -159,6 +159,39 @@ enum LabelBagUnion {
     Name(String),
 }
 
+// A self-naming map member keyed by a type that enumerates its members. An index signature
+// parameter cannot be a literal type (TS1337), so the spelling `JsonValueUnion` is deferred with
+// is unavailable here and the equal mapped type carries the deferral instead.
+#[model_schema()]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+enum BucketTreeUnion {
+    Leaf(String),
+    Nested(HashMap<Bucket, Self>),
+}
+
+// The self-naming map member whose key spells as `number`: the index signature has a parameter
+// type for it, so it keeps that spelling rather than the mapped one.
+#[cfg(feature = "typescript")]
+#[model_schema()]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+enum CodeTreeUnion {
+    Leaf(String),
+    Nested(HashMap<u32, Self>),
+}
+
+// An enumerated key on a map member naming nothing recursive: no cycle to break, so the member
+// keeps the `Partial<Record<…>>` every other map is written in.
+#[cfg(feature = "typescript")]
+#[model_schema()]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+enum BucketBagUnion {
+    Bag(HashMap<Bucket, u32>),
+    Name(String),
+}
+
 // A tuple written in an untagged member. Serde writes it as the fixed-arity array a tuple field
 // writes, so the member has to describe as that field does.
 #[model_schema()]
@@ -511,6 +544,97 @@ fn test_serde_round_trip_non_recursive_map_member() {
     let json = serde_json::to_string(&value).unwrap();
     assert_eq!(json, r#"{"a":"b"}"#);
     let back: LabelBagUnion = serde_json::from_str(&json).unwrap();
+    assert_eq!(back, value);
+}
+
+/// An enumerated key is a literal type, which an index signature parameter cannot be (TS1337), so
+/// the spelling that carries the open-keyed deferral is unavailable. The mapped type the key can be
+/// written in states the same object and resolves its value lazily.
+#[test]
+#[cfg(feature = "typescript")]
+fn test_recursive_enum_keyed_map_member_typescript_uses_mapped_type() {
+    let ts = BucketTreeUnion::ts_definition();
+    assert!(
+        ts.contains(
+            "export type BucketTreeUnion = string | { [key in Bucket]?: BucketTreeUnion };"
+        ),
+        "Got:\n{ts}"
+    );
+    assert!(
+        !ts.contains("Partial<Record<Bucket, BucketTreeUnion>>"),
+        "the mapped-type spelling is the circularity itself. Got:\n{ts}"
+    );
+    assert!(!ts.contains("[key: Bucket]"), "Got:\n{ts}");
+}
+
+/// A key the index signature does have a parameter type for keeps that spelling: the mapped type is
+/// paid only where the literal key rules the index signature out.
+#[test]
+#[cfg(feature = "typescript")]
+fn test_recursive_number_keyed_map_member_typescript_keeps_index_signature() {
+    let ts = CodeTreeUnion::ts_definition();
+    assert!(
+        ts.contains(
+            "export type CodeTreeUnion = string | { [key: number]: CodeTreeUnion | undefined };"
+        ),
+        "Got:\n{ts}"
+    );
+    assert!(!ts.contains("key in"), "Got:\n{ts}");
+}
+
+/// The rewrite is a break of a cycle, never a restyling of the key: an enumerated key with nothing
+/// recursive under it keeps `Partial<Record<…>>`.
+#[test]
+#[cfg(feature = "typescript")]
+fn test_non_recursive_enum_keyed_map_member_keeps_mapped_record() {
+    let ts = BucketBagUnion::ts_definition();
+    assert!(
+        ts.contains("export type BucketBagUnion = Partial<Record<Bucket, number>> | string;"),
+        "Got:\n{ts}"
+    );
+    assert!(!ts.contains("key in"), "Got:\n{ts}");
+}
+
+/// The Zod surface reads the member through a thunk, which the TypeScript spelling does not change.
+#[test]
+#[cfg(feature = "zod")]
+fn test_recursive_enum_keyed_map_member_zod_defers_self_reference() {
+    let zod = BucketTreeUnion::zod_schema();
+    assert!(
+        zod.contains("z.lazy(() => z.record(Bucket$Schema, BucketTreeUnion$Schema))"),
+        "Got:\n{zod}"
+    );
+}
+
+/// The JSON surface hoists the union into `$defs` and points the member's values back at it.
+#[test]
+#[cfg(feature = "jsonschema")]
+fn test_recursive_enum_keyed_map_member_json_schema_refers_to_definition() {
+    let schema = BucketTreeUnion::json_schema();
+    assert_eq!(schema["$ref"], "#/$defs/BucketTreeUnion");
+    let properties = &schema["$defs"]["BucketTreeUnion"]["anyOf"][1]["properties"];
+    for bucket in ["Large", "Small"] {
+        assert_eq!(
+            properties[bucket],
+            serde_json::json!({ "$ref": "#/$defs/BucketTreeUnion" }),
+            "Got:\n{schema:#?}"
+        );
+    }
+}
+
+/// The nesting the enumerated-key deferral exists for, written and read back.
+#[test]
+fn test_serde_round_trip_enum_keyed_recursive_union() {
+    let value = BucketTreeUnion::Nested(HashMap::from([(
+        Bucket::Large,
+        BucketTreeUnion::Nested(HashMap::from([(
+            Bucket::Small,
+            BucketTreeUnion::Leaf("leaf".to_owned()),
+        )])),
+    )]));
+    let json = serde_json::to_string(&value).unwrap();
+    assert_eq!(json, r#"{"Large":{"Small":"leaf"}}"#);
+    let back: BucketTreeUnion = serde_json::from_str(&json).unwrap();
     assert_eq!(back, value);
 }
 


### PR DESCRIPTION
A self-recursive untagged enum whose recursive member is a map keyed by an
enumerated type still emitted `Partial<Record<Bucket, Self>>`, a mapped type
TypeScript resolves while resolving the alias — a hard TS2456. The
index-signature rewrite that fixed the string- and number-keyed cases cannot
reach it: an index signature parameter cannot be a literal type (TS1337), which
is exactly why the rewrite had restricted itself to those two keys and left the
enumerated key circular.

The third spelling is the direct mapped type:

    export type A = string | { [key in Bucket]?: A };

Measured against tsc 6.0.3, and cross-checked on 5.9.3 and 7.0.2, before
anything was written: `Partial<Record<...>>` fails because `Partial` applied to
`Record` resolves eagerly, while a map written directly over the literal union
defers its value — exit 0 under --strict. A mutual-extends witness pins that
the two spellings are the same type, not merely similar, and the new one still
rejects an unknown key and a wrong value type. Unlike a named helper interface,
which also compiles, this adds no exported name, so the published surface does
not move.

The key-spelling test moves out of the bail-out condition into a two-arm
choice: a `string`/`number` key keeps the index signature, any other key takes
the mapped spelling. A non-recursive enum-keyed map keeps
`Partial<Record<...>>` byte-identical, as does a map under an array wrap, the
wrap having deferred it already. Zod and the JSON document were already correct
and are now pinned. The real `ts_definition()` output was piped through tsc:
exit 0.

just fmt, just check, just quick, just lint-all across all 68 toggles, and the
test powerset across all 68 in four partitions — all green.

