### PR TITLE
annotate a brand's const off the value it binds, and retire the class table that guessed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -427,7 +427,7 @@ const CorrelationId$RawSchema = z.string().brand<"CorrelationId">().meta({
   description: "CorrelationId",
 });
 
-export const CorrelationId$Schema: $ZodBranded<ZodString, "CorrelationId"> = CorrelationId$RawSchema;
+export const CorrelationId$Schema: typeof CorrelationId$RawSchema = CorrelationId$RawSchema;
 ```
 
 A brand with a type parameter publishes `X$SchemaFactory` plus `X$SchemaDefault` instead, exactly
@@ -469,7 +469,9 @@ export function UserId$SchemaFactory(
   return schema;
 }
 
-export const UserId$SchemaDefault: $ZodBranded<ZodString, "UserId"> = UserId$SchemaFactory(z.string());
+const UserId$RawSchemaDefault = UserId$SchemaFactory(z.string());
+
+export const UserId$SchemaDefault: typeof UserId$RawSchemaDefault = UserId$RawSchemaDefault;
 ```
 
 With `typescript` only (no `zod`):
@@ -481,8 +483,14 @@ export type UserId<IdType> = IdType & { readonly [__brand_UserId]: true };
 Rules:
 - Generic parameter names are preserved exactly (`IdType` stays `IdType` in TypeScript)
 - A brand with no type parameter publishes the `$RawSchema`/`$Schema` const pair; a brand with a
-  type parameter publishes `$SchemaFactory`/`$SchemaDefault` instead — the parameter's inner
-  composes the factory's bound argument (`idType`), never the opaque `z.unknown()`
+  type parameter publishes `$SchemaFactory`/`$SchemaDefault` instead, the default binding its
+  factory call to `{Name}$RawSchemaDefault` first — the parameter's inner composes the factory's
+  bound argument (`idType`), never the opaque `z.unknown()`
+- Either binding is annotated `typeof` the raw `const` beneath it, never a Zod class: `.brand()`
+  narrows at the value position, and the class an inner renders to is zod's to decide
+  (`z.coerce.date()` is a `ZodCoercedDate`, `z.iso.date()` a `ZodISODate`, a brand over a brand a
+  `$ZodBranded` of a `$ZodBranded`). Reading the annotation off the value is the one spelling that
+  stays true of all of them
 - Serde transparent serialization works normally — the newtype is invisible in JSON
 - The slot takes no `#[model_schema_prop(...)]`: a brand publishes its inner's own schema with a
   `.brand()` written onto it, so no key written there reaches any surface, and one written there is

--- a/README.md
+++ b/README.md
@@ -1122,14 +1122,16 @@ export function UserId$SchemaFactory(
   return schema;
 }
 
-export const UserId$SchemaDefault: $ZodBranded<ZodString, "UserId"> = UserId$SchemaFactory(z.string());
+const UserId$RawSchemaDefault = UserId$SchemaFactory(z.string());
+
+export const UserId$SchemaDefault: typeof UserId$RawSchemaDefault = UserId$RawSchemaDefault;
 
 export type CorrelationId = string & $brand<"CorrelationId">;
 const CorrelationId$RawSchema = z.string().brand<"CorrelationId">().meta({
   description: "CorrelationId",
 });
 
-export const CorrelationId$Schema: $ZodBranded<ZodString, "CorrelationId"> = CorrelationId$RawSchema;
+export const CorrelationId$Schema: typeof CorrelationId$RawSchema = CorrelationId$RawSchema;
 ```
 
 Generated TypeScript (without `zod` feature):
@@ -1298,7 +1300,7 @@ const SlugId$RawSchema = z.string().min(3).max(50).check(z.regex(/^[a-z0-9_]+$/)
   description: "SlugId",
 });
 
-export const SlugId$Schema: $ZodBranded<ZodString, "SlugId"> = SlugId$RawSchema;
+export const SlugId$Schema: typeof SlugId$RawSchema = SlugId$RawSchema;
 ```
 
 Serde deserialization validates automatically:
@@ -1441,7 +1443,9 @@ export function DocumentId$SchemaFactory(
   return schema;
 }
 
-export const DocumentId$SchemaDefault: $ZodBranded<ZodString, "DocumentId"> = DocumentId$SchemaFactory(z.string());
+const DocumentId$RawSchemaDefault = DocumentId$SchemaFactory(z.string());
+
+export const DocumentId$SchemaDefault: typeof DocumentId$RawSchemaDefault = DocumentId$RawSchemaDefault;
 ```
 
 ## Field Validation (`model_schema_prop`)

--- a/src/model_schema.rs
+++ b/src/model_schema.rs
@@ -273,17 +273,6 @@ struct BrandedValidation {
     validate_fn: proc_macro2::TokenStream,
 }
 
-/// What a branded newtype's inner writes when what it writes is a composite: an array, a map, a
-/// tuple, or a value the parser could not classify at all.
-#[cfg(any(feature = "jsonschema", all(feature = "typescript", feature = "zod")))]
-enum BrandedComposite {
-    Array,
-    Map,
-    /// A value with no type name to narrow with, which admits anything.
-    Opaque,
-    Tuple,
-}
-
 /// The JSON schema shape a branded newtype's inner field describes.
 #[cfg(feature = "jsonschema")]
 enum BrandedJsonInner {
@@ -645,12 +634,12 @@ struct BrandedDefaultChecks {
 /// parameters as `clippy::too_many_arguments` admits.
 #[cfg(feature = "zod")]
 struct ZodDefaultInputs<'defaults> {
+    /// Whether `$SchemaDefault`'s annotation is read back off the value it binds rather than
+    /// restating the type the item declares — see [`raw_default_block`].
     #[cfg(feature = "typescript")]
-    brand: Option<BrandedAnnotation<'defaults>>,
+    annotated_by_value: bool,
     constrained: Option<(&'defaults str, &'defaults BrandedDefaultChecks)>,
     default_types: &'defaults [(syn::Ident, syn::Type)],
-    #[cfg(feature = "typescript")]
-    republished: bool,
 }
 
 /// What [`zod_published_binding`] needs beside the item's own name, parameters and expression.
@@ -660,20 +649,6 @@ struct PublishedBinding<'binding> {
     /// Whether the published expression *is* a sibling's own binding — see
     /// [`republishes_sibling_binding`].
     republished: bool,
-}
-
-/// What a branded newtype's `$SchemaDefault` is annotated with, read off the shape of the brand's
-/// own inner rather than off any one parameter's filling — see [`branded_default_annotation`].
-#[cfg(all(feature = "zod", feature = "typescript"))]
-enum BrandedAnnotation<'defaults> {
-    /// The inner is exactly one bare type parameter (`pub struct Name<T>(pub T)`) — the erased
-    /// inner itself carries no concrete class to name, so the annotation is read off that one
-    /// parameter's own declared default instead.
-    BareParameter(&'defaults str),
-    /// Every other inner shape — a tuple, an array, a concrete sibling — annotated with the bare
-    /// class [`branded_zod_type_name`] already reads off it for the non-generic const, widened
-    /// the same way regardless of what fills the brand's parameters.
-    Widened(String),
 }
 
 /// What [`default_zod_rendering`] found: a self-contained expression left eager, or a name
@@ -4540,7 +4515,7 @@ fn branded_json_inner(inner: &FieldDef) -> BrandedJsonInner {
     if branded_inner_is_object_id(inner) {
         return BrandedJsonInner::ObjectId;
     }
-    if branded_inner_composite(inner).is_some() {
+    if branded_inner_is_composite(inner) {
         return BrandedJsonInner::Slot(Box::new(inner.clone()));
     }
     #[cfg(feature = "chrono")]
@@ -4611,23 +4586,24 @@ const fn branded_inner_is_object_id(inner: &FieldDef) -> bool {
     matches!(inner.field_type, FieldDefType::ObjectId) && !inner.is_array()
 }
 
-/// What a branded newtype's inner writes when it writes a composite, and `None` when it writes a
-/// value one `"type"` keyword and one Zod class already name.
-#[cfg(any(feature = "jsonschema", all(feature = "typescript", feature = "zod")))]
-fn branded_inner_composite(inner: &FieldDef) -> Option<BrandedComposite> {
+/// Whether a branded newtype's inner writes a composite — an array, a map, a tuple, or a value the
+/// parser could not classify at all — rather than a value one `"type"` keyword already names.
+#[cfg(feature = "jsonschema")]
+fn branded_inner_is_composite(inner: &FieldDef) -> bool {
     if inner.is_array() {
-        return Some(BrandedComposite::Array);
+        return true;
     }
     if let FieldDefType::SiblingType(name, args) = &inner.field_type
         && matches!(args.as_slice(), [_])
         && is_sequence_wrapper(name)
     {
-        return Some(BrandedComposite::Array);
+        return true;
     }
     match &inner.field_type {
-        FieldDefType::Map(..) => Some(BrandedComposite::Map),
-        FieldDefType::Tuple(..) => Some(BrandedComposite::Tuple),
-        FieldDefType::TypeParam(_) | FieldDefType::Unknown => Some(BrandedComposite::Opaque),
+        FieldDefType::Map(..)
+        | FieldDefType::Tuple(..)
+        | FieldDefType::TypeParam(_)
+        | FieldDefType::Unknown => true,
         FieldDefType::Boolean
         | FieldDefType::BooleanLiteral(_)
         | FieldDefType::Char
@@ -4646,14 +4622,14 @@ fn branded_inner_composite(inner: &FieldDef) -> Option<BrandedComposite> {
         | FieldDefType::U16
         | FieldDefType::U32
         | FieldDefType::U64
-        | FieldDefType::Usize => None,
+        | FieldDefType::Usize => false,
         #[cfg(feature = "object_id")]
-        FieldDefType::ObjectId => None,
+        FieldDefType::ObjectId => false,
         #[cfg(feature = "chrono")]
         FieldDefType::DateTime
         | FieldDefType::NaiveDate
         | FieldDefType::NaiveDateTime
-        | FieldDefType::NaiveTime => None,
+        | FieldDefType::NaiveTime => false,
     }
 }
 
@@ -4669,58 +4645,6 @@ fn branded_zod_inner(args: &ModelSchemaArgs, inner: &FieldDef) -> String {
         return get_object_id_zod_schema_with(&checks);
     }
     format!("{}{checks}", inner.zod_type())
-}
-
-/// The Zod class a branded newtype's base schema is an instance of, for the exported binding's
-/// type annotation.
-#[cfg(all(feature = "zod", feature = "typescript"))]
-fn branded_zod_type_name(inner: &FieldDef) -> String {
-    #[cfg(feature = "object_id")]
-    if branded_inner_is_object_id(inner) {
-        return "ZodObject".to_owned();
-    }
-    if let Some(composite) = branded_inner_composite(inner) {
-        return match composite {
-            BrandedComposite::Array => "ZodArray".to_owned(),
-            BrandedComposite::Map => "ZodRecord".to_owned(),
-            BrandedComposite::Opaque => "ZodUnknown".to_owned(),
-            BrandedComposite::Tuple => "ZodTuple".to_owned(),
-        };
-    }
-    if let FieldDefType::SiblingType(name, args) = &inner.field_type {
-        return if args.is_empty() {
-            format!("typeof {}", inner.zod_type())
-        } else {
-            branded_zod_instantiated_type_name(name, args)
-        };
-    }
-    match inner.typescript_typename().as_str() {
-        "number" => "ZodNumber".to_owned(),
-        "boolean" => "ZodBoolean".to_owned(),
-        _ => "ZodString".to_owned(),
-    }
-}
-
-/// The Zod class a filled generic name composes to. Only a family publisher proves one — its
-/// argument's own class; every other shape widens to `ZodType` rather than guess.
-#[cfg(all(feature = "zod", feature = "typescript"))]
-fn branded_zod_instantiated_type_name(name: &str, args: &[FieldDef]) -> String {
-    match lookup_alias_info(name).map(|info| info.value_shape) {
-        Some(PublishedShape::Parameter(position)) => match args.get(position) {
-            Some(argument)
-                if argument.is_array()
-                    || !matches!(argument.field_type, FieldDefType::TypeParam(_)) =>
-            {
-                branded_zod_type_name(argument)
-            }
-            _ => "ZodType".to_owned(),
-        },
-        // A plain struct's own object shape is produced by exactly one registration site
-        // (`Surface::object()` — see its own doc comment), so unlike `union`/`container`/the
-        // bare-string bucket, the word alone already proves the Zod class.
-        Some(PublishedShape::Flat(Some("object"))) => "ZodObject".to_owned(),
-        _ => "ZodType".to_owned(),
-    }
 }
 
 /// Builds the `ts_definition()` method for a branded newtype's schema module.
@@ -4806,7 +4730,7 @@ fn build_branded_zod_schema_method(
     let expression = branded_zod_expression(args, item_name, parameters, inner, plain_description);
     let reexport = zod_binding_reexport(rust_ident, item_name, parameters);
     let body = if parameters.is_empty() {
-        branded_zod_const_block(item_name, inner, &expression, &reexport)
+        branded_zod_const_block(item_name, &expression, &reexport)
     } else {
         let checks = branded_zod_string_checks(args);
         let branded_checks = BrandedDefaultChecks {
@@ -4819,24 +4743,12 @@ fn build_branded_zod_schema_method(
             }
             _ => None,
         };
-        #[cfg(feature = "typescript")]
-        let brand = Some(
-            if let FieldDefType::TypeParam(parameter) = &inner.field_type
-                && !inner.is_array()
-            {
-                BrandedAnnotation::BareParameter(parameter.as_str())
-            } else {
-                BrandedAnnotation::Widened(branded_zod_type_name(inner))
-            },
-        );
         let defaults = ZodDefaultInputs {
+            // `.brand()` narrows at the value position, which no restated type can name.
             #[cfg(feature = "typescript")]
-            brand,
+            annotated_by_value: true,
             constrained: constrained_default,
             default_types: &args.default_types,
-            // A brand writes `.brand()` onto whatever it publishes, so it never republishes.
-            #[cfg(feature = "typescript")]
-            republished: false,
         };
         zod_factory_block(
             item_name,
@@ -4855,28 +4767,12 @@ fn build_branded_zod_schema_method(
     }
 }
 
-/// The binding a brand that declares no parameter publishes: the raw schema, then the exported
-/// `const` annotated with the branded class the inner's own rendering produces.
+/// The binding a brand that declares no parameter publishes. A brand always reads its annotation
+/// back off the value: `.brand()` narrows at the value position, and no class named here could
+/// stay true of whatever the inner rendered to.
 #[cfg(feature = "zod")]
-fn branded_zod_const_block(
-    item_name: &str,
-    inner: &FieldDef,
-    expression: &str,
-    reexport: &str,
-) -> String {
-    #[cfg(feature = "typescript")]
-    {
-        format!(
-            "const {item_name}$RawSchema = {expression};\n\nexport const {item_name}$Schema: \
-             $ZodBranded<{}, \"{item_name}\"> = {item_name}$RawSchema;{reexport}",
-            branded_zod_type_name(inner)
-        )
-    }
-    #[cfg(not(feature = "typescript"))]
-    {
-        let _: &FieldDef = inner;
-        format!("export const {item_name}$Schema = {expression};{reexport}")
-    }
+fn branded_zod_const_block(item_name: &str, expression: &str, reexport: &str) -> String {
+    zod_const_block(item_name, "", expression, reexport, true)
 }
 
 /// Builds the delegate methods (on the newtype impl) that forward to its schema module.
@@ -11870,12 +11766,6 @@ fn zod_default_block(
     record_zod_default_arguments(rust_ident, fold_keys);
     let renderings: Vec<DefaultZodRendering> = fields.iter().map(default_zod_rendering).collect();
 
-    #[cfg(feature = "typescript")]
-    let annotation =
-        branded_default_annotation(item_name, defaults, parameters, &fields, &renderings);
-    #[cfg(not(feature = "typescript"))]
-    let annotation = String::new();
-
     let arguments: Vec<String> = parameters
         .iter()
         .zip(renderings)
@@ -11895,77 +11785,35 @@ fn zod_default_block(
     let call = format!("{item_name}$SchemaFactory({})", arguments.join(", "));
 
     #[cfg(feature = "typescript")]
-    if defaults.republished {
-        return republished_default_block(item_name, &call);
+    if defaults.annotated_by_value {
+        return raw_default_block(item_name, &call);
     }
+
+    #[cfg(feature = "typescript")]
+    let annotation = format!(
+        ": ZodType<{item_name}<{}>>",
+        fields
+            .iter()
+            .map(FieldDef::typescript_typename)
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+    #[cfg(not(feature = "typescript"))]
+    let annotation = String::new();
 
     format!("\n\nexport const {item_name}$SchemaDefault{annotation} = {call};")
 }
 
-/// The `$SchemaDefault` of an item whose factory republishes another item's: the call is bound to a
-/// raw `const` first so the export can read its type back, the same two lines [`zod_const_block`]
+/// The `$SchemaDefault` of an item whose annotation is read back off the value: the call is bound
+/// to a raw `const` first so the export can name its type, the same two lines [`zod_const_block`]
 /// writes one level up. A generic item has no `$RawSchema` of its own to name.
 #[cfg(all(feature = "zod", feature = "typescript"))]
-fn republished_default_block(item_name: &str, call: &str) -> String {
+fn raw_default_block(item_name: &str, call: &str) -> String {
     format!(
         "\n\nconst {item_name}$RawSchemaDefault = {call};\n\nexport const \
          {item_name}$SchemaDefault: typeof {item_name}$RawSchemaDefault = \
          {item_name}$RawSchemaDefault;"
     )
-}
-
-/// The `$SchemaDefault` annotation [`zod_default_block`] writes: plain `ZodType<Name<...>>` for an
-/// ordinary generic item, and `$ZodBranded<Argument, Name>` for a branded newtype — whose factory
-/// always ends in `.brand()`, a return type strict tsc rejects under the plain spelling.
-#[cfg(all(feature = "zod", feature = "typescript"))]
-fn branded_default_annotation(
-    item_name: &str,
-    defaults: &ZodDefaultInputs<'_>,
-    parameters: &[String],
-    fields: &[FieldDef],
-    renderings: &[DefaultZodRendering],
-) -> String {
-    let plain_annotation = || {
-        format!(
-            ": ZodType<{item_name}<{}>>",
-            fields
-                .iter()
-                .map(FieldDef::typescript_typename)
-                .collect::<Vec<_>>()
-                .join(", ")
-        )
-    };
-    let Some(brand) = &defaults.brand else {
-        return plain_annotation();
-    };
-    let argument_type = match brand {
-        BrandedAnnotation::Widened(class) => class.clone(),
-        BrandedAnnotation::BareParameter(target) => {
-            // Structurally always found: `target` is read off this same brand's own inner, which
-            // names one of its own declared parameters. Falling back to the plain annotation
-            // rather than panicking if that ever stopped holding costs nothing real — a branded
-            // `$SchemaDefault` is never reached without a parameter list to search.
-            let Some(index) = parameters.iter().position(|parameter| parameter == target) else {
-                return plain_annotation();
-            };
-            branded_default_argument_class(&fields[index], &renderings[index])
-        }
-    };
-    format!(": $ZodBranded<{argument_type}, \"{item_name}\">")
-}
-
-/// The class a bare-parameter brand's own declared-default argument is annotated with: the eager
-/// expression's class bare, or that class inside `ZodLazy<...>` for a deferred one — `typeof
-/// {schema}` for a binding name, widened for a factory call `typeof` cannot read.
-#[cfg(all(feature = "zod", feature = "typescript"))]
-fn branded_default_argument_class(field: &FieldDef, rendering: &DefaultZodRendering) -> String {
-    match rendering {
-        DefaultZodRendering::Eager(_) => branded_zod_type_name(field),
-        DefaultZodRendering::Deferred(schema) if !schema.contains('(') => {
-            format!("ZodLazy<typeof {schema}>")
-        }
-        DefaultZodRendering::Deferred(_) => format!("ZodLazy<{}>", branded_zod_type_name(field)),
-    }
 }
 
 /// What a generic type's Zod surface is written as: the builder holding the schema its arguments
@@ -12049,13 +11897,14 @@ fn zod_const_block(
     preamble: &str,
     expression: &str,
     reexport: &str,
-    republished: bool,
+    annotated_by_value: bool,
 ) -> String {
     #[cfg(feature = "typescript")]
     {
-        // A republished binding reads its annotation back off what it published: `.brand()`
-        // narrows at the value position, which restating the item's own type discards.
-        let annotation = if republished {
+        // `.brand()` narrows at the value position, which restating the item's own type discards
+        // — so a binding carrying one, republished or the brand's own, reads its type back off
+        // what it published.
+        let annotation = if annotated_by_value {
             format!("typeof {item_name}$RawSchema")
         } else {
             format!("ZodType<{item_name}>")
@@ -12067,7 +11916,7 @@ fn zod_const_block(
     }
     #[cfg(not(feature = "typescript"))]
     {
-        let _: &_ = &republished;
+        let _: &_ = &annotated_by_value;
         format!("{preamble}export const {item_name}$Schema = {expression};{reexport}")
     }
 }
@@ -12095,11 +11944,9 @@ fn zod_published_binding(
     } else {
         let defaults = ZodDefaultInputs {
             #[cfg(feature = "typescript")]
-            brand: None,
+            annotated_by_value: published.republished,
             constrained: None,
             default_types: published.default_types,
-            #[cfg(feature = "typescript")]
-            republished: published.republished,
         };
         zod_factory_block(
             item_name, rust_ident, parameters, &defaults, preamble, expression, reexport,

--- a/tests/branded_newtype_tests/tests.rs
+++ b/tests/branded_newtype_tests/tests.rs
@@ -45,9 +45,8 @@ mod zod_ts_tests {
         );
     }
 
-    /// The brand lands on the caller's supplied schema, not a value that admits anything. Only
-    /// `$SchemaDefault` has a concrete filling to annotate with `$ZodBranded`; the builder's own
-    /// bound stays `IdType extends ZodType`.
+    /// The brand lands on the caller's supplied schema, not a value that admits anything. The
+    /// builder's own bound stays `IdType extends ZodType`, and no Zod class is named anywhere.
     #[test]
     fn test_branded_newtype_zod_schema() {
         let zod = RoleId::<String>::zod_schema();
@@ -58,20 +57,23 @@ mod zod_ts_tests {
         assert!(zod.contains("idType.meta({"), "Got: {zod}");
         assert!(zod.contains("}).brand<\"RoleId\">();"), "Got: {zod}");
         assert!(!zod.contains("z.unknown()"), "Got: {zod}");
-        let builder_end = zod.find("RoleId$SchemaDefault").unwrap();
-        assert!(!zod[..builder_end].contains("$ZodBranded"), "Got: {zod}");
+        assert!(!zod.contains("$ZodBranded"), "Got: {zod}");
     }
 
-    /// An unconstrained generic brand still has its `$SchemaDefault` annotated
-    /// `$ZodBranded<ZodString, "RoleId">` rather than `ZodType<RoleId<string>>` — the factory's
-    /// chain ends in `.brand()` regardless.
+    /// A generic brand's `$SchemaDefault` binds the factory call to a raw `const` and reads its
+    /// annotation back off it, rather than restating `ZodType<RoleId<string>>` — the factory's
+    /// chain ends in `.brand()`, which the restated type discards.
     #[test]
-    fn an_unconstrained_generic_brands_default_is_still_branded() {
+    fn an_unconstrained_generic_brands_default_is_annotated_by_value() {
         let zod = RoleId::<String>::zod_schema();
         assert!(
+            zod.contains("const RoleId$RawSchemaDefault = RoleId$SchemaFactory(z.string());"),
+            "Got:\n{zod}"
+        );
+        assert!(
             zod.contains(
-                "export const RoleId$SchemaDefault: $ZodBranded<ZodString, \"RoleId\"> = \
-                 RoleId$SchemaFactory(z.string());"
+                "export const RoleId$SchemaDefault: typeof RoleId$RawSchemaDefault = \
+                 RoleId$RawSchemaDefault;"
             ),
             "Got:\n{zod}"
         );
@@ -99,10 +101,7 @@ mod zod_ts_tests {
     fn test_branded_newtype_non_generic_zod() {
         let zod = CorrelationId::zod_schema();
         assert!(zod.contains("z.string().brand"), "Got: {zod}");
-        assert!(
-            zod.contains("$ZodBranded<ZodString, \"CorrelationId\">"),
-            "Got: {zod}"
-        );
+        assert!(zod.contains("typeof CorrelationId$RawSchema"), "Got: {zod}");
     }
 
     #[test]
@@ -113,7 +112,7 @@ mod zod_ts_tests {
             "Should contain raw schema. Got: {zod}"
         );
         assert!(
-            zod.contains("export const CorrelationId$Schema: $ZodBranded<ZodString, \"CorrelationId\"> = CorrelationId$RawSchema"),
+            zod.contains("export const CorrelationId$Schema: typeof CorrelationId$RawSchema = CorrelationId$RawSchema"),
             "Should contain exported schema referencing raw schema. Got: {zod}"
         );
     }
@@ -433,7 +432,7 @@ mod objectid_branded_surface_tests {
             "Got:\n{zod}"
         );
         assert!(
-            zod.contains(r#"PlainObjectId$Schema: $ZodBranded<ZodObject, "PlainObjectId">"#),
+            zod.contains("PlainObjectId$Schema: typeof PlainObjectId$RawSchema"),
             "Got:\n{zod}"
         );
         assert_eq!(
@@ -464,7 +463,7 @@ mod objectid_branded_surface_tests {
             "a string check must never sit on the $oid object. Got:\n{zod}"
         );
         assert!(
-            zod.contains(r#"HexObjectId$Schema: $ZodBranded<ZodObject, "HexObjectId">"#),
+            zod.contains("HexObjectId$Schema: typeof HexObjectId$RawSchema"),
             "Got:\n{zod}"
         );
         assert_eq!(
@@ -548,7 +547,7 @@ mod objectid_branded_surface_tests {
             "Got:\n{zod}"
         );
         assert!(
-            zod.contains(r#"ObjectIdList$Schema: $ZodBranded<ZodArray, "ObjectIdList">"#),
+            zod.contains("ObjectIdList$Schema: typeof ObjectIdList$RawSchema"),
             "Got:\n{zod}"
         );
         assert_eq!(
@@ -961,8 +960,7 @@ mod constrained_generic_branded_tests {
         let zod = StrictDocumentId::<String>::zod_schema();
         assert!(
             zod.contains(
-                "export const StrictDocumentId$SchemaDefault: $ZodBranded<ZodString, \
-                 \"StrictDocumentId\"> = \
+                "const StrictDocumentId$RawSchemaDefault = \
                  StrictDocumentId$SchemaFactory(z.string().min(24).max(24).check(z.regex(/^[a-f0-9]{24}$/)));"
             ),
             "Got:\n{zod}"
@@ -998,18 +996,22 @@ mod constrained_generic_branded_tests {
 
     /// `OuterId`'s declared default folds onto `StrictDocumentId$SchemaDefault`, and its own
     /// `minLength` composes inside the `z.lazy(...)` thunk over `.check(...)` — the deferred
-    /// target's annotation is not guaranteed to carry `ZodString`'s chain methods, only
-    /// `.check(...)`.
+    /// target is not guaranteed to carry `ZodString`'s chain methods, only `.check(...)`.
     #[test]
     fn a_constrained_brands_default_naming_another_constrained_brands_default_composes_the_checks_inside_the_thunk()
      {
         let zod = OuterId::<String>::zod_schema();
         assert!(
             zod.contains(
-                "export const OuterId$SchemaDefault: $ZodBranded<ZodLazy<typeof \
-                 StrictDocumentId$SchemaDefault>, \"OuterId\"> = \
-                 OuterId$SchemaFactory(z.lazy(() => \
+                "const OuterId$RawSchemaDefault = OuterId$SchemaFactory(z.lazy(() => \
                  StrictDocumentId$SchemaDefault.check(z.minLength(10))));"
+            ),
+            "Got:\n{zod}"
+        );
+        assert!(
+            zod.contains(
+                "export const OuterId$SchemaDefault: typeof OuterId$RawSchemaDefault = \
+                 OuterId$RawSchemaDefault;"
             ),
             "Got:\n{zod}"
         );
@@ -1068,18 +1070,22 @@ mod constrained_default_names_a_sibling_tests {
     pub struct OuterBrand<T>(pub T);
 
     /// The check composes inside the thunk, over `InnerString$Schema`'s own base `.check(...)` —
-    /// `.min` after the thunk closed would land on `ZodLazy`, which lacks it. Annotated
-    /// `$ZodBranded<ZodLazy<typeof InnerString$Schema>, "OuterBrand">` for the same
-    /// `.brand()`-vs-`ZodType` mismatch.
+    /// `.min` after the thunk closed would land on `ZodLazy`, which lacks it.
     #[test]
     fn a_constrained_brands_default_naming_a_non_generic_sibling_composes_the_check_inside_the_thunk()
      {
         let zod = OuterBrand::<String>::zod_schema();
         assert!(
             zod.contains(
-                "export const OuterBrand$SchemaDefault: $ZodBranded<ZodLazy<typeof \
-                 InnerString$Schema>, \"OuterBrand\"> = \
+                "const OuterBrand$RawSchemaDefault = \
                  OuterBrand$SchemaFactory(z.lazy(() => InnerString$Schema.check(z.minLength(3))));"
+            ),
+            "Got:\n{zod}"
+        );
+        assert!(
+            zod.contains(
+                "export const OuterBrand$SchemaDefault: typeof OuterBrand$RawSchemaDefault = \
+                 OuterBrand$RawSchemaDefault;"
             ),
             "Got:\n{zod}"
         );
@@ -1362,7 +1368,7 @@ mod branded_composite_inner_tests {
             "Got:\n{zod}"
         );
         assert!(
-            zod.contains(r#"LabelList$Schema: $ZodBranded<ZodArray, "LabelList">"#),
+            zod.contains("LabelList$Schema: typeof LabelList$RawSchema"),
             "Got:\n{zod}"
         );
         assert_eq!(
@@ -1385,7 +1391,7 @@ mod branded_composite_inner_tests {
             "Got:\n{zod}"
         );
         assert!(
-            zod.contains(r#"WeightMap$Schema: $ZodBranded<ZodRecord, "WeightMap">"#),
+            zod.contains("WeightMap$Schema: typeof WeightMap$RawSchema"),
             "Got:\n{zod}"
         );
         assert_eq!(
@@ -1408,7 +1414,7 @@ mod branded_composite_inner_tests {
             "Got:\n{zod}"
         );
         assert!(
-            zod.contains(r#"LabelPair$Schema: $ZodBranded<ZodTuple, "LabelPair">"#),
+            zod.contains("LabelPair$Schema: typeof LabelPair$RawSchema"),
             "Got:\n{zod}"
         );
         assert_eq!(
@@ -1433,7 +1439,7 @@ mod branded_composite_inner_tests {
             serde_json::json!({ "type": "array", "items": { "type": "string" } })
         );
         assert!(
-            LabelSet::zod_schema().contains(r#"$ZodBranded<ZodArray, "LabelSet">"#),
+            LabelSet::zod_schema().contains("LabelSet$Schema: typeof LabelSet$RawSchema"),
             "Got:\n{}",
             LabelSet::zod_schema()
         );
@@ -1447,7 +1453,7 @@ mod branded_composite_inner_tests {
             })
         );
         assert!(
-            ByteQuad::zod_schema().contains(r#"$ZodBranded<ZodArray, "ByteQuad">"#),
+            ByteQuad::zod_schema().contains("ByteQuad$Schema: typeof ByteQuad$RawSchema"),
             "Got:\n{}",
             ByteQuad::zod_schema()
         );
@@ -1467,7 +1473,7 @@ mod branded_composite_inner_tests {
             "Got:\n{zod}"
         );
         assert!(
-            zod.contains(r#"Payload$Schema: $ZodBranded<ZodUnknown, "Payload">"#),
+            zod.contains("Payload$Schema: typeof Payload$RawSchema"),
             "Got:\n{zod}"
         );
         assert_eq!(Payload::json_schema(), serde_json::json!({}));
@@ -1510,7 +1516,7 @@ mod branded_composite_inner_tests {
             })
         );
         assert!(
-            LabelRow::zod_schema().contains(r#"$ZodBranded<ZodArray, "LabelRow">"#),
+            LabelRow::zod_schema().contains("LabelRow$Schema: typeof LabelRow$RawSchema"),
             "Got:\n{}",
             LabelRow::zod_schema()
         );
@@ -1913,7 +1919,7 @@ mod branded_sibling_inner_tests {
 
     // The same forward declaration with the inner's argument fixed where it is written. Written
     // above `LateTag`, with `TrailingFixedTag` below it, so the one declaration stands in both the
-    // orders it can be written in — the registry silent for the first, answering for the second.
+    // orders it can be written in.
     #[model_schema(minLength = 3)]
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     #[serde(transparent)]
@@ -1939,8 +1945,7 @@ mod branded_sibling_inner_tests {
     pub struct TrailingFixedTag(pub LateTag<String>);
 
     // A brand over a concrete instantiation of a generic sibling, at each scalar filling the
-    // constrained-brand guard's own vocabulary names — the shape a family publisher like `LateTag`
-    // resolves an argument to.
+    // constrained-brand guard's own vocabulary names.
     #[model_schema()]
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     #[serde(transparent)]
@@ -1961,9 +1966,8 @@ mod branded_sibling_inner_tests {
     #[serde(transparent)]
     pub struct PlainCount(pub u64);
 
-    // A plain generic struct of named fields — the one shape `Surface::object()` registers, so a
-    // brand over its instantiation can be annotated the precise `ZodObject` rather than the
-    // widened `ZodType`.
+    // A plain generic struct of named fields, so a brand stands over an object-shaped sibling
+    // instantiation.
     #[model_schema(default_types(T = String))]
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     pub struct Wrapper<T> {
@@ -1975,9 +1979,8 @@ mod branded_sibling_inner_tests {
     #[serde(transparent)]
     pub struct WrappedBrand(pub Wrapper<u32>);
 
-    // A generic, tag-discriminated enum — a union-shaped sibling, whose registered word stays
-    // genuinely ambiguous between a plain and a discriminated union, so a brand over it keeps
-    // widening to `ZodType`.
+    // A generic, tag-discriminated enum, so a brand stands over a union-shaped sibling
+    // instantiation.
     #[model_schema(default_types(T = String))]
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     #[serde(tag = "kind")]
@@ -2019,7 +2022,7 @@ mod branded_sibling_inner_tests {
             "Got:\n{zod}"
         );
         assert!(
-            zod.contains(r#"WrappedPart$Schema: $ZodBranded<typeof Part$Schema, "WrappedPart">"#),
+            zod.contains("WrappedPart$Schema: typeof WrappedPart$RawSchema"),
             "Got:\n{zod}"
         );
         assert_eq!(WrappedPart::json_schema(), Part::json_schema());
@@ -2041,8 +2044,7 @@ mod branded_sibling_inner_tests {
     fn a_forward_declared_sibling_brand_carries_the_named_types_schema() {
         assert_eq!(WrappedTail::json_schema(), Tail::json_schema());
         assert!(
-            WrappedTail::zod_schema()
-                .contains(r#"WrappedTail$Schema: $ZodBranded<typeof Tail$Schema, "WrappedTail">"#),
+            WrappedTail::zod_schema().contains("WrappedTail$Schema: typeof WrappedTail$RawSchema"),
             "Got:\n{}",
             WrappedTail::zod_schema()
         );
@@ -2091,7 +2093,7 @@ mod branded_sibling_inner_tests {
             "Got:\n{zod}"
         );
         assert!(
-            zod.contains(r#"ShortSlug$Schema: $ZodBranded<typeof Slug$Schema, "ShortSlug">"#),
+            zod.contains("ShortSlug$Schema: typeof ShortSlug$RawSchema"),
             "Got:\n{zod}"
         );
     }
@@ -2193,110 +2195,43 @@ mod branded_sibling_inner_tests {
         );
     }
 
-    /// A brand's inner naming a family publisher — a generic item whose whole published value is
-    /// one of its own parameters, like `LateTag<TagType>(pub TagType)` — composes to the class the
-    /// written argument resolves to, not the sibling's own name. Guessing `ZodString` regardless
-    /// of the argument is what once left `tsc` unable to compile: the runtime value for a numeric
-    /// filling is `$ZodBranded<$ZodBranded<ZodNumber, "LateTag">, "PlainNumTag">`, and no
-    /// number-shaped value is a `ZodString`.
+    /// The annotation is read back off the raw `const`, so it does not vary with the inner: the
+    /// argument a family publisher is filled at, whether the named sibling had registered when the
+    /// brand reached it, and whether that sibling publishes an object or a union all reach the
+    /// same line. `PlainNumTag`'s runtime value carries two brand markers, `LateTag`'s and its
+    /// own, and `typeof` is the one spelling that keeps both.
     #[test]
-    fn a_brand_over_a_numeric_generic_instantiation_is_annotated_by_the_arguments_own_class() {
-        let zod = PlainNumTag::zod_schema();
-        assert!(
-            zod.contains(r#"PlainNumTag$Schema: $ZodBranded<ZodNumber, "PlainNumTag">"#),
-            "Got:\n{zod}"
-        );
+    fn every_sibling_inner_brand_reads_its_annotation_off_its_own_raw_schema() {
+        for (name, zod) in [
+            ("PlainNumTag", PlainNumTag::zod_schema()),
+            ("PlainBoolTag", PlainBoolTag::zod_schema()),
+            ("PlainStrTag", PlainStrTag::zod_schema()),
+            ("PlainCount", PlainCount::zod_schema()),
+            ("FixedTag", FixedTag::zod_schema()),
+            ("TrailingFixedTag", TrailingFixedTag::zod_schema()),
+            ("WrappedBrand", WrappedBrand::zod_schema()),
+            ("WrappedChoice", WrappedChoice::zod_schema()),
+        ] {
+            let line =
+                format!("export const {name}$Schema: typeof {name}$RawSchema = {name}$RawSchema;");
+            assert!(zod.contains(&line), "want: {line}\ngot:\n{zod}");
+        }
     }
 
-    /// The same guessed-`ZodString` defect, at the boolean filling.
+    /// A generic brand's `$SchemaDefault` binds the factory call and reads its annotation off that
+    /// binding, whatever the inner names.
     #[test]
-    fn a_brand_over_a_boolean_generic_instantiation_is_annotated_by_the_arguments_own_class() {
-        let zod = PlainBoolTag::zod_schema();
-        assert!(
-            zod.contains(r#"PlainBoolTag$Schema: $ZodBranded<ZodBoolean, "PlainBoolTag">"#),
-            "Got:\n{zod}"
-        );
-    }
-
-    /// The filling `ZodString` already named by coincidence — pinned so the fix is proven to keep
-    /// the case it used to get right, not only the two it got wrong.
-    #[test]
-    fn a_brand_over_a_string_generic_instantiation_is_annotated_by_the_arguments_own_class() {
-        let zod = PlainStrTag::zod_schema();
-        assert!(
-            zod.contains(r#"PlainStrTag$Schema: $ZodBranded<ZodString, "PlainStrTag">"#),
-            "Got:\n{zod}"
-        );
-    }
-
-    /// A brand over a plain, non-generic inner takes the scalar arm it always has — untouched by
-    /// what a *generic* sibling's own argument resolves to, since this inner names no sibling at
-    /// all.
-    #[test]
-    fn a_brand_over_a_plain_concrete_inner_is_unchanged() {
-        let zod = PlainCount::zod_schema();
-        assert!(
-            zod.contains(r#"PlainCount$Schema: $ZodBranded<ZodNumber, "PlainCount">"#),
-            "Got:\n{zod}"
-        );
-    }
-
-    /// `FixedTag` reaches `LateTag` before it has registered, so nothing proves what class its
-    /// argument resolves to — widening to the class every Zod schema is an instance of still
-    /// compiles, where guessing would not.
-    #[test]
-    fn a_forward_declared_family_publisher_widens_its_annotation() {
-        let zod = FixedTag::zod_schema();
-        assert!(
-            zod.contains(r#"FixedTag$Schema: $ZodBranded<ZodType, "FixedTag">"#),
-            "Got:\n{zod}"
-        );
-    }
-
-    /// `TrailingFixedTag` reaches the same name `FixedTag` does, after it has registered, and gets
-    /// the precise class instead of the widened one — the same runtime value, two annotations, both
-    /// sound.
-    #[test]
-    fn a_trailing_family_publisher_reference_is_annotated_precisely() {
-        let zod = TrailingFixedTag::zod_schema();
-        assert!(
-            zod.contains(r#"TrailingFixedTag$Schema: $ZodBranded<ZodString, "TrailingFixedTag">"#),
-            "Got:\n{zod}"
-        );
-    }
-
-    /// A generic brand's own inner naming another generic sibling leaves that sibling's parameter
-    /// unresolved at the point `$SchemaDefault`'s annotation is built — no argument class to read
-    /// yet, only the outer parameter — so it widens rather than guessing.
-    #[test]
-    fn a_generic_brands_default_over_a_generic_sibling_widens_its_annotation() {
+    fn a_generic_brands_default_over_a_generic_sibling_is_annotated_by_value() {
         let zod = OpenTag::<String>::zod_schema();
         assert!(
-            zod.contains(r#"OpenTag$SchemaDefault: $ZodBranded<ZodType, "OpenTag"> ="#),
+            zod.contains("const OpenTag$RawSchemaDefault = OpenTag$SchemaFactory(z.string());"),
             "Got:\n{zod}"
         );
-    }
-
-    /// A brand over a plain generic struct instantiation is annotated the precise `ZodObject`:
-    /// the sibling's registered shape (`Surface::object()`) is produced by exactly one site, used
-    /// for exactly one thing, so the word alone already proves the class.
-    #[test]
-    fn a_brand_over_a_plain_generic_struct_instantiation_is_annotated_zodobject() {
-        let zod = WrappedBrand::zod_schema();
         assert!(
-            zod.contains(r#"WrappedBrand$Schema: $ZodBranded<ZodObject, "WrappedBrand">"#),
-            "Got:\n{zod}"
-        );
-    }
-
-    /// A brand over a union-shaped generic sibling instantiation keeps widening to `ZodType`: the
-    /// registered word covers more than one Zod class, so nothing proves which one without
-    /// guessing.
-    #[test]
-    fn a_brand_over_a_union_shaped_generic_instantiation_stays_widened() {
-        let zod = WrappedChoice::zod_schema();
-        assert!(
-            zod.contains(r#"WrappedChoice$Schema: $ZodBranded<ZodType, "WrappedChoice">"#),
+            zod.contains(
+                "export const OpenTag$SchemaDefault: typeof OpenTag$RawSchemaDefault = \
+                 OpenTag$RawSchemaDefault;"
+            ),
             "Got:\n{zod}"
         );
     }
@@ -2406,24 +2341,196 @@ mod branded_chrono_inner_tests {
         );
     }
 
-    /// The Zod value already emitted the same `z.iso.*` schema field position emits, and the
-    /// annotation is the class zod gives it; only the JSON schema moved.
+    /// The Zod value is the same `z.iso.*` schema a field position emits; only the JSON schema
+    /// moved. The annotation the binding carries is pinned in `branded_chrono_zod_tests`, which
+    /// needs no `jsonschema` to be on.
     #[cfg(all(feature = "typescript", feature = "zod"))]
     #[test]
-    fn the_zod_surfaces_of_a_chrono_brand_are_unchanged() {
+    fn the_zod_value_of_a_chrono_brand_is_the_one_a_field_writes() {
         let zod = Stamp::zod_schema();
         assert!(
             zod.contains(r#"const Stamp$RawSchema = z.iso.date().brand<"Stamp">()"#),
-            "Got:\n{zod}"
-        );
-        assert!(
-            zod.contains(r#"Stamp$Schema: $ZodBranded<ZodString, "Stamp">"#),
             "Got:\n{zod}"
         );
         assert_eq!(
             Stamp::ts_definition(),
             r#"export type Stamp = string & $brand<"Stamp">;"#
         );
+    }
+}
+
+/// A chrono brand's published Zod binding. None of the four constructors a chrono inner renders
+/// through produces a `ZodString`, and the ISO three extend `ZodStringFormat`, a *sibling* of
+/// `ZodString` rather than a subtype — so a binding annotated with a class read off the inner's
+/// TypeScript name did not compile at all. Recorded verbatim on these same fixtures from tsc 5.9.3
+/// under `--strict --target ES2022 --module ESNext --moduleResolution bundler` against zod 4.4.3:
+///
+/// ```text
+/// export const UtcStamp$Schema: $ZodBranded<ZodString, "UtcStamp"> = UtcStamp$RawSchema;
+///
+/// error TS2322: Type '$ZodBranded<ZodCoercedDate<unknown>, "UtcStamp", "out">' is not assignable
+/// to type '$ZodBranded<ZodString, "UtcStamp">'.
+///   Type 'ZodCoercedDate<unknown> & { _zod: { output: Date & $brand<"UtcStamp">; }; }' is missing
+///   the following properties from type 'ZodString': email, url, jwt, emoji, and 38 more.
+///
+/// error TS2322: Type '$ZodBranded<ZodISODate, "DayStamp", "out">' is not assignable to type
+/// '$ZodBranded<ZodString, "DayStamp">'.
+///
+/// error TS2322: Type '$ZodBranded<ZodISODateTime, "MomentStamp", "out">' is not assignable to
+/// type '$ZodBranded<ZodString, "MomentStamp">'.
+///
+/// error TS2322: Type '$ZodBranded<ZodPreprocess<ZodISOTime>, "ClockStamp", "out">' is not
+/// assignable to type '$ZodBranded<ZodString, "ClockStamp">'.
+///
+/// error TS2322: Type '$ZodBranded<ZodISODate, "BoundedDay", "out">' is not assignable to type
+/// '$ZodBranded<ZodString, "BoundedDay">'.
+///
+/// error TS2322: Type '$ZodBranded<$ZodBranded<ZodISODate, "DayFamily", "out">, "BoundDay", "out">'
+/// is not assignable to type '$ZodBranded<ZodString, "BoundDay">'.
+/// ```
+///
+/// Reading the annotation back off the raw `const` clears every one of them, and `UtcStamp` then
+/// infers `Date & $brand<"UtcStamp">` where the class spelling reported
+/// `string & $brand<"UtcStamp">`.
+#[cfg(all(
+    feature = "chrono",
+    feature = "zod",
+    feature = "typescript",
+    feature = "serde"
+))]
+mod branded_chrono_zod_tests {
+    use super::*;
+    use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
+
+    #[model_schema()]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct UtcStamp(pub DateTime<Utc>);
+
+    #[model_schema()]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct DayStamp(pub NaiveDate);
+
+    #[model_schema()]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct MomentStamp(pub NaiveDateTime);
+
+    #[model_schema()]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct ClockStamp(pub NaiveTime);
+
+    #[model_schema(minLength = 10, maxLength = 10)]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct BoundedDay(pub NaiveDate);
+
+    /// A brand over a generic brand already filled at a chrono argument: the value carries two
+    /// brand markers over an ISO schema, which no single class could name.
+    #[model_schema(default_types(IdType = NaiveDate), no_display)]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct DayFamily<IdType>(pub IdType);
+
+    #[model_schema(no_display)]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct BoundDay(pub DayFamily<NaiveDate>);
+
+    #[model_schema(default_types(IdType = DateTime<Utc>), no_display)]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    pub struct InstantFamily<IdType>(pub IdType);
+
+    #[test]
+    fn every_chrono_brand_reads_its_annotation_off_its_own_raw_schema() {
+        for (name, value, zod) in [
+            ("UtcStamp", "z.coerce.date()", UtcStamp::zod_schema()),
+            ("DayStamp", "z.iso.date()", DayStamp::zod_schema()),
+            (
+                "MomentStamp",
+                "z.iso.datetime({ local: true })",
+                MomentStamp::zod_schema(),
+            ),
+            (
+                "BoundedDay",
+                "z.iso.date().min(10).max(10)",
+                BoundedDay::zod_schema(),
+            ),
+            (
+                "BoundDay",
+                "DayFamily$SchemaFactory(z.iso.date())",
+                BoundDay::zod_schema(),
+            ),
+        ] {
+            let raw = format!("const {name}$RawSchema = {value}.brand<\"{name}\">()");
+            assert!(zod.contains(&raw), "want: {raw}\ngot:\n{zod}");
+            let line =
+                format!("export const {name}$Schema: typeof {name}$RawSchema = {name}$RawSchema;");
+            assert!(zod.contains(&line), "want: {line}\ngot:\n{zod}");
+        }
+    }
+
+    /// The `NaiveTime` inner renders through an inline preprocessor whose body is long enough to
+    /// be worth matching at its two ends rather than verbatim.
+    #[test]
+    fn a_time_brand_reads_its_annotation_off_its_own_raw_schema() {
+        let zod = ClockStamp::zod_schema();
+        assert!(
+            zod.contains("const ClockStamp$RawSchema = z.preprocess("),
+            "Got:\n{zod}"
+        );
+        assert!(
+            zod.contains(r#"z.iso.time()).brand<"ClockStamp">()"#),
+            "Got:\n{zod}"
+        );
+        assert!(
+            zod.contains(
+                "export const ClockStamp$Schema: typeof ClockStamp$RawSchema = \
+                 ClockStamp$RawSchema;"
+            ),
+            "Got:\n{zod}"
+        );
+    }
+
+    /// A generic brand's `$SchemaDefault` at a chrono filling, where the same guess reached one
+    /// level up:
+    ///
+    /// ```text
+    /// export const InstantFamily$SchemaDefault: $ZodBranded<ZodString, "InstantFamily"> =
+    ///   InstantFamily$SchemaFactory(z.coerce.date());
+    ///
+    /// error TS2322: Type '$ZodBranded<ZodCoercedDate<unknown>, "InstantFamily", "out">' is not
+    /// assignable to type '$ZodBranded<ZodString, "InstantFamily">'.
+    ///   Type 'ZodCoercedDate<unknown> & { _zod: { output: Date & $brand<"InstantFamily">; }; }' is
+    ///   missing the following properties from type 'ZodString': email, url, jwt, emoji, and 38
+    ///   more.
+    /// ```
+    #[test]
+    fn a_generic_brands_default_at_a_chrono_filling_is_annotated_by_value() {
+        for (name, argument, zod) in [
+            (
+                "DayFamily",
+                "z.iso.date()",
+                DayFamily::<NaiveDate>::zod_schema(),
+            ),
+            (
+                "InstantFamily",
+                "z.coerce.date()",
+                InstantFamily::<DateTime<Utc>>::zod_schema(),
+            ),
+        ] {
+            let bound =
+                format!("const {name}$RawSchemaDefault = {name}$SchemaFactory({argument});");
+            assert!(zod.contains(&bound), "want: {bound}\ngot:\n{zod}");
+            let line = format!(
+                "export const {name}$SchemaDefault: typeof {name}$RawSchemaDefault = \
+                 {name}$RawSchemaDefault;"
+            );
+            assert!(zod.contains(&line), "want: {line}\ngot:\n{zod}");
+        }
     }
 }
 

--- a/tests/republished_binding_tests/tests.rs
+++ b/tests/republished_binding_tests/tests.rs
@@ -497,14 +497,15 @@ fn a_generic_slot_over_a_bare_parameter_keeps_the_annotation_naming_its_own_type
     assert!(!zod.contains("$RawSchemaDefault"), "got: {zod}");
 }
 
-/// A brand's own binding is annotated from its inner's class and never republishes anything.
+/// A brand republishes nothing, yet reads its annotation off the value for the same reason a
+/// republishing binding does: `.brand()` narrows where no restated type reaches.
 #[cfg(all(feature = "zod", feature = "typescript"))]
 #[test]
-fn a_brands_own_binding_keeps_the_annotation_it_already_wrote() {
+fn a_brands_own_binding_reads_its_annotation_off_the_value_too() {
     let zod = CorrelationId::zod_schema();
     assert!(
         zod.contains(
-            "export const CorrelationId$Schema: $ZodBranded<ZodString, \"CorrelationId\"> = \
+            "export const CorrelationId$Schema: typeof CorrelationId$RawSchema = \
              CorrelationId$RawSchema;"
         ),
         "got: {zod}"
@@ -512,12 +513,17 @@ fn a_brands_own_binding_keeps_the_annotation_it_already_wrote() {
     let generic = GenericBrand::<String>::zod_schema();
     assert!(
         generic.contains(
-            "export const GenericBrand$SchemaDefault: $ZodBranded<ZodString, \"GenericBrand\"> = \
-             GenericBrand$SchemaFactory(z.string());"
+            "const GenericBrand$RawSchemaDefault = GenericBrand$SchemaFactory(z.string());"
         ),
         "got: {generic}"
     );
-    assert!(!generic.contains("$RawSchemaDefault"), "got: {generic}");
+    assert!(
+        generic.contains(
+            "export const GenericBrand$SchemaDefault: typeof GenericBrand$RawSchemaDefault = \
+             GenericBrand$RawSchemaDefault;"
+        ),
+        "got: {generic}"
+    );
 }
 
 /// A build emitting no TypeScript writes every binding as a bare `const`: an annotation is a type,


### PR DESCRIPTION
A brand's published const named its own Zod class — `$ZodBranded<ZodString,
"Stamp">` — read off a table keyed by the inner's rendered name. The table was
wrong twice over. Where it missed, tsc refused the module outright: a chrono
inner binds a date coercer, not a string schema, and the fallthrough said
`ZodString` anyway — eight hard errors across the chrono brands, the
instantiated path and the generic default. Where it hit, six of sixteen brands
type-checked while silently widening what `.parse()` infers: a `Vec` inner
became `unknown[]`, a map became `Record<string | number | symbol, unknown>`,
an `ObjectId` a bare string record, and a brand over a brand dropped the inner
mark.

The annotation now reads off the value instead of naming its class:

    export const Stamp$Schema: typeof Stamp$RawSchema = Stamp$RawSchema;

the same spelling a republished binding already carries, and exact by
construction whatever the inner is — the chrono brands infer their real `Date`,
the composites keep their element types, and a brand over a brand keeps both
marks. Being exact by naming classes would have meant restating zod's type
algebra in Rust, arm by arm, forever.

The table and everything that served it are deleted: the class-name dispatch,
its instantiated and default-argument readers, and both enums. Its one
surviving question — is the inner a composite — became a predicate on the JSON
gate that asks it. `$ZodBranded` no longer appears in the emission at all, and
a consumer's preamble needs only `z`, `ZodType`, and `$brand`.

Measured on the crate's own emission: eight TS2322s to zero, declaration emit
clean, and every one of twenty brands inferring exactly, where fourteen did
before. Runtime parse and brand behaviour byte-identical.

just fmt, just check, just quick, just lint-all across all 68 toggles, and the
test powerset across all 68 in four partitions — all green.

